### PR TITLE
refactor(ui): unify padding APIs on setPadding

### DIFF
--- a/changelog.d/9962-padding-api.md
+++ b/changelog.d/9962-padding-api.md
@@ -1,0 +1,5 @@
+**UI padding API:** `setPadding` is now the canonical imperative API on every
+backend and accepts both `(widget, value)` and `(widget, top, left, bottom,
+right)`. The `widgetSetEdgeInsets` spelling remains as a deprecated alias for
+the compatibility window. Web, WASM, native, and HarmonyOS now agree on side
+ordering, including asymmetric inline `padding` objects.

--- a/crates/perry-codegen-arkts/src/mutations.rs
+++ b/crates/perry-codegen-arkts/src/mutations.rs
@@ -309,15 +309,22 @@ pub(crate) fn collect_mutations_in_expr(
             );
         }
         "setPadding" | "widgetSetEdgeInsets" => {
-            // Args: (widget, top, right, bottom, left)
+            // Canonical forms: (widget, value) or
+            // (widget, top, left, bottom, right).
             // Resolve through bindings so Mango's `setPadding(box, isIOS
             // ? 52 : 12, mobile ? 16 : 24, ...)` ternary-and-binding
             // chain resolves to literal numbers; default to 0 only if
             // the leaf truly isn't a number (function call etc).
             let top = numeric_arg_resolved(&args[1..], 0, bindings).unwrap_or(0.0);
-            let right = numeric_arg_resolved(&args[1..], 1, bindings).unwrap_or(0.0);
-            let bottom = numeric_arg_resolved(&args[1..], 2, bindings).unwrap_or(0.0);
-            let left = numeric_arg_resolved(&args[1..], 3, bindings).unwrap_or(0.0);
+            let (left, bottom, right) = if args.len() == 2 {
+                (top, top, top)
+            } else {
+                (
+                    numeric_arg_resolved(&args[1..], 1, bindings).unwrap_or(0.0),
+                    numeric_arg_resolved(&args[1..], 2, bindings).unwrap_or(0.0),
+                    numeric_arg_resolved(&args[1..], 3, bindings).unwrap_or(0.0),
+                )
+            };
             push_mut(
                 Mutation::Modifier(format!(
                     ".padding({{ top: {}, right: {}, bottom: {}, left: {} }})",

--- a/crates/perry-codegen-arkts/src/tests/mutations.rs
+++ b/crates/perry-codegen-arkts/src/tests/mutations.rs
@@ -107,7 +107,7 @@ fn issue_408_scrollview_set_child_replaces_body() {
 #[test]
 fn issue_408_set_padding_emits_modifier_chain() {
     // const card = VStack([]);
-    // setPadding(card, 8, 12, 8, 12);
+    // setPadding(card, 8, 12, 16, 20);
     // setCornerRadius(card, 16);
     // widgetSetBackgroundColor(card, 0.2, 0.5, 0.95, 1);
     // App({body: card});
@@ -124,8 +124,8 @@ fn issue_408_set_padding_emits_modifier_chain() {
             Expr::LocalGet(card_id),
             Expr::Number(8.0),
             Expr::Number(12.0),
-            Expr::Number(8.0),
-            Expr::Number(12.0),
+            Expr::Number(16.0),
+            Expr::Number(20.0),
         ],
     ));
     m.init.push(mutator_stmt(
@@ -146,7 +146,7 @@ fn issue_408_set_padding_emits_modifier_chain() {
     let r = emit_index_ets(&mut m).unwrap().unwrap();
     assert!(
         r.ets_source
-            .contains(".padding({ top: 8, right: 12, bottom: 8, left: 12 })"),
+            .contains(".padding({ top: 8, right: 20, bottom: 16, left: 12 })"),
         "expected padding modifier:\n{}",
         r.ets_source
     );
@@ -160,6 +160,30 @@ fn issue_408_set_padding_emits_modifier_chain() {
         r.ets_source
             .contains(".backgroundColor('rgba(51, 128, 242, 1)')"),
         "expected rgba background:\n{}",
+        r.ets_source
+    );
+}
+
+#[test]
+fn issue_9955_uniform_padding_expands_to_every_side() {
+    let mut m = empty_module();
+    let card_id: LocalId = 31;
+    m.init.push(let_widget(
+        card_id,
+        "card",
+        nmc("VStack", vec![Expr::Array(vec![])]),
+    ));
+    m.init.push(mutator_stmt(
+        "setPadding",
+        vec![Expr::LocalGet(card_id), Expr::Number(14.0)],
+    ));
+    m.init.push(app_with_body(Expr::LocalGet(card_id)));
+
+    let r = emit_index_ets(&mut m).unwrap().unwrap();
+    assert!(
+        r.ets_source
+            .contains(".padding({ top: 14, right: 14, bottom: 14, left: 14 })"),
+        "expected uniform padding modifier:\n{}",
         r.ets_source
     );
 }

--- a/crates/perry-codegen-js/src/web_runtime.js
+++ b/crates/perry-codegen-js/src/web_runtime.js
@@ -40,7 +40,7 @@ function wrapWidget(h) {
         setFontSize(size) { perry_ui_set_font_size(h, size); },
         setFontWeight(weight) { perry_ui_set_font_weight(h, weight); },
         setFontFamily(family) { perry_ui_set_font_family(h, family); },
-        setPadding(val) { perry_ui_set_padding(h, val); },
+        setPadding(top, left, bottom, right) { perry_ui_set_padding(h, top, left, bottom, right); },
         setFrame(w, ht) { perry_ui_set_frame(h, w, ht); },
         setCornerRadius(r) { perry_ui_set_corner_radius(h, r); },
         setBorder(w, r, g, b, a) { perry_ui_set_border(h, w, r, g, b, a); },
@@ -441,9 +441,11 @@ function perry_ui_set_font_family(h, family) {
     if (el) el.style.fontFamily = family;
 }
 
-function perry_ui_set_padding(h, value) {
+function perry_ui_set_padding(h, top, left, bottom, right) {
     const el = getHandle(h);
-    if (el) el.style.padding = value + "px";
+    if (!el) return;
+    if (left === undefined) left = bottom = right = top;
+    el.style.padding = top + "px " + right + "px " + bottom + "px " + left + "px";
 }
 
 function perry_ui_set_frame(h, width, height) {
@@ -2848,9 +2850,8 @@ function perry_ui_widget_set_overlay_frame(overlay_h, x, y, width, height) {
     el.style.height = height + "px";
 }
 
-function perry_ui_widget_set_edge_insets(h, top, right, bottom, left) {
-    var el = getHandle(h);
-    if (el) el.style.padding = top + "px " + right + "px " + bottom + "px " + left + "px";
+function perry_ui_widget_set_edge_insets(h, top, left, bottom, right) {
+    perry_ui_set_padding(h, top, left, bottom, right);
 }
 
 function perry_ui_stack_set_detaches_hidden(h, detaches) {

--- a/crates/perry-codegen-wasm/src/wasm_runtime.js
+++ b/crates/perry-codegen-wasm/src/wasm_runtime.js
@@ -2982,7 +2982,11 @@ function perry_ui_set_foreground(h, r, g, b, a) {
 function perry_ui_set_font_size(h, size) { const el = uiGet(h); if (el) el.style.fontSize = size + "px"; }
 function perry_ui_set_font_weight(h, weight) { const el = uiGet(h); if (el) el.style.fontWeight = weight; }
 function perry_ui_set_font_family(h, family) { const el = uiGet(h); if (el) el.style.fontFamily = family; }
-function perry_ui_set_padding(h, value) { const el = uiGet(h); if (el) el.style.padding = value + "px"; }
+function perry_ui_set_padding(h, top, left, bottom, right) {
+  const el = uiGet(h); if (!el) return;
+  if (left === undefined) left = bottom = right = top;
+  el.style.padding = `${top}px ${right}px ${bottom}px ${left}px`;
+}
 function perry_ui_set_frame(h, width, height) {
   const el = uiGet(h); if (!el) return;
   if (width > 0) el.style.width = width + "px";
@@ -3100,8 +3104,8 @@ function perry_ui_widget_set_height(h, height) { const el = uiGet(h); if (el) el
 function perry_ui_widget_set_hugging(h) { const el = uiGet(h); if (el) el.style.flex = "0 0 auto"; }
 function perry_ui_widget_match_parent_width(h) { const el = uiGet(h); if (el) el.style.width = "100%"; }
 function perry_ui_widget_match_parent_height(h) { const el = uiGet(h); if (el) el.style.height = "100%"; }
-function perry_ui_widget_set_edge_insets(h, top, right, bottom, left) {
-  const el = uiGet(h); if (el) el.style.padding = `${top}px ${right}px ${bottom}px ${left}px`;
+function perry_ui_widget_set_edge_insets(h, top, left, bottom, right) {
+  perry_ui_set_padding(h, top, left, bottom, right);
 }
 function perry_ui_stack_set_detaches_hidden(h) { /* no-op in web */ }
 function perry_ui_stack_set_distribution(h) { /* no-op in web */ }

--- a/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
@@ -7,6 +7,29 @@
         let blk = ctx.block();
         let handle = unbox_to_i64(blk, &recv_val);
         if let Some(sig) = perry_ui_instance_method_lookup(method) {
+            let padding_args: Vec<Expr>;
+            let args: &[Expr] = if sig.method == "setPadding"
+                && args.len() == 1
+                && sig.args.len() == 4
+            {
+                padding_args = vec![
+                    args[0].clone(),
+                    args[0].clone(),
+                    args[0].clone(),
+                    args[0].clone(),
+                ];
+                &padding_args
+            } else {
+                args
+            };
+            if sig.method == "setPadding" && args.len() != sig.args.len() {
+                bail!(
+                    "perry/ui: '.{}(...)' takes {} argument(s), but it was called with {}.",
+                    method,
+                    sig.args.len(),
+                    args.len()
+                );
+            }
             // Build args: handle is the first arg, then the call args.
             let mut llvm_args: Vec<(crate::types::LlvmType, String)> =
                 Vec::with_capacity(1 + args.len());

--- a/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
@@ -7,22 +7,9 @@
         let blk = ctx.block();
         let handle = unbox_to_i64(blk, &recv_val);
         if let Some(sig) = perry_ui_instance_method_lookup(method) {
-            let padding_args: Vec<Expr>;
-            let args: &[Expr] = if sig.method == "setPadding"
-                && args.len() == 1
-                && sig.args.len() == 4
-            {
-                padding_args = vec![
-                    args[0].clone(),
-                    args[0].clone(),
-                    args[0].clone(),
-                    args[0].clone(),
-                ];
-                &padding_args
-            } else {
-                args
-            };
-            if sig.method == "setPadding" && args.len() != sig.args.len() {
+            let uniform_padding =
+                sig.method == "setPadding" && args.len() == 1 && sig.args.len() == 4;
+            if sig.method == "setPadding" && !uniform_padding && args.len() != sig.args.len() {
                 bail!(
                     "perry/ui: '.{}(...)' takes {} argument(s), but it was called with {}.",
                     method,
@@ -32,41 +19,51 @@
             }
             // Build args: handle is the first arg, then the call args.
             let mut llvm_args: Vec<(crate::types::LlvmType, String)> =
-                Vec::with_capacity(1 + args.len());
+                Vec::with_capacity(1 + sig.args.len());
             let mut runtime_param_types: Vec<crate::types::LlvmType> =
-                Vec::with_capacity(1 + args.len());
+                Vec::with_capacity(1 + sig.args.len());
             llvm_args.push((I64, handle));
             runtime_param_types.push(I64);
-            for (kind, arg) in sig.args.iter().zip(args.iter()) {
-                match kind {
-                    UiArgKind::Widget => {
-                        let v = lower_expr(ctx, arg)?;
-                        let blk = ctx.block();
-                        let h = unbox_to_i64(blk, &v);
-                        llvm_args.push((I64, h));
-                        runtime_param_types.push(I64);
-                    }
-                    UiArgKind::Str => {
-                        let h = get_raw_string_ptr(ctx, arg)?;
-                        llvm_args.push((I64, h));
-                        runtime_param_types.push(I64);
-                    }
-                    UiArgKind::F64 => {
-                        let v = lower_expr(ctx, arg)?;
-                        llvm_args.push((DOUBLE, v));
-                        runtime_param_types.push(DOUBLE);
-                    }
-                    UiArgKind::Closure => {
-                        let v = lower_expr(ctx, arg)?;
-                        llvm_args.push((DOUBLE, v));
-                        runtime_param_types.push(DOUBLE);
-                    }
-                    UiArgKind::I64Raw => {
-                        let v = lower_expr(ctx, arg)?;
-                        let blk = ctx.block();
-                        let i = blk.fptosi(DOUBLE, &v, I64);
-                        llvm_args.push((I64, i));
-                        runtime_param_types.push(I64);
+            if uniform_padding {
+                // A source expression is evaluated once even when the native
+                // four-edge ABI consumes the resulting value four times.
+                let value = lower_expr(ctx, &args[0])?;
+                for _ in 0..4 {
+                    llvm_args.push((DOUBLE, value.clone()));
+                    runtime_param_types.push(DOUBLE);
+                }
+            } else {
+                for (kind, arg) in sig.args.iter().zip(args.iter()) {
+                    match kind {
+                        UiArgKind::Widget => {
+                            let v = lower_expr(ctx, arg)?;
+                            let blk = ctx.block();
+                            let h = unbox_to_i64(blk, &v);
+                            llvm_args.push((I64, h));
+                            runtime_param_types.push(I64);
+                        }
+                        UiArgKind::Str => {
+                            let h = get_raw_string_ptr(ctx, arg)?;
+                            llvm_args.push((I64, h));
+                            runtime_param_types.push(I64);
+                        }
+                        UiArgKind::F64 => {
+                            let v = lower_expr(ctx, arg)?;
+                            llvm_args.push((DOUBLE, v));
+                            runtime_param_types.push(DOUBLE);
+                        }
+                        UiArgKind::Closure => {
+                            let v = lower_expr(ctx, arg)?;
+                            llvm_args.push((DOUBLE, v));
+                            runtime_param_types.push(DOUBLE);
+                        }
+                        UiArgKind::I64Raw => {
+                            let v = lower_expr(ctx, arg)?;
+                            let blk = ctx.block();
+                            let i = blk.fptosi(DOUBLE, &v, I64);
+                            llvm_args.push((I64, i));
+                            runtime_param_types.push(I64);
+                        }
                     }
                 }
             }

--- a/crates/perry-codegen/src/lower_call/ui_styling.rs
+++ b/crates/perry-codegen/src/lower_call/ui_styling.rs
@@ -201,9 +201,11 @@ pub(super) fn apply_inline_style(
                     &[
                         (I64, handle),
                         (DOUBLE, &top),
-                        (DOUBLE, &right),
-                        (DOUBLE, &bottom),
+                        // The cross-platform FFI ABI follows the public
+                        // setPadding order: top, left, bottom, right.
                         (DOUBLE, &left),
+                        (DOUBLE, &bottom),
+                        (DOUBLE, &right),
                     ],
                 );
             }

--- a/crates/perry-codegen/src/lower_call/ui_tables.rs
+++ b/crates/perry-codegen/src/lower_call/ui_tables.rs
@@ -389,21 +389,9 @@ pub fn lower_perry_ui_table_call(
     // user supplies only 2 args, prepend a synthetic 0 Widget so the
     // call still matches the 3-arg ABI without changing the runtime
     // signatures across 8 platform crates.
+    let uniform_padding = sig.method == "setPadding" && args.len() == 2 && sig.args.len() == 5;
     let synthesised_args: Vec<Expr>;
-    let args: &[Expr] = if sig.method == "setPadding" && args.len() == 2 && sig.args.len() == 5 {
-        // Canonical padding accepts both `(widget, value)` and
-        // `(widget, top, left, bottom, right)`. The native runtime keeps one
-        // fixed four-edge ABI, so expand the uniform form before the normal
-        // arity and coercion machinery runs.
-        synthesised_args = vec![
-            args[0].clone(),
-            args[1].clone(),
-            args[1].clone(),
-            args[1].clone(),
-            args[1].clone(),
-        ];
-        &synthesised_args[..]
-    } else if sig.method == "appSetTimer" && args.len() == 2 && sig.args.len() == 3 {
+    let args: &[Expr] = if sig.method == "appSetTimer" && args.len() == 2 && sig.args.len() == 3 {
         synthesised_args = std::iter::once(Expr::Integer(0))
             .chain(args.iter().cloned())
             .collect();
@@ -466,7 +454,8 @@ pub fn lower_perry_ui_table_call(
     // `Widget` handle or `Closure` can't be synthesized, so those fall
     // through to the hard error.
     let padded_args: Vec<Expr>;
-    let args: &[Expr] = if args.len() < sig.args.len()
+    let args: &[Expr] = if !uniform_padding
+        && args.len() < sig.args.len()
         && sig.args[args.len()..]
             .iter()
             .all(|k| matches!(k, UiArgKind::Str | UiArgKind::F64))
@@ -492,7 +481,7 @@ pub fn lower_perry_ui_table_call(
         };
     let declared_arg_count = sig.args.len();
 
-    if args.len() != declared_arg_count && inline_style_arg.is_none() {
+    if !uniform_padding && args.len() != declared_arg_count && inline_style_arg.is_none() {
         // Issue #6087: a `perry/*` builtin called with an arity the runtime
         // ABI cannot accept. Everything legitimate has been absorbed above
         // (arg adapters, inline style, optional trailing params), so this is
@@ -517,45 +506,62 @@ pub fn lower_perry_ui_table_call(
         Vec::with_capacity(declared_arg_count);
     let mut runtime_param_types: Vec<crate::types::LlvmType> =
         Vec::with_capacity(declared_arg_count);
-    for (kind, arg) in sig.args.iter().zip(args.iter().take(declared_arg_count)) {
-        match kind {
-            UiArgKind::Widget => {
-                // Widgets are NaN-boxed pointers. Lower as JSValue,
-                // strip the POINTER_TAG bits to get the raw 1-based
-                // handle as i64.
-                let v = lower_expr(ctx, arg)?;
-                let blk = ctx.block();
-                let h = unbox_to_i64(blk, &v);
-                llvm_args.push((I64, h));
-                runtime_param_types.push(I64);
-            }
-            UiArgKind::Str => {
-                let h = super::get_raw_string_ptr(ctx, arg)?;
-                llvm_args.push((I64, h));
-                runtime_param_types.push(I64);
-            }
-            UiArgKind::F64 => {
-                let v = lower_expr(ctx, arg)?;
-                llvm_args.push((DOUBLE, v));
-                runtime_param_types.push(DOUBLE);
-            }
-            UiArgKind::Closure => {
-                // Closures are NaN-boxed pointers passed as f64. The
-                // runtime side calls `js_closure_call0` (or callN) on
-                // them, so it expects the f64 representation.
-                let v = lower_expr(ctx, arg)?;
-                llvm_args.push((DOUBLE, v));
-                runtime_param_types.push(DOUBLE);
-            }
-            UiArgKind::I64Raw => {
-                // Numeric arg the runtime wants as i64 (e.g. enum tag,
-                // boolean flag). `fptosi` converts the f64 to a signed
-                // integer.
-                let v = lower_expr(ctx, arg)?;
-                let blk = ctx.block();
-                let i = blk.fptosi(DOUBLE, &v, I64);
-                llvm_args.push((I64, i));
-                runtime_param_types.push(I64);
+    if uniform_padding {
+        // Preserve JavaScript evaluation semantics: `setPadding(widget,
+        // next())` calls `next` once, then fans that one result out to the
+        // fixed four-edge native ABI.
+        let widget = lower_expr(ctx, &args[0])?;
+        let blk = ctx.block();
+        let handle = unbox_to_i64(blk, &widget);
+        llvm_args.push((I64, handle));
+        runtime_param_types.push(I64);
+
+        let value = lower_expr(ctx, &args[1])?;
+        for _ in 0..4 {
+            llvm_args.push((DOUBLE, value.clone()));
+            runtime_param_types.push(DOUBLE);
+        }
+    } else {
+        for (kind, arg) in sig.args.iter().zip(args.iter().take(declared_arg_count)) {
+            match kind {
+                UiArgKind::Widget => {
+                    // Widgets are NaN-boxed pointers. Lower as JSValue,
+                    // strip the POINTER_TAG bits to get the raw 1-based
+                    // handle as i64.
+                    let v = lower_expr(ctx, arg)?;
+                    let blk = ctx.block();
+                    let h = unbox_to_i64(blk, &v);
+                    llvm_args.push((I64, h));
+                    runtime_param_types.push(I64);
+                }
+                UiArgKind::Str => {
+                    let h = super::get_raw_string_ptr(ctx, arg)?;
+                    llvm_args.push((I64, h));
+                    runtime_param_types.push(I64);
+                }
+                UiArgKind::F64 => {
+                    let v = lower_expr(ctx, arg)?;
+                    llvm_args.push((DOUBLE, v));
+                    runtime_param_types.push(DOUBLE);
+                }
+                UiArgKind::Closure => {
+                    // Closures are NaN-boxed pointers passed as f64. The
+                    // runtime side calls `js_closure_call0` (or callN) on
+                    // them, so it expects the f64 representation.
+                    let v = lower_expr(ctx, arg)?;
+                    llvm_args.push((DOUBLE, v));
+                    runtime_param_types.push(DOUBLE);
+                }
+                UiArgKind::I64Raw => {
+                    // Numeric arg the runtime wants as i64 (e.g. enum tag,
+                    // boolean flag). `fptosi` converts the f64 to a signed
+                    // integer.
+                    let v = lower_expr(ctx, arg)?;
+                    let blk = ctx.block();
+                    let i = blk.fptosi(DOUBLE, &v, I64);
+                    llvm_args.push((I64, i));
+                    runtime_param_types.push(I64);
+                }
             }
         }
     }

--- a/crates/perry-codegen/src/lower_call/ui_tables.rs
+++ b/crates/perry-codegen/src/lower_call/ui_tables.rs
@@ -390,7 +390,20 @@ pub fn lower_perry_ui_table_call(
     // call still matches the 3-arg ABI without changing the runtime
     // signatures across 8 platform crates.
     let synthesised_args: Vec<Expr>;
-    let args: &[Expr] = if sig.method == "appSetTimer" && args.len() == 2 && sig.args.len() == 3 {
+    let args: &[Expr] = if sig.method == "setPadding" && args.len() == 2 && sig.args.len() == 5 {
+        // Canonical padding accepts both `(widget, value)` and
+        // `(widget, top, left, bottom, right)`. The native runtime keeps one
+        // fixed four-edge ABI, so expand the uniform form before the normal
+        // arity and coercion machinery runs.
+        synthesised_args = vec![
+            args[0].clone(),
+            args[1].clone(),
+            args[1].clone(),
+            args[1].clone(),
+            args[1].clone(),
+        ];
+        &synthesised_args[..]
+    } else if sig.method == "appSetTimer" && args.len() == 2 && sig.args.len() == 3 {
         synthesised_args = std::iter::once(Expr::Integer(0))
             .chain(args.iter().cloned())
             .collect();

--- a/crates/perry-codegen/tests/padding_single_evaluation.rs
+++ b/crates/perry-codegen/tests/padding_single_evaluation.rs
@@ -1,0 +1,106 @@
+//! Uniform padding is one JavaScript expression even though the native ABI
+//! receives four edge values. These IR tests keep both public call forms from
+//! cloning and re-evaluating a side-effecting expression.
+
+use perry_codegen::{compile_module, CompileOptions};
+use perry_hir::types::Type;
+use perry_hir::{Expr, Function, Module, Stmt};
+
+fn value_call() -> Expr {
+    Expr::Call {
+        callee: Box::new(Expr::FuncRef(1)),
+        args: Vec::new(),
+        type_args: Vec::new(),
+        byte_offset: 0,
+    }
+}
+
+fn module_with_padding_call(call: Expr) -> Module {
+    let mut module = Module::new("padding_single_evaluation");
+    module.functions.push(Function {
+        id: 1,
+        name: "next_padding".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Number,
+        body: vec![Stmt::Return(Some(Expr::Number(7.0)))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    });
+    module.functions.push(Function {
+        id: 2,
+        name: "apply_padding".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Number,
+        body: vec![Stmt::Expr(call), Stmt::Return(Some(Expr::Number(0.0)))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    });
+    module
+}
+
+fn compile_ir(call: Expr) -> String {
+    let options = CompileOptions {
+        emit_ir_only: true,
+        ..Default::default()
+    };
+    String::from_utf8(compile_module(&module_with_padding_call(call), options).unwrap()).unwrap()
+}
+
+fn assert_one_value_evaluation(ir: &str) {
+    let body = ir
+        .split("define double @perry_fn_padding_single_evaluation__apply_padding()")
+        .nth(1)
+        .and_then(|rest| rest.split("\n}\n").next())
+        .expect("apply_padding body is present");
+    // A direct call has one typed arm and one generic fallback arm in the IR;
+    // only one arm executes. Cloning the source expression four times emits
+    // four such pairs, which is the regression this count detects.
+    let calls = body
+        .lines()
+        .filter(|line| {
+            line.contains("call double @perry_fn_padding_single_evaluation__next_padding$")
+        })
+        .count();
+    assert_eq!(
+        calls, 2,
+        "uniform padding must evaluate its value once:\n{ir}"
+    );
+}
+
+#[test]
+fn free_function_uniform_padding_evaluates_value_once() {
+    let ir = compile_ir(Expr::NativeMethodCall {
+        module: "perry/ui".to_string(),
+        class_name: None,
+        object: None,
+        method: "setPadding".to_string(),
+        args: vec![Expr::Number(1.0), value_call()],
+    });
+    assert_one_value_evaluation(&ir);
+}
+
+#[test]
+fn instance_uniform_padding_evaluates_value_once() {
+    let ir = compile_ir(Expr::NativeMethodCall {
+        module: "perry/ui".to_string(),
+        class_name: None,
+        object: Some(Box::new(Expr::Number(1.0))),
+        method: "setPadding".to_string(),
+        args: vec![value_call()],
+    });
+    assert_one_value_evaluation(&ir);
+}

--- a/crates/perry-dispatch/src/ui_instance_table.rs
+++ b/crates/perry-dispatch/src/ui_instance_table.rs
@@ -16,6 +16,12 @@ pub const PERRY_UI_INSTANCE_TABLE: &[MethodRow] = &[
         args: &[],
         ret: ReturnKind::Void,
     },
+    MethodRow {
+        method: "setPadding",
+        runtime: "perry_ui_widget_set_edge_insets",
+        args: &[ArgKind::F64, ArgKind::F64, ArgKind::F64, ArgKind::F64],
+        ret: ReturnKind::Void,
+    },
     // ---- Window instance methods ----
     MethodRow {
         method: "show",

--- a/crates/perry-dispatch/tests/dispatch_drift.rs
+++ b/crates/perry-dispatch/tests/dispatch_drift.rs
@@ -66,6 +66,10 @@ fn widget_compat_methods_use_native_abi_symbols() {
         perry_ui_instance_lookup("removeAllChildren").map(|row| row.runtime),
         Some("perry_ui_widget_clear_children")
     );
+    let padding = perry_ui_instance_lookup("setPadding")
+        .expect("Widget.setPadding must use the native padding ABI");
+    assert_eq!(padding.runtime, "perry_ui_widget_set_edge_insets");
+    assert_eq!(padding.args.len(), 4);
 }
 
 #[test]

--- a/docs/examples/ui/styling/counter_card.ts
+++ b/docs/examples/ui/styling/counter_card.ts
@@ -15,7 +15,7 @@ import {
     textSetFontFamily,
     textSetColor,
     widgetSetBackgroundColor,
-    widgetSetEdgeInsets,
+    setPadding,
     setCornerRadius,
 } from "perry/ui"
 
@@ -43,10 +43,10 @@ setCornerRadius(incBtn, 20)
 widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)
 
 const controls = HStack(8, [decBtn, Spacer(), incBtn])
-widgetSetEdgeInsets(controls, 20, 20, 20, 20)
+setPadding(controls, 20)
 
 const container = VStack(16, [title, display, controls])
-widgetSetEdgeInsets(container, 40, 40, 40, 40)
+setPadding(container, 40)
 setCornerRadius(container, 16)
 widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)
 

--- a/docs/examples/ui/styling/snippets.ts
+++ b/docs/examples/ui/styling/snippets.ts
@@ -20,7 +20,6 @@ import {
     widgetAddChild,
     widgetSetBackgroundColor, widgetSetBackgroundGradient,
     widgetSetBorderColor, widgetSetBorderWidth,
-    widgetSetEdgeInsets,
     widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,
     widgetSetOpacity,
     widgetSetControlSize,
@@ -55,9 +54,8 @@ widgetSetBorderWidth(bordered, 1)
 
 // ANCHOR: padding
 const padded = VStack(8, [Text("Padded content")])
-// Both names accept (widget, top, left, bottom, right):
-setPadding(padded, 16, 16, 16, 16)
-widgetSetEdgeInsets(padded, 10, 20, 10, 20)
+setPadding(padded, 16)                 // uniform padding
+setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right
 // ANCHOR_END: padding
 
 // ANCHOR: sizing

--- a/docs/examples/ui/styling/style_props.ts
+++ b/docs/examples/ui/styling/style_props.ts
@@ -58,7 +58,7 @@ if (cardStyle.borderRadius !== undefined) {
     setCornerRadius(card, cardStyle.borderRadius)
 }
 if (typeof cardStyle.padding === "number") {
-    setPadding(card, cardStyle.padding, cardStyle.padding, cardStyle.padding, cardStyle.padding)
+    setPadding(card, cardStyle.padding)
 }
 if (cardStyle.opacity !== undefined) {
     widgetSetOpacity(card, cardStyle.opacity)

--- a/docs/po/de.po
+++ b/docs/po/de.po
@@ -214,7 +214,7 @@ msgstr "Hooks"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Beispiele"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "CI-Stufen (PR-Prüfung / Testlauf / vollständige Suite)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Planung der CI-Prüfungen"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "CLI-Referenz"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Befehle"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Compiler-Flags"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Cache-Verzeichnis"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dynamischer Stdlib-Dispatch"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS-Runtime Opt-In"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (binärer Attestierungsanhang)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Ausgangs-Allowlist (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Paketspezifische Berechtigungen (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Host-Allowlist (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "perry.toml-Referenz"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Update-Prüfungen in Ihren Apps"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Datenschutz & Telemetrie"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Interna"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Speichermodell"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Garbage Collector"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Explizite Speicherverwaltung"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "Die GC-Rooting-Invariante (Codegenerierung)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Typnachweise für lokale Bindungen"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Grenzen inkrementeller GC-Schritte"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: Rooting durch Konstruktion"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Mitwirken"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Architektur"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Crate-Richtlinie"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Aus dem Quellcode bauen"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Perry veröffentlichen"
 
@@ -935,7 +943,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Öffnet ein natives macOS/Windows/Linux-Fenster"
 
 #: src/introduction.md:79
@@ -968,11 +977,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -981,9 +990,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -993,7 +1002,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Nächste Schritte"
@@ -1066,27 +1075,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux Linker Toolchain nach Verteilung:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Bogen / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS Stream"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# Alpen-/Musl-basiert"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Leere Linux"
 
 #: src/getting-started/installation.md:41
@@ -1128,15 +1143,18 @@ msgstr ""
 "einem einzigen Befehl:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Projekt-lokal (pins Perry Version neben Ihren deps)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Null-install, ein Schuss"
 
 #: src/getting-started/installation.md:66
@@ -1337,7 +1355,8 @@ msgstr ""
 "Ihrem PATH hinzu:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Zu ~/.zshrc oder ~/.bashrc hinzufügen"
 
 #: src/getting-started/installation.md:129
@@ -1476,16 +1495,14 @@ msgstr ""
 "erfordern sie nicht.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2178,26 +2195,31 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "Derselbe Code läuft auf allen 6 Plattformen:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (Standard)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOS Simulator"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr ""
 "# Web (kompiliert WebAssembly + DOM-Brücke in einer eigenständigen HTML-"
 "Datei)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# alias: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Andere Plattformen"
 
 #: src/getting-started/first-app.md:138
@@ -2441,7 +2463,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2459,7 +2481,7 @@ msgstr "\"Perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2686,7 +2708,8 @@ msgstr ""
 "Validator als einfacher Quellcode ausgegeben. Das Generator-Skript:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2718,7 +2741,8 @@ msgid "\"port\""
 msgstr "\"Hafen\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// eigenständige Quelle"
 
 #: src/getting-started/project-config.md:122
@@ -2964,19 +2988,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Feld"
 
@@ -2991,9 +3016,9 @@ msgstr "Feld"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3114,11 +3139,13 @@ msgstr ""
 "Konfiguration:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3173,7 +3200,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3182,7 +3209,7 @@ msgstr ""
 "Implementierungen. Siehe [Standardbibliothek](../stdlib/overview.md) für die "
 "vollständige Liste."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3190,44 +3217,47 @@ msgstr ""
 "Für nicht nativ unterstützte Pakete verwenden Sie `compilePackages` für "
 "reine TS/JS-Pakete oder den JavaScript-Runtime-Fallback für komplexe Pakete."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Projektstruktur"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry ist flexibel bei der Projektstruktur. Übliche Muster:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Für UI-Apps:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Kompilierung"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Eine Datei kompilieren"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# Kompilieren mit einem bestimmten Ziel"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Debug: Zwischendarstellung drucken"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "Siehe [CLI-Befehle](../cli/commands.md) für alle Optionen."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr "[CLI-Befehle](../cli/commands.md) — Alle Compiler-Befehle und Flags"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3235,7 +3265,7 @@ msgstr ""
 "[Unterstützte Funktionen](../language/supported-features.md) — Welche "
 "TypeScript-Funktionen funktionieren"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Standardbibliothek](../stdlib/overview.md) — Unterstützte npm-Pakete"
 
@@ -3374,32 +3404,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Klassen"
 
@@ -5441,6 +5472,7 @@ msgstr ""
 "unterstützt zwei Pfade:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5450,7 +5482,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Legacy-Klassen-Decorators, Methoden-Decorators, Property-Decorators, "
 "Konstruktor-Parameter-Decorators und Methoden-Parameter-Decorators** für "
@@ -5462,7 +5498,7 @@ msgstr ""
 "`@Reflect.metadata(...)` sind verfügbar. Perry emittiert `design:paramtypes` "
 "für dekorierte Klassen/Methoden und `design:type` für dekorierte Properties."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5475,15 +5511,15 @@ msgstr ""
 "Runtime-Decorator-Maschinerie. Die Implementierung findet sich in `crates/"
 "perry-hir/src/decorator_log.rs`."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Was nicht funktioniert"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Accessor-Decorators und Descriptor-Replacement"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5499,17 +5535,17 @@ msgstr ""
 "zurückgeben, benötigen einen Perry-kompatiblen Port – die abgesenkte Klasse "
 "ist im IR fixiert und kann zur Laufzeit nicht ersetzt werden."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Allgemeine `Reflect.metadata(...)`-Hilfsaufrufe außerhalb der Decorator-"
 "Syntax"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` als Metadaten-Schlüssel"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5517,7 +5553,7 @@ msgstr ""
 "`emitDecoratorMetadata` über `design:paramtypes` für Klassen/Methoden und "
 "`design:type` für Properties hinaus"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5527,11 +5563,11 @@ msgstr ""
 "Konstruktor-Canary hinaus nach Typ auflösen (`tsyringe`, vollständiges "
 "NestJS-Injector-Verhalten, Angulars Root-Injector)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr "`class-validator`, `type-graphql`, `TypeORM`-Laufzeit-Metadatenflüsse"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5541,11 +5577,11 @@ msgstr ""
 "explizites Verdrahten oder ein dedizierter AOT-Transform – und nicht das "
 "Verlassen auf die vollständige Legacy-TypeScript-Decorator-Runtime."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Empfohlenes Muster: explizite Konstruktion"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5558,7 +5594,7 @@ msgstr ""
 "funktionieren decorator-freie TS-Frameworks (Hono, tRPC-Server, Drizzle-"
 "Apps) bereits."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5574,7 +5610,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5584,11 +5620,11 @@ msgstr ""
 "die Konstruktions-Reihenfolge _ist_ der Abhängigkeitsgraph, und sie wird vom "
 "TypeScript-Compiler geprüft."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Migrationsrezept: ein Angular-Dienst"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5598,19 +5634,19 @@ msgstr ""
 "services/rating.service.ts`, ~80 Zeilen), gezeigt in seiner originalen "
 "Angular-Form und auf Perry portiert."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Vorher — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Nachher — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Drei mechanische Änderungen:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5618,7 +5654,7 @@ msgstr ""
 "**Lassen Sie `@Injectable` weg.** Es trug keine Information, die die "
 "Klassenstruktur nicht bereits trägt."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5628,7 +5664,7 @@ msgstr ""
 "meisten Angular-Observables-aus-HTTP sind Single-Value und verhalten sich "
 "wie Promises. (Für Multi-Value-Streams verwenden Sie `AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5640,11 +5676,11 @@ msgstr ""
 "Properties, aber explizite Felder lesen sich klarer, wenn die Klasse von "
 "Hand statt von einem Container instanziiert wird."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Verdrahtung"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5664,7 +5700,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5682,7 +5718,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5692,12 +5728,12 @@ msgstr ""
 "'root'`-Token, die implizite Container-Suche — all das kollabiert zu einer "
 "`new RatingService(api)`-Zeile in `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr ""
 "Was ist mit Angular-Komponenten, NestJS-Controllern, TypeORM-Entitäten?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5720,11 +5756,11 @@ msgstr ""
 "Sie die entsprechende explizite Konstruktion, Registerrouten oder Schema als "
 "einfache Funktionsaufrufe / Modul-Level-Konstanten."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Zukünftige Richtung"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6443,12 +6479,13 @@ msgstr ""
 "nutzt die anmutige Oberfläche oben und braucht nichts zur Linkzeit."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Schreibstatische Anrufe** (`WebAssembly.instantiate(bytes)` geschrieben "
@@ -8031,55 +8068,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Eine Bindung erstellen — die 60-Sekunden-Tour"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF rendering bindings\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "'pdfium-Render = 0.8'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# Bearbeiten Sie src/lib.rs — fügen Sie Ihre `js_*`-Funktionen hinzu, alle "
-"nur mit"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# src/index.ts bearbeiten — Importe des TS-Benutzercodes angeben"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# package.json bearbeiten — alle js_*-Exporte im"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# - manifestiert sich mit der statischenlib"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# das Gerüst release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr "                                    # baut Vorbauten für alle Ziele"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr ""
-"                                    # und befestigt sie an die Freigabe"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8477,7 +8472,7 @@ msgstr "Gegenwärtiger Stand"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8497,7 +8492,7 @@ msgstr "Gebündelt; Abschiebung anhängig"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8549,7 +8544,7 @@ msgstr "Gebündelt; Migration anhängig"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8609,7 +8604,7 @@ msgstr "Kompilieren der vorgelagerten Paketquelle"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8617,7 +8612,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8625,7 +8620,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8633,7 +8628,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8665,7 +8660,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8673,7 +8668,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8681,7 +8676,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8713,7 +8708,7 @@ msgstr "zusammengeschlossen, behalten"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8721,7 +8716,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8753,7 +8748,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8761,7 +8756,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8769,7 +8764,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8777,7 +8772,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8793,7 +8788,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8801,7 +8796,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8809,7 +8804,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8817,7 +8812,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8841,7 +8836,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8849,7 +8844,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8857,7 +8852,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8865,7 +8860,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8873,7 +8868,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8881,7 +8876,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8889,7 +8884,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8897,7 +8892,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8905,7 +8900,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8913,7 +8908,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8921,7 +8916,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8929,7 +8924,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8985,14 +8980,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr "1. Gerüst erstellen"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Native Bindungen für <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Dies erstellt:"
@@ -9024,29 +9011,14 @@ msgstr ""
 "TypeScript-sichtbarem Aufruf, der **nur** Typen aus `perry_ffi` verwendet:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `pdf.parse(buf) -> string` — Text aus einem PDF-Puffer extrahieren."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "Sicherheit"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
-msgstr ""
-"/// `buf_ptr` muss für `buf_len` Bytes null oder gültig sein. Perry "
-"Durchläufe"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// dieses Paar aus einem `buffer+len` Manifest-Parameter."
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9182,7 +9154,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"gütig\""
 
@@ -9424,7 +9396,8 @@ msgid "In a separate directory:"
 msgstr "In einem separaten Verzeichnis:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# oder jeden Pfad, den Ihr Tooling unterstützt"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9819,7 +9792,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Event-Listener (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// Verschlusszeiger, am Leben gehalten durch den GC-Scanner unten"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10264,7 +10238,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... Datei lesen, env vars einstellen, 1.0 / 0.0 zurückgeben "
 
 #: src/native-libraries/abi.md:165
@@ -10575,8 +10550,8 @@ msgstr "Erforderlich"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Anmerkungen"
 
@@ -10634,14 +10609,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12384,34 +12359,41 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Werkzeugbau — `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Bereitstellung oder Beugung eines Pins zu einer bestimmten Version "
 "(Standard: aktueller stabiler)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# Bereitstellung jeder aktuell ungepinnten Bindung spätestens stabil"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Offline-Gate (CI): Stifte vorhanden, verriegelt, Kisten vorhanden. Ausgang "
 "1 auf jeder"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Advisory: zusätzlich Flag Pins, deren Upstream eine neuere stabile "
 "Freigabe hat"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# Materialisieren Sie die Upstream-Repo an der gepinnten Ref in gitignored "
 "upstream/<name>"
@@ -12653,15 +12635,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "Bei CI, die niemals einen Teilumschlag ersetzen dürfen, Satz:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12816,7 +12798,7 @@ msgstr "Realität"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12833,7 +12815,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14821,19 +14803,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Im Vergleich zu Node.js worker_threads"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// Node.js: ~15 Zeilen, separate Datei benötigt"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14853,13 +14835,11 @@ msgid "/* handle */"
 msgstr "/* Handle */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// Perry: 1 Zeile"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr ""
-"// Const-Ergebnis = warten auf spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -15073,13 +15053,14 @@ msgid "Mental Model"
 msgstr "Mentales Modell"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "Perrys UI folgt demselben Modell wie SwiftUI und Flutter: Sie komponieren "
 "native Widgets mit stack-basierten Layout-Containern (`VStack`, `HStack`, "
@@ -15167,7 +15148,7 @@ msgstr ""
 msgid "Property"
 msgstr "Eigenschaft"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15614,7 +15595,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15638,7 +15619,7 @@ msgstr ""
 "Plattformspezifisches Verhalten wird auf der Dokumentationsseite jedes "
 "Widgets vermerkt."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17266,7 +17247,8 @@ msgid "Double-click handler"
 msgstr "Doppelklick-Handler"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17327,12 +17309,13 @@ msgstr ""
 "snippets.ts) — CI kompiliert und führt es bei jedem PR aus."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Layout-Helfer sind freie Funktionen: `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17815,7 +17798,7 @@ msgstr "Effekt"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17828,7 +17811,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "Kinder richten sich zur führenden (linken) Kante aus"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17841,7 +17824,7 @@ msgid "Children centered horizontally"
 msgstr "Kinder horizontal zentriert"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17862,7 +17845,7 @@ msgstr "**HStack-Ausrichtung** (Querachse = vertikal):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17889,8 +17872,8 @@ msgstr "Kinder vertikal zentriert"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17944,9 +17927,9 @@ msgstr "Verhalten"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17969,11 +17952,11 @@ msgstr "Alle Kinder erhalten gleiche Größe"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18175,9 +18158,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stacks mit integriertem Padding"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Erstellen Sie einen Stack mit Padding in einem einzigen Aufruf. Die "
 "Reihenfolge ist **oben, links, unten, rechts** (CSS-Shorthand-Stil), nicht "
@@ -18202,11 +18186,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` ist das horizontale "
 "Gegenstück. Äquivalent zum Erstellen eines Stacks und anschließendem Aufruf "
@@ -18496,8 +18481,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18882,6 +18868,7 @@ msgstr ""
 "die der Compiler akzeptiert."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18893,7 +18880,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18921,11 +18907,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Farben"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18941,11 +18927,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Schriften"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18961,15 +18947,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Verwenden Sie `\"monospaced\"` für die System-Monospace-Schrift."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Eckenradius"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18981,21 +18967,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Rahmen"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding und Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -19005,11 +18991,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Größenanpassung"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -19025,11 +19019,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Deckkraft"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -19041,11 +19035,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Hintergrund-Gradient"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -19067,11 +19061,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Steuerelement-Größe"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -19083,7 +19077,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -19091,11 +19085,11 @@ msgstr ""
 "**macOS**: Wird auf `NSControl.ControlSize` abgebildet. Andere Plattformen "
 "können dies anders interpretieren."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltips"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -19107,7 +19101,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -19115,11 +19109,11 @@ msgstr ""
 "**macOS/Windows/Linux**: Native Tooltips. **iOS/Android**: Keine Tooltip-"
 "Unterstützung. **Web**: HTML-`title`-Attribut."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Aktiviert/Deaktiviert"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -19131,11 +19125,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Vollständiges imperatives Beispiel"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -19155,7 +19150,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19183,10 +19178,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19259,15 +19254,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Stile komponieren (imperative Hilfsfunktionen)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Reduzieren Sie Wiederholungen, indem Sie Hilfsfunktionen erstellen:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19277,11 +19272,11 @@ msgstr ""
 "in JSON zu definieren und eine typisierte Theme-Datei zu generieren. Siehe "
 "[Theming](theming.md) für den vollständigen Workflow."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Plattform-Unterstützung"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19292,7 +19287,7 @@ msgstr ""
 "styling_matrix.rs` und bei jedem PR gegen die `lib.rs`-Exporte jedes "
 "Backends durch CI geprüft."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19313,15 +19308,15 @@ msgstr ""
 "konsultieren Sie die Matrix, damit die Dokumentation nicht aus dem Backend-"
 "Inventar abdriften kann."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — Layout-Container"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — Stil-Änderungen animieren"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — Design-Tokens über das `perry-styling`-Paket"
 
@@ -20663,8 +20658,8 @@ msgstr "Implementierung"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Status"
 
@@ -24217,7 +24212,7 @@ msgstr ""
 msgid "Options"
 msgstr "Optionen"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25826,7 +25821,7 @@ msgstr "Äquivalenz mit ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26551,15 +26546,18 @@ msgid "Cross-Compilation"
 msgstr "Cross-Kompilierung"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# Standard: Kompilieren für aktuelle Plattform"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# Kompilieren für ein bestimmtes Ziel"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS — Android auf einer Uhr"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26775,7 +26773,8 @@ msgid "Building"
 msgstr "Build"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS ist das Standard-Ziel"
 
 #: src/platforms/macos.md:18
@@ -26878,7 +26877,8 @@ msgid "App Store Distribution"
 msgstr "App Store-Distribution"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Mit dem App Store-Zertifikat unterschreiben"
 
 #: src/platforms/macos.md:60
@@ -26886,7 +26886,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -27019,15 +27020,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "Der einfachste Weg, auf iOS zu bauen und auszuführen, ist `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# device/simulator automatisch erkennen"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# Live Streamen stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Perry Hub Build Server verwenden"
 
 #: src/platforms/ios.md:40
@@ -27679,7 +27683,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Dies erzeugt ein ARM64-Binary für physische Apple TV-Hardware."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Auto-Erkennen gebooteten Apple TV-Simulator"
 
 #: src/platforms/tvos.md:39
@@ -28171,11 +28176,13 @@ msgstr ""
 "(#building-for-device)) gebaut werden:"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# Simulator (Tier 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28285,20 +28292,14 @@ msgstr ""
 "`PERRY_RUNTIME_DIR` auf sie:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (Serie 9+ / watchOS 26+) — das Standard-Geräteziel"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (Serie 4-8 / SE) — mit PERRY_WATCHOS_ARM64_32 einschalten"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28315,7 +28316,7 @@ msgid "Build environment variables"
 msgstr "Umgebungsvariablen erstellen"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Variable"
@@ -28437,7 +28438,8 @@ msgstr ""
 "den Verschluss als Objekt."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Auto-Erkennen gebooteten Uhrensimulator"
 
 #: src/platforms/watchos.md:126
@@ -29037,36 +29039,13 @@ msgstr ""
 "Stempel kosmetisch), dann `lipo` sie zusammen:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. Schnitt arm64_32 am gemeinsamen Bereitstellungsziel (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. Arm64-Scheibe (Standard-Geräteziel)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. Minos + Sicherung ausrichten"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -29187,19 +29166,8 @@ msgstr ""
 "für die Uhr **eigener neuer App-Record** Im App Store verbinden."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Apple Distribution: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -29212,6 +29180,10 @@ msgid ""
 msgstr ""
 "`altool` kann keine Watch-Apps hochladen (\"Plattform nicht ermitteln\"). "
 "Transporter verwenden:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29568,19 +29540,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Einmalige Einrichtung (macOS Beispiel)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (Die Homebrews `gradle` kann 9.x sein — Pin 8.x "
 "wenn ja)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# oder irgendwelche Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 "# 2. Zeigen Sie das Env auf das SDK / NDK / JDK 17 (zu Ihrem Shell-Profil "
 "hinzufügen)"
@@ -29590,7 +29565,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr ""
 "\"$ANDROID_HOME- Nein, nein<installed-version>\" # e.g. . 28.2.13676358"
 
@@ -29603,32 +29579,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. SDK Pakete + ein Wear OS arm64 Bild"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"Plattform-Tools\" \"Emulator\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"Plattformen;android-35\" \"Build-Tools;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"Systembilder;Android-34;Android-Verkleidung;Arm64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Das Kreuzziel Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Erstellen + Booten eines Wear OS Emulators (runde Uhr)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29653,7 +29610,8 @@ msgstr ""
 "APK geschieht zur Laufzeit (unten)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# Auto-Detektion einer angeschlossenen Uhr / gebootet Wear-Emulator"
 
 #: src/platforms/wearos.md:82
@@ -31655,7 +31613,8 @@ msgstr ""
 "verwenden `WidgetPaintable` + `GskRenderer` für pixelgenaue Aufnahmen."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# In einem anderen Terminal:"
 
 #: src/platforms/linux.md:82
@@ -31675,7 +31634,8 @@ msgstr ""
 "einer JavaScript-Brücke für DOM-Widgets."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# gleiche Ausgabe wie --target wasm"
 
 #: src/platforms/web.md:10
@@ -31753,15 +31713,18 @@ msgstr ""
 "Threading erhalten."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# Selbstintegriertes HTML (Standard)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# Das Gleiche"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm binär (kein HTML-Wrapper)"
 
 #: src/platforms/wasm.md:21
@@ -32084,11 +32047,13 @@ msgid "Provide them when instantiating:"
 msgstr "Stellen Sie sie bei der Instanziierung bereit:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Über __ffiImports global (vor dem Booten einstellen)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// Oder über bootPerryWasm zweites Argument"
 
 #: src/platforms/wasm.md:95
@@ -32640,7 +32605,7 @@ msgstr "Vollständige stdlib"
 msgid "The compiler links only the required runtime components."
 msgstr "Der Compiler linkt nur die erforderlichen Laufzeitkomponenten."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Externe native Bindungen"
 
@@ -32755,7 +32720,7 @@ msgstr "[Dateisystem](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Netzwerk](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Datenbanken](database.md)"
 
@@ -32978,8 +32943,8 @@ msgstr ""
 "Übergeben Sie Dateipfade über Thread-Grenzen hinweg und öffnen Sie Dateien "
 "innerhalb des Workers neu."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Überblick](overview.md) — Alle stdlib-Module"
 
@@ -33078,10 +33043,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Unterstützt auf `IncomingMessage`: `.method`, `.url`, `.headers`, "
@@ -33090,10 +33056,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33694,10 +33661,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / S3-kompatibler Objektspeicher"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33713,11 +33706,11 @@ msgstr ""
 "erforderliche Patches — verifiziert gegen einen SigV4-Presigned-URL-Byte-für-"
 "Byte-Match mit `bun` (Issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33791,78 +33784,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "Derselbe Code funktioniert gegen jeden S3-kompatiblen Dienst — nur der "
 "`endPoint` ändert sich:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Service"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (Test)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33878,7 +33871,7 @@ msgstr ""
 "`presignedPostObject`) sind byte-identisch zu `bun` gegen gepinnte Test-"
 "Vektoren verifiziert und werden gegen echtes S3 authentifizieren."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33891,7 +33884,7 @@ msgstr ""
 "kompiliert, ist aber hier nicht unabhängig gegen gepinnte Vektoren "
 "verifiziert."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34537,9 +34530,10 @@ msgstr ""
 "`inRange`. ."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Benutze benannte Importe: Das Standard-Import-Empfänger-Formular (`import _ "
@@ -34753,20 +34747,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Zusätzliche npm-Pakete und Node.js-APIs, die von Perry unterstützt werden. "
-"Alle hier aufgeführten sind über Perrys Well-Known-Native-Bindings-Registry "
-"(#466) verdrahtet und kompilieren ohne JavaScript-Runtime-Beteiligung zu "
-"nativem Code."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Bildverarbeitung)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34774,7 +34763,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-sharp` (v0.5.551). Resizes, "
 "Formatkonvertierung und Buffer-/Datei-Ausgabe funktionieren alle."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34824,15 +34813,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (HTML-Parsing)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Native Bindungen über `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34850,11 +34839,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (E-Mail)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34894,15 +34883,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Komprimierung)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Native Bindungen über `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34920,11 +34909,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Job-Scheduling)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34932,7 +34921,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-cron` (v0.5.564). Sowohl die Paketnamen "
 "`cron` als auch `node-cron` werden auf dasselbe Backend geroutet."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34952,11 +34941,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34966,7 +34955,7 @@ msgstr ""
 "rs`](https://github.com/gakonst/ethers-rs)\\-artige ABI-Verdrahtung über die "
 "BigInt- + Buffer-Oberflächen von `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34984,11 +34973,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -34996,7 +34985,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-events` (v0.5.546). Die `EventEmitter`-Form "
 "entspricht Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -35014,15 +35003,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Retry-Logik)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Native Bindungen über `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -35044,11 +35033,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Beliebige Präzision)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -35056,7 +35045,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-decimal` (v0.5.547). Beide Paketnamen routen "
 "auf dasselbe Backend — `Decimal` und `BigNumber` werden beide exponiert."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -35092,11 +35081,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Datums-Manipulation)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -35104,7 +35093,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-dayjs` (v0.5.548). Beide Paketnamen routen "
 "auf dasselbe Rust-Backend — dieselbe Parse-/Format-/Diff-Oberfläche."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -35122,11 +35111,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Legacy Date)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -35136,7 +35125,7 @@ msgstr ""
 "upstream im Maintenance-Modus — bevorzugen Sie `dayjs` für neuen Code, aber "
 "Perry unterstützt beide für bestehende Codebasen."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -35152,11 +35141,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -35164,7 +35153,7 @@ msgstr ""
 "Native Bindungen via `perry-ext-ratelimit` (v0.5.552). Der In-Memory-Limiter "
 "ist verdrahtet; Redis- / Cluster-Backing-Stores sind Follow-ups."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -35188,11 +35177,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -35210,7 +35199,7 @@ msgstr ""
 "`parallelMap` / `parallelFilter` / `spawn` von `perry/thread` die einfachere "
 "Schnittstelle (siehe [Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -35248,13 +35237,13 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Web Worker Modul URLs werden relativ zur importierenden Quelldatei entdeckt:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -35287,10 +35276,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (CLI-Parsing)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35332,11 +35494,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35359,7 +35521,7 @@ msgstr ""
 "`sizeCalculation`, `dispose`, `fetch`, `allowStale` und die "
 "Iteratoroberfläche sind noch nicht implementiert."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35389,11 +35551,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35443,11 +35605,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35461,7 +35623,7 @@ msgstr ""
 "`import()`. POSIX nur für jetzt (macOS + Linux); auf anderen Hosts `spawn` "
 "wirft, die Verbraucher nicht-pty Fallback-Pfade auslösen."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35473,7 +35635,7 @@ msgstr ""
 "numerischen Signal für einen Signaltod und `undefined` sonst; `kill()` ist "
 "standardmäßig auf `SIGHUP` wie Node-pty. `TERM` im Kind kommt von `name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35519,11 +35681,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35539,7 +35701,7 @@ msgstr ""
 "zur nativen Fassade gefaltet. Das Verhalten wurde gegen `@parcel/watcher` "
 "2.5.1 überprüft."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35561,7 +35723,7 @@ msgstr ""
 "overflow/rescan Benachrichtigungen auslösen einen frischen Baum Snapshot und "
 "geben seinen Diff aus."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35580,7 +35742,7 @@ msgstr ""
 "halten die Eventschleife aktiv. `writeSnapshot` und `getEventsSince` "
 "verwenden die gleiche Snapshot-Dif-Semantik wie Überlaufwiederherstellung."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35590,7 +35752,7 @@ msgstr ""
 "werden mit `bun add` wie jedes andere npm-Paket importiert, sind aber Rust-"
 "gestützt und werden via `perry-ffi` nativ kompiliert:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35598,7 +35760,7 @@ msgstr ""
 "**`@perryts/tursodb`** — Turso (libSQL-Fork)-Datenbank-Client. Siehe "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35606,11 +35768,11 @@ msgstr ""
 "**`@perryts/iroh`** — Iroh-Peer-to-Peer-Netzwerk. Siehe [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "Reine TypeScript-Treiber, kompiliert über `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35620,7 +35782,7 @@ msgstr ""
 "**`@perryts/redis`** — Wire-Protocol-Clients, die auch unter Node.js und Bun "
 "unverändert laufen."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35628,11 +35790,11 @@ msgstr ""
 "Siehe [Native Bindings — Überblick](../native-libraries/overview.md) für den "
 "Vertrag, dem diese externen Pakete folgen."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[Dateisystem](fs.md) — fs- und path-APIs"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[Native Bindungen](../native-libraries/overview.md) — Eigene erstellen"
 
@@ -35656,7 +35818,8 @@ msgstr ""
 "Target No-ops."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Insgesamt: 3019 Einträge in 138 Modulen."
 
 #: src/api/reference.md:9
@@ -35753,4831 +35916,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Methoden"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — Modul"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Eigenschaften"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount` — Modul"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince` — Modul"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — Modul"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — Modul"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot` — Modul"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — Modul"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — Modul"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — Modul"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — Modul"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — Modul"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — Instanz"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — Instanz"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — Instanz"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — Instanz"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — Instanz"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — Instanz"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — Instanz"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — Modul"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — Modul"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — Modul"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — Modul"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — Modul"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — Modul"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — Modul"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — Modul"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — Modul"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — Modul"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — Modul"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — Modul"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — Modul"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — Modul"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — Modul"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — Modul"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — Modul"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — Modul"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — Modul"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — Modul"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — Modul"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — Modul"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — Instanz _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — Modul _(Klasse: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — Modul _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — Instanz _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — Modul"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — Instanz"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — Instanz _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — Instanz _(Klasse: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — Instanz"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — Modul"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — Modul"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — Instanz"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — Instanz"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — Instanz"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — Instanz _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — Modul _(Klasse: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — Modul"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — Instanz _(Klasse: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — Modul"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — Modul"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — Modul"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — Modul"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — Modul"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — Modul"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — Modul"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — Modul"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — Modul"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — Modul"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — Modul"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — Instanz"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — Instanz"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — Instanz"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — Instanz"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — Instanz"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — Instanz"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — Instanz"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — Instanz"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — Instanz"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — Instanz"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — Instanz"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — Modul"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — Modul"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — Modul"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — Modul"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — Modul"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — Modul"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Transfer"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob` — Modul"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — Modul"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — Modul"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — Modul"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — Modul"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — Modul"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — Modul"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file` — Modul"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — Modul"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — Modul"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — Modul"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — Modul"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — Modul"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — Instanz _(Klasse: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — Instanz _(Klasse: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — Modul"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth` — Modul"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — Modul"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — Instanz _(Klasse: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction` — Instanz _(Klasse: `Database`)_"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported` — Modul"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — Modul"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — Modul"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — Modul"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — Modul"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — Modul"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction` — Modul"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString` — Modul"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback` — Modul"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — Modul"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols` — Modul"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr` — Modul"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer` — Modul"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer` — Modul"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource` — Modul"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — Modul"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database` — Modul"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction` — Instanz _(Klasse: `Database`)_"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values` — Instanz _(Klasse: `Statement`)_"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — Instanz"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — Instanz"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — Instanz"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — Instanz"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — Instanz"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — Instanz"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — Instanz"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — Instanz"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — Instanz"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — Modul"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — Instanz"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — Instanz"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — Instanz"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — Modul"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — Modul"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — Modul"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — Modul"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — Modul"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — Modul"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — Modul"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — Modul"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — Modul"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — Modul"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — Instanz"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args` — Instanz"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument` — Instanz"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — Instanz"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — Instanz"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — Instanz"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — Instanz"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — Instanz"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — Instanz"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — Instanz"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — Instanz"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — Modul"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — Modul"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — Modul"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — Modul"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — Modul"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — Modul"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — Modul"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — Modul"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — Modul"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — Modul"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — Modul"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — Modul"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — Modul"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — Modul"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — Modul"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — Modul"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — Modul"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — Modul"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — Modul"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — Modul"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — Modul"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — Modul"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — Modul"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — Modul"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — Modul"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — Instanz"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — Instanz"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — Modul"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — Instanz"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — Instanz"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — Modul"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — Modul"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — Modul"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — Modul"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — Modul"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — Modul"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — Modul"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — Modul"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — Modul"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — Modul"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — Modul"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — Modul"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — Modul"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — Modul"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — Modul"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — Modul"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — Modul"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — Modul"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — Modul"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — Modul"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — Modul"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — Modul"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — Modul"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — Modul"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — Modul"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — Modul"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — Modul"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — Modul"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — Modul"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — Modul"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — Modul"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — Modul"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — Modul"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — Modul"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — Modul"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — Modul"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — Modul"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — Modul"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — Modul"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — Modul"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — Modul"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — Modul"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — Modul"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — Modul"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — Modul"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — Modul"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — Modul"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — Modul"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — Modul"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — Modul"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — Modul"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — Modul"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — Modul"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — Modul"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — Modul"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — Modul"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — Modul"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — Modul"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — Modul"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — Modul"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — Modul"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — Modul"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — Modul"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — Modul"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — Modul"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — Modul"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — Modul"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — Modul"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — Instanz"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — Instanz"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — Instanz"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — Instanz"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — Modul"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — Instanz"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — Instanz"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — Instanz"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — Instanz"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — Instanz"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — Instanz"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — Instanz"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — Instanz"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — Instanz"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — Instanz"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — Instanz"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — Instanz"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — Instanz"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — Instanz"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — Instanz"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — Instanz"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — Instanz"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — Instanz"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — Instanz"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — Instanz"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — Instanz"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — Instanz"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — Instanz"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — Instanz"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — Instanz"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — Instanz"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — Instanz"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — Instanz"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — Instanz"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — Instanz"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — Instanz"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — Instanz"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — Instanz"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — Instanz"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — Instanz"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — Instanz"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — Instanz"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — Instanz"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — Instanz"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — Instanz"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — Instanz"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — Modul"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — Modul"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — Modul"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — Modul"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — Modul"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — Modul"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — Modul"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — Modul"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — Modul"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — Modul"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — Modul"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — Modul"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — Modul"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — Modul"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — Modul"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — Modul"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — Modul"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — Modul"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — Modul"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — Modul"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — Modul"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — Modul"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — Modul"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — Modul"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — Modul"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — Modul"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — Modul"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — Modul"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — Instanz _(Klasse: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — Modul"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — Instanz"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — Instanz"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — Modul"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — Instanz"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — Instanz"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — Instanz"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — Instanz"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — Instanz"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — Modul"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — Modul"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — Modul _(Klasse: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — Modul"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — Modul"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — Modul"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — Modul"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — Modul"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — Modul"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — Modul"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — Modul"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — Instanz _(Klasse: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — Instanz _(Klasse: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — Instanz"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — Instanz _(Klasse: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — Instanz"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — Modul"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — Instanz"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — Modul"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — Modul"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — Instanz"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — Modul"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — Instanz"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — Instanz"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — Modul"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — Instanz"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — Modul"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — Instanz"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — Instanz"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — Instanz"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — Instanz"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — Instanz"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — Instanz"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — Modul"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — Instanz _(Klasse: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — Modul"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — Instanz"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — Instanz"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — Instanz"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — Instanz"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — Instanz"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — Instanz"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — Instanz"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — Instanz"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — Instanz"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — Instanz"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — Instanz"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — Instanz"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — Instanz"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — Instanz"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — Instanz"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — Instanz"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — Instanz"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — Instanz"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — Instanz"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — Instanz"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — Instanz"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — Instanz"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — Instanz"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — Instanz"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — Instanz"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — Instanz"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — Instanz"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — Instanz"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer` — Modul"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString` — Modul"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — Modul"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — Modul"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — Modul"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — Modul"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — Modul"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — Modul"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — Modul"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — Modul"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — Modul"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — Modul"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — Modul"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — Modul"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — Modul"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — Modul"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — Modul"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — Modul"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — Modul"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — Modul"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — Modul"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — Modul"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — Modul"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — Modul"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — Modul"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — Modul"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — Modul"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — Modul"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — Modul"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — Modul"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — Modul"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — Modul"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — Modul"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — Modul"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — Modul"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — Modul"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — Modul"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — Modul"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — Modul"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — Modul"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — Modul"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — Modul"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — Modul"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — Modul"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — Modul"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — Modul"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — Modul"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — Modul"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — Modul"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — Modul"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — Modul"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — Modul"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — Modul"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — Modul"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — Modul"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — Modul"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — Modul"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — Modul"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — Modul"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — Modul"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — Modul"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — Modul"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — Modul"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — Modul"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — Modul"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — Modul"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — Modul"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — Modul"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — Modul"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — Modul"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — Modul"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — Modul"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — Modul"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — Modul"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — Modul"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — Modul"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — Modul"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — Modul"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — Modul"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — Modul"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — Modul"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — Modul"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — Modul"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — Modul"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — Modul"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — Modul"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — Modul"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — Modul"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — Modul"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — Modul"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — Modul"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — Modul"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — Modul"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — Modul"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — Modul"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — Modul"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — Instanz _(Klasse: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — Instanz _(Klasse: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — Instanz _(Klasse: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — Modul"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — Modul"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — Modul"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — Modul"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40586,103 +40896,103 @@ msgstr ""
 "besitzt den keep-alive pool; per-socket Haken sind keine opps, warnt einmal "
 "(#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40691,375 +41001,369 @@ msgstr ""
 "besitzt den keep-alive pool; per-socket Haken sind keine opps, warnt einmal "
 "(#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — Modul"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — Modul"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — Instanz _(Klasse: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — Instanz _(Klasse: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref` — Instanz _(Klasse: `HttpServer`)_"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — Instanz _(Klasse: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — Modul"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — Modul"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — Instanz _(Klasse: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — Modul"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — Modul"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — Modul"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — Modul"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — Modul"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — Modul"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref` — Instanz _(Klasse: `HttpsServer`)_"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — Modul"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug` — Modul _(Klasse: `console`)_"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error` — Modul _(Klasse: `console`)_"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info` — Modul _(Klasse: `console`)_"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log` — Modul _(Klasse: `console`)_"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -41067,7 +41371,7 @@ msgstr ""
 "`open` — Modul **Stub** — akzeptiert port/host, bindet aber keinen echten "
 "WebSocket-Inspektor-Endpunkt; Sitzungen sind In-Prozess-Fakten (#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -41077,7 +41381,7 @@ msgstr ""
 "und eine Runtime.evaluate-Untergruppe reagieren; jede andere "
 "Protokollmethode wirft Inspektor-Fehler -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -41085,7 +41389,7 @@ msgstr ""
 "`url` — Modul **Stub** — immer undefiniert: Perry setzt nie einen echten "
 "Inspector-Endpunkt (#4916) frei"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -41093,3285 +41397,3276 @@ msgstr ""
 "`waitForDebugger` — Modul **Stub** — kehrt sofort nach open() zurück; es "
 "gibt keinen Debugger, auf den man warten kann (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn` — Modul _(Klasse: `console`)_"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — Instanz _(Klasse: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — Instanz"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — Modul"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — Instanz"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — Instanz"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — Instanz"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — Instanz"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — Instanz"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — Instanz"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — Instanz"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — Instanz"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — Instanz"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — Instanz"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — Modul"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — Instanz"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — Instanz"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — Instanz"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — Instanz"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — Instanz"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — Instanz"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — Modul"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — Modul"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — Modul"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — Modul"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — Modul"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — Modul"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — Modul"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — Modul"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — Modul"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — Modul"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — Modul"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — Modul"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — Modul"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — Modul"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — Modul"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — Modul"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — Modul"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — Modul"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — Modul"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — Modul"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — Modul"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — Modul"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — Modul"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — Modul"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — Modul"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — Modul"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — Modul"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — Instanz"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — Instanz"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek` — Instanz"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — Instanz"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — Modul"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — Modul"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — Modul"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — Modul"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — Modul"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — Modul"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — Modul"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — Modul"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — Modul"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — Modul"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — Modul"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — Modul"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — Modul"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — Modul"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — Modul"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — Modul"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — Modul"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — Modul"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — Modul"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — Modul"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — Modul"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — Modul"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — Modul"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow` — Instanz"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween` — Instanz"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — Modul"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate` — Instanz"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — Instanz"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — Instanz"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — Instanz"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — Instanz"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — Instanz"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — Instanz"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — Instanz"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — Instanz"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — Instanz"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — Instanz"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — Instanz"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — Instanz"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — Modul"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — Modul"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — Instanz _(Klasse: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — Instanz"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — Instanz _(Klasse: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — Instanz _(Klasse: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — Instanz"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — Instanz"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — Instanz _(Klasse: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — Instanz _(Klasse: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — Instanz"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — Instanz"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — Modul"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — Modul"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — Modul"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — Modul"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — Modul"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — Modul"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — Instanz _(Klasse: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — Instanz _(Klasse: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — Instanz _(Klasse: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — Modul"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — Modul"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — Modul _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — Modul"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — Modul"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — Modul"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — Modul _(Klasse: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — Instanz _(Klasse: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — Modul"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — Modul"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — Instanz _(Klasse: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — Instanz _(Klasse: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem` — Modul"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem` — Modul"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate` — Modul"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem` — Modul"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem` — Modul"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem` — Modul"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions` — Instanz _(Klasse: `Certificate`)_"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer` — Instanz _(Klasse: `Certificate`)_"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject` — Instanz _(Klasse: `Certificate`)_"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign` — Instanz _(Klasse: `Certificate`)_"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — Modul"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — Instanz"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — Instanz"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — Modul"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — Modul"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — Modul"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — Modul"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — Modul"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — Modul"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — Modul"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — Modul"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — Modul"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — Modul"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — Modul"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — Modul"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — Modul"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — Modul"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — Modul"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — Modul"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — Modul"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — Modul"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — Modul"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — Modul"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — Modul"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — Modul"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — Modul"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — Modul"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — Modul"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — Modul"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — Modul"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — Modul"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — Modul"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — Modul"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — Modul"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — Instanz _(Klasse: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization` — Modul"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — Modul"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — Instanz _(Klasse: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — Instanz _(Klasse: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — Modul"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles` — Modul"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded` — Modul"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — Modul"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — Modul"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — Modul"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — Modul"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent` — Modul"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — Modul"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — Modul"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — Modul"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — Modul"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — Modul"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — Modul"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — Modul"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — Modul"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — Modul"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — Modul"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — Modul"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — Modul"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — Modul"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — Modul"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — Modul"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — Modul"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — Modul"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — Modul"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — Modul"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — Modul"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — Modul"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — Modul"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — Modul"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — Modul"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — Modul"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — Modul"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — Modul"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — Modul"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — Modul"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — Modul"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — Modul"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — Modul"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — Modul"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — Modul"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — Modul"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — Modul"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — Modul"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — Modul"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — Modul"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — Modul"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — Modul"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — Modul"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — Modul"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — Modul"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — Modul"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — Modul"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — Modul"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — Modul"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — Modul"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — Modul"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — Modul"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — Modul"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect` — Modul"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint` — Modul"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor` — Modul"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — Modul"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — Modul"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — Modul"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — Modul"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — Modul"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — Modul"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — Modul"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — Modul"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession` — Modul"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession` — Modul"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability` — Modul"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment` — Modul"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange` — Modul"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange` — Modul"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond` — Modul"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — Modul"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — Modul"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — Modul"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — Modul"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — Modul"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — Modul"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — Modul"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — Modul"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof` — Modul _(intrinsisch)_"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32` — Modul"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64` — Modul"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16` — Modul"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32` — Modul"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64` — Modul"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8` — Modul"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize` — Modul"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof` — Modul _(intrinsisch)_"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof` — Modul _(intrinsisch)_"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16` — Modul"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32` — Modul"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64` — Modul"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8` — Modul"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize` — Modul"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — Modul"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — Modul"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — Modul"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — Modul"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — Modul"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — Modul"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — Modul"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — Modul"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — Modul"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — Modul"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — Modul"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — Modul"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — Modul"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — Modul"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — Modul"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — Modul"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — Modul"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — Modul"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — Modul"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — Modul"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — Modul"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — Modul"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — Modul"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — Modul"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — Modul"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — Modul"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — Modul"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — Modul"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — Modul"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — Modul"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — Modul"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — Modul"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — Modul"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — Modul"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — Modul"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — Modul"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — Modul"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — Modul"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — Modul"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — Modul"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay` — Modul"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — Modul"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — Modul"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — Modul"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — Modul"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — Modul"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — Modul"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — Modul"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — Modul"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — Modul"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — Modul"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — Modul"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — Modul"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — Modul"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — Modul"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — Modul"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — Modul"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — Modul"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — Modul"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — Modul"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — Modul"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — Modul"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — Modul"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — Modul"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — Modul"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — Modul"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — Modul"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — Modul"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — Modul"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — Modul"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — Modul"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — Modul"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — Modul"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — Modul"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — Modul"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — Modul"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — Modul"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — Modul"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — Modul"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — Modul"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — Modul"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — Modul"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — Modul"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — Modul"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — Modul"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — Modul"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — Modul"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — Modul"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — Modul"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — Modul"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — Modul"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — Instanz _(Klasse: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — Modul"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — Modul"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — Instanz _(Klasse: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — Modul"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — Instanz _(Klasse: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — Modul"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — Instanz _(Klasse: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — Modul"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — Instanz _(Klasse: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — Instanz _(Klasse: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — Instanz _(Klasse: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — Modul"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — Instanz _(Klasse: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — Instanz _(Klasse: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — Instanz _(Klasse: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — Modul"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — Modul"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — Modul"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — Modul"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — Modul"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — Modul"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — Modul"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — Modul"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — Modul"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — Modul"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — Modul"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — Modul"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — Modul"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — Instanz _(Klasse: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — Instanz _(Klasse: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — Modul"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — Modul"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView` — Modul"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — Modul"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — Modul"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — Modul"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — Modul"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — Modul"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — Modul"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — Modul"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — Modul"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — Modul"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — Modul"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — Modul"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — Modul"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — Modul"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — Modul"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — Modul"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — Modul"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — Modul"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — Modul"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — Modul"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — Modul"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — Modul"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — Modul"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — Modul"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — Modul"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — Modul"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — Modul"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — Modul"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — Modul"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker` — Modul"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — Modul"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — Modul"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — Modul"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — Modul"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — Modul"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy` — Modul"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — Modul"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — Modul"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — Modul"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — Modul"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — Modul"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd` — Modul"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle` — Modul"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — Modul"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — Modul"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — Modul"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — Modul"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — Modul"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — Modul"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — Modul"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — Modul"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — Modul"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — Modul"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — Modul"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — Modul"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — Modul"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — Modul"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — Modul"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — Modul"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — Modul"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — Modul"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — Modul"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — Modul"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — Modul"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — Modul"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — Modul"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — Modul"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — Modul"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — Modul"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — Modul"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — Modul"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — Modul"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — Modul"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — Modul"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — Modul"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — Modul"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — Modul"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — Modul"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — Modul"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — Modul"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — Modul"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — Modul"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — Modul"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — Modul"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — Modul"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — Modul"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — Modul"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — Modul"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — Modul"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — Modul"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — Modul"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — Modul"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — Modul"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — Modul"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — Modul"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — Modul"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — Modul"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — Modul"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — Modul"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — Modul"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — Modul"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — Modul"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — Modul"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — Modul"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — Modul"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — Modul"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — Modul"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — Modul"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — Modul"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — Modul"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — Modul"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — Modul"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — Modul"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — Modul"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem` — Modul"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected` — Modul"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected` — Modul"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — Modul"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — Modul"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — Modul"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders` — Modul"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl` — Modul"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue` — Modul"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — Modul"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig` — Modul"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — Modul"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — Modul"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — Modul"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — Modul"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — Modul"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse` — Modul"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — Modul"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — Modul"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — Modul"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — Modul"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — Modul"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — Modul"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — Modul"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — Modul"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — Modul"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — Modul"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout` — Modul"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount` — Modul"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed` — Modul"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge` — Modul"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild` — Modul"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree` — Modul"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew` — Modul"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild` — Modul"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge` — Modul"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum` — Modul"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap` — Modul"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc` — Modul"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber` — Modul"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc` — Modul"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — Modul"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — Instanz _(Klasse: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — Modul"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — Modul"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — Modul"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — Modul"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — Modul"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — Modul"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — Modul"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — Modul"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — Modul"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — Modul"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — Modul"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — Modul"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — Modul"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — Modul"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — Modul"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — Modul"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — Modul"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — Modul"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — Modul"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — Modul"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — Modul"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — Modul"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — Modul"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — Modul"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — Modul"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — Modul"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — Modul"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — Modul"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — Modul"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — Modul"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — Modul"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — Modul"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — Modul"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — Modul"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — Modul"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — Modul"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — Modul"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — Modul"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — Modul"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — Modul"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — Modul"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — Modul"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — Modul"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — Modul"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — Modul"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — Modul"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — Modul"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — Modul"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — Modul"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — Modul"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — Modul"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — Modul"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — Modul"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — Modul"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — Modul"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — Modul"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — Modul"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block` — Instanz"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume` — Instanz"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty` — Instanz"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward` — Instanz"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — Modul"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — Modul"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — Modul"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — Modul"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — Modul"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — Instanz"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — Instanz"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — Instanz"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — Instanz"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — Modul"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — Instanz"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — Instanz"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — Instanz"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — Instanz"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — Instanz"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — Instanz"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — Instanz"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44381,43 +44676,43 @@ msgstr ""
 "nie und .write() wertet nur numerische Literatur, Kontext-Suchen und eine "
 "einzelne '+' aus; keine echte JS-Eval-Loop (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — Modul"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44427,1459 +44722,1459 @@ msgstr ""
 "und .write() wertet nur numerische Literatur, Kontext-Suchen und eine "
 "einzelne '+' aus; keine echte JS-Eval-Loop (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — Instanz _(Klasse: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — Modul"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — Modul"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — Modul"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — Modul"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — Modul"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient` — Instanz"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif` — Instanz"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — Instanz"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite` — Instanz"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend` — Instanz"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract` — Instanz"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — Instanz"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — Instanz"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — Instanz"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — Instanz"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — Instanz"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — Instanz"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — Instanz"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — Instanz"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — Instanz"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — Modul"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen` — Instanz"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — Instanz"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — Instanz"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim` — Instanz"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — Instanz"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — Instanz"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — Instanz"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — Modul"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — Modul"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — Instanz"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — Instanz _(Klasse: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — Instanz"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — Modul"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — Instanz"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — Instanz"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — Instanz _(Klasse: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize` — Instanz"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — Instanz _(Klasse: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — Instanz"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — Instanz"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — Instanz _(Klasse: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — Instanz"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — Instanz"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — Instanz"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — Instanz"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — Instanz"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — Instanz"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — Instanz"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize` — Instanz"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — Instanz"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — Instanz"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — Instanz _(Klasse: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — Instanz"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — Instanz"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — Instanz _(Klasse: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — Instanz"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — Modul"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — Modul"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — Modul"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — Modul"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — Instanz"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — Instanz"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — Modul"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — Instanz"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — Instanz"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — Instanz"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — Modul"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — Instanz"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — Modul"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — Modul"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — Modul"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — Modul"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — Modul"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — Instanz"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — Modul"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — Modul"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — Instanz"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — Modul"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — Instanz"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — Instanz"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — Instanz"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — Instanz"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — Instanz"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — Instanz"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — Instanz"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — Instanz"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — Instanz"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — Instanz"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — Instanz"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — Modul"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — Instanz"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — Instanz"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — Instanz"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — Instanz"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — Instanz"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — Instanz"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — Instanz"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — Instanz"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — Instanz"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — Instanz"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — Instanz"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — Instanz"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — Modul"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — Modul"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — Modul"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — Modul"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — Modul"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — Modul"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — Instanz _(Klasse: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — Instanz _(Klasse: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — Modul"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — Modul"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — Modul"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — Modul"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — Modul"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — Modul"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — Modul"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — Modul"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — Modul"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — Modul"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — Modul"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — Modul"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — Modul"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — Modul"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — Modul"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — Modul"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — Modul"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — Modul"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — Modul"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — Modul"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — Modul"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — Modul"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — Modul"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — Modul"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — Modul"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — Modul"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — Modul"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — Modul"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — Modul"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — Modul"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — Modul"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — Modul"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — Modul _(Klasse: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — Modul"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — Modul"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — Modul"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — Modul _(Klasse: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — Modul _(Klasse: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — Modul _(Klasse: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — Modul _(Klasse: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — Modul _(Klasse: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — Modul"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — Modul"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — Modul"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — Modul _(Klasse: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — Modul"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — Modul"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — Modul"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — Modul"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — Modul"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — Modul"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — Modul"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — Modul"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — Modul"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — Modul"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — Modul"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — Modul"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — Modul"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — Modul"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — Modul"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols` — Modul"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — Modul"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — Modul"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms` — Modul"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — Modul"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — Instanz _(Klasse: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — Modul"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — Modul"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — Modul"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — Instanz _(Klasse: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — Instanz _(Klasse: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — Instanz"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — Instanz"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — Instanz"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — Instanz"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — Instanz"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText` — Modul"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule` — Modul"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent` — Modul"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close` — Instanz _(Klasse: `ProxyAgent`)_"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy` — Instanz _(Klasse: `ProxyAgent`)_"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch` — Modul"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher` — Modul"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher` — Modul"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — Modul"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — Modul"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — Modul"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — Instanz _(Klasse: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — Modul"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — Modul"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — Instanz _(Klasse: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — Modul"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — Modul"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — Modul"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — Modul"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — Modul"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — Modul"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — Modul"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — Modul"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — Modul"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — Modul"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — Modul"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — Modul"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — Modul"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — Modul"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — Modul"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — Modul"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — Modul"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — Modul"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — Modul"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — Modul"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — Modul"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — Modul"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — Modul"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — Modul"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — Modul"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — Modul"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — Modul"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — Modul"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — Modul"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — Modul"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — Modul"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — Modul"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — Modul"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — Modul"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — Modul"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — Modul"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — Modul"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — Modul"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — Modul"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — Modul"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — Modul"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — Modul"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — Modul"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — Modul"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — Modul"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3` — Modul"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — Modul"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5` — Modul"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — Modul"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — Instanz _(Klasse: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — Instanz _(Klasse: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — Modul"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — Instanz _(Klasse: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — Modul"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — Modul"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45887,11 +46182,11 @@ msgstr ""
 "`getHeapCodeStatistics` — Modul **Stub** — alle Felder 0; Perry kompiliert "
 "AOT, es gibt keinen JIT-Codehaufen (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — Modul"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45901,7 +46196,7 @@ msgstr ""
 "Nutzungen, die old_space von Perry-Arenen zugeschrieben werden; andere Räume "
 "melden 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45915,87 +46210,87 @@ msgstr ""
 "durchgesetzt); \\*\\_ausführbar, external_memory, Global-Handles und Zap-"
 "Felder sind 0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — Instanz _(Klasse: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — Modul"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — Instanz _(Klasse: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — Instanz _(Klasse: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — Instanz _(Klasse: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — Instanz _(Klasse: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — Modul"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — Instanz _(Klasse: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — Modul"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — Instanz _(Klasse: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — Modul"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — Modul"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — Instanz _(Klasse: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — Modul"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -46003,459 +46298,469 @@ msgstr ""
 "`stop` — Instanz _(Klasse: `GCProfiler`)_       ] **Stub** — Bericht hat die "
 "Node-Form, aber das Statistik-Array ist immer leer (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — Modul"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — Modul"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — Modul"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — Instanz _(Klasse: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — Modul"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — Modul"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — Modul"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — Modul"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — Modul"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — Modul"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — Instanz"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — Modul"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — Modul"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — Instanz"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — Instanz"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — Instanz"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — Instanz"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — Instanz"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — Instanz"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — Instanz"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — Modul"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — Instanz"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — Instanz"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — Modul"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — Instanz"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — Instanz"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — Modul"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — Modul"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — Modul"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — Instanz"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — Modul"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — Instanz _(Klasse: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — Instanz _(Klasse: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — Instanz _(Klasse: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — Instanz _(Klasse: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — Modul"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — Modul"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener` — Instanz"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — Modul"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — Modul"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — Modul"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — Modul"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — Modul"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — Modul"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — Modul"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener` — Instanz"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — Modul"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — Instanz _(Klasse: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — Modul"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — Instanz _(Klasse: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — Instanz"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — Instanz"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — Instanz _(Klasse: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — Modul"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — Instanz"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — Instanz _(Klasse: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState` — Instanz"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — Instanz _(Klasse: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — Modul"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — Modul"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — Modul"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — Modul"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — Modul"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — Modul"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46463,7 +46768,7 @@ msgstr ""
 "`createBrotliCompress` — Modul **Stub** — params/quality-Optionen "
 "akzeptiert, aber ignoriert, warnt einmal (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46471,7 +46776,7 @@ msgstr ""
 "`createBrotliDecompress` — Modul **Stub** — params/quality-Optionen "
 "akzeptiert, aber ignoriert, warnt einmal (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46479,7 +46784,7 @@ msgstr ""
 "`createDeflate` — Modul **Stub** — Stufe ausgezeichnet; strategy/memLevel "
 "validiert, aber nicht angewendet (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46487,11 +46792,11 @@ msgstr ""
 "`createDeflateRaw` — Modul **Stub** — Stufe ausgezeichnet; strategy/memLevel "
 "validiert, aber nicht angewendet (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — Modul"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46499,19 +46804,19 @@ msgstr ""
 "`createGzip` — Modul **Stub** — Stufe ausgezeichnet; strategy/memLevel "
 "validiert, aber nicht angewendet (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — Modul"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — Modul"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — Modul"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46519,7 +46824,7 @@ msgstr ""
 "`createZstdCompress` — Modul **Stub** — params/quality-Optionen akzeptiert, "
 "aber ignoriert, warnt einmal (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46527,79 +46832,71 @@ msgstr ""
 "`createZstdDecompress` — Modul **Stub** — params/quality-Optionen "
 "akzeptiert, aber ignoriert, warnt einmal (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — Modul"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — Modul"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — Modul"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — Modul"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — Modul"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — Modul"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — Modul"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — Modul"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — Modul"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — Modul"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — Modul"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — Modul"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — Modul"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — Modul"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — Modul"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — Modul"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — Modul"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — Modul"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -47137,9 +47434,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "Sie andernfalls eine `docker-compose.yaml`-Datei verwenden würden."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "Die beiden Module teilen sich eine Laufzeit; Sie können sie im gleichen "
@@ -47673,12 +47971,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` entspricht `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Anmerkung auf der Rücklaufform `logs` und `exec`:** Heute gibt das FFI "
 "einen registry-id-Handle in ein `Vec<ContainerLogs>` anstatt ein JS-Objekt "
@@ -47808,9 +48107,10 @@ msgstr ""
 "und kehren sofort zurück."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` ist async und gibt ein JSON-Array mit _every_ sonded "
@@ -48571,9 +48871,10 @@ msgstr ""
 "antwortet:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Verwenden Sie den `healthcheck`-Block auf dem Dienst** (eingebaut, "
@@ -48954,8 +49255,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "Das Forgejo-Beispiel verwendet dieses portable Muster (`container_name:  "
@@ -49028,8 +49330,9 @@ msgid "Single-network shorthand"
 msgstr "Kurzform für ein einzelnes Netzwerk"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49445,9 +49748,10 @@ msgid "External volumes"
 msgstr "Externe Volumes"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Markieren Sie ein Volume `external: true`, um es über Stapel zu teilen oder "
@@ -49469,8 +49773,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49540,15 +49845,18 @@ msgstr ""
 "Runtime-CLI zur Inspektion:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# Liste App-voreingestellte Volumes"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# Mountpoint, Treiber, Etiketten"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# mount + inspect Inhalt"
 
 #: src/container/volumes.md:160
@@ -49718,9 +50026,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49910,8 +50219,9 @@ msgstr ""
 "nachfolgende Ausführungen gegen denselben Digest sind kostenlos."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -50181,8 +50491,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**Als Nicht-Root ausführen** (`user: \"nobody\"` oder numerische UID)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Alle Funktionen fallen lassen, spezifische hinzufügen** (`cap_drop:  "
@@ -50333,7 +50644,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "Ausgabe eines Operator-Banners mit URLs und Hinweisen zum Abbau."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr "Ausfahrt 0. Container laufen dank `restart:  unless-stopped` weiter."
 
 #: src/container/production-patterns.md:42
@@ -50558,11 +50870,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Healthcheck-gesteuerter Abhängigkeitsstart"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "Nachgres dauert ~5–10 Sekunden, um beim ersten Lauf zu initiieren (initdb + "
 "listener bind). Ohne Gitter, beginnt Forgejo sofort, kann sich nicht "
@@ -50738,7 +51051,8 @@ msgstr ""
 "`.env`-Datei oder einen Secrets-Manager:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -50751,7 +51065,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50815,11 +51130,13 @@ msgstr ""
 "durch:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# Volumenkonserven"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# Neuausrichtung mit neuer Version"
 
 #: src/container/production-patterns.md:268
@@ -50837,35 +51154,42 @@ msgid "Running it"
 msgstr "Ausführen"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Perry einmal erstellen"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Beispiel erstellen"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# - Hinterteil: Docker"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Besuchen Sie http://localhost:3000/ in einem Browser."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Herunterfahren (behält Volumes für eine erneute Bereitstellung bei):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Reißen Sie + fallen Volumen (DESTROYS DATEN):"
 
 #: src/container/production-patterns.md:300
@@ -51182,19 +51506,23 @@ msgstr ""
 "Backends stabil — die Werte sind unterschiedlich."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// getestet + emittiert wie-ist"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// Motor emuliert Host-Seite"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// fallen gelassen + Warnung"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// begrenzte Untermenge; Grund dokumentiert"
 
 #: src/container/determinism.md:156
@@ -51320,7 +51648,8 @@ msgstr ""
 "zurück:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... arg Bauherren"
 
 #: src/container/determinism.md:192
@@ -51348,7 +51677,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"Feld dropped/translated für Backend angeben\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- Saubere Spezifikation"
 
 #: src/container/determinism.md:212
@@ -51361,15 +51691,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// Feld entfernt"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// dem Gegenwert zugeordnet"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// Motor emuliert stattdessen"
 
 #: src/container/determinism.md:231
@@ -51377,15 +51710,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. Durchsetzungsmodus — wählen Sie, wie Warnungen angezeigt werden"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// Standardeinstellung — stille Verfolgung::warn!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// Oberfläche auf TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// nicht unterstütztes Feld → harter up() Fehler"
 
 #: src/container/determinism.md:241
@@ -51447,7 +51783,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "Normalisierung der Ausgabe — gleiche Form unabhängig vom Backend"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker Form (NDJSON Linie)"
 
 #: src/container/determinism.md:292
@@ -51455,7 +51792,8 @@ msgid "/* docker JSON */"
 msgstr "* docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Apple-Form (JSON-Array von `configuration`-wrapped-Objekten)"
 
 #: src/container/determinism.md:294
@@ -51463,7 +51801,8 @@ msgid "/* apple JSON */"
 msgstr "* Apfel JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// Beide produzieren ContainerInfo mit der gleichen Feldsemantik:"
 
 #: src/container/determinism.md:301
@@ -51808,7 +52147,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51821,7 +52161,8 @@ msgid "\"Back\""
 msgstr "Zurück"
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (leere Werte = muss übersetzt werden)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -52052,7 +52393,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -52173,7 +52515,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (Polnisch: eins, wenige, viele)"
 
 #: src/i18n/interpolation.md:65
@@ -52953,21 +53296,25 @@ msgid "Typical translation workflow:"
 msgstr "Typischer Übersetzungs-Workflow:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Schreibcode mit englischen Zeichenfolgen"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Strings in lokale Dateien extrahieren"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 "# 3. locales/de.json an Übersetzer senden (leere Werte müssen ausgefüllt "
 "werden)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Bauen — Perry bestätigt alles"
 
 #: src/i18n/cli.md:49
@@ -53653,57 +54000,25 @@ msgstr ""
 "update` verbrauchte authentifizierte Manifest."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr ""
 "# 1) Einmalige Schlüsselpaar-Generation. Speichern Sie kp.json mit Modus "
 "0600 und"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr ""
 "# 2) Pro-Release-Unterzeichnung. Der Ausgabe-JSON-Hüllkurve enthält jede"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 3) Sanity-Check die Signatur lokal vor dem Hochladen des Manifests —"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    hier sagt eine Weitergabe auf den Kunden überprüfen."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) Veröffentlichung CI unterzeichnet das CLI Manifest und bindet seine "
-"Archiv URL, Plattform,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Komponieren Sie ein finales Manifest, indem Sie die `sign`-Ausgabe über `jq` "
@@ -55349,9 +55664,10 @@ msgstr ""
 "kann (z. B. mehrere Schüsse, mehrere Schrittgeräusche)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** — eine Mischergruppe. Sounds Route durch einen Bus, Bus-Route "
@@ -56363,6 +56679,7 @@ msgstr ""
 "Loop nach jedem Dispatch, per Wall-Clock-Vergleich auf 100 ms gedrosselt."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -56372,7 +56689,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57571,23 +57888,28 @@ msgstr ""
 "Erweiterung — keine plattformspezifischen Sprachkenntnisse erforderlich."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS WidgetKit Erweiterung"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android App Widget"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS-Komplikation"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOS Simulator"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS Fliesen"
 
 #: src/widgets/overview.md:60
@@ -58505,10 +58827,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -59111,11 +59429,13 @@ msgid "Build Commands"
 msgstr "Build-Befehle"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -60010,19 +60330,23 @@ msgid "Build Instructions"
 msgstr "Build-Anweisungen"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# .kt-Dateien in app/src/main/java/com/example/app/ kopieren"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# AndroidManifest_snippet.xml in AndroidManifest.xml zusammenführen"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# .kt-Dateien in Wear OS-Modul kopieren"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# AndroidManifest_snippet.xml zusammenführen"
 
 #: src/widgets/watchos.md:3
@@ -60212,11 +60536,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "Hintergrund-Refresh verwendet das `BackgroundTask`-Framework"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Für Apple Watch Gerät"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Für Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -61835,11 +62161,13 @@ msgstr ""
 "mit `#[no_mangle] pub extern \"C\"` implementiert:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry Laufzeit FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... Anruf Plattform API, Lösung Versprechen, wenn getan ..."
 
 #: src/plugins/native-extensions.md:200
@@ -61970,25 +62298,21 @@ msgstr ""
 "Bibliothek und zielt auf das richtige Plattform-SDK:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (vereinfacht)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// Ziel erkennen: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// Kompilieren: schnelle -emit-library -static -target ... -sdk ... "
-"-framework StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// Link: Fracht:rustc-link-lib=static=review_bridge"
+"// Target erkennen: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Kompilieren: swiftc -emit-library -static -target ... -sdk ... "
+"-framework StoreKit\n"
+"    // Linken:    cargo:rustc-link-lib=static=review_bridge\n"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -62015,7 +62339,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Das Perry-Promise mit dem Ergebnis auflösen"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Aktivität von PerryBridge erhalten"
 
 #: src/plugins/native-extensions.md:266
@@ -62031,7 +62356,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "// Aufrufen von Plattform-APIs über JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -62662,15 +62988,18 @@ msgstr ""
 "braucht keinen Compiler, keinen Knoten und keinen Bau."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# das Tor"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# was im Rahmen ist und was nicht"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# Beweisen Sie, dass das Tor noch scheitern kann"
 
 #: src/testing/test-registration.md:18
@@ -63029,33 +63358,40 @@ msgstr ""
 "automatisch, wenn Sie mit `--enable-geisterhand` kompilieren."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Kompilieren Sie mit aktivierter geisterhand (Libs auto-build bei "
 "Erstnutzung)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Die App ausführen"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. In einem anderen Terminal — mit der App interagieren"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Alle Widgets auflisten"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Klicken Sie auf Knopf mit Griff 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Bildschirmfoto des Fensters erfassen"
 
 #: src/testing/geisterhand.md:25
@@ -63072,7 +63408,8 @@ msgstr ""
 "Flags brauchen):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# oder mit Perry-Lauf:"
 
 #: src/testing/geisterhand.md:35
@@ -63218,8 +63555,8 @@ msgid "Menu item"
 msgstr "Menüeintrag"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -63231,8 +63568,8 @@ msgstr "Tastenkürzel"
 msgid "Data table"
 msgstr "Datentabelle"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -63347,17 +63684,6 @@ msgstr ""
 "Setzt den Inhalt des Textfeldes und löst dessen `onChange`-Callback mit dem "
 "neuen Text als NaN-geboxtem String aus."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "„Inhaltstyp: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "'{\"Text\":\"Hallo-Welt\"}'"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Einen Slider bewegen"
@@ -63382,10 +63708,6 @@ msgstr ""
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr ""
 "Setzt die Slider-Position und löst `onChange` mit dem numerischen Wert aus."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "'{\"Wert\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -63436,10 +63758,6 @@ msgstr ""
 "Setzt direkt den Wert einer `State`-Zelle und umgeht dabei Widget-Callbacks. "
 "Dies löst alle reaktiven Bindings aus, die an den State angehängt sind "
 "(gebundene Text-Labels, Sichtbarkeit, forEach-Loops usw.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "'{\"Wert\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -63517,10 +63835,6 @@ msgstr ""
 "Key-String, der an `menuAddItem` übergeben wurde (z. B. `\"s\"` für Cmd+S, "
 "`\"S\"` für Cmd+Umschalt+S, `\"n\"` für Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "'{\"Kurzbefehl\":\"s\"}\""
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63555,10 +63869,6 @@ msgid ""
 msgstr ""
 "Setzt den Scroll-Offset eines ScrollView-Widgets. Sowohl `x` als auch `y` "
 "sind in Punkten."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -63659,12 +63969,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Feuern Sie zufällige Eingaben alle 200ms"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -63804,12 +64111,16 @@ msgstr ""
 "(gleiches Wi-Fi-Netzwerk) oder verwenden Sie `iproxy` aus `libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Installieren und starten Sie über Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -63837,7 +64148,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Paket in APK und installieren"
 
 #: src/testing/geisterhand.md:381
@@ -63845,7 +64157,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Installieren Sie zuerst die GTK4-Entwicklungsbibliotheken:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -63869,15 +64182,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Ein einfacher End-to-End-Test mit bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Mit geisterhand bauen"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Starten Sie die App im Hintergrund"
 
 #: src/testing/geisterhand.md:419
@@ -63889,33 +64205,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"Kill $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Warten Sie, bis die App fertig ist"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Widgets abrufen"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Finden Sie die Schaltfläche \"Abschicken\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Klicken Sie darauf"
 
 #: src/testing/geisterhand.md:436
@@ -63923,7 +64243,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Machen Sie einen Screenshot nach der Interaktion"
 
 #: src/testing/geisterhand.md:441
@@ -63935,7 +64256,8 @@ msgid "Python Test Example"
 msgstr "Python-Test-Beispiel"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# App starten"
 
 #: src/testing/geisterhand.md:450
@@ -63943,11 +64265,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Warten Sie auf Start"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Widgets auflisten"
 
 #: src/testing/geisterhand.md:455
@@ -63955,11 +64279,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Widgets nach Beschriftung suchen"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# In das erste Textfeld eingeben"
 
 #: src/testing/geisterhand.md:464
@@ -63979,7 +64305,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Klicken Sie auf die erste Schaltfläche"
 
 #: src/testing/geisterhand.md:470
@@ -63987,7 +64314,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Screenshot für visuelle Regression aufnehmen"
 
 #: src/testing/geisterhand.md:473
@@ -64003,7 +64331,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Assert die App ist immer noch gesund"
 
 #: src/testing/geisterhand.md:478
@@ -64035,40 +64364,14 @@ msgstr ""
 "unerwarteten State zu finden:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Bauen und starten"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Beginnen Sie aggressives Chaos (alle 50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Lass es 30 Sekunden laufen"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Statistiken überprüfen"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# \"Laufen\": wahr, \"events_fired\":600, \"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Machen Sie einen Screenshot, um den Endzustand zu sehen"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Chaos stoppen"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Überprüfen Sie die App ist noch am Leben"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -64082,11 +64385,13 @@ msgstr ""
 "Sie sie mit Baselines:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# Ausgangszustand"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -64094,24 +64399,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Erfassung nach Interaktion"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# Vergleichen (mit ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "CI-Pipeline-Integration"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# GitHub Aktionen Beispiel"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# GitHub-Actions-Beispiel\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -64160,7 +64467,8 @@ msgid "Run UI tests"
 msgstr "UI-Tests ausführen"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Führen Sie Ihr Testskript aus"
 
 #: src/testing/geisterhand.md:568
@@ -64338,20 +64646,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Nach der Kompilierung mit `--enable-geisterhand` und dem Ausführen:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Alle interaktiven Widgets anzeigen"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Inkremente\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   ‚Begriff‘:4,‚widget_type‘:0,‚callback_kind‘:0,‚Beschriftung‘:"
 "‚Zurücksetzen‘},"
@@ -64361,8 +64672,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr "#   \"Griff\":6,\"widget_type\":2,\"callback_kind\":1,\"Griff\":\"},"
 
 #: src/testing/geisterhand.md:661
@@ -64370,19 +64682,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Klicken Sie 3 mal auf Inkrement"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# Counter-Label zeigt jetzt \"Count: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Einen Namen eingeben"
 
 #: src/testing/geisterhand.md:669
@@ -64390,7 +64705,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Schieberegler auf 80% einstellen"
 
 #: src/testing/geisterhand.md:672
@@ -64398,11 +64714,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Dunkelmodus einschalten"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64712,16 +65030,13 @@ msgstr ""
 "Wenn der Auto-Build fehlschlägt oder Sie manuell cross-kompilieren möchten:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Geisterhand-Libs für macOS erstellen"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Für iOS (kompilierbar)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -64919,15 +65234,18 @@ msgstr ""
 "Run sind. Enge weiter:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# ein paar Module"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# Nur diese Ausfuhren"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# kombinierte Form mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -64948,15 +65266,18 @@ msgid "Full sweep and the CI gate"
 msgstr "Voller Sweep und das CI-Tor"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# Gesamtmatrix + Übersichtstabelle"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# Exit 1 bei Regressionen gegenüber dem Ausgangswert"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# Umschreiben der zugesagten Basislinie"
 
 #: src/testing/node-compat-matrix.md:43
@@ -65245,7 +65566,7 @@ msgstr ""
 "ist `needs: plan` und ist auf `fromJSON(needs.plan.outputs.plan).jobs."
 "<name>` gegated."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -65341,11 +65662,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -65370,94 +65691,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6x schnell"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3x schnell"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x vollständig"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "nur Deps"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "In der **pr** Ebene die geänderte Dateiliste verengt den Plan weiter:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -65465,7 +65799,7 @@ msgstr ""
 "**Nur für** (nur `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, ... — siehe `NON_CORE_GLOBS` in `ci_plan.py`) → nur `lint` läuft."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -65473,7 +65807,7 @@ msgstr ""
 "**Kern** (alles, was den Compiler, die Laufzeit oder ein Testergebnis ändern "
 "kann) → die gesamte PR-Ebene."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -65481,7 +65815,7 @@ msgstr ""
 "**Depens** (ein Lockfile, Manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, ...) → zusätzlich der wiederverwendbare Workflow `security-audit`."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -65496,7 +65830,7 @@ msgstr ""
 "HIR, transformieren, oder eine andere Abhängigkeit, ohne Rust-Setup zu docs-"
 "only PRs hinzuzufügen."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -65506,11 +65840,11 @@ msgstr ""
 "fehlgeschlagener `plan`-Job versagt das Tor direkt – ein kaputter Planer "
 "darf sich nie in \"alles übersprungen, also grün\" verwandeln."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "Warum es so aussieht (gemessen 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -65523,13 +65857,13 @@ msgstr ""
 "sah ~66 PR drückt und ~58 verschmilzt pro Tag. Das ist 1.5–2× "
 "Gesamtkapazität, also:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "Die Wartezeiten für die Job-Warteschlange betrugen 3–7 h (`conformance-"
 "smoke`-Scherben: mediane 4 h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -65538,7 +65872,7 @@ msgstr ""
 "im Beispielfenster — 8 fehlgeschlagen, 56 wurden durch den nächsten Push "
 "abgesagt;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -65551,7 +65885,7 @@ msgstr ""
 "Zusammenführungen war ein Admin Bypass** mit `lint` und `cargo-test` stehen "
 "noch an."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -65566,11 +65900,11 @@ msgstr ""
 "ersetzt die fragmentierte erforderliche-Kontext-Liste durch die einzige `pr-"
 "gate`-Fan-In oben beschrieben."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Zwei spezifische Kosten dominierten:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -65591,7 +65925,7 @@ msgstr ""
 "Optimierungsmodus wird in der ganzen Ebene gehalten, weil er der einzige Arm "
 "ist, der nur auto-Optimierungs-Verbindungsfehler sieht."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -65607,7 +65941,19 @@ msgstr ""
 "`cache-warm.yml` ist weg: der Sweep ist der Cache-produzierende Build auf "
 "`main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -65630,75 +65976,75 @@ msgstr ""
 "bekommt immer noch eine Runde von jedem – mit jedem Job übersprungen, was "
 "keinen Läufer-Slot kostet."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "typische Arbeitsplätze"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "typische Runner-Minuten"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "Zielwanduhr"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (Kern)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 Spaltscheren)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 min einmal in der Warteschlange"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (nur für Ärzte)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 min"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "kein Ziel — es verschmolzen"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "kein Ziel"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -65728,11 +66074,20 @@ msgstr ""
 "eines Sweep-Ausfalles erfolgt durch Fenster (`previous sweep SHA .. this "
 "sweep SHA`), genau wie bei den sechsstündigen Toren."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Eine PR in mehr entscheiden"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -65746,7 +66101,7 @@ msgstr ""
 "werden sollten, und für alles, was eine voll-tier-only Suite berührt. Das "
 "Anwenden des Etiketts feuert die Runs erneut (`labeled` Trigger)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -65755,7 +66110,7 @@ msgstr ""
 "`lint` (eine `crates/`-Änderung muss ansonsten ein `changelog.d/<PR>-"
 "<slug>.md`-Fragment hinzufügen)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -65763,11 +66118,11 @@ msgstr ""
 "**`workflow_dispatch`** auf jedem Zweig: `tier` (`pr` / `sweep` / `full`) "
 "und `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Den Lücken-Snapshot neu basieren"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -65780,15 +66135,17 @@ msgstr ""
 "Orakeländerung), regenerieren Sie es **von CI**, nicht von einem Laptop (der "
 "erforderliche Ausgangswert ist Linux, `fast`-Modus):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# warten Sie auf den Lauf, dann:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# `issue` / `reason` für jeden neuen Eintrag ausfüllen, dann übergeben"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -65798,11 +66155,11 @@ msgstr ""
 "Problem und einen Grund vor dem Zusammenführen. Ein Absturz darf niemals im "
 "Snapshot geparkt werden (`run_gap_tests.sh` verweigert)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Zweigschutz"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -65819,11 +66176,11 @@ msgstr ""
 "der eigene Lauf des Gates trägt, ob das Ergebnis passiert oder "
 "fehlgeschlagen ist."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -65835,7 +66192,7 @@ msgstr ""
 "suite-gate`** job succeeded — ein grüner Sweep- oder PR-Tierlauf auf "
 "demselben SHA zählt nicht. Siehe [Releasing](../contributing/releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -65851,6 +66208,173 @@ msgstr ""
 "einmal in `parity-aggregate` über den zusammengeführten Bericht (`scripts/"
 "parity_report_merge.py`, die einen fehlenden Shard ablehnt, anstatt die "
 "Suite zu schrumpfen)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Was ein Scheck schickt"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Führen Sie es lokal mit:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"Befehl\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -65973,36 +66497,13 @@ msgid "Reproduce the core of it with:"
 msgstr "Reproduzieren Sie den Kern mit:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# Was läuft eigentlich, repo-wide, auf der Job-Ebene:"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\"workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "\".Jobs[] | select(.status==\"in_progress\") | (Marken)|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Wie tief die Warteschlange ist und auf welcher Pools:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "\".Jobs[] | select(.status==\"queued\") | (Marken)|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -66193,24 +66694,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# unverändert — jede PR wird noch gemessen"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # gestaffelt; siehe Tabelle unten"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -66221,12 +66720,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# Freigaben bleiben individuell verschlossen"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -66507,11 +67005,13 @@ msgstr ""
 "auslässt, ist es nicht."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# beweist, dass es immer noch scheitern kann"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# echte API, kein Problem schreibt"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -66545,10 +67045,49 @@ msgstr ""
 "bedeutet, dass der Detektor funktioniert, nicht dass nichts versucht wurde."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "Die Schlange vor dem Zeitplan (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -66556,57 +67095,57 @@ msgstr ""
 "Ein sechsstündiger Sweep hilft nur, wenn die Warteschlange schneller als "
 "sechs Stunden abläuft. Am 2026-08-12 nicht, und der Grund war nicht die Tore:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "Warteschlange läuft"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "gleichzeitig beobachtete Ausläufe"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "Warteschlange nach Ereignis"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "verschiedene Kopfzweige unter Schlange PR-Laufs"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**Zweige, die noch existierten**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -66623,11 +67162,12 @@ msgstr ""
 "nicht in 32+ Stunden abgeschlossen hatte. Davon erholt sich keine Menge an "
 "Terminkadenz; der Müll muss entfernt werden."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -66644,7 +67184,7 @@ msgstr ""
 "was Gabel PRs sicher hält — ein Gabelkopfzweig erscheint nie in diesem "
 "repo's refs."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -66657,7 +67197,7 @@ msgstr ""
 "reap_stale_ci_runs.py --apply` (Trockenlauf ist die Standardeinstellung); "
 "der Zeitplan hält ihn danach klar."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
@@ -66665,7 +67205,7 @@ msgstr ""
 "Warum \"das Tor dunkel war\" ist nicht dasselbe wie \"das Tor hätte es "
 "gefangen\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -66677,7 +67217,7 @@ msgstr ""
 "dunkle Tor ließ es durch — überlebt nicht die Überprüfung, und es wird "
 "aufgezeichnet, warum es wichtiger ist als der Vorfall:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -66690,7 +67230,7 @@ msgstr ""
 "nicht einer von ihnen. Kein Tor in der Repo Ratsche eine Sammlung-_kind_ "
 "zählen."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -66702,7 +67242,7 @@ msgstr ""
 "in `tolerances.json` aufgezeichnet. Sie gate nur unter `pinned_host`, die CI "
 "nie verwendet."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -66710,7 +67250,7 @@ msgstr ""
 "Die Workloads, die es gezeigt haben (`retain`, `deeplist`, ...) sind der gc-"
 "handoff Korpus, nicht die festen 14 Sonden von `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -66939,14 +67479,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Kompiliert TypeScript zu einer nativen ausführbaren Datei."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# Oder Shorthand (auto-detects compilieren):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Flag"
 
@@ -66975,7 +67516,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (Standard) oder `dylib` (Plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -66983,7 +67524,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "HIR-Zwischendarstellung ausgeben"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -66995,7 +67536,7 @@ msgstr ""
 "Nur Objekt file(s) herstellen, Verknüpfung überspringen; in `-o` geschrieben "
 "(siehe [Compiler-Flaggen](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -67003,7 +67544,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "`.o`- und `.asm`-Dateien behalten"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -67011,7 +67552,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "V8-JavaScript-Runtime-Fallback aktivieren"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -67023,8 +67564,8 @@ msgstr ""
 "Erzwingt die Einbindung der wasmi WebAssembly-Host-Runtime (wird bei "
 "Verwendung von `WebAssembly.*` automatisch erkannt)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -67032,17 +67573,17 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Typprüfung über tsgo aktivieren"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr ""
 "Ausgabe minifizieren und obfuskieren (automatisch aktiviert für `--target "
 "web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -67050,7 +67591,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle-ID (erforderlich für Widget-Targets)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -67059,23 +67600,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "TypeScript-Erweiterungen aus Verzeichnis bündeln"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Grundlegende Erstellung"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Cross-Compile für iOS Simulator"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Ein Plugin erstellen"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: Ansicht Zwischendarstellung"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Erstellen eines iOS-Widgets"
 
 #: src/cli/commands.md:82
@@ -67083,23 +67629,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Ihre App in einem Schritt kompilieren und starten."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# Eintragsdatei automatisch erkennen"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Laufen auf iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Auf Apple Vision Pro simulator/device ausführen"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Auf Android Gerät ausführen"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Args an Ihr Programm weiterleiten"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -67233,19 +67784,23 @@ msgstr ""
 "Sie `--local` oder `--remote`, um einen der beiden Pfade zu erzwingen."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Ein CLI-Programm ausführen"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Auf einem bestimmten Simulator ausführen"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Remote-Build erzwingen"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Web-Ziel ausführen"
 
 #: src/cli/commands.md:131
@@ -67261,19 +67816,23 @@ msgstr ""
 "automatisch bei jedem Speichern neu."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# watch + rebuilt + relaunch on save"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# Args an das Kind weiterleiten"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# ein zusätzliches Verzeichnis ansehen"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# Ausgabepfad überschreiben"
 
 #: src/cli/commands.md:144
@@ -67413,7 +67972,7 @@ msgstr ""
 "State-Erhaltung über Rebuilds / HMR — \"schneller Restart\" ist das ehrliche "
 "Ziel."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -67478,19 +68037,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Korrekturen mittlerer Konfidenz einbeziehen"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Eine einzelne Datei überprüfen"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Überprüfung mit Abhängigkeitsanalyse"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Auto-Fix Probleme"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Vorschaukorrekturen ohne Anwendung"
 
 #: src/cli/commands.md:207
@@ -67786,27 +68349,33 @@ msgstr ""
 "Einrichtung für Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Plattformmenü anzeigen"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# macOS-Einrichtung (Anmeldeinformationen)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# iOS-Einrichtung (Anmeldeinformationen)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# visionOS-Einrichtung (Anmeldeinformationen)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Android-Einrichtung (Anmeldeinformationen)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows Toolchain (Downloads MS CRT + Windows SDK via xwin)"
 
 #: src/cli/commands.md:318
@@ -67836,19 +68405,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Aktualisierung auf das letzte"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Überprüfung ohne Installation"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Die zwischengespeicherte Antwort ignorieren"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Speichern, wie sich Updates verhalten sollen, dann beenden"
 
 #: src/cli/commands.md:333
@@ -67866,7 +68439,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` schreibt `[update] mode` auf `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -67980,14 +68553,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Ein neues Native-Bindings-Paket gerüstartig erstellen:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"Native Bindungen für libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "'libfoo = '1.0'\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -68527,10 +69092,21 @@ msgstr ""
 "Ausgabe ausführbar, Bündel, freigegebene Bibliothek, Archiv oder Objektpfad."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -68538,18 +69114,18 @@ msgstr ""
 "Wählen Sie Linux libc/linkage; `musl` aktualisiert das entsprechende Linux-"
 "Ziel auf einen vollständig statischen kopflosen Aufbau."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "Bundle-Kennung durch Home-Screen-Widget-Ziele."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr ""
 "Entdecke und bündele statisch native Erweiterungspakete aus einem "
 "Verzeichnis."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -68557,22 +69133,22 @@ msgstr ""
 "Führen Sie den nativen TypeScript-Checker (`@typescript/native-preview`) vor "
 "dem Codegen aus."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Setzen Sie den Windows PE Kompatibilitätsboden; ignoriert für nicht-Windows-"
 "Ziele."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -68580,11 +69156,11 @@ msgstr ""
 "Wählen Sie das Windows PE-Subsystem, anstatt sich auf die auto-Import-"
 "Erkennung zu verlassen."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -68592,11 +69168,11 @@ msgstr ""
 "Für Apple-Widget-Ziele senden Sie SwiftUI-Quelle und Metadaten aus, ohne "
 "`swiftc` aufzurufen."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -68604,35 +69180,68 @@ msgstr ""
 "Wählen Sie HarmonyOS HAP Signiermaterial. Bevorzugen Sie die entsprechenden "
 "environment/config-Quellen für Geheimnisse."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS-Anwendungszertifikatkette."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS unterzeichnet Provisioning-Profil."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS keystore alias; Standardwerte für `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — Modul"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Einbettung von Vermögenswerten"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -68641,11 +69250,11 @@ msgstr ""
 "Schriftarten, ...) in die eigenständige ausführbare Datei, so dass es ohne "
 "externe Dateien auf der Festplatte läuft (#5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -68655,11 +69264,23 @@ msgstr ""
 "(relativ zur Projektwurzel). Repeatable. Zusammengelegt mit `perry.embed` "
 "(package.json) und `[compile] embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -68668,19 +69289,20 @@ msgstr ""
 "unterhalb von `dir` auf einen stabilen `$perryfs`-Handle abbildet. "
 "Wiederholbar; Quellkarten sind ausgeschlossen."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# dient dist/ aus dem Speicher — kein dist/Ordner benötigt"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "Eingebettete Dateien sind zur Laufzeit auf drei Arten erreichbar:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -68712,7 +69334,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -68724,7 +69346,7 @@ msgstr ""
 "`readEmbedded(path)` und `node:fs` akzeptieren entweder den virtuellen Pfad "
 "`$perryfs/<path>` oder den embed-relative Schlüssel."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -68732,7 +69354,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -68742,7 +69364,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -68756,7 +69406,7 @@ msgstr ""
 "\"file\" }`-Kante auf und behält die generierte Quelle in seinem Cache, "
 "anstatt die Kasse zu modifizieren."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -68765,11 +69415,7 @@ msgstr ""
 "vorgelagerte Web-UI und kompilieren Sie dann aus dem Paketstamm von "
 "`packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -68784,7 +69430,7 @@ msgstr ""
 "Führen Sie den Vorbereitungsbefehl für jede Quellrevision aus, damit die "
 "generierten Eingänge nicht veralten können."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -68797,7 +69443,7 @@ msgstr ""
 "Ursprung, die Byte-Größe, SHA-256 Digest und gegebenenfalls das generierende "
 "Asset-Modul."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -68813,7 +69459,7 @@ msgstr ""
 "explizite Formular `$perryfs/<path>`, wenn Sie die eingebettete Kopie "
 "speziell meinen."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -68825,19 +69471,19 @@ msgstr ""
 "Sie `PERRY_LLVM_CLANG`, wenn das passende Clang nicht zuerst auf `PATH` ist. "
 "Cross-Target-Einbettung wird derzeit nicht unterstützt."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Debug-Flags"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "HIR (Zwischendarstellung) auf stdout ausgeben"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -68846,11 +69492,11 @@ msgstr ""
 "(post-transform HIR), `llvm` (pro Modul `.ll` in `.perry-trace/llvm/`), oder "
 "`all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -68860,7 +69506,7 @@ msgstr ""
 "enthält, und unterdrückt Import-/Export-/Init-Rauschen. Impliziert `--trace "
 "hir`, wenn keine Stufe angegeben ist"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -68875,11 +69521,11 @@ msgstr ""
 "aktuellen Verzeichnis. Jeder Pfad wird als `Wrote object file: <path>` "
 "gedruckt"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -68889,15 +69535,15 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`). Siehe [Projektkonfiguration](../getting-started/"
 "project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "`.o`- und `.asm`-Zwischendateien behalten"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
@@ -68905,33 +69551,33 @@ msgstr ""
 "Behalten Sie symbols/DWARF (und emittieren Sie eine Windows PDB) statt das "
 "Ergebnis zu entfernen."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Deaktivieren Sie den pro-Module Objekt-Cache für diesen Build; auch "
 "`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "Überschreiben Sie die maschinen-lokale Cache-Root; siehe [Cache-Verzeichnis]"
 "(cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -68939,31 +69585,31 @@ msgstr ""
 "Führen Sie native-Representation senken Invarianten und Kraft Codegen statt "
 "Cache Wiederverwendung."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 "Deaktivieren native Buffer/Uint8Array load/store Senkung für A/B Diagnose."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 "Geben Sie einen typsenkenden Beweisbericht aus; impliziert eine Überprüfung "
 "der Heimatregion."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -68973,11 +69619,11 @@ msgstr ""
 "beheben können. Text standardmäßig; `--opt-report=json` emittiert ein "
 "stabiles Schema für das Tooling. Auch über `PERRY_OPT_REPORT=1` einstellbar"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -68990,7 +69636,7 @@ msgstr ""
 "native-root-Backend (die einfache Stack-Map und explizite Bridge-Modi, die "
 "es auch genannt werden, sind weg)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -69008,11 +69654,11 @@ msgstr ""
 "andernfalls das Codegen für unveränderte Module und lässt das Trace-"
 "Verzeichnis leer)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report` — warum ein Wert verschachtelt blieb"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -69030,11 +69676,11 @@ msgstr ""
 "Analog von LLVM's `-Rpass-missed` Bemerkungen: es druckt, was bewiesen "
 "wurde, was nicht, und welche Regel machte den Anruf."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Jeder verweigerte Wert enthält:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -69044,7 +69690,7 @@ msgstr ""
 "Objekt, das niemals an einen lokalen, das `.map(x => ({...}))`-Idiom "
 "gebunden ist)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -69052,7 +69698,7 @@ msgstr ""
 "**Die Regel, die es verweigert**, in der eigenen Nummerierung des "
 "Kollektors, so dass Sie es gegen die benannte Quelldatei überprüfen können."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -69064,7 +69710,7 @@ msgstr ""
 "(korrigiert — keine Aktion), oder _Perry limitation_ (nicht Ihr Code; "
 "benennt das Tracking Problem, wo man existiert)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -69079,7 +69725,7 @@ msgstr ""
 "dass die Schleifentiefe alleine die letzte zählt. Auch kein Profil – es sind "
 "statische Proxies."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -69087,7 +69733,7 @@ msgstr ""
 "Gewinne werden neben den Misses gemeldet, so dass das Verhältnis sichtbar "
 "ist, anstatt nur die Beschwerden."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -69102,7 +69748,7 @@ msgstr ""
 "geht an **Stderr**, also mischt es sich nie in eine `--format json` Nutzlast "
 "oder die piped Ausgabe Ihres Programms."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -69116,15 +69762,15 @@ msgstr ""
 "`schema_version: 1`; das Diffing von zwei Builds' JSON ist eine billige CI-"
 "Prüfung gegen eine Darstellung, die lautlos auf Null zurückgeht."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Ausgabe-Optimierung"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -69146,11 +69792,11 @@ msgstr ""
 "für `generic`. Gilt für App-Code und den autooptimierten runtime/stdlib-"
 "Rebuilt."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -69158,11 +69804,11 @@ msgstr ""
 "Definieren Sie Komma-getrennte Compil-Time `__feature_NAME__` Konstanten für "
 "Dead-Code Elimination."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -69170,28 +69816,28 @@ msgstr ""
 "Verwenden Sie das vorgefertigte volle runtime/stdlib anstatt das kleinste "
 "erreichbare Feature-Set neu aufzubauen."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "Erlauben Sie die Wiedervereinigung von Gleitpunkten; siehe [Fast-math](fast-"
 "math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr ""
 "Kontrolle der verschmolzenen Multiplikations-Add-Kontraktion getrennt von "
 "der Reassoziation."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -69199,11 +69845,11 @@ msgstr ""
 "Minifizierung entfernt Kommentare, kollabiert Whitespace und mangelt lokale "
 "Variablen-/Parameter-/nicht-exportierte-Funktions-Namen für kleinere Ausgabe."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Größenoptimierte Builds"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -69215,11 +69861,11 @@ msgstr ""
 "Geschwindigkeit abgestimmt sind (sie benötigen einen Perry-Workspace "
 "Checkout, wie der Rest von Auto-optimize):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -69232,11 +69878,11 @@ msgstr ""
 "Größenoptimierte und normale Archive werden unabhängig voneinander "
 "zwischengespeichert."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -69245,11 +69891,11 @@ msgstr ""
 "Archive (langsamer Wiederaufbau, kleinere Binär). Nur sinnvoll zusammen mit "
 "`PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -69268,7 +69914,7 @@ msgstr ""
 "ohne ein symbolisiertes Backtrace ab — JS `throw`/`catch`, `finally`, "
 "Fehlerstacks und `uncaughtException` bleiben unberührt."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -69280,15 +69926,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. Programme, die mehr der Laufzeit "
 "verwenden, schrumpfen proportional weniger."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Test-Flags"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -69296,26 +69942,26 @@ msgstr ""
 "Bettet den [Geisterhand](../testing/geisterhand.md)-HTTP-Server für "
 "programmatisches UI-Testing ein (Standard-Port 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Benutzerdefinierten Port für den Geisterhand-Server setzen (impliziert `--"
 "enable-geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Runtime-Flags"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "V8-JavaScript-Runtime für nicht unterstützte npm-Pakete aktivieren"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -69325,15 +69971,15 @@ msgstr ""
 "erkannt, wenn `WebAssembly.*` referenziert wird; nur erforderlich beim Laden "
 "via dlopen / FFI ohne statische Referenz)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Typprüfung über tsgo-IPC aktivieren"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -69350,11 +69996,11 @@ msgstr ""
 "(package.json oder perry.toml) einstellbar. `PERRY_ALLOW_EVAL=1` zwingt es "
 "ab. Siehe [Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -69378,11 +70024,11 @@ msgstr ""
 "unberührt. Siehe [Limitations](../language/limitations.md#no-eval-or-dynamic-"
 "code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -69391,22 +70037,22 @@ msgstr ""
 "Node/stdlib API referenziert wird, anstatt einen latenten Laufzeitfehler "
 "auszusenden."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Emit `<binary>.attest.json`; siehe [Binäre Bescheinigung](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Die Sandkasten-Sandbox auslassen; siehe [Sandkastenprofile](emit-sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -69414,31 +70060,31 @@ msgstr ""
 "Nicht erreichbare beliebige Code-Ausführungsflächen; siehe [Lockdown]"
 "(lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Umgebungsvariablen"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Perry-Hub-Lizenzschlüssel für `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Passwort für .p12-Zertifikat"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -69446,62 +70092,62 @@ msgstr ""
 "CPU-Basiswert für generierten Maschinencode (gleiche Werte wie `--march`; "
 "die Flagge und perry.toml `[build] march` gewinnen über die Env var)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Automatische Update-Prüfungen deaktivieren"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "Gleiches gilt für die Verwendung der ökosystemweiten Rechtschreibung"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` für einen Lauf — siehe [Updates](updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL für benutzerdefinierten Update-Server"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Update-Prüfungen automatisch überspringen (von den meisten CI-Systemen "
 "gesetzt)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Debug-Logging-Level (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -69510,7 +70156,7 @@ msgstr ""
 "Berichts aus einer Umgebung, in der das Hinzufügen einer Flagge unangenehm "
 "ist"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -69525,15 +70171,15 @@ msgstr ""
 "ein fünfter GC-env-Knopf ohne CI-Arm und wurde unter CLAUDE.mds GC-Knopf-"
 "Kill-Richtlinie gelöscht."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "Konfigurationsdateien"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (Projekt)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -69613,11 +70259,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (global)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -69639,57 +70285,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Einfaches CLI-Programm"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# iOS App für Simulator"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# visionOS App für Simulator"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Web-App (WASM mit DOM-Brücke — Alias: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Freigabebibliothek des Moduls"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# iOS Widget mit Bundle ID"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Debug-Compilation"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Verbose Zusammenstellung"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Typgesteuerte Zusammenstellung"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# Raw WASM binär (kein HTML-Wrapper)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Minifizierte Webausgabe (komprimiert eingebettete JS-Brücke)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Befehle](commands.md) — Alle CLI-Befehle"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[Plattform-Überblick](../platforms/overview.md) — Plattform-Targets"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"Module\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Identität des Caches"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"Module\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"Quelle\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"Lodash\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"Ziele\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"Funktionen\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Inkremente\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"caption\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -69935,15 +70777,18 @@ msgid "CLI flag wins over env var, env var wins over package.json:"
 msgstr "CLI-Flag schlägt env-Variable, env-Variable schlägt package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. CLI-Flagge pro Bau"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Per-shell-Umgebung"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. Pro Projekt package.json (am häufigsten)"
 
 #: src/cli/fast-math.md:35
@@ -69959,19 +70804,22 @@ msgid "Contraction is separate from reassociation:"
 msgstr "Kontraktion ist von Reassoziation getrennt:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Nur FMA-Kontraktion zulassen."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Erlaubt den aggressivsten Kontraktionsmodus des Frontends ohne "
 "Reassoziation."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr ""
 "# Halten Sie die Reassoziation von --fast-math, blockieren Sie aber die FMA-"
 "Kontraktion."
@@ -70989,7 +71837,8 @@ msgid "Emit"
 msgstr "Ausgabe"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → Myapp"
 
 #: src/cli/emit-attest.md:27
@@ -71077,7 +71926,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "Größe"
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -72315,10 +73164,6 @@ msgstr ""
 msgid "produces:"
 msgstr "erzeugt:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"Module\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -72401,9 +73246,10 @@ msgstr ""
 "Quellcode wird unter `<host source>` ausgegeben."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Gibt einen eindeutigen Fehler zurück, wenn das Manifest noch nicht existiert "
 "— `perry  compile` oder `perry run` schreibt es auf jedem erfolgreichen "
@@ -74570,7 +75416,7 @@ msgstr "Perry liest Konfiguration aus beiden Dateien. Was wo hingehört:"
 msgid "Setting"
 msgstr "Einstellung"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "Datei"
 
@@ -74655,15 +75501,18 @@ msgstr ""
 "auch `~/.perry/config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# iOS-Signierung konfigurieren (Zertifikat, Provisionsprofil)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Android-Signierung einrichten (Keystore, Play Store-Schlüssel)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Konfigurieren der macOS-Distribution (App Store, Beglaubigung)"
 
 #: src/cli/perry-toml.md:605
@@ -74704,8 +75553,11 @@ msgstr ""
 "`perry.toml` zu speichern:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# GitHub Aktionen Beispiel"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -75973,20 +76825,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Perry Schiffe **zwei unabhängige Opt-in-Kanäle** für das Senden von Daten "
-"nach Hause — nichts verlässt Ihre Maschine ohne eine explizite `enabled = "
-"true` oder `on` in `~/.perry/config.toml`. Beide ehren "
-"`PERRY_NO_TELEMETRY=1` und `CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Allgemeine Analyse der Nutzung — `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Allgemeine Analyse der Nutzung — `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -75996,14 +76848,16 @@ msgstr ""
 "Hintergrund HTTP POST. Sendet: Befehlsname, Plattform (`darwin`/"
 "`linux`/...), Perry-Version, success/error-Status und anonymer Client UUID."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. Kompatibilitätsberichte — `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -76014,15 +76868,15 @@ msgstr ""
 "`UnsupportedExpression`, `UnsupportedStatement`, `DynamicPropertyAccess`, "
 "`ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Drei Modi:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr "`off` — nie senden. Sink ist nicht einmal installiert; Null Overhead."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -76030,101 +76884,101 @@ msgstr ""
 "`ask` (Standard) — wenn ein qualifiziertes Diagnosefeuer, prompt einmal pro "
 "Sitzung: `[y] just this once / [a] always / [n] not this time / [N] never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr ""
 "`on` — immer senden (nach der Entschlüsselung + Redaktion). Keine "
 "Vorankündigung."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**Was gesendet wird (das gesamte Nutzlastschema):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"Code\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"Kategorie\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"Gap-categorical\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"Stufe\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"Hir-Tier\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:...\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"Dekorator\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"Knoten:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"o\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -76141,7 +76995,7 @@ msgstr ""
 "`Math`, `Promise`) → `<id1>`, `<id2>`, mit 200 Zeichen, mit einer harten "
 "Ablehnung, wenn ein Invariant fehlschlägt."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -76149,32 +77003,36 @@ msgstr ""
 "Ein lokaler 30-Tage-Dedup-Cache bei `~/.perry/.report-cache` verhindert, "
 "dass derselbe `snippet_hash` bei jedem Nachladen erneut angezeigt wird."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Inspizieren & verwalten"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# zeigt den aktuellen Modus an, sent/queued zählt"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# print Redacted payloads in der Warteschlange"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# Den 30-Tage-Dedup-Cache wischen"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "Um auf Dateiebene zu optieren, bearbeiten Sie `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -76183,7 +77041,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -76435,15 +77293,18 @@ msgstr ""
 "perry-runtime/src/gc/types.rs`) voreingestellt:"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "WICHTIG | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// Gesamtgröße des Allocs, verwendet für Arena Block Walking"
 
 #: src/internals/memory-model.md:69
@@ -76784,7 +77645,7 @@ msgstr ""
 "runtime-genaue Helper-Barriers zur Laufzeit für Benchmark-/Debug-Bisection. "
 "Nicht gesetzt, `=1`, `=on` und `=true` halten Barriers aktiviert."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -76976,10 +77837,11 @@ msgstr ""
 "fromspace-protect] retired_set=#N`-Linie unter `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -77212,10 +78074,24 @@ msgstr ""
 "Prozess tatsächlich unter Druck halten würde."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Quellzuordnung"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -77224,183 +78100,183 @@ msgstr ""
 "wiedergibt, und jede Zeile dieser Tabelle hat einmal in eine `gc.rs` "
 "gezeigt, die nicht mehr existiert."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Thema"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Symbol für die Suche nach"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaN-Box-Tags"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, Typ-/Flag-Konstanten"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Schatten-Rahmen (Fallback-Root-Absenkung)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Registrierte Root-Scanner"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Minderjährige kopieren"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Ganzer Block an Ort und Stelle Beförderung"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Absatzförderungspolitik"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Anpassungsschwelle"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Schreibbarrieren"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Explizites Anstecken"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Prädikat der Konservativen"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Sammelauslöser und Tempos"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Seite der laufenden Operationen"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Entwurfsplan (historisch)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -77841,12 +78717,18 @@ msgstr ""
 "heap_budget.rs` abgeleitet: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "auf einem unbeschränkten desktop/server-Prozess, skaliert auf ein Achtel "
 "eines device/container-Budgets mit einem 1 MiB-Boden. Der Überfluss wird an "
@@ -77855,7 +78737,7 @@ msgstr ""
 "unsafe/deferred Perioden und entleert den Pool, wenn die geschuldete "
 "Vollsammlung seine Arena-Reklamation beendet."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -77866,101 +78748,215 @@ msgstr ""
 "**Lebendzählung** plus inkrementelle Deltas, keine Summe von Blockhochwasser-"
 "Offsets."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Unterstützte Steuerungen"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr "Dies sind die am nützlichsten außerhalb der Kollektor-Entwicklung:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "bis zum Ende des Mark-Sweep"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime Barriere Bisektion; auch Kräfte volle Markierung-Sweep"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr ""
 "Deaktivieren Sie das direkte Kinderzimmer-Scavenging für den Schrittvergleich"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "Ganzblockförderung auf Objekt-für-Objekt-Evakuierung umkehren"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "Einstellung der Basis Kindermütze"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "überschreiben Sie das Prozesshaufenbudget in MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "Wählen Sie Schattenwurzeln auf einem nativen-root-fähigen Ziel"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "Diagnose-Voll-Native-Stacks-Scan; deaktiviert Kopieren"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "emittieren strukturierte pro-Zyklus-Trace-Datensätze"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "emittieren Mensch-lesbare Kollektor-Diagnose"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -77969,10 +78965,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "Der Wurzelstress verwendet `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -77987,7 +78984,7 @@ msgstr ""
 "`PERRY_STACKMAP_WALKER` werden akzeptiert, sind aber keine zusätzlichen "
 "unterstützten Kollektormodi."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -78017,11 +79014,11 @@ msgstr ""
 "fehlschlägt `cargo-test`; auch kann nicht ruhig gehen, während diese Seite "
 "hält Anspruch auf die alte Sache."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Validierung und CI-Behörde"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -78033,37 +79030,37 @@ msgstr ""
 "tiers.md`; die Ebenenrichtlinie ist `scripts/ci_plan.py`). Die GC-"
 "spezifische Abdeckung wird bewusst aufgeteilt:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "wo es läuft"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "erforderlicher Status"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 "root-holder-Gewahrsam, GC-Knob Drift, und diese Seite path/number Ansprüche"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "Ja (über `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "Laufzeiteinheit Suite und `run_memory_stability_tests.sh` Vier-Modus-Matrix"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -78071,7 +79068,7 @@ msgstr ""
 "ja (über `pr-gate`; die PR-Ebene ist diff-scoped, die sweep/full-Ebenen "
 "laufen den Arbeitsbereich)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -78079,25 +79076,25 @@ msgstr ""
 "GC × Darstellungs-Auswahl-Matrix, Rooting-Bug-Instrumente, Schreib-Barriere-"
 "Stress"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "ja (über `pr-gate`; PR-Teilmenge auf PRs, volle Matrix im Sweep)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "emittierte Root-Dominanz, einschließlich nativer Statepoint IR"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -78105,27 +79102,27 @@ msgstr ""
 "nicht verzweigt erforderlich; PR-Arm Opt-in über `run-extended-tests`, sechs "
 "Stunden lang auf `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "gepinnter Kollektor counters/RSS/wall Matrix"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "thread-local mechanism/policy Budget"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Nützliche lokale Vorflugbefehle:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -78135,11 +79132,11 @@ msgstr ""
 "Compiler- und Host-Anforderungen; ihre Workflow-Dateien sind die Autorität "
 "für exakte Befehle und Relevanzfilter."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Historische Beweise"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -78147,7 +79144,7 @@ msgstr ""
 "[Generationenplan für GC](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): Originalentwurf und Phasen-für-Phasen-Landebuch."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -78157,7 +79154,7 @@ msgstr ""
 "statepoint-gc-experiment.md): chronologische Prototypenmessungen und "
 "Korrekturen, die zum nativen Standard führen."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -78166,7 +79163,7 @@ msgstr ""
 "Soundness-Regel, Checker-Modi, bekannte Blind-Spots und Debugging-"
 "Instrumente."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -78498,7 +79495,8 @@ msgstr ""
 "nicht die Korrektur, war jedes Mal der Preis."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "Die fünf Wege, die es tatsächlich gebrochen hat"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -78660,14 +79658,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` in `gc/mod.rs` in der gleichen Commit."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Wie Sie Ihre Arbeit überprüfen"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. Der statische Checker — führen Sie diesen"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -78678,7 +79717,7 @@ msgstr ""
 "einzige Instrument, das einen Defekt sieht, bevor er abstürzt, weshalb es "
 "zuerst läuft."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -78686,7 +79725,7 @@ msgstr ""
 "**Es ist blind für drei Klassen, alle fanden den harten Weg. Ein sauberer "
 "Bericht ist kein Beweis für einen von ihnen:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -78695,7 +79734,7 @@ msgstr ""
 "und kann keine Laufzeitzelle sehen. Sagen Sie: fehlschlägt 10/10 eher als "
 "intermittierend."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -78705,7 +79744,7 @@ msgstr ""
 "`0 violations` auf beiden Seiten eines echten Bugs, dessen Fix ein "
 "einzeiliges `GcSuppressScope` im `globalThis` Bootstrap war."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -78724,7 +79763,7 @@ msgstr ""
 "diese setzt gegen, was Codegen tatsächlich emittiert, die Art und Weise "
 "#7227 Audits `ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -78735,7 +79774,7 @@ msgstr ""
 "Arbeitsbelastung — #7280 zeichnet 25 kuratierte Corpus-Dateien auf, die "
 "passieren, während 20 Zeilen Stock zod fehlschlagen."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -78753,31 +79792,15 @@ msgstr ""
 "Aussage über eine Senkung, die seit #7370 auf keinem begehbaren Frame-Ziel "
 "voreingestellt ist. **Beides ausführen**, und wissen, welche Sie lief:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr ""
 "# SHADOW (PERRY_RS4GC=0): immer noch die Senkung auf arm64_32 watchOS und "
 "ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr ""
-"# NATIVE (PERRY_RS4GC=1): die Standardeinstellung überall sonst. Anker an"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` Root Allocas und LLVM fügt die sicheren Punkte später, "
-"so dass die"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -78788,11 +79811,11 @@ msgstr ""
 "fehlschlägt, und der Schattenkorpus hat Null-Safepoints, so dass `--min-"
 "statepoints` dort fehlschlägt."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Was `--statepoints` überprüft und wie es sich unterscheidet"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -78804,7 +79827,7 @@ msgstr ""
 "Identität unterhalb des sicheren Punktes ist das `gc.relocate` Ergebnis. So "
 "\"muss der Wurzelspeicher jeden späteren Sammelpunkt beherrschen\" wird:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -78812,7 +79835,7 @@ msgstr ""
 "Kein Register, das ein GC-Objekt benannt, darf unterhalb eines sicheren "
 "Punktes ANGEWENDET werden, es sei denn, es ist der verschobene Wert."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -78826,23 +79849,23 @@ msgstr ""
 "NaN-Boxen, so dass ein JSValue den größten Teil seines Lebens als `double` "
 "verbringt. Zwei Urteilsklassen, weil sie zwei verschiedene Korrekturen haben:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -78850,15 +79873,15 @@ msgstr ""
 "kein `ptr addrspace(1)`-Wert in der Cast-Kette des Registers ist im Live-"
 "Bundle des Safepoints. Nichts markiert oder schreibt das Objekt um."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "Wurzel es"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -78866,11 +79889,11 @@ msgstr ""
 "das Objekt IST im Bundle und wird verschoben, aber eine rohe Kopie seiner "
 "Pre-Move-Adresse wird unten verwendet"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "Re-Derivat aus dem verschobenen Wert (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -78887,7 +79910,7 @@ msgstr ""
 "Callee**`--moving-only` klassiert sich also eher gegen das reale Symbol als "
 "gegen `llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -78912,15 +79935,15 @@ msgstr ""
 "Sammeln, so dass eine Lücke in seinem Modell einen falsch positiven, nie "
 "verpassten Fehler kostet."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Für eine einzelne Datei iterieren Sie auf:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "Beide Env-Knöpfe sind aus unterschiedlichen Gründen wichtig."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -78936,7 +79959,7 @@ msgstr ""
 "zwei Punkten eines sonst inerten Schleifenkörpers benötigt, kann also nicht "
 "ohne ihn im Korpus erscheinen."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -78958,7 +79981,7 @@ msgstr ""
 "wie `js_object_set_field_by_name`, `js_object_get_field_ic_miss` und "
 "`js_closure_call1`. Die bewegen sich ohne Umfragen in ihrer Nähe."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -78966,14 +79989,14 @@ msgstr ""
 "Also: Schalten Sie den Knopf ein, denn er erweitert, was der Korpus "
 "ausdrücken kann, aber lesen Sie keine pollefreie Funktion als sicher."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` ist durch EXACT emittiertes Symbol, und das hat "
 "zweimal gebissen"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -78985,7 +80008,8 @@ msgstr ""
 "sieht genau wie Abdeckung während es tut. Zwei Runden davon wurden nun "
 "gemessen:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -78996,7 +80020,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -79013,7 +80037,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` bei zod `clone` Fehler. Der Beschützer "
 "und der Checker waren anderer Meinung; der Checker war falsch."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -79036,7 +80060,7 @@ msgstr ""
 "`js_closure_callN`, die `RECEIVER_SINKS` in der gleichen Datei bereits "
 "richtig geschrieben."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -79057,60 +80081,60 @@ msgstr ""
 "Modus CI läuft. Umsetzen des genauen Codes und Ausführung jedes Modus "
 "(#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (Beherrschung)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (die Senkung, die Schiffe)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (unfiltert)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (unfiltert)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -79122,7 +80146,7 @@ msgstr ""
 "für die Verschiffung Senkung. Der eine Name nimmt die sabotierten Arme auf "
 "13 und 8 und hinterlässt die sauberen Arme auf 2 und 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -79152,7 +80176,7 @@ msgstr ""
 "kann, fügen Sie ihn in der gleichen Commit zu `POLL_CAPABLE_RUNTIME` "
 "hinzu.** Nichts wird dich darum bitten."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -79162,7 +80186,7 @@ msgstr ""
 "ist das Tor für Runde 3; Runde 4 hat kein Tor. `gc-root-dominance.yml` läuft "
 "beides neben `--audit-alloc-re` vor dem Build."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -79189,7 +80213,7 @@ msgstr ""
 "Codegen emittiert tatsächlich anstatt es zu löschen — Löschen dreht das "
 "Audit grün und verlässt das Loch."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -79220,21 +80244,17 @@ msgstr ""
 "Kommentare und Zeichenketten wörtliche werden zuerst entfernt, so dass ein "
 "Name in Prosa erwähnt kann nicht eine Prämisse werden."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "Einen _plausible_-Namen zu überprüfen, reicht nicht aus. Bestätigen Sie "
 "gegen emittierte IR:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -79242,7 +80262,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` macht jeden Wurzelspeicher den "
 "`js_shadow_slot_bind` Aufruf als Checker-Anker an."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -79259,7 +80279,7 @@ msgstr ""
 "wird, so dass die Fälle 3 und 4 nur Oberfläche sind, wenn Sie diesen Modus "
 "von Hand ausführen."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -79275,7 +80295,7 @@ msgstr ""
 "von Binds startet, ruft die Funktion sauber. Er fand `lower_call/new.rs`s "
 "Inline-Ctor `this_slot` unabhängig von jeder Laufzeitsonde."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -79293,15 +80313,15 @@ msgstr ""
 "`Symbol` lokal keinen Schatten-Slot überhaupt bekam. Führen Sie es von Hand, "
 "wenn Sie eine `alloca_entry`-Website berühren:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. Die Laufzeitinstrumente — zweitens, und bedenken Sie die Tiefe"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Von #7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -79316,7 +80336,7 @@ msgstr ""
 "buchstäblichen Every-Poll-Modus hinzu, wenn das Fenster, das Sie jagen, nur "
 "einmal ausgeführt wird – es ist viel langsamer."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -79324,11 +80344,12 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` aus dem Weltraum nach der "
 "Evakuierung so eine alte Lesefehler sofort statt des Lesens plausible Müll."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT` — läuft jetzt tatsächlich."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -79336,7 +80357,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -79353,7 +80374,7 @@ msgstr ""
 "sich aufrüsten kann. `scripts/gc_schedule_fuzz.sh <binary> [seed-count]` "
 "fegt Samen und druckt pro Fehler einen reproduzieren Befehl."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -79368,7 +80389,7 @@ msgstr ""
 "Sammlungen Feuer ist der einzige billige Weg, um den Raum zu erkunden, in "
 "dem der Bug tatsächlich lebt."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -79381,7 +80402,7 @@ msgstr ""
 "Zeiger ist in der Zeit, es wird dereferenziert. **Benutze 800.** Ein "
 "sauberer Lauf in der Standardtiefe bedeutet nichts."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -79411,7 +80432,7 @@ msgstr ""
 "einverstanden ist, schauen Sie zuerst auf den Checker. So wurde die Zod "
 "`clone` Uneinigkeit beigelegt."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -79423,7 +80444,7 @@ msgstr ""
 "normalerweise nicht der Rahmen ist, der das Register besitzt — der Wert "
 "kommt gewöhnlich als Argument von einem Anrufer, der ihn abstreift."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -79435,11 +80456,11 @@ msgstr ""
 "Moment für jede Laufzeit Sonde zu bemerken. Diese Instrumente fangen die "
 "_consequence_, später. Der statische Checker fängt den _cause_, jetzt."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "Das Spiegelbild: eine fehlende Schreibbarriere (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -79451,43 +80472,43 @@ msgstr ""
 "Die beiden sind Duale, und — das ist der Teil, der die Menschen immer wieder "
 "fängt — **ihre Detektoren werden ausgetauscht**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "Rooting Bug"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted Schreibschranke"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "was schief geht"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "ein Live-Wert ist für den Root-Scan unsichtbar"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "ein alter→junger Rand fehlt aus dem erinnerten Set"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "wenn es schief geht"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "in der Sammlung, still"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "gar nicht im Laden; bei einigen _später_-Moll"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "der Detektor"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -79497,30 +80518,30 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE`) sowie die statische Kontrolle für die IR-"
 "sichtbare Hälfte"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **statische IR-Anweisung**, und sonst nichts"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "der blinde Fleck"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "der statische Prüfer kann keinen runtime-side-Cache eines Heap-Pointers "
 "sehen (siehe §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**jede Laufzeitsonde, die wir haben**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "Warum es keine Laufzeitsonde sehen kann"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -79535,19 +80556,19 @@ msgstr ""
 "beobachtbaren Fehler zu verwandeln, braucht eine Konjunktion, die das "
 "Programm alleine liefern muss:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "der Elternteil muss in altes Gen überleben (oder gehalten werden) **Vorher** "
 "das Lager;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr ""
 "das Kind muss noch im Kinderzimmer sein **bei der nächsten Minderjährigen**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -79555,7 +80576,7 @@ msgstr ""
 "a **Klein** die Sammlung — nicht ein voller Mark-Sweep, der alles und Papier "
 "über die ganze Klasse nachverfolgt — muss in diesem Fenster landen; und"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -79563,7 +80584,7 @@ msgstr ""
 "Diese Kante muss der _only_ Pfad zum Kind sein, oder eine andere Wurzel "
 "findet sie sowieso und die Sammlung ist sauber."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -79571,7 +80592,7 @@ msgstr ""
 "Vermissen Sie jede und die Minor sammelt korrekt, das Programm druckt die "
 "richtige Antwort, und die Sonde berichtet Erfolg. Es wurde nichts versucht."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -79581,7 +80602,7 @@ msgstr ""
 "auf eine andere Eigenschaft völlig gerichtet, und es ist leicht, ihr Grün "
 "als Beweis zu lesen:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -79595,7 +80616,7 @@ msgstr ""
 "Slot, den es nicht neu zu schreiben vermochte. Erinnern und Neuschreiben "
 "sind verschiedene Eigenschaften, und der Prüfer fragt nur nach der zweiten."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -79607,7 +80628,7 @@ msgstr ""
 "sichtbar; es macht den Fehler unerreichbar. Ein grüner Lauf hier ist der "
 "stärkste und leerste Beweis für die drei."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -79619,7 +80640,7 @@ msgstr ""
 "auf der Wurzelseite der Dualität. Sie sind schuld an einem baumelnden "
 "Raumzeiger, nicht an einem lebenden Objekt, das nie verfolgt wurde."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -79634,7 +80655,7 @@ msgstr ""
 "oben. Jeder Name in diesem Dokument ist einer, den das Tor einem Live-Parser-"
 "Eigenen bestätigt hat."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -79646,7 +80667,7 @@ msgstr ""
 "durch das Programm beobachtet werden.** Es gibt keine Ausführung, in der "
 "\"die Barriere nicht lief\" ein unterscheidendes Ereignis ist."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -79666,13 +80687,13 @@ msgstr ""
 "Ausgang, Ausgang 0**, sowohl auf eine Lücke und eine größere gegnerische "
 "ein. Der statische IR-Test war das Einzige, das nein gesagt hat."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr ""
 "Was eine PR, die einen Speicher auf einem GC-Slot hinzufügt oder bewegt, "
 "schuldet"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -79682,7 +80703,7 @@ msgstr ""
 "Verhaltenstest. Vier Dinge, die sie anheften muss, weil eine Sabotage, die "
 "sie übersprungen hat, nicht erwischt wurde:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -79692,7 +80713,7 @@ msgstr ""
 "Schreibbarriere, die Layout-Note und die Zeichenfolge addref. Jede der drei "
 "vermissten Personen ist die Familie #5094 / #7511, die still strandet."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -79706,7 +80727,7 @@ msgstr ""
 "IR** dass jede inhaltliche Behauptung glücklich inspiziert, und zunächst "
 "bestanden. Die Anwesenheit von Code ist kein Beweis, dass es läuft."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -79717,7 +80738,7 @@ msgstr ""
 "Diskriminator aufgehört hat, zu unterscheiden, und die \"Optimierung\" misst "
 "nichts."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -79727,9 +80748,10 @@ msgstr ""
 "aufzeichnen, dass der Test rot wird. Ein Test, der nie fehlgeschlagen ist, "
 "ist ein Test, dessen Ausfallmodus unbekannt ist."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -79746,36 +80768,25 @@ msgstr ""
 "class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` und "
 "`write_pic_barrier_tests.rs` sind die Form."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "Der `GC_STORE_AUDIT` Marker, und was er tut und nicht beweist"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Jeder rohe GC-relevante Laden ist mit einem nahegelegenen Marker versehen, "
 "der sein Urteil nennt:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// GC_STORE_AUDIT(BARRIERED): der Slot-Schreiben ist bedingungslos; die "
-"Barriere"
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr ""
-"// unten wird nur durch einen Live-Test bewacht, dass die gespeicherten Bits "
-"keinen Haufen tragen"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// Zeiger, der der erste Test der Barriere ist."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -79788,7 +80799,7 @@ msgstr ""
 "hat — so ein **neu** Lagerplatz kann nicht mit der Frage unbeantwortet "
 "landen."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -79797,7 +80808,7 @@ msgstr ""
 "nicht nur der Kommentar, für die beiden Klassen, wo ein falscher Anspruch "
 "strandet:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -79839,7 +80850,7 @@ msgstr ""
 "Sie den Anruf aus seinem Block, umgehen Sie das Tor) laufen in der Suite "
 "gegen jeden Stamm."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -79866,7 +80877,7 @@ msgstr ""
 "Barrierespeicher und ein Barriereaufruf in derselben Funktion passieren "
 "immer noch), und das Skript druckt das Limit."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -79890,11 +80901,11 @@ msgstr ""
 "und seine `--self-test`-Pflanzen fünfzehn Formen, von denen jede zu "
 "entscheiden ist."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "Das Korpusproblem und die beiden Korpora (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -79903,7 +80914,7 @@ msgstr ""
 "Abhängigkeitsskala nicht ausdrücken, und für eine Weile konnte niemand "
 "erkennen, weil es grün war.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -79918,7 +80929,7 @@ msgstr ""
 "verschuldet wurden. #7280 setzt es in einen Satz: _25 kuratierte Dateien "
 "passieren, während 20 Zeilen des Vorrats zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -79926,39 +80937,39 @@ msgstr ""
 "Das ist kein Größenproblem. Beide Corpora wurden auf demselben Compiler mit "
 "`--stale-registers --moving-only` gemessen:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "Verwendungen"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "was dominiert"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "kuratiert, 124 Quellen / 144 Module"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "property-GET-Helferfenster, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "Abhängigkeitsskala, 81 Module / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -79966,7 +80977,7 @@ msgstr ""
 "`js_object_assign_one` (Objektausbreitung) 137, `js_new_function_construct` "
 "102, `js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -79983,7 +80994,7 @@ msgstr ""
 "so kann ein Korpus ohne die Formen sie nicht ausdrücken, wie viele Dateien "
 "es hat."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -79991,11 +81002,12 @@ msgstr ""
 "Es gibt also einen zweiten Korpus, der aus einer echten npm-Abhängigkeit "
 "erzeugt wird, anstatt von etwas, das für den Anlass geschrieben wurde:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod ist ein package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -80010,7 +81022,7 @@ msgstr ""
 "kann, da ~90 Module von `zod` Sumpf jeder Zählung eine fehlende 40-Linien-"
 "Quelle würde kreuzen."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -80022,11 +81034,11 @@ msgstr ""
 "linear in der Unterrichtszahl sind. Das `--stale-registers` Budget ist das "
 "teure (~5 min): sein Scan ist superlinear und 62 MB ist 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "Das CI-Tor"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -80038,19 +81050,19 @@ msgstr ""
 "Compiler Build; die beiden gated Checks sind etwa drei Sekunden pro über "
 "~2000 und ~12900 Funktionen."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "Es ist gebaut, um scheitern zu können, gegen alle vier Gefahren in CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "der Status des Checkers ist der des Jobs — kein `continue-on-error`, kein "
 "Rohr;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -80058,7 +81070,7 @@ msgstr ""
 "`concurrency` storniert Pull-Request läuft nur, so dass `main` läuft nie "
 "ausgehungert werden;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -80069,7 +81081,7 @@ msgstr ""
 "druckt `checked N functions / M modules`, so dass ein still-leerer Lauf "
 "sichtbar ist;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -80082,7 +81094,7 @@ msgstr ""
 "Arm, der den Prüfer gefangen hat, ohne dabei die Fähigkeit zu verlieren, "
 "Perrys Ausgang zu lesen;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -80098,11 +81110,11 @@ msgstr ""
 "und sofortige sind und beide tote Einträge versendet haben: neun in "
 "`ALLOC_RE` über zwei Runden, zehn in `POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "Die Erlaubensliste, und warum es keine Zahl ist"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -80112,7 +81124,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, einem Eintrag mit einem Fingerabdruck, "
 "einem Problem und einer schriftlichen Begründung."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -80125,11 +81137,11 @@ msgstr ""
 "billigste Weg zu grün ein roter Bau ist, um die Zahl um einen zu erhöhen, "
 "und nichts in der Differenz sagt, was zugegeben wurde."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Der Checker erzwungen also drei Eigenschaften:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -80140,7 +81152,7 @@ msgstr ""
 "Ratsche, und deshalb kann ein fester Käfer keinen Grabstein verlassen, der "
 "die Abdeckung später leise erweitert."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -80148,14 +81160,14 @@ msgstr ""
 "**ein Eintrag unterdrückt höchstens seine `count`.** Eine zweite Verletzung "
 "derselben Form in derselben Funktion ist neu und scheitert."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**ein Verstoß ohne Eintrag fehlschlägt**, unabhängig davon, wie viele "
 "Einträge existieren."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -80163,11 +81175,11 @@ msgstr ""
 "Ein Eintrag hinzuzufügen ist ein Code-Review-Ereignis. Ein `count` zu grün "
 "zu blasen ist genau das, was diese Datei zu verhindern existiert."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Förderung dieses Tors"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -80176,11 +81188,11 @@ msgstr ""
 "erforderlichen Statusprüfungen des Branch-Schutzes**, er kann einen Merge "
 "also nicht fehlschlagen lassen — Risiko 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Beide Bedingungen #7198 sind nun erfüllt:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -80190,7 +81202,7 @@ msgstr ""
 "Allowlist (die #7211-Einträge wurden gelöscht, wenn das Prädikat in \\#7226 "
 "festgelegt wurde);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -80200,7 +81212,7 @@ msgstr ""
 "Arbeit (#7236). Das war die herausragende: es war 98 vor #7235, 2 nach, und "
 "0 einmal `Type::Symbol` nicht mehr als sofortige eingestuft."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -80208,7 +81220,7 @@ msgstr ""
 "Der verbleibende Schritt ist also für eine **Verwaltungsrätin** um `gc-root-"
 "dominance` zu den erforderlichen Kontexten des Zweigschutzes hinzuzufügen:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -80222,7 +81234,7 @@ msgstr ""
 "Schritt enthalten - ein Tor, das noch nie grün in seiner aktuellen Form "
 "Blöcke jeder offenen PR am Tag, an dem es erforderlich ist."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -80245,11 +81257,11 @@ msgstr ""
 "Sie es, wie die Bevölkerung festgelegt ist; eine Förderung, die das Budget, "
 "wo es ist, einfriert hat eine Zahl gekauft, nicht eine invariant."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Faustregeln"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -80264,7 +81276,7 @@ msgstr ""
 "Initialisierern, nie über die selbst emittierten "
 "`js_object_set_field_by_name`-Aufrufe der Absenkung."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -80273,7 +81285,7 @@ msgstr ""
 "niemals eine Last aus einem Root-Slot über einen Anruf. `rooted_handle_get` "
 "existiert dafür."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -80283,7 +81295,7 @@ msgstr ""
 "oder mehr Operanden, bei denen sich eine vor der anderen niederschlägt, "
 "benötigt die erste verwurzelt."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -80291,7 +81303,7 @@ msgstr ""
 "**`--trace llvm` und lesen Sie es.** Drei Sekunden des Checkers schlägt "
 "einen Tag, an dem ein `not a function` fünf Zyklen stromabwärts bisecting."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -80555,6 +81567,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Führen Sie es lokal mit:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Compile-Zeit-Validierung"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "Benutzer wählt Backend pro Workload"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -81015,7 +82196,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: String -- der Registername, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -81054,38 +82236,36 @@ msgid "Three types and one rule."
 msgstr "Drei Typen und eine Regel."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 "/// Ein Register mit einem GC-gemanagten Wert, der NICHT verwurzelt ist."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr ""
-"/// Leiht den Emitter unveränderlich aus. Nicht Klonen, nicht Kopieren."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Eine Schatten-Slot Wurzel. Lebt Sammelpunkte aus; kann nicht direkt "
 "gelesen werden."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// nur erhältlich bei ShadowFrame::alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 "/// Ein Register, das etwas hält, das der GC nicht verwaltet: i32, double, "
 "bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// einen Slot-Index. Frei klonbar, kein Leben, keine Leihe des Emitters."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -81096,28 +82276,33 @@ msgstr ""
 "sammeln können**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "/// kann nicht sammeln. Nehmen & sich, so herausragende `Raw` Griffe bleiben "
 "gültig."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// KANN sammeln. Nimmt &mut selbst, das endet jede herausragende `Raw` "
 "leihen."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// Lesen Sie den Steckplatz erneut. Der zurückgegebene Raw ist gültig, bis "
 "der nächste &mut emittiert."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 "/// Dieses Register in eine Wurzel aufnehmen. Der einzige Weg, einen "
 "Wurzeligen zu machen."
@@ -81137,24 +82322,22 @@ msgstr ""
 "Sammelpunkt verwendet werden** — der Compiler lehnt sie ab."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw <'_>, leiht e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// benötigt &mut e"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERROR: Obj borgt e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// die mutabel ist"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// oben ausgeliehen"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -81163,7 +82346,8 @@ msgstr ""
 "Der Fix ist der richtige Code, und es ist der kürzeste Weg aus dem Fehler:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// neu lesen, richtig"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -81808,8 +82992,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**Die Fluchtluke**, solange jeder Anrufer es verwendet."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -83468,11 +84653,15 @@ msgstr ""
 "`node_modules`-Baum der Baumaschine."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Dieses Sidecar-Modell hat kein Erst-Run-Write, daher werden nur "
 "schreibgeschützte Installationsverzeichnisse unterstützt. Das Verschieben "
@@ -83480,7 +84669,21 @@ msgstr ""
 "Schwinglings. Fehlende oder hash-mismatched Dateien scheitern vor `dlopen` "
 "mit einem Verpackungsfehler."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -83497,7 +84700,7 @@ msgstr ""
 "einem Archiv. Perry entfernt Quarantäne-Attribute nicht von nicht "
 "vertrauenswürdigen heruntergeladenen Binärdateien zur Laufzeit."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -83516,11 +84719,11 @@ msgstr ""
 "verhindert gleichzeitig, dass eine Host-`.node`-Datei ein Zielartefakt "
 "eingibt."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Identität des Caches"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -83528,31 +84731,31 @@ msgstr ""
 "Das Compil-Time-Addon-Manifest ist deterministisch sortiert und trägt zum "
 "Aufbau und zur Verknüpfung von Cache-Identitäten bei:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "Richtlinienschema-Version und Node-API-Version;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "Zieltupel und normalisierte Allowlist;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "ausgewähltes Paket name/version und relativer Eintragspfad;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 und Größe jeder Seitenwagen Nutzlastdatei;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "bestelltes Ausfuhr-Symbol-Inventar;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "Versandmodell (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -83567,11 +84770,11 @@ msgstr ""
 "build cache vermissen, auch wenn alle TypeScript- und Objektdateien "
 "unverändert sind."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -83590,22 +84793,15 @@ msgstr ""
 "binäre Auflösung erforderlich, aber es deterministisch berichtet die "
 "angegebene nicht unterstützte Einrichtung."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: Kern durch Version 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Eingangspunkte"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -83613,49 +84809,56 @@ msgstr "Eingangspunkte"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Stabile Lagerung pro Umwelt"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "Singleton-Werte erhalten gewöhnliche Scope-Handles"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Perry object/array Allokatoren"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -83663,11 +84866,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN-Box-Konvertierungen"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -83675,37 +84878,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Längengebunden; `NAPI_AUTO_LENGTH` unterstützt"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "Native Callbacks verwenden Host-Datensätze"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` wird bei Lieferung installiert"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "Einschließlich Funktion, externe, Symbol und große Unterscheidungen"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -83713,11 +84916,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Kontrolliertes type/status-Verhalten"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -83725,11 +84928,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "Abfrage-Länge und NUL-Terminationssemantik enthalten"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -83737,19 +84940,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "Benutzercode ist ausnahmslos"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Allgemeine Objektsemantik"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -83757,11 +84960,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "Zeichenkette, Symbol und numerische Tasten"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -83769,11 +84972,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "UTF-8-Bezeichnungen"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -83781,43 +84984,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Arrays und exotische indexierte Objekte"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Daten, Methode und Accessor Deskriptoren"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Keine Verknüpfung von Zeiger-Identität"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "Allgemeines Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "Callback-info-Lebensdauer ist der native Anruf"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -83825,11 +85028,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Native Objekt Metadaten Tabelle"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -83837,11 +85040,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Starkes und schwaches Referenzdesign oben"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -83851,11 +85054,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Strenge Nist- und Erzeugungsvalidierung"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -83863,19 +85066,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Ausstehendes Losmodell"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Noch nicht verfügbar"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -83883,37 +85086,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Stabile Rückwärtszeiger"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Alle elf deklarierten Typen von Mustern"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Backing Identität und Offsets erhalten"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Gibt 8 zurück"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -83921,19 +85124,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "Deferred Records sind umwelteigene Wurzeln"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -83941,40 +85144,40 @@ msgstr ""
 "Gibt `napi_generic_failure` zurück; willkürliche Ausführung der "
 "Laufzeitquelle würde das Modell der No-Runtime-Engine verletzen"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Berechnung des Drucks des Kollektors"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: Versionen 5 bis 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "Nach der GC-Abschlussprüfung angelaufen"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -83982,11 +85185,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Willkürliche Präzision"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -83994,23 +85197,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "Exaktes `lossless`- und Wortzählverhalten"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "Sammlungsmodus, Filter und Schlüsselkonvertierung ausgezeichnet"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -84018,46 +85221,46 @@ msgstr ""
 "Ein Datensatz pro Umgebung; Ersatz überschreibt, ohne den vorherigen "
 "Finalizer zu rufen"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Bestehende Ablösungspropaganda"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "128-Bit-Tag in Objekt-Metadaten"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Maschinen und Apparate zum Beschreiben von Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: Version 9, Version 10 und experimentelle"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -84065,16 +85268,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "Werbung nur mit einer kompletten Version-9 Oberfläche"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -84082,11 +85285,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Benötigt externe Zeichenkette lifetime/accounting Arbeit"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -84094,29 +85297,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "Alias für Fast-Pfad-Version-10"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "Nicht Teil der ausgeschriebenen stabilen ABI"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -84124,33 +85327,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Vermächtnis-Registrierung und Weg abbrechen"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Bestehende Integration von async-hooks"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -84158,11 +85361,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` Identität und stabile Bytes"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -84170,15 +85373,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Explizite Zustandsmaschine oben"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -84186,17 +85389,17 @@ msgstr ""
 "Gibt die Semver-Komponenten von Perry mit dem Release-String `perry` zurück; "
 "es beansprucht keine Node-Version"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "Gibt `napi_generic_failure` und eine Nullschleife zurück; Perry hat keine "
 "Libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -84204,19 +85407,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Lebenszyklus mit Hauptthread"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Async-Kontext und strenges Nesten"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -84224,11 +85427,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "Event-Pumpen-gestütztes TSFN"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -84236,35 +85439,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Thread Count und Event-Loop keepalive"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "Shutdown wartet auf Fertigstellung"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "Umwelt erfasst bereits den zukünftigen Wert"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Werbung mit Version 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -84274,18 +85477,18 @@ msgstr ""
 "und `napi_register_module_v1`; diese werden im Addon nachgeschaut und sind "
 "keine Host-Exporte."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Erforderliche Tore"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "Die Implementierung ist erst abgeschlossen, wenn die folgenden Tore "
 "selbstständig ausfallen können:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -84298,7 +85501,7 @@ msgstr ""
 "Validierung der Ausfallgeneration; die Root-Inhaber und Rekey-Table-Audit-"
 "Skripte sind sauber."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -84309,7 +85512,7 @@ msgstr ""
 "ein Instrumentiertes Addon behauptet, dass kein Abschalten in seine Frames "
 "eintritt."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -84319,7 +85522,7 @@ msgstr ""
 "Funktion auf und der Test beweist, dass die Adresse zum ausführbaren Perry "
 "gehört. Die Rauchrufzahl muss größer als Null sein."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -84331,7 +85534,7 @@ msgstr ""
 "und Puffer ab. Nicht unterstützte NAPI-Versionen, NAN/V8 und `uv_*`-Fesseln "
 "behaupten ihre exakte Diagnose."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -84342,7 +85545,7 @@ msgstr ""
 "zusammengeschmolzene Ströme; beide Seiten behaupten, dass ihre native "
 "Umsetzung tatsächlich lief."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -84353,7 +85556,7 @@ msgstr ""
 "oder die Mutation eines Sidecars schlägt die manifestierte Hash-Kontrolle "
 "fehl."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -84361,7 +85564,7 @@ msgstr ""
 "**Cache-Tor:** Nur Addon Bytes oder Police zu ändern verpasst den Build-"
 "Cache; der Wiederaufbau unveränderter Eingaben trifft ihn."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -84370,7 +85573,7 @@ msgstr ""
 "Graph; melden Sie das Host-Only-Delta für einen Addon-Build und erzwingen "
 "Sie das 0.6 MB Budget."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -84940,28 +86143,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "Verwenden Sie explizite Befehle für breitere Bereiche:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Produkt feedback Schleife"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Jedes Host-kompatible Workspace-Mitglied (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$Paket\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Die Workspace-Architektur überprüfen oder validieren"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -85114,7 +86303,8 @@ msgstr ""
 "no-default-features` das textual-IR-Backend aufbauen."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# Bauen Sie das Standardprodukt und seinen Abhängigkeitsverschluss"
 
 #: src/contributing/building.md:37
@@ -85238,7 +86428,8 @@ msgstr ""
 "Ihrer Benutzerumgebung, dann führen Sie Cargo durch den Wrapper:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# Schlanker, optimierter Entwickler CLI"
 
 #: src/contributing/building.md:80
@@ -85272,26 +86463,31 @@ msgid "Build Specific Crates"
 msgstr "Spezifische Crates bauen"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# Nur Laufzeit (muss auch stdlib neu aufbauen!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Die .a statischen Archive werden durch separate Wrapperkisten (#5422) "
 "emittiert, so dass ein"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# explizit, wenn Sie libperry_runtime.a / libperry_stdlib.a benötigen (e.g. "
 "zum Verlinken"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Nur Codegen"
 
 #: src/contributing/building.md:106
@@ -85338,17 +86534,21 @@ msgid "Run Tests"
 msgstr "Tests ausführen"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Produkt Einzelziele"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Prüfen Sie den nächtlichen CI-Testbereich (alle Linux-kompatiblen "
 "Testkisten)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Spezifische Kiste"
 
 #: src/contributing/building.md:137
@@ -85356,11 +86556,13 @@ msgid "Compile and Run TypeScript"
 msgstr "TypeScript kompilieren und ausführen"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Eine TypeScript-Datei kompilieren"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Debug: HIR drucken"
 
 #: src/contributing/building.md:148
@@ -85428,19 +86630,23 @@ msgstr ""
 "oder eine öffentliche Registrierungs-Shasum unterscheidet."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Bestätigen Sie, dass die Kasse aktuell und sauber ist."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# muss drucken 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# darf nichts drucken"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Schnelle Richtlinien und Skriptprüfungen."
 
 #: src/contributing/releasing.md:23
@@ -85448,7 +86654,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Host-übertragbare Verhaltenskontrollen. Diese verbessern den Turnaround, "
 "aber nicht"
@@ -85475,7 +86683,8 @@ msgstr ""
 "durch den normalen Merge-Prozess."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Ersetzen Sie die Version bereits in Cargo.toml vorhanden."
 
 #: src/contributing/releasing.md:48
@@ -85495,7 +86704,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # darf nichts drucken"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -85603,9 +86813,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "zulässige Maßnahmen: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -85638,22 +86849,15 @@ msgstr ""
 "lehnt einen Teilsatz absichtlich ab."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# ein Release-Paket läuft: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # publizieren + alle 9 über OIDC überprüfen, "
-"dann erstellen"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + die letzte GitHub Version"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# inspizieren Sie den commit/run/package/Socket Empfang"
 
 #: src/contributing/releasing.md:128
@@ -85873,11 +87077,13 @@ msgstr ""
 "überprüfen:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# Kompilieren für den Simulator"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr ""
 "# Booten Sie ein Gerät (einmal; verwenden Sie die UDID über den Lauf hinweg)"
 
@@ -85886,21 +87092,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Installieren + Starten mit Testmodus"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# App beendet 0 nach dem Rendering; Screenshot landet am Zähler-ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -86173,6 +87367,10 @@ msgid "patch distance"
 msgstr "Abstand des Pflasters"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -86207,15 +87405,18 @@ msgstr ""
 "und Stelle; es schließt sich, sobald die Registry aufgeholt hat."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# beweist, dass es fehlschlagen kann"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# echte Registrierung, kein Problem schreibt"
 
 #: src/contributing/releasing.md:289
@@ -86275,6 +87476,374 @@ msgstr ""
 "Verteilungsbeine erneut zu testen, schicken Sie sie mit "
 "`existing_tag=vX.Y.Z`; fügen Sie `publish_npm=true` nur dann hinzu, wenn das "
 "idempotent npm Bein selbst ebenfalls erneut getestet werden muss."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "'pdfium-Render = 0.8'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# Bearbeiten Sie src/lib.rs — fügen Sie Ihre `js_*`-Funktionen hinzu, "
+#~ "alle nur mit"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# src/index.ts bearbeiten — Importe des TS-Benutzercodes angeben"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# package.json bearbeiten — alle js_*-Exporte im"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# - manifestiert sich mit der statischenlib"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# das Gerüst release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr "                                    # baut Vorbauten für alle Ziele"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr ""
+#~ "                                    # und befestigt sie an die Freigabe"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Native Bindungen für <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr ""
+#~ "/// `pdf.parse(buf) -> string` — Text aus einem PDF-Puffer extrahieren."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "Sicherheit"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` muss für `buf_len` Bytes null oder gültig sein. Perry "
+#~ "Durchläufe"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// dieses Paar aus einem `buffer+len` Manifest-Parameter."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr ""
+#~ "// Const-Ergebnis = warten auf spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding und Insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. Arm64-Scheibe (Standard-Geräteziel)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. Minos + Sicherung ausrichten"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"Plattformen;android-35\" \"Build-Tools;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"Systembilder;Android-34;Android-Verkleidung;Arm64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Das Kreuzziel Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Erstellen + Booten eines Wear OS Emulators (runde Uhr)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Zusätzliche npm-Pakete und Node.js-APIs, die von Perry unterstützt "
+#~ "werden. Alle hier aufgeführten sind über Perrys Well-Known-Native-"
+#~ "Bindings-Registry (#466) verdrahtet und kompilieren ohne JavaScript-"
+#~ "Runtime-Beteiligung zu nativem Code."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr ""
+#~ "# 3) Sanity-Check die Signatur lokal vor dem Hochladen des Manifests —"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    hier sagt eine Weitergabe auf den Kunden überprüfen."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Veröffentlichung CI unterzeichnet das CLI Manifest und bindet seine "
+#~ "Archiv URL, Plattform,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// Ziel erkennen: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// Kompilieren: schnelle -emit-library -static -target ... -sdk ... "
+#~ "-framework StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// Link: Fracht:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "„Inhaltstyp: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "'{\"Text\":\"Hallo-Welt\"}'"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "'{\"Wert\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "'{\"Wert\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "'{\"Kurzbefehl\":\"s\"}\""
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Lass es 30 Sekunden laufen"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Statistiken überprüfen"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# \"Laufen\": wahr, \"events_fired\":600, \"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Machen Sie einen Screenshot, um den Endzustand zu sehen"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Chaos stoppen"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Überprüfen Sie die App ist noch am Leben"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Für iOS (kompilierbar)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\"workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "\".Jobs[] | select(.status==\"in_progress\") | (Marken)|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# Wie tief die Warteschlange ist und auf welcher Pools:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "\".Jobs[] | select(.status==\"queued\") | (Marken)|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"Native Bindungen für libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "'libfoo = '1.0'\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Perry Schiffe **zwei unabhängige Opt-in-Kanäle** für das Senden von Daten "
+#~ "nach Hause — nichts verlässt Ihre Maschine ohne eine explizite `enabled = "
+#~ "true` oder `on` in `~/.perry/config.toml`. Beide ehren "
+#~ "`PERRY_NO_TELEMETRY=1` und `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "emittieren Mensch-lesbare Kollektor-Diagnose"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr ""
+#~ "# NATIVE (PERRY_RS4GC=1): die Standardeinstellung überall sonst. Anker an"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` Root Allocas und LLVM fügt die sicheren Punkte "
+#~ "später, so dass die"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): der Slot-Schreiben ist bedingungslos; die "
+#~ "Barriere"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// unten wird nur durch einen Live-Test bewacht, dass die gespeicherten "
+#~ "Bits keinen Haufen tragen"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// Zeiger, der der erste Test der Barriere ist."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr ""
+#~ "/// Leiht den Emitter unveränderlich aus. Nicht Klonen, nicht Kopieren."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// einen Slot-Index. Frei klonbar, kein Leben, keine Leihe des Emitters."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERROR: Obj borgt e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// die mutabel ist"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// oben ausgeliehen"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$Paket\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Die Workspace-Architektur überprüfen oder validieren"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# ein Release-Paket läuft: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # publizieren + alle 9 über OIDC überprüfen, "
+#~ "dann erstellen"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + die letzte GitHub Version"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# App beendet 0 nach dem Rendering; Screenshot landet am Zähler-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -87332,9 +88901,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "`LANG` / `LC_ALL` / `LC_MESSAGES` env-Variablen"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Compile-Zeit-Validierung"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""
 #~ "Perry validiert Parameter über alle Locales während der Kompilierung:"
@@ -87422,18 +88988,6 @@ msgstr ""
 #~ msgstr "Wendet Padding auf bestimmte Kanten an:"
 
 #~ msgid ""
-#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
-#~ "    // Compile: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
-#~ msgstr ""
-#~ "// Target erkennen: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos "
-#~ "SDK\n"
-#~ "    // Kompilieren: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // Linken:    cargo:rustc-link-lib=static=review_bridge\n"
-
-#~ msgid ""
 #~ "Uses [`SKStoreReviewController.requestReview(in:)`](https://"
 #~ "developer.apple.com/documentation/storekit/skstorereviewcontroller/"
 #~ "requestreview(in:)) from StoreKit."
@@ -87447,13 +89001,6 @@ msgstr ""
 
 #~ msgid "`SKStoreReviewController.requestReview()`"
 #~ msgstr "`SKStoreReviewController.requestReview()`"
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# GitHub-Actions-Beispiel\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "Nur Objektdatei erzeugen, Linking überspringen"

--- a/docs/po/es.po
+++ b/docs/po/es.po
@@ -214,7 +214,7 @@ msgstr "Hooks"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Ejemplos"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "Niveles de CI (comprobación de PR / barrido / suite completa)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Programación de comprobaciones de CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "Referencia de la CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Comandos"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Flags del compilador"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Directorio de caché"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Despacho Dinámico de Stdlib"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "Habilitación del Runtime JS"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar de atestación binaria)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Lista de Permitidos de Egress (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Capacidades por Paquete (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Lista de Permitidos del Host (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "Referencia de perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Comprobaciones de actualizaciones en tus aplicaciones"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Privacidad y Telemetría"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Aspectos Internos"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Modelo de Memoria"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Recolector de basura"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Gestión explícita de memoria"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "La invariante de enraizamiento del GC (generación de código)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Evidencia de tipo para bindings locales"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Límites de los pasos del GC incremental"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: enraizamiento por construcción"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Contribuir"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Arquitectura"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Política de crates"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Compilar desde el código fuente"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Publicar una versión de Perry"
 
@@ -932,7 +940,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Abre una ventana nativa macOS/Windows/Linux"
 
 #: src/introduction.md:79
@@ -966,11 +975,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -979,9 +988,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -991,7 +1000,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Próximos pasos"
@@ -1065,27 +1074,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux cadena de herramientas de enlace por distribución:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS Stream"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# Alpino/a base de musgo"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Vacío Linux"
 
 #: src/getting-started/installation.md:41
@@ -1127,15 +1142,18 @@ msgstr ""
 "solo comando:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Proyecto-local (pins de la versión de Perry junto a sus deps)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Cero-instalación, un solo disparo"
 
 #: src/getting-started/installation.md:66
@@ -1334,7 +1352,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "El binario está en `target/release/perry`. Agrégalo a tu PATH:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Añadir a ~/.zshrc o ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1473,16 +1492,14 @@ msgstr ""
 "no las requieren.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2170,24 +2187,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "El mismo código se ejecuta en las 6 plataformas:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (por defecto)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# Simulador iOS"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# Web (compila a WebAssembly + puente DOM en un archivo HTML autónomo)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# alias: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Otras plataformas"
 
 #: src/getting-started/first-app.md:138
@@ -2435,7 +2457,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2453,7 +2475,7 @@ msgstr "\"Perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2680,7 +2702,8 @@ msgstr ""
 "mismo validador como código fuente simple. El script generador:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2712,7 +2735,8 @@ msgid "\"port\""
 msgstr "\"puerto\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// Fuente autónoma"
 
 #: src/getting-started/project-config.md:122
@@ -2959,19 +2983,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Campo"
 
@@ -2986,9 +3011,9 @@ msgstr "Campo"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3112,11 +3137,13 @@ msgstr ""
 "configuración:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3171,7 +3198,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3180,7 +3207,7 @@ msgstr ""
 "de Perry. Consulta [Biblioteca estándar](../stdlib/overview.md) para ver la "
 "lista completa."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3189,48 +3216,51 @@ msgstr ""
 "paquetes puros de TS/JS, o el respaldo del runtime de JavaScript para "
 "paquetes complejos."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Estructura del proyecto"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr ""
 "Perry es flexible respecto a la estructura del proyecto. Patrones comunes:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Para aplicaciones de UI:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Compilación"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Compilar un archivo"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# Compilar con un objetivo específico"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Debug: imprimir representación intermedia"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr ""
 "Consulta [Comandos de CLI](../cli/commands.md) para todas las opciones."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 "[Comandos de CLI](../cli/commands.md) — Todos los comandos y opciones del "
 "compilador"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3238,7 +3268,7 @@ msgstr ""
 "[Características soportadas](../language/supported-features.md) — Qué "
 "características de TypeScript funcionan"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Biblioteca estándar](../stdlib/overview.md) — Paquetes npm soportados"
 
@@ -3378,32 +3408,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Clases"
 
@@ -5455,6 +5486,7 @@ msgstr ""
 "y admite dos rutas:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5464,7 +5496,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Decoradores de clase, de método, de propiedad, de parámetro de constructor "
 "y de parámetro de método heredados** para DI de estilo Nest y canarios de "
@@ -5476,7 +5512,7 @@ msgstr ""
 "emite `design:paramtypes` para clases y métodos decorados y `design:type` "
 "para propiedades decoradas."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5489,15 +5525,15 @@ msgstr ""
 "ninguna maquinaria de decorador en runtime. Véase `crates/perry-hir/src/"
 "decorator_log.rs` para la implementación."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Qué no funciona"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Decoradores de accesores y reemplazo de descriptores"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5513,17 +5549,17 @@ msgstr ""
 "devuelven clases envueltas necesitan un port compatible con Perry: la clase "
 "reducida está fijada en el IR y no puede reemplazarse en runtime."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Llamadas de ayuda generales a `Reflect.metadata(...)` fuera de la sintaxis "
 "de decoradores"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` como clave de metadatos"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5531,7 +5567,7 @@ msgstr ""
 "`emitDecoratorMetadata` más allá de `design:paramtypes` de clase/método y "
 "`design:type` de propiedad"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5541,13 +5577,13 @@ msgstr ""
 "canario de constructor de clase reducido (`tsyringe`, comportamiento "
 "completo del inyector de NestJS, inyector raíz de Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "Flujos de metadatos en tiempo de ejecución de `class-validator`, `type-"
 "graphql`, `TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5557,11 +5593,11 @@ msgstr ""
 "cableado explícito o una transformación AOT dedicada, y no depender del "
 "runtime completo de decoradores TypeScript heredados."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Patrón recomendado: construcción explícita"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5573,7 +5609,7 @@ msgstr ""
 "o Rust compondría servicios, y es como ya funcionan los frameworks de TS sin "
 "decoradores (Hono, servidores tRPC, aplicaciones Drizzle)."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5589,7 +5625,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5599,11 +5635,11 @@ msgstr ""
 "construcción _es_ el grafo de dependencias, y lo verifica el compilador de "
 "TypeScript."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Receta de migración: un servicio de Angular"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5613,19 +5649,19 @@ msgstr ""
 "rating.service.ts`, ~80 líneas), mostrado en su forma original de Angular y "
 "portado a Perry."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Antes — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Después — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Tres cambios mecánicos:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5633,7 +5669,7 @@ msgstr ""
 "**Elimina `@Injectable`.** No aportaba información que la forma de la clase "
 "no aporte ya."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5643,7 +5679,7 @@ msgstr ""
 "de los Observables de HTTP de Angular son de un único valor y se comportan "
 "como Promesas. (Para flujos de varios valores, usa `AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5656,11 +5692,11 @@ msgstr ""
 "claridad cuando la clase se instancia a mano en lugar de mediante un "
 "contenedor."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Cableado"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5680,7 +5716,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5698,7 +5734,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5708,13 +5744,13 @@ msgstr ""
 "'root'`, la búsqueda implícita del contenedor — todo se reduce a una línea "
 "`new RatingService(api)` en `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr ""
 "¿Y los componentes de Angular, los controladores de NestJS, las entidades de "
 "TypeORM?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5737,11 +5773,11 @@ msgstr ""
 "escribir la construcción explícita equivalente, registrar rutas o esquema "
 "como simples llamadas a funciones / constantes de nivel de módulo."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Dirección futura"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6466,12 +6502,13 @@ msgstr ""
 "arriba y no necesita nada en el momento del enlace."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Llamadas estáticas literales** (`WebAssembly.instantiate(bytes)` escrito "
@@ -8065,57 +8102,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Cómo crear un binding — tour de 60 segundos"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF rendering bindings\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "«pdfium-render = \"0.8\"»"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# Editar src/lib.rs — añadir sus funciones `js_*`, todos utilizando sólo"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr ""
-"# Editar src/index.ts — declarar las importaciones de código de usuario de "
-"superficie TS"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# Editar package.json — lista cada exportación js_* en el"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# Manifiesto que coincide con la lib estática"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# el andamio release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # construye preconstruidos para todos "
-"los objetivos"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # y los une a la liberación"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8515,7 +8508,7 @@ msgstr "Situación actual"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8535,7 +8528,7 @@ msgstr "Agrupado; pendiente de expulsión"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8587,7 +8580,7 @@ msgstr "Agrupado; migración pendiente"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8647,7 +8640,7 @@ msgstr "Compilar la fuente del paquete"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8655,7 +8648,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8663,7 +8656,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8671,7 +8664,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8703,7 +8696,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8711,7 +8704,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8719,7 +8712,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8751,7 +8744,7 @@ msgstr "Agrupados; retenidos"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8759,7 +8752,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8791,7 +8784,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8799,7 +8792,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8807,7 +8800,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8815,7 +8808,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8831,7 +8824,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8839,7 +8832,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8847,7 +8840,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8855,7 +8848,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8879,7 +8872,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8887,7 +8880,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8895,7 +8888,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8903,7 +8896,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8911,7 +8904,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8919,7 +8912,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8927,7 +8920,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8935,7 +8928,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8943,7 +8936,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8951,7 +8944,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8959,7 +8952,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8967,7 +8960,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -9022,14 +9015,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr "1. Scaffold"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Encuadernaciones nativas para <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Esto crea:"
@@ -9062,27 +9047,14 @@ msgstr ""
 "`perry_ffi`:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string` — extraer el texto de un buffer PDF."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "///# Seguridad"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr` debe ser nulo o válido para los bytes `buf_len`. Perry pasa"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// este par de un parámetro de manifiesto `buffer+len`."
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9218,7 +9190,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"malos\""
 
@@ -9460,7 +9432,8 @@ msgid "In a separate directory:"
 msgstr "En un directorio separado:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# o cualquier camino que sus herramientas soportan"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9857,7 +9830,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Listeners de eventos (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// punteros de cierre, mantenidos vivos por el escáner GC de abajo"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10306,7 +10280,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... leer el archivo, establecer env vars, devolver 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10617,8 +10592,8 @@ msgstr "Requerido"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Notas"
 
@@ -10676,14 +10651,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12426,35 +12401,42 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Herramientas: `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Provisión o golpe de un pin a una versión específica (por defecto: último "
 "estable)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr ""
 "# Provisión de cada vinculante actualmente sin soporte en su último estable"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Puerta fuera de línea (CI): los pines presentes, escalonados, cajas "
 "existen. Salida 1 en cualquier"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Asesoramiento: además, marque los pines cuyo upstream tiene una nueva "
 "versión estable"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# Materializar la repo aguas arriba en el ref en gitignored aguas arriba/"
 "<name>"
@@ -12692,15 +12674,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "Para IC que nunca debe sustituir una envoltura parcial, conjunto:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12856,7 +12838,7 @@ msgstr "Realidad"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12873,7 +12855,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14870,19 +14852,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Comparado con worker_threads de Node.js"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// Node.js: ~15 líneas, archivo separado necesario"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14902,12 +14884,11 @@ msgid "/* handle */"
 msgstr "/* manija */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// Perry: 1 línea"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const result = fail spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -15121,13 +15102,14 @@ msgid "Mental Model"
 msgstr "Modelo Mental"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "La UI de Perry sigue el mismo modelo que SwiftUI y Flutter: compones widgets "
 "nativos usando contenedores de layout basados en stacks (`VStack`, `HStack`, "
@@ -15216,7 +15198,7 @@ msgstr ""
 msgid "Property"
 msgstr "Propiedad"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15663,7 +15645,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15687,7 +15669,7 @@ msgstr ""
 "El comportamiento específico de cada plataforma se indica en la página de "
 "documentación de cada widget."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17318,7 +17300,8 @@ msgid "Double-click handler"
 msgstr "Manejador de doble clic"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17382,12 +17365,13 @@ msgstr ""
 "ejecuta en cada PR."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Los ayudantes de distribución son funciones gratuitas: "
 "`widgetAddChild(parent, child)`, `stackSetAlignment(stack, value)`, "
@@ -17869,7 +17853,7 @@ msgstr "Efecto"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17882,7 +17866,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "Los hijos se alinean al borde inicial (izquierdo)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17895,7 +17879,7 @@ msgid "Children centered horizontally"
 msgstr "Los hijos se centran horizontalmente"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17916,7 +17900,7 @@ msgstr "**Alineación de HStack** (eje cruzado = vertical):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17943,8 +17927,8 @@ msgstr "Los hijos se centran verticalmente"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17998,9 +17982,9 @@ msgstr "Comportamiento"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -18024,11 +18008,11 @@ msgstr "Todos los hijos obtienen el mismo tamaño"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18228,9 +18212,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stacks con padding incorporado"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Crea un stack con padding en una sola llamada. El orden es **top, left, "
 "bottom, right** (estilo abreviado de CSS), no top/right/bottom/left:"
@@ -18254,11 +18239,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` es el equivalente "
 "horizontal. Equivale a crear un stack y luego llamar a "
@@ -18548,8 +18534,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18936,6 +18923,7 @@ msgstr ""
 "compilador acepta."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18947,7 +18935,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18975,11 +18962,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Colores"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18995,11 +18982,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Fuentes"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -19015,15 +19002,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Usa `\"monospaced\"` para la fuente monoespaciada del sistema."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Radio de esquina"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -19035,21 +19022,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Bordes"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Relleno e insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -19059,11 +19046,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Dimensionamiento"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -19079,11 +19074,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Opacidad"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -19095,11 +19090,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Degradado de fondo"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -19121,11 +19116,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Tamaño de control"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -19137,7 +19132,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -19145,11 +19140,11 @@ msgstr ""
 "**macOS**: Se mapea a `NSControl.ControlSize`. Otras plataformas pueden "
 "interpretarlo de forma diferente."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltips"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -19161,7 +19156,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -19169,11 +19164,11 @@ msgstr ""
 "**macOS/Windows/Linux**: Tooltips nativos. **iOS/Android**: Sin soporte de "
 "tooltips. **Web**: Atributo HTML `title`."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Habilitado/Deshabilitado"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -19185,11 +19180,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Ejemplo imperativo completo"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -19209,7 +19205,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19237,10 +19233,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19313,15 +19309,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Composición de estilos (funciones auxiliares imperativas)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Reduce la repetición creando funciones auxiliares:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19331,11 +19327,11 @@ msgstr ""
 "design tokens en JSON y generar un archivo de tema tipado. Consulta [Temas]"
 "(theming.md) para ver el flujo de trabajo completo."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Compatibilidad de plataformas"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19346,7 +19342,7 @@ msgstr ""
 "ui/src/styling_matrix.rs` y verificada en CI contra las exportaciones de "
 "`lib.rs` de cada backend en cada PR."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19366,15 +19362,15 @@ msgstr ""
 "mantenida a mano; consulte la matriz para que la documentación no pueda "
 "desviarse del inventario de backend."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — Contenedores de diseño"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animación](animation.md) — Animar cambios de estilo"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr ""
 "[Temas](theming.md) — Design tokens mediante el paquete `perry-styling`"
@@ -20726,8 +20722,8 @@ msgstr "Implementación"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Estado"
 
@@ -24285,7 +24281,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opciones"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25891,7 +25887,7 @@ msgstr "Equivalencia con ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26617,15 +26613,18 @@ msgid "Cross-Compilation"
 msgstr "Compilación cruzada"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# Predeterminado: compilar para la plataforma actual"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# Compilar para un objetivo específico"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS — Android en un reloj"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26841,7 +26840,8 @@ msgid "Building"
 msgstr "Compilación"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS es el objetivo predeterminado"
 
 #: src/platforms/macos.md:18
@@ -26946,7 +26946,8 @@ msgid "App Store Distribution"
 msgstr "Distribución en el App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Firmar con el certificado de App Store"
 
 #: src/platforms/macos.md:60
@@ -26954,7 +26955,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -27087,15 +27089,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "La forma más sencilla de compilar y ejecutar en iOS es `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# Autodetectar device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# Transmitir en vivo stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Usar servidor de compilación de Hub Perry"
 
 #: src/platforms/ios.md:40
@@ -27757,7 +27762,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Esto produce un binario ARM64 para hardware físico de Apple TV."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Simulador de Apple TV de detección automática"
 
 #: src/platforms/tvos.md:39
@@ -28246,11 +28252,13 @@ msgstr ""
 "(#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# simulador (nivel 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28362,22 +28370,16 @@ msgstr ""
 "vez, y luego apunta `PERRY_RUNTIME_DIR` hacia ellos:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr ""
 "# brazo64 (Series 9+ / watchOS 26+) — el objetivo predeterminado del "
 "dispositivo"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (Series 4-8 / SE) — optar por PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28394,7 +28396,7 @@ msgid "Build environment variables"
 msgstr "Construir variables de entorno"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Variable"
@@ -28516,7 +28518,8 @@ msgstr ""
 "`TypeError` resultante desvió el cierre como un objeto."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Simulador de reloj de detección automática"
 
 #: src/platforms/watchos.md:126
@@ -29123,37 +29126,14 @@ msgstr ""
 "hardware, por lo que el sello es cosmético), luego `lipo` ellos juntos:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr ""
 "# 1. Rebanada arm64_32 en el objetivo de despliegue compartido (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 rebanada (objetivo predeterminado del dispositivo)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. alinear minos + fusible"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => brazo arm64_3264"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -29276,19 +29256,8 @@ msgstr ""
 "**propio nuevo registro de aplicaciones** en App Store Connect."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Distribución de manzana: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -29301,6 +29270,10 @@ msgid ""
 msgstr ""
 "`altool` no puede subir aplicaciones de reloj (\"no puede determinar la "
 "plataforma\"). Use Transportador:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29659,19 +29632,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Configuración única (ejemplo macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (`gradle` de Homebrew puede ser 9.x — pin 8.x si es "
 "así)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# o cualquier Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 "# 2. Apunta el env en el SDK / NDK / JDK 17 (añadir a tu perfil de shell)"
 
@@ -29680,7 +29656,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g. 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -29692,32 +29669,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. Paquetes SDK + una imagen de brazo 64 Wear OS"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"herramientas-plataforma\" \"emulador\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"plataformas;android-35\" \"herramientas de construcción;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "«imágenes del sistema;android-34;confección de android;arm64-v8a»"
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. El objetivo transversal Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Crear + arrancar un emulador Wear OS (reloj redondo)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29743,7 +29701,8 @@ msgstr ""
 "el tiempo de ejecución (abajo)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# Auto-detectar un reloj conectado / arrancado Emulador de desgaste"
 
 #: src/platforms/wearos.md:82
@@ -31767,7 +31726,8 @@ msgstr ""
 "de píxel."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# En otra terminal:"
 
 #: src/platforms/linux.md:82
@@ -31787,7 +31747,8 @@ msgstr ""
 "JavaScript para widgets DOM."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# la misma salida que --target wasm"
 
 #: src/platforms/web.md:10
@@ -31865,15 +31826,18 @@ msgstr ""
 "con Web Worker \"de forma gratuita\"."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML autónomo (por defecto)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# Lo mismo"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm binario (sin envoltorio HTML)"
 
 #: src/platforms/wasm.md:21
@@ -32195,11 +32159,13 @@ msgid "Provide them when instantiating:"
 msgstr "Proporciónelas al instanciar:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Via __ffiImports global (set antes del arranque)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// O a través de bootPerryWasm segundo argumento"
 
 #: src/platforms/wasm.md:95
@@ -32754,7 +32720,7 @@ msgstr "stdlib completa"
 msgid "The compiler links only the required runtime components."
 msgstr "El compiler enlaza únicamente los componentes del runtime necesarios."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Bindings nativos externos"
 
@@ -32873,7 +32839,7 @@ msgstr "[Sistema de Archivos](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP y Redes](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Bases de Datos](database.md)"
 
@@ -33098,8 +33064,8 @@ msgstr ""
 "Pasa rutas de archivo entre límites de hilo y reabre los archivos dentro del "
 "worker."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Descripción General](overview.md) — Todos los módulos de la stdlib"
 
@@ -33199,10 +33165,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Apoyado en `IncomingMessage`: `.method`, `.url`, `.headers`, `.rawHeaders`, "
@@ -33211,10 +33178,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33815,10 +33783,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / Almacenamiento de objetos compatible con S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33834,11 +33828,11 @@ msgstr ""
 "sin necesidad de parches — verificado con una coincidencia byte a byte de "
 "URLs prefirmadas con SigV4 contra `bun` (issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33912,78 +33906,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "El mismo código funciona con cualquier servicio compatible con S3 — solo "
 "cambia `endPoint`:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Servicio"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (pruebas)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -34000,7 +33994,7 @@ msgstr ""
 "`bun` con vectores de prueba fijados y autenticarán correctamente contra S3 "
 "real."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -34013,7 +34007,7 @@ msgstr ""
 "compila pero no está verificada de forma independiente contra vectores "
 "fijados aquí."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34661,9 +34655,10 @@ msgstr ""
 "`minBy` y `inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Use importaciones con nombre: el formulario receptor de importación por "
@@ -34878,20 +34873,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Paquetes npm adicionales y APIs de Node.js compatibles con Perry. Todo lo "
-"listado aquí está conectado a través del registro de bindings nativos bien "
-"conocidos de Perry (#466) y compila a código nativo sin ninguna "
-"participación del runtime de JavaScript."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Procesamiento de Imágenes)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34900,7 +34890,7 @@ msgstr ""
 "la conversión de formato y la salida a buffer/archivo funcionan "
 "correctamente."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34950,15 +34940,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (Análisis de HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Bindings nativos mediante `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34976,11 +34966,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (Correo Electrónico)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -35020,15 +35010,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Compresión)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Bindings nativos mediante `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -35046,11 +35036,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Programación de Tareas)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -35058,7 +35048,7 @@ msgstr ""
 "Bindings nativos mediante `perry-ext-cron` (v0.5.564). Los nombres de "
 "paquete `cron` y `node-cron` enrutan al mismo backend."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -35078,11 +35068,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -35092,7 +35082,7 @@ msgstr ""
 "[`ethers-rs`](https://github.com/gakonst/ethers-rs)\\-style ABI a través de "
 "las superficies BigInt + Buffer de `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -35110,11 +35100,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -35123,7 +35113,7 @@ msgstr ""
 "`EventEmitter` coincide con Node.js — `on`, `off`, `once`, `emit`, "
 "`removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -35141,15 +35131,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Lógica de Reintentos)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Bindings nativos mediante `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -35171,11 +35161,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Precisión Arbitraria)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -35184,7 +35174,7 @@ msgstr ""
 "paquete enrutan al mismo backend — tanto `Decimal` como `BigNumber` están "
 "expuestos."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -35220,11 +35210,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Manipulación de Fechas)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -35233,7 +35223,7 @@ msgstr ""
 "paquete enrutan al mismo backend de Rust — la misma superficie de parse/"
 "format/diff."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -35251,11 +35241,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Fechas Heredadas)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -35265,7 +35255,7 @@ msgstr ""
 "modo de mantenimiento en upstream — para código nuevo se prefiere `dayjs`, "
 "pero Perry es compatible con ambos para bases de código existentes."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -35281,11 +35271,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -35294,7 +35284,7 @@ msgstr ""
 "memoria está conectado; los almacenes de respaldo de Redis / cluster son "
 "trabajo pendiente."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -35318,11 +35308,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -35341,7 +35331,7 @@ msgstr ""
 "`spawn` de `perry/thread` siguen siendo la interfaz más simple (véase "
 "[Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -35379,14 +35369,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Las URLs del módulo Web Worker se descubren en relación con el archivo de "
 "origen de importación:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -35419,10 +35409,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (análisis de CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35464,11 +35627,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35490,7 +35653,7 @@ msgstr ""
 "honrados; `maxSize`/`sizeCalculation`, `dispose`, `fetch`, `allowStale` y la "
 "superficie del iterador aún no están implementados."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35520,11 +35683,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35574,11 +35737,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35593,7 +35756,7 @@ msgstr ""
 "+ Linux); en otros hosts `spawn` lanza, lo que desencadena los caminos de "
 "retroceso no aptos de los consumidores."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35605,7 +35768,7 @@ msgstr ""
 "numérica para una muerte de señal y `undefined` de lo contrario; `kill()` "
 "por defecto a `SIGHUP` como nodo-pty. `TERM` en el niño proviene de `name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35651,11 +35814,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35671,7 +35834,7 @@ msgstr ""
 "se pliega a la fachada nativa en el momento de la compilación. El "
 "comportamiento fue verificado con `@parcel/watcher` 2.5.1."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35692,7 +35855,7 @@ msgstr ""
 "notificaciones del motor overflow/rescan activan una instantánea de árbol "
 "fresco y emiten su diff."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35712,7 +35875,7 @@ msgstr ""
 "`getEventsSince` usan la misma semántica de diff de instantáneas que la "
 "recuperación de desbordamiento."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35722,7 +35885,7 @@ msgstr ""
 "semver — se importan con `bun add` como cualquier paquete npm, pero "
 "respaldados en Rust y compilados de forma nativa mediante `perry-ffi`:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35731,7 +35894,7 @@ msgstr ""
 "libSQL). Consulta [PerryTS/tursodb-bindings](https://github.com/PerryTS/"
 "tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35739,11 +35902,11 @@ msgstr ""
 "**`@perryts/iroh`** — redes peer-to-peer con Iroh. Consulta [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "Drivers TypeScript puro compilados mediante `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35753,7 +35916,7 @@ msgstr ""
 "**`@perryts/redis`** — clientes de protocolo de cable que también funcionan "
 "sin cambios en Node.js y Bun."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35761,11 +35924,11 @@ msgstr ""
 "Consulta [Bindings nativos — Descripción general](../native-libraries/"
 "overview.md) para conocer el contrato que siguen estos paquetes externos."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[Sistema de archivos](fs.md) — APIs de fs y path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr ""
 "[Bindings nativos](../native-libraries/overview.md) — Creación de los tuyos "
@@ -35791,7 +35954,8 @@ msgstr ""
 "en tiempo de ejecución en el objetivo seleccionado."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Total: 3019 entradas en 138 módulos."
 
 #: src/api/reference.md:9
@@ -35888,4831 +36052,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Métodos"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — módulo"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Propiedades"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount` — módulo"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince` — módulo"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — módulo"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — módulo"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot` — módulo"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — módulo"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — módulo"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — módulo"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — módulo"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — módulo"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — instancia"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — instancia"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — instancia"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — instancia"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — instancia"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — instancia"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — instancia"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — módulo"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — módulo"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — módulo"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — módulo"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — módulo"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — módulo"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — módulo"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — módulo"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — módulo"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — módulo"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — módulo"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — módulo"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — módulo"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — módulo"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — módulo"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — módulo"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — módulo"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — módulo"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — módulo"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — módulo"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — módulo"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — módulo"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — instancia _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — módulo _(clase: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — módulo _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — instancia _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — módulo"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — instancia"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — instancia _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — instancia _(clase: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — instancia"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — módulo"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — módulo"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — instancia"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — instancia"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — instancia"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — instancia _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — módulo _(clase: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — módulo"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — instancia _(clase: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — módulo"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — módulo"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — módulo"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — módulo"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — módulo"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — módulo"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — módulo"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — módulo"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — módulo"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — módulo"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — módulo"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — instancia"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — instancia"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — instancia"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — instancia"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — instancia"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — instancia"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — instancia"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — instancia"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — instancia"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — instancia"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — instancia"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — módulo"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — módulo"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — módulo"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — módulo"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — módulo"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — módulo"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Transferencia"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob` — módulo"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — módulo"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — módulo"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — módulo"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — módulo"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — módulo"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — módulo"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file` — módulo"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — módulo"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — módulo"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — módulo"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — módulo"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — módulo"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — instancia _(clase: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instancia _(clase: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — módulo"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth` — módulo"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — módulo"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instancia _(clase: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction` — instancia _(clase: `Database`)_"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported` — módulo"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — módulo"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — módulo"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — módulo"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — módulo"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — módulo"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction` — módulo"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString` — módulo"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback` — módulo"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — módulo"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols` — módulo"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr` — módulo"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer` — módulo"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer` — módulo"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource` — módulo"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — módulo"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database` — módulo"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction` — instancia _(clase: `Database`)_"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values` — instancia _(clase: `Statement`)_"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — instancia"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — instancia"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — instancia"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — instancia"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — instancia"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — instancia"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — instancia"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — instancia"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — instancia"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — módulo"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — instancia"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — instancia"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — instancia"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — módulo"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — módulo"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — módulo"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — módulo"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — módulo"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — módulo"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — módulo"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — módulo"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — módulo"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — módulo"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — instancia"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args` — instancia"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument` — instancia"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — instancia"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — instancia"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — instancia"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — instancia"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — instancia"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — instancia"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — instancia"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — instancia"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — módulo"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — módulo"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — módulo"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — módulo"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — módulo"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — módulo"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — módulo"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — módulo"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — módulo"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — módulo"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — módulo"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — módulo"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — módulo"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — módulo"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — módulo"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — módulo"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — módulo"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — módulo"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — módulo"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — módulo"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — módulo"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — módulo"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — módulo"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — módulo"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — módulo"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — instancia"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — instancia"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — módulo"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — instancia"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — instancia"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — módulo"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — módulo"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — módulo"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — módulo"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — módulo"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — módulo"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — módulo"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — módulo"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — módulo"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — módulo"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — módulo"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — módulo"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — módulo"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — módulo"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — módulo"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — módulo"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — módulo"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — módulo"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — módulo"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — módulo"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — módulo"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — módulo"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — módulo"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — módulo"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — módulo"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — módulo"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — módulo"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — módulo"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — módulo"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — módulo"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — módulo"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — módulo"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — módulo"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — módulo"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — módulo"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — módulo"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — módulo"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — módulo"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — módulo"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — módulo"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — módulo"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — módulo"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — módulo"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — módulo"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — módulo"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — módulo"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — módulo"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — módulo"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — módulo"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — módulo"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — módulo"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — módulo"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — módulo"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — módulo"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — módulo"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — módulo"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — módulo"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — módulo"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — módulo"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — módulo"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — módulo"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — módulo"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — módulo"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — módulo"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — módulo"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — módulo"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — módulo"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — módulo"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — instancia"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — instancia"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — instancia"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — instancia"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — módulo"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — instancia"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — instancia"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — instancia"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — instancia"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — instancia"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — instancia"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — instancia"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — instancia"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — instancia"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — instancia"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — instancia"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — instancia"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — instancia"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — instancia"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — instancia"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — instancia"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — instancia"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — instancia"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — instancia"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — instancia"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — instancia"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — instancia"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — instancia"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — instancia"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — instancia"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — instancia"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — instancia"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — instancia"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — instancia"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — instancia"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — instancia"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — instancia"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — instancia"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — instancia"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — instancia"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — instancia"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — instancia"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — instancia"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — instancia"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — instancia"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — instancia"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — módulo"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — módulo"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — módulo"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — módulo"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — módulo"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — módulo"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — módulo"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — módulo"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — módulo"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — módulo"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — módulo"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — módulo"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — módulo"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — módulo"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — módulo"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — módulo"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — módulo"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — módulo"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — módulo"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — módulo"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — módulo"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — módulo"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — módulo"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — módulo"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — módulo"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — módulo"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — módulo"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — módulo"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — instancia _(clase: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — módulo"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — instancia"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — instancia"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — módulo"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — instancia"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — instancia"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — instancia"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — instancia"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — instancia"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — módulo"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — módulo"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — módulo _(clase: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — módulo"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — módulo"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — módulo"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — módulo"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — módulo"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — módulo"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — módulo"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — módulo"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — instancia _(clase: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — instancia _(clase: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — instancia"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — instancia _(clase: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — instancia"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — módulo"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — instancia"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — módulo"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — módulo"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — instancia"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — módulo"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — instancia"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — instancia"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — módulo"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — instancia"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — módulo"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — instancia"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — instancia"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — instancia"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — instancia"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — instancia"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — instancia"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — módulo"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — instancia _(clase: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — módulo"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — instancia"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — instancia"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — instancia"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — instancia"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — instancia"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — instancia"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — instancia"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — instancia"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — instancia"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — instancia"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — instancia"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — instancia"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — instancia"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — instancia"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — instancia"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — instancia"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — instancia"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — instancia"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — instancia"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — instancia"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — instancia"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — instancia"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — instancia"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — instancia"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — instancia"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — instancia"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — instancia"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — instancia"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer` — módulo"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString` — módulo"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — módulo"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — módulo"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — módulo"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — módulo"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — módulo"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — módulo"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — módulo"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — módulo"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — módulo"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — módulo"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — módulo"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — módulo"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — módulo"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — módulo"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — módulo"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — módulo"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — módulo"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — módulo"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — módulo"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — módulo"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — módulo"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — módulo"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — módulo"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — módulo"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — módulo"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — módulo"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — módulo"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — módulo"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — módulo"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — módulo"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — módulo"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — módulo"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — módulo"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — módulo"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — módulo"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — módulo"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — módulo"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — módulo"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — módulo"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — módulo"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — módulo"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — módulo"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — módulo"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — módulo"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — módulo"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — módulo"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — módulo"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — módulo"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — módulo"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — módulo"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — módulo"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — módulo"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — módulo"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — módulo"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — módulo"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — módulo"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — módulo"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — módulo"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — módulo"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — módulo"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — módulo"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — módulo"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — módulo"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — módulo"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — módulo"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — módulo"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — módulo"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — módulo"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — módulo"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — módulo"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — módulo"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — módulo"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — módulo"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — módulo"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — módulo"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — módulo"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — módulo"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — módulo"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — módulo"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — módulo"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — módulo"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — módulo"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — módulo"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — módulo"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — módulo"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — módulo"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — módulo"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — módulo"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — módulo"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — módulo"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — módulo"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — módulo"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — módulo"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — módulo"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — instancia _(clase: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — instancia _(clase: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — instancia _(clase: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — módulo"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — módulo"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — módulo"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — módulo"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40721,103 +41032,103 @@ msgstr ""
 "la piscina de mantenimiento; los ganchos de per-socket son no-ops, advierte "
 "una vez (#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40826,375 +41137,369 @@ msgstr ""
 "piscina de mantenimiento; los ganchos de per-socket son no-ops, advierte una "
 "vez (#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — módulo"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — módulo"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — instancia _(clase: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — instancia _(clase: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref` — instancia _(clase: `HttpServer`)_"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — instancia _(clase: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — módulo"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — módulo"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — instancia _(clase: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — módulo"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — módulo"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — módulo"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — módulo"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — módulo"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — módulo"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref` — instancia _(clase: `HttpsServer`)_"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — módulo"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug` — módulo _(clase: `console`)_"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error` — módulo _(clase: `console`)_"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info` — módulo _(clase: `console`)_"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log` — módulo _(clase: `console`)_"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -41203,7 +41508,7 @@ msgstr ""
 "final de inspector real WebSocket; las sesiones son falsas en el proceso "
 "(#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -41213,7 +41518,7 @@ msgstr ""
 "un subconjunto enlatado Runtime.evaluate responden; cualquier otro método de "
 "protocolo lanza error Inspector -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -41221,7 +41526,7 @@ msgstr ""
 "`url` — módulo ­ **talón** — siempre indefinido: Perry nunca expone un punto "
 "final de inspector real (#4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -41229,3285 +41534,3276 @@ msgstr ""
 "`waitForDebugger` — módulo ­ **talón** — vuelve inmediatamente después de "
 "open(); no hay depurador que esperar (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn` — módulo _(clase: `console`)_"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — instancia _(clase: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — instancia"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — módulo"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — instancia"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — instancia"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — instancia"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — instancia"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — instancia"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — instancia"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — instancia"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — instancia"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — instancia"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — instancia"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — módulo"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — instancia"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — instancia"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — instancia"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — instancia"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — instancia"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — instancia"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — módulo"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — módulo"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — módulo"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — módulo"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — módulo"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — módulo"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — módulo"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — módulo"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — módulo"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — módulo"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — módulo"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — módulo"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — módulo"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — módulo"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — módulo"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — módulo"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — módulo"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — módulo"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — módulo"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — módulo"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — módulo"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — módulo"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — módulo"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — módulo"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — módulo"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — módulo"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — módulo"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — instancia"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — instancia"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek` — instancia"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — instancia"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — módulo"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — módulo"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — módulo"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — módulo"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — módulo"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — módulo"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — módulo"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — módulo"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — módulo"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — módulo"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — módulo"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — módulo"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — módulo"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — módulo"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — módulo"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — módulo"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — módulo"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — módulo"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — módulo"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — módulo"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — módulo"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — módulo"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — módulo"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow` — instancia"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween` — instancia"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — módulo"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate` — instancia"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — instancia"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — instancia"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — instancia"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — instancia"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — instancia"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — instancia"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — instancia"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — instancia"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — instancia"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — instancia"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — instancia"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — instancia"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — módulo"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — módulo"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — instancia _(clase: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — instancia"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — instancia _(clase: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — instancia _(clase: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — instancia"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — instancia"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — instancia _(clase: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — instancia _(clase: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — instancia"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — instancia"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — módulo"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — módulo"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — módulo"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — módulo"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — módulo"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — módulo"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — instancia _(clase: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — instancia _(clase: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — instancia _(clase: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — módulo"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — módulo"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — módulo _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — módulo"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — módulo"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — módulo"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — módulo _(clase: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — instancia _(clase: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — módulo"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — módulo"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — instancia _(clase: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — instancia _(clase: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem` — módulo"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem` — módulo"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate` — módulo"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem` — módulo"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem` — módulo"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem` — módulo"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions` — instancia _(clase: `Certificate`)_"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer` — instancia _(clase: `Certificate`)_"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject` — instancia _(clase: `Certificate`)_"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign` — instancia _(clase: `Certificate`)_"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — módulo"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — instancia"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — instancia"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — módulo"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — módulo"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — módulo"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — módulo"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — módulo"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — módulo"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — módulo"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — módulo"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — módulo"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — módulo"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — módulo"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — módulo"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — módulo"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — módulo"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — módulo"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — módulo"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — módulo"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — módulo"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — módulo"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — módulo"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — módulo"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — módulo"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — módulo"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — módulo"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — módulo"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — módulo"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — módulo"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — módulo"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — módulo"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — módulo"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — módulo"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — instancia _(clase: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization` — módulo"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — módulo"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — instancia _(clase: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — instancia _(clase: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — módulo"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles` — módulo"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded` — módulo"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — módulo"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — módulo"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — módulo"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — módulo"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent` — módulo"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — módulo"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — módulo"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — módulo"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — módulo"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — módulo"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — módulo"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — módulo"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — módulo"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — módulo"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — módulo"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — módulo"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — módulo"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — módulo"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — módulo"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — módulo"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — módulo"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — módulo"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — módulo"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — módulo"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — módulo"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — módulo"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — módulo"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — módulo"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — módulo"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — módulo"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — módulo"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — módulo"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — módulo"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — módulo"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — módulo"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — módulo"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — módulo"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — módulo"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — módulo"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — módulo"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — módulo"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — módulo"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — módulo"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — módulo"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — módulo"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — módulo"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — módulo"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — módulo"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — módulo"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — módulo"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — módulo"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — módulo"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — módulo"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — módulo"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — módulo"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — módulo"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — módulo"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect` — módulo"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint` — módulo"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor` — módulo"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — módulo"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — módulo"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — módulo"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — módulo"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — módulo"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — módulo"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — módulo"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — módulo"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession` — módulo"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession` — módulo"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability` — módulo"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment` — módulo"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange` — módulo"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange` — módulo"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond` — módulo"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — módulo"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — módulo"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — módulo"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — módulo"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — módulo"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — módulo"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — módulo"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — módulo"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof` — módulo _(intrínseco)_"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32` — módulo"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64` — módulo"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16` — módulo"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32` — módulo"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64` — módulo"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8` — módulo"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize` — módulo"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof` — módulo _(intrínseco)_"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof` — módulo _(intrínseco)_"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16` — módulo"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32` — módulo"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64` — módulo"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8` — módulo"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize` — módulo"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — módulo"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — módulo"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — módulo"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — módulo"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — módulo"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — módulo"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — módulo"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — módulo"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — módulo"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — módulo"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — módulo"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — módulo"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — módulo"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — módulo"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — módulo"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — módulo"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — módulo"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — módulo"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — módulo"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — módulo"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — módulo"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — módulo"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — módulo"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — módulo"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — módulo"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — módulo"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — módulo"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — módulo"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — módulo"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — módulo"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — módulo"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — módulo"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — módulo"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — módulo"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — módulo"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — módulo"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — módulo"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — módulo"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — módulo"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — módulo"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay` — módulo"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — módulo"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — módulo"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — módulo"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — módulo"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — módulo"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — módulo"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — módulo"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — módulo"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — módulo"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — módulo"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — módulo"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — módulo"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — módulo"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — módulo"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — módulo"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — módulo"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — módulo"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — módulo"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — módulo"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — módulo"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — módulo"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — módulo"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — módulo"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — módulo"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — módulo"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — módulo"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — módulo"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — módulo"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — módulo"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — módulo"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — módulo"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — módulo"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — módulo"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — módulo"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — módulo"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — módulo"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — módulo"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — módulo"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — módulo"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — módulo"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — módulo"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — módulo"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — módulo"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — módulo"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — módulo"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — módulo"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — módulo"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — módulo"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — módulo"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — módulo"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — instancia _(clase: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — módulo"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — módulo"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — instancia _(clase: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — módulo"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — instancia _(clase: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — módulo"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — instancia _(clase: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — módulo"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — instancia _(clase: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — instancia _(clase: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — instancia _(clase: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — módulo"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — instancia _(clase: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — instancia _(clase: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — instancia _(clase: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — módulo"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — módulo"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — módulo"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — módulo"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — módulo"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — módulo"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — módulo"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — módulo"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — módulo"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — módulo"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — módulo"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — módulo"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — módulo"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — instancia _(clase: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — instancia _(clase: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — módulo"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — módulo"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView` — módulo"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — módulo"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — módulo"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — módulo"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — módulo"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — módulo"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — módulo"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — módulo"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — módulo"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — módulo"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — módulo"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — módulo"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — módulo"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — módulo"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — módulo"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — módulo"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — módulo"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — módulo"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — módulo"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — módulo"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — módulo"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — módulo"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — módulo"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — módulo"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — módulo"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — módulo"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — módulo"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — módulo"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — módulo"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker` — módulo"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — módulo"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — módulo"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — módulo"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — módulo"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — módulo"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy` — módulo"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — módulo"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — módulo"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — módulo"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — módulo"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — módulo"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd` — módulo"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle` — módulo"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — módulo"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — módulo"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — módulo"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — módulo"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — módulo"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — módulo"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — módulo"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — módulo"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — módulo"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — módulo"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — módulo"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — módulo"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — módulo"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — módulo"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — módulo"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — módulo"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — módulo"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — módulo"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — módulo"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — módulo"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — módulo"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — módulo"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — módulo"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — módulo"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — módulo"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — módulo"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — módulo"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — módulo"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — módulo"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — módulo"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — módulo"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — módulo"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — módulo"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — módulo"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — módulo"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — módulo"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — módulo"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — módulo"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — módulo"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — módulo"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — módulo"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — módulo"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — módulo"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — módulo"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — módulo"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — módulo"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — módulo"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — módulo"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — módulo"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — módulo"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — módulo"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — módulo"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — módulo"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — módulo"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — módulo"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — módulo"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — módulo"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — módulo"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — módulo"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — módulo"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — módulo"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — módulo"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — módulo"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — módulo"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — módulo"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — módulo"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — módulo"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — módulo"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — módulo"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — módulo"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — módulo"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem` — módulo"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected` — módulo"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected` — módulo"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — módulo"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — módulo"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — módulo"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders` — módulo"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl` — módulo"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue` — módulo"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — módulo"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig` — módulo"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — módulo"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — módulo"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — módulo"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — módulo"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — módulo"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse` — módulo"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — módulo"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — módulo"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — módulo"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — módulo"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — módulo"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — módulo"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — módulo"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — módulo"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — módulo"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — módulo"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout` — módulo"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount` — módulo"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed` — módulo"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge` — módulo"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild` — módulo"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree` — módulo"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew` — módulo"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild` — módulo"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge` — módulo"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum` — módulo"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap` — módulo"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc` — módulo"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber` — módulo"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc` — módulo"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — módulo"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — instancia _(clase: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — módulo"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — módulo"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — módulo"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — módulo"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — módulo"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — módulo"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — módulo"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — módulo"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — módulo"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — módulo"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — módulo"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — módulo"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — módulo"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — módulo"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — módulo"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — módulo"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — módulo"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — módulo"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — módulo"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — módulo"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — módulo"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — módulo"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — módulo"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — módulo"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — módulo"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — módulo"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — módulo"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — módulo"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — módulo"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — módulo"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — módulo"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — módulo"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — módulo"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — módulo"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — módulo"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — módulo"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — módulo"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — módulo"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — módulo"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — módulo"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — módulo"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — módulo"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — módulo"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — módulo"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — módulo"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — módulo"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — módulo"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — módulo"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — módulo"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — módulo"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — módulo"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — módulo"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — módulo"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — módulo"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — módulo"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — módulo"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — módulo"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block` — instancia"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume` — instancia"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty` — instancia"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward` — instancia"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — módulo"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — módulo"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — módulo"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — módulo"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — módulo"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — instancia"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — instancia"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — instancia"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — instancia"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — módulo"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — instancia"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — instancia"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — instancia"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — instancia"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — instancia"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — instancia"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — instancia"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44517,43 +44813,43 @@ msgstr ""
 "flujo de entrada, y .write() evalúa sólo literales numéricos, búsquedas de "
 "contexto, y un solo '+'; no real JS eval loop (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — módulo"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44563,1459 +44859,1459 @@ msgstr ""
 "flujo de entrada, y .write() evalúa sólo literales numéricos, búsquedas de "
 "contexto, y un solo '+'; no real JS eval loop (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — instancia _(clase: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — módulo"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — módulo"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — módulo"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — módulo"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — módulo"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient` — instancia"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif` — instancia"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — instancia"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite` — instancia"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend` — instancia"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract` — instancia"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — instancia"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — instancia"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — instancia"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — instancia"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — instancia"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — instancia"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — instancia"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — instancia"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — instancia"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — módulo"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen` — instancia"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — instancia"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — instancia"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim` — instancia"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — instancia"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — instancia"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — instancia"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — módulo"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — módulo"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — instancia"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — instancia _(clase: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — instancia"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — módulo"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — instancia"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — instancia"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — instancia _(clase: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize` — instancia"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — instancia _(clase: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — instancia"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — instancia"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — instancia _(clase: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — instancia"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — instancia"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — instancia"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — instancia"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — instancia"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — instancia"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — instancia"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize` — instancia"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — instancia"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — instancia"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — instancia _(clase: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — instancia"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — instancia"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — instancia _(clase: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — instancia"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — módulo"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — módulo"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — módulo"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — módulo"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — instancia"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — instancia"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — módulo"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — instancia"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — instancia"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — instancia"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — módulo"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — instancia"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — módulo"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — módulo"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — módulo"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — módulo"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — módulo"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — instancia"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — módulo"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — módulo"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — instancia"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — módulo"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — instancia"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — instancia"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — instancia"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — instancia"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — instancia"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — instancia"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — instancia"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — instancia"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — instancia"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — instancia"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — instancia"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — módulo"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — instancia"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — instancia"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — instancia"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — instancia"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — instancia"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — instancia"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — instancia"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — instancia"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — instancia"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — instancia"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — instancia"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — instancia"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — módulo"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — módulo"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — módulo"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — módulo"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — módulo"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — módulo"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — instancia _(clase: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — instancia _(clase: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — módulo"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — módulo"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — módulo"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — módulo"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — módulo"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — módulo"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — módulo"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — módulo"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — módulo"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — módulo"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — módulo"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — módulo"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — módulo"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — módulo"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — módulo"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — módulo"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — módulo"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — módulo"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — módulo"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — módulo"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — módulo"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — módulo"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — módulo"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — módulo"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — módulo"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — módulo"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — módulo"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — módulo"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — módulo"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — módulo"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — módulo"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — módulo"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — módulo _(clase: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — módulo"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — módulo"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — módulo"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — módulo _(clase: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — módulo _(clase: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — módulo _(clase: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — módulo _(clase: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — módulo _(clase: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — módulo"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — módulo"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — módulo"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — módulo _(clase: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — módulo"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — módulo"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — módulo"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — módulo"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — módulo"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — módulo"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — módulo"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — módulo"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — módulo"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — módulo"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — módulo"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — módulo"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — módulo"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — módulo"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — módulo"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols` — módulo"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — módulo"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — módulo"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms` — módulo"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — módulo"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — instancia _(clase: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — módulo"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — módulo"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — módulo"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — instancia _(clase: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — instancia _(clase: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — instancia"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — instancia"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — instancia"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — instancia"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — instancia"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText` — módulo"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule` — módulo"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent` — módulo"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close` — instancia _(clase: `ProxyAgent`)_"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy` — instancia _(clase: `ProxyAgent`)_"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch` — módulo"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher` — módulo"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher` — módulo"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — módulo"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — módulo"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — módulo"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — instancia _(clase: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — módulo"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — módulo"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — instancia _(clase: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — módulo"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — módulo"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — módulo"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — módulo"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — módulo"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — módulo"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — módulo"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — módulo"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — módulo"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — módulo"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — módulo"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — módulo"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — módulo"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — módulo"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — módulo"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — módulo"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — módulo"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — módulo"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — módulo"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — módulo"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — módulo"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — módulo"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — módulo"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — módulo"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — módulo"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — módulo"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — módulo"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — módulo"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — módulo"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — módulo"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — módulo"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — módulo"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — módulo"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — módulo"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — módulo"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — módulo"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — módulo"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — módulo"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — módulo"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — módulo"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — módulo"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — módulo"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — módulo"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — módulo"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — módulo"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3` — módulo"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — módulo"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5` — módulo"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — módulo"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — instancia _(clase: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — instancia _(clase: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — módulo"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — instancia _(clase: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — módulo"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — módulo"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -46023,11 +46319,11 @@ msgstr ""
 "`getHeapCodeStatistics` — módulo ­ **talón** — todos los campos 0; Perry "
 "compila AOT, no hay un montón de código JIT (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — módulo"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -46037,7 +46333,7 @@ msgstr ""
 "con todo uso en vivo atribuido a old_space de las arenas Perry; otros "
 "espacios reportan 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -46051,87 +46347,87 @@ msgstr ""
 "aplicado); \\*\\_ ejecutable, external_memory, las manos globales y los "
 "campos zap son 0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — instancia _(clase: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — módulo"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — instancia _(clase: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — instancia _(clase: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — instancia _(clase: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — instancia _(clase: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — módulo"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — instancia _(clase: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — módulo"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — instancia _(clase: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — módulo"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — módulo"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — instancia _(clase: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — módulo"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -46139,459 +46435,469 @@ msgstr ""
 "`stop` — instancia _(clase: `GCProfiler`)_ ­ **talón** — el informe tiene la "
 "forma del Nodo pero la matriz estadística está siempre vacía (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — módulo"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — módulo"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — módulo"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — instancia _(clase: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — módulo"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — módulo"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — módulo"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — módulo"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — módulo"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — módulo"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — instancia"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — módulo"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — módulo"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — instancia"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — instancia"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — instancia"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — instancia"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — instancia"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — instancia"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — instancia"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — módulo"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — instancia"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — instancia"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — módulo"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — instancia"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — instancia"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — módulo"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — módulo"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — módulo"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — instancia"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — módulo"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — instancia _(clase: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — instancia _(clase: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — instancia _(clase: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — instancia _(clase: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — módulo"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — módulo"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener` — instancia"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — módulo"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — módulo"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — módulo"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — módulo"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — módulo"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — módulo"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — módulo"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener` — instancia"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — módulo"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — instancia _(clase: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — módulo"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — instancia _(clase: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — instancia"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — instancia"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — instancia _(clase: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — módulo"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — instancia"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — instancia _(clase: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState` — instancia"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — instancia _(clase: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — módulo"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — módulo"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — módulo"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — módulo"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — módulo"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — módulo"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46599,7 +46905,7 @@ msgstr ""
 "`createBrotliCompress` — módulo ­ **talón** — params/quality opciones "
 "aceptadas pero ignoradas, advierte una vez (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46607,7 +46913,7 @@ msgstr ""
 "`createBrotliDecompress` — módulo ­ **talón** — params/quality opciones "
 "aceptadas pero ignoradas, advierte una vez (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46615,7 +46921,7 @@ msgstr ""
 "`createDeflate` — módulo ­ **talón** — nivel cumplido; strategy/memLevel "
 "validado pero no aplicado (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46623,11 +46929,11 @@ msgstr ""
 "`createDeflateRaw` — módulo ­ **talón** — nivel cumplido; strategy/memLevel "
 "validado pero no aplicado (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — módulo"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46635,19 +46941,19 @@ msgstr ""
 "`createGzip` — módulo ­ **talón** — nivel cumplido; strategy/memLevel "
 "validado pero no aplicado (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — módulo"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — módulo"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — módulo"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46655,7 +46961,7 @@ msgstr ""
 "`createZstdCompress` — módulo ­ **talón** — params/quality opciones aceptadas "
 "pero ignoradas, advierte una vez (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46663,79 +46969,71 @@ msgstr ""
 "`createZstdDecompress` — módulo ­ **talón** — params/quality opciones "
 "aceptadas pero ignoradas, advierte una vez (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — módulo"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — módulo"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — módulo"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — módulo"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — módulo"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — módulo"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — módulo"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — módulo"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — módulo"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — módulo"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — módulo"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — módulo"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — módulo"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — módulo"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — módulo"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — módulo"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — módulo"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — módulo"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -47276,9 +47574,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "De otro modo recurriría a un archivo `docker-compose.yaml`."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "Los dos módulos comparten un tiempo de ejecución; puede mezclarlos en el "
@@ -47816,12 +48115,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` equivale a `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Nota sobre el retorno `logs` y `exec`:** Hoy en día la FFI devuelve un "
 "hall de registro-id a un `Vec<ContainerLogs>` en lugar de un objeto JS. "
@@ -47950,9 +48250,10 @@ msgstr ""
 "retornan instantáneamente."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` es asíncrona y devuelve una matriz JSON de candidato de "
@@ -48715,9 +49016,10 @@ msgstr ""
 "peticiones:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Utilice el bloque `healthcheck` en el servicio** (integrado, el tiempo de "
@@ -49100,8 +49402,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "El ejemplo de Forgejo utiliza este patrón portátil (`container_name:  "
@@ -49174,8 +49477,9 @@ msgid "Single-network shorthand"
 msgstr "Atajo de red única"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49592,9 +49896,10 @@ msgid "External volumes"
 msgstr "Volúmenes externos"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Marque un volumen `external: true` para compartirlo entre pilas o para "
@@ -49616,8 +49921,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49688,15 +49994,18 @@ msgstr ""
 "subyacente:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# listar volúmenes prefijados por aplicación"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# punto de montaje, controlador, etiquetas"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# montaje + inspeccionar el contenido"
 
 #: src/container/volumes.md:160
@@ -49870,9 +50179,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -50062,8 +50372,9 @@ msgstr ""
 "posteriores contra el mismo digest son gratuitas."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -50334,8 +50645,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**Ejecutar como usuario no root** (`user: \"nobody\"` o UID numérico)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Abandonar todas las capacidades, añadir las específicas de nuevo** "
@@ -50489,7 +50801,8 @@ msgstr ""
 "Mostrar un banner orientado al operador con las URLs + \"cómo desmontar\"."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 "Salida 0. Los contenedores siguen funcionando gracias a `restart:  unless-"
 "stopped`."
@@ -50714,11 +51027,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Inicio de dependencias controlado por healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres tarda ~5–10 segundos en inicializarse en la primera ejecución "
 "(initdb + listen bind). Sin regar, fraguar comienza inmediatamente, no puede "
@@ -50893,7 +51207,8 @@ msgstr ""
 "`.env` o un gestor de secretos:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -50906,7 +51221,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50969,11 +51285,13 @@ msgstr ""
 "explícito primero:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# conservar los volúmenes"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# redespliegue con nueva versión"
 
 #: src/container/production-patterns.md:268
@@ -50991,35 +51309,42 @@ msgid "Running it"
 msgstr "Ejecutarlo"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Construir Perry una vez"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Construir el ejemplo"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Backend: docker"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Visite http://localhost:3000/ en un navegador."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Desmontar (conserva los volúmenes para volver a desplegar):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Desgarra + volúmenes de caída (DATOS DE DESTROYAS):"
 
 #: src/container/production-patterns.md:300
@@ -51334,19 +51659,23 @@ msgstr ""
 "los valores difieren."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// probado + emitido tal cual"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// motor emula el lado del host"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// caída + advertencia"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// subconjunto limitado; razón documentada"
 
 #: src/container/determinism.md:156
@@ -51470,7 +51799,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "Cada protocolo devuelve su constante de un método `capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... constructores arg"
 
 #: src/container/determinism.md:192
@@ -51498,7 +51828,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"campo específico dropped/translated para motor\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- spec limpio"
 
 #: src/container/determinism.md:212
@@ -51511,15 +51842,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// campo eliminado"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// mapeado en equivalente"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// motor emula en su lugar"
 
 #: src/container/determinism.md:231
@@ -51527,15 +51861,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. Modo de aplicación: elija cómo aparecen las advertencias"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// por defecto — rastreo silencioso::advertencia!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// superficie a TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// campo no soportado → fallo duro de up()"
 
 #: src/container/determinism.md:241
@@ -51598,7 +51935,8 @@ msgstr ""
 "Normalización de la salida: la misma forma, independientemente del motor"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Forma Docker (línea NDJSON)"
 
 #: src/container/determinism.md:292
@@ -51606,7 +51944,8 @@ msgid "/* docker JSON */"
 msgstr "/* docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Forma de manzana (arreglo JSON de objetos `configuration`-wrapped)"
 
 #: src/container/determinism.md:294
@@ -51614,7 +51953,8 @@ msgid "/* apple JSON */"
 msgstr "/* manzana JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// Ambos producen ContainerInfo con la misma semántica de campo:"
 
 #: src/container/determinism.md:301
@@ -51955,7 +52295,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51968,7 +52309,8 @@ msgid "\"Back\""
 msgstr "\"Atrás\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (valores vacíos = necesidad de traducción)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -52199,7 +52541,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -52323,7 +52666,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (polaco: uno, pocos, muchos)"
 
 #: src/i18n/interpolation.md:65
@@ -53107,21 +53451,25 @@ msgid "Typical translation workflow:"
 msgstr "Flujo de trabajo típico de traducción:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Escribir código con cadenas inglesas"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Extraer cadenas a archivos de localización"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 "# 3. Enviar locales/de.json a los traductores (los valores vacíos necesitan "
 "llenarse)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Construyendo — Perry valida todo"
 
 #: src/i18n/cli.md:49
@@ -53811,57 +54159,24 @@ msgstr ""
 "manifiesto autenticado consumido por `perry update`."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr ""
 "# 1) Generación de una sola vez de keypair. Guardar kp.json con el modo 0600 "
 "y"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) Firma por liberación. El sobre de salida JSON contiene cada"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr ""
-"# 3) Sanidad-comprobar la firma localmente antes de subir el manifiesto —"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    aquí predice una verificación de paso en el cliente."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) Lanzamiento CI firma el manifiesto CLI, encuadernando su URL de "
-"archivo, plataforma,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Componga un manifiesto final con la salida `sign` a través de `jq` para cada "
@@ -55517,9 +55832,10 @@ msgstr ""
 "pasos)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** — un grupo de mezcla. Sonidos ruta a través de un autobús, "
@@ -56539,6 +56855,7 @@ msgstr ""
 "reloj de pared."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -56548,7 +56865,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57766,23 +58083,28 @@ msgstr ""
 "plataforma."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS Extensión WidgetKit"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Widget de aplicación Android"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS Complicación"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# Simulador watchOS"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS Tile"
 
 #: src/widgets/overview.md:60
@@ -58714,10 +59036,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -59322,11 +59640,13 @@ msgid "Build Commands"
 msgstr "Comandos de Build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -60228,19 +60548,23 @@ msgid "Build Instructions"
 msgstr "Instrucciones de Compilación"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# Copiar archivos .kt a app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# Fusionar AndroidManifest_snippet.xml en AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Copiar archivos .kt al módulo Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# Fusionar AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -60434,11 +60758,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "La actualización en segundo plano usa el framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Para el dispositivo Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Para Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -62070,11 +62396,13 @@ msgstr ""
 "declaradas usando `#[no_mangle] pub extern \"C\"`:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry tiempo de ejecución FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr ""
 "// ... API de la plataforma de llamada, la promesa de resolución cuando se "
 "hace ..."
@@ -62208,25 +62536,17 @@ msgstr ""
 "estática usando `swiftc`, apuntando al SDK de plataforma correcto:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (simplificado)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// Detectar objetivo: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// Compilar: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// Enlace: carga:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -62254,7 +62574,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Resuelve la promise de Perry con el resultado"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Obtener actividad de PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -62270,7 +62591,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "// API de la plataforma de llamadas a través de JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -62897,15 +63219,18 @@ msgstr ""
 "de segundo, y no necesita compilador, nodo y no construir."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# la puerta"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# lo que está en alcance, y lo que no"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# probar que la puerta todavía puede fallar"
 
 #: src/testing/test-registration.md:18
@@ -63262,33 +63587,40 @@ msgstr ""
 "cuando compilas con `--enable-geisterhand`."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Compilar con geisterhand activado (libra autoconstrucción en el primer "
 "uso)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Ejecutar la aplicación"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. En otro terminal — interactuar con la aplicación"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Listar todos los widgets"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Haga clic en el botón con el mango 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Captura de pantalla de la ventana de captura"
 
 #: src/testing/geisterhand.md:25
@@ -63305,7 +63637,8 @@ msgstr ""
 "ambos flags):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# o con perry run:"
 
 #: src/testing/geisterhand.md:35
@@ -63452,8 +63785,8 @@ msgid "Menu item"
 msgstr "Elemento de menú"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -63465,8 +63798,8 @@ msgstr "Atajo de teclado"
 msgid "Data table"
 msgstr "Tabla de datos"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -63580,17 +63913,6 @@ msgstr ""
 "Establece el contenido del campo de texto y activa su callback `onChange` "
 "con el nuevo texto como cadena NaN-boxed."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "«Tipo de contenido: application/json»"
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "'{\"texto\":\"hola mundo\"}"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Mover un Slider"
@@ -63615,10 +63937,6 @@ msgstr ""
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr ""
 "Establece la posición del slider y activa `onChange` con el valor numérico."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "«{\"valor\":0.75}»"
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -63669,10 +63987,6 @@ msgstr ""
 "Establece directamente el valor de una celda `State`, sin pasar por los "
 "callbacks del widget. Esto activa cualquier binding reactivo asociado al "
 "estado (etiquetas de texto enlazadas, visibilidad, bucles forEach, etc.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "«{\"valor\":42}»"
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -63750,10 +64064,6 @@ msgstr ""
 "cadena de tecla pasada a `menuAddItem` (p. ej., `\"s\"` para Cmd+S, `\"S\"` "
 "para Cmd+Shift+S, `\"n\"` para Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "'{\"Shortcut\":\"s\"}"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63788,10 +64098,6 @@ msgid ""
 msgstr ""
 "Establece el desplazamiento de un widget ScrollView. Tanto `x` como `y` se "
 "expresan en puntos."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -63893,12 +64199,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Incendio de entradas aleatorias cada 200 ms"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -64039,12 +64342,16 @@ msgstr ""
 "(misma red Wi-Fi) o usar `iproxy` de `libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Instalar y lanzar mediante Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -64071,7 +64378,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Paquete en APK e instalar"
 
 #: src/testing/geisterhand.md:381
@@ -64079,7 +64387,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Instala primero las bibliotecas de desarrollo de GTK4:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -64103,15 +64412,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Una prueba simple de extremo a extremo usando bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Construir con geisterhand"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Iniciar la aplicación en segundo plano"
 
 #: src/testing/geisterhand.md:419
@@ -64123,33 +64435,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"matar a $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Espera a que la aplicación esté lista"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Obtener widgets"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Inscripciones registradas: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Encuentre el botón \"Enviar\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Haga clic en él"
 
 #: src/testing/geisterhand.md:436
@@ -64157,7 +64473,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Captura de pantalla después de la interacción"
 
 #: src/testing/geisterhand.md:441
@@ -64169,7 +64486,8 @@ msgid "Python Test Example"
 msgstr "Ejemplo de Prueba en Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# Iniciar la aplicación"
 
 #: src/testing/geisterhand.md:450
@@ -64177,11 +64495,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Esperar al inicio"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Listar los widgets"
 
 #: src/testing/geisterhand.md:455
@@ -64189,11 +64509,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Buscar widgets por etiqueta"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# Escriba en el primer campo de texto"
 
 #: src/testing/geisterhand.md:464
@@ -64213,7 +64535,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Haga clic en el primer botón"
 
 #: src/testing/geisterhand.md:470
@@ -64221,7 +64544,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Captura de pantalla para regresión visual"
 
 #: src/testing/geisterhand.md:473
@@ -64237,7 +64561,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Assert la aplicación sigue siendo saludable"
 
 #: src/testing/geisterhand.md:478
@@ -64269,40 +64594,14 @@ msgstr ""
 "estados inesperados:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Construir y lanzar"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Comience el caos agresivo (cada 50 ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Déjalo correr durante 30 segundos"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Comprobar estadísticas"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"correr\":true,\"events_fired\":600,\"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Toma una captura de pantalla para ver el estado final"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Detener el caos"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Compruebe que la aplicación sigue viva"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -64316,11 +64615,13 @@ msgstr ""
 "base:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# Estado inicial"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -64328,24 +64629,25 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"texto\":\"Hola\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Captura después de la interacción"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# Comparar (utilizando ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "Integración en Pipeline de CI"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# Ejemplo de acciones GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr "# Ejemplo de acciones GitHub"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -64394,7 +64696,8 @@ msgid "Run UI tests"
 msgstr "Ejecutar pruebas de UI"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Ejecute su script de prueba"
 
 #: src/testing/geisterhand.md:568
@@ -64572,20 +64875,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Después de compilar con `--enable-geisterhand` y ejecutar:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Ver todos los elementos interactivos"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Incremento\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
 
@@ -64594,8 +64900,9 @@ msgid "\"Enter your name\""
 msgstr "\"Introduce tu nombre\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr "#   {\"mano\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
 
 #: src/testing/geisterhand.md:661
@@ -64603,19 +64910,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Modo oscuro\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Haga clic en Incremento 3 veces"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# La contraetiqueta ahora muestra \"Count: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Escriba un nombre"
 
 #: src/testing/geisterhand.md:669
@@ -64623,7 +64933,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "«{\"texto\":\"Perry\"}»"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Establecer el deslizador al 80%"
 
 #: src/testing/geisterhand.md:672
@@ -64631,11 +64942,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "«{\"valor\":0.8}»"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Activar el modo oscuro"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64950,16 +65263,13 @@ msgstr ""
 "manualmente:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Construya libs de geisterhand para macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Construcción para iOS (compilación cruzada)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -65157,15 +65467,18 @@ msgstr ""
 "Más adelante:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# algunos módulos"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# sólo estas exportaciones"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# Forma mod.export combinada"
 
 #: src/testing/node-compat-matrix.md:30
@@ -65186,15 +65499,18 @@ msgid "Full sweep and the CI gate"
 msgstr "El barrido completo y la puerta del CI"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# matriz completa + cuadro de resumen"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# salida 1 en regresión frente al valor basal"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# volver a escribir la base de referencia comprometida"
 
 #: src/testing/node-compat-matrix.md:43
@@ -65486,7 +65802,7 @@ msgstr ""
 "trabajo es `needs: plan` y cerrado en "
 "`fromJSON(needs.plan.outputs.plan).jobs.<name>`."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -65583,11 +65899,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -65612,96 +65928,109 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6 veces rápido"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3 veces rápido"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x lleno"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "sólo deps"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr ""
 "Dentro de la **pr** nivel la lista de archivos cambiados reduce el plan aún "
 "más:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -65710,7 +66039,7 @@ msgstr ""
 "`.claude/`, ... — véase `NON_CORE_GLOBS` en `ci_plan.py`) → sólo `lint` se "
 "ejecuta."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -65718,7 +66047,7 @@ msgstr ""
 "**core** (cualquier cosa que pueda cambiar el compilador, el tiempo de "
 "ejecución o un resultado de prueba) → todo el nivel PR."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -65727,7 +66056,7 @@ msgstr ""
 "`.claude/`, `skills/`, ...) → adicionalmente el flujo de trabajo "
 "reutilizable `security-audit`."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -65742,7 +66071,7 @@ msgstr ""
 "hechas en HIR, transformar, u otra dependencia sin añadir la configuración "
 "Rust a PRs sólo docs."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -65752,11 +66081,11 @@ msgstr ""
 "fallido de `plan` falla en la puerta, un planificador roto nunca debe "
 "convertirse en \"todo salteado, por lo tanto verde\"."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "¿Por qué se ve así (medido 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -65769,13 +66098,13 @@ msgstr ""
 "trabajos / ~650 segundos**, y `main` vio ~66 PR empuja y ~58 fusiona al día. "
 "Es decir, 1.5–2× capacidad total, así que:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "las esperas de la cola de trabajo fueron de 3-7 h (los fragmentos de "
 "`conformance-smoke`: mediana 4 h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -65784,7 +66113,7 @@ msgstr ""
 "una conclusión en la ventana de muestra: 8 fallaron, 56 fueron canceladas "
 "por el siguiente empujón;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -65796,7 +66125,7 @@ msgstr ""
 "había sido rojo en `main` durante días, así que **cada una de las últimas 12 "
 "fusiones fue un bypass administrador** con `lint` y `cargo-test` en cola."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -65811,11 +66140,11 @@ msgstr ""
 "Linux, y #8187 reemplazó la fragmentada lista de contexto requerido con el "
 "solo ventilador `pr-gate` descrito anteriormente."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Dos costes específicos predominaron:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -65837,7 +66166,7 @@ msgstr ""
 "automática de 8-shard se mantiene en el nivel completo porque es el único "
 "brazo que ve errores de enlace de sólo auto-optimizar."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -65853,7 +66182,19 @@ msgstr ""
 "warm.yml` se ha ido: el barrido es la compilación productora de caché en "
 "`main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -65877,75 +66218,75 @@ msgstr ""
 "de cada uno — con cada trabajo omitido, que no cuesta ninguna ranura de "
 "corredor."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "trabajos típicos"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "Los típicos minutos de corredor"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "reloj de pared objetivo"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (básico)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 fragmentos de espacio)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 min una vez en cola"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (solo docs)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 min"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "no un objetivo — se funde"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "no es un objetivo"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -65976,11 +66317,20 @@ msgstr ""
 "de barrido es por ventana (`previous sweep SHA .. this sweep SHA`), "
 "exactamente como para las puertas de seis horas."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Optar por una RRPP en más"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -65994,7 +66344,7 @@ msgstr ""
 "para cualquier cosa que toque una suite de nivel completo. La aplicación de "
 "la etiqueta reinicia las ejecuciones (`labeled` trigger)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -66003,7 +66353,7 @@ msgstr ""
 "`lint` (un cambio de `crates/` debe añadir de otro modo un fragmento de "
 "`changelog.d/<PR>-<slug>.md`)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -66011,11 +66361,11 @@ msgstr ""
 "**`workflow_dispatch`** en cualquier rama: `tier` (`pr` / `sweep` / `full`) "
 "y `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Rebasado de la instantánea de la brecha"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -66028,15 +66378,17 @@ msgstr ""
 "cambio de oráculo), regenerarlo **de CI**, no desde una computadora portátil "
 "(la línea de base requerida es Linux, modo `fast`):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# Espera a que corra, entonces:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# llenar `issue` / `reason` para cada nueva entrada, a continuación,"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -66046,11 +66398,11 @@ msgstr ""
 "problema y una razón antes de fusionarse. Un accidente nunca se puede "
 "estacionar en la instantánea (`run_gap_tests.sh` se niega)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Protección de las subdivisiones"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -66067,11 +66419,11 @@ msgstr ""
 "su presupuesto; la propia ejecución de la puerta lleva si ese resultado pasó "
 "o falló."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -66083,7 +66435,7 @@ msgstr ""
 "suite-gate`** trabajo succeeded — un barrido verde o PR-tier ejecutar en el "
 "mismo SHA no cuenta. Véase [Releasing](../contributing/releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -66099,6 +66451,173 @@ msgstr ""
 "umbral y la tendencia de matriz por módulo se ejecutan una vez en `parity-"
 "aggregate` sobre el informe fusionado (`scripts/parity_report_merge.py`, que "
 "rechaza un fragmento faltante en lugar de reducir la suite)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Lo que envía un cheque"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Ejecutarlo localmente con:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"orden\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -66220,37 +66739,13 @@ msgid "Reproduce the core of it with:"
 msgstr "Reproducir el núcleo de la misma con:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# ¿Qué es realmente funcionando, repo-wide, en el nivel de trabajo:"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr ""
-"'.jobs[] | select(.status==\"in_progress\") | (.etiquetas|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Qué tan profunda es la cola, y en qué piscinas:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "'.jobs[] | select(.status==\"queued\") | (.etiquetas|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -66442,24 +66937,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# sin cambios — cada PR se mide todavía"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # escalonado; véase la tabla de abajo"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -66470,12 +66963,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# las liberaciones permanecen cerradas individualmente"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -66756,11 +67248,13 @@ msgstr ""
 "seguridad; una persona que se salta incluso uno de los cinco no lo es."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# prueba que todavía puede fallar"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# API real, ningún problema escribe"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -66795,10 +67289,49 @@ msgstr ""
 "funciona, no que nada fue probado."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "La cola delante del horario (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -66806,57 +67339,57 @@ msgstr ""
 "Un barrido de seis horas sólo ayuda si la cola se drena más rápido que seis "
 "horas. El 2026-08-12 no lo hizo, y la razón no eran las puertas:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "ejecuciones en cola"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "Se observan ejecuciones simultáneas"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "cola por evento"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "distintas ramas de la cabeza entre las corridas PR en cola"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**ramas que aún existían**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -66874,11 +67407,12 @@ msgstr ""
 "Ninguna cantidad de cadencia de programación se recupera de eso; la basura "
 "tiene que ser removida."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -66896,7 +67430,7 @@ msgstr ""
 "relaciones públicas de tenedores — la rama de la cabeza de un tenedor nunca "
 "aparece en los refs de este repo."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -66908,7 +67442,7 @@ msgstr ""
 "`python3 scripts/reap_stale_ci_runs.py --apply` manual (el funcionamiento en "
 "seco es el predeterminado); el horario lo mantiene despejado después."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
@@ -66916,7 +67450,7 @@ msgstr ""
 "¿Por qué \"la puerta estaba oscura\" no es lo mismo que \"la puerta lo "
 "habría atrapado\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -66928,7 +67462,7 @@ msgstr ""
 "oscura la dejó pasar— no sobrevive a la comprobación, y al registro de por "
 "qué importa más que el incidente:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -66941,7 +67475,7 @@ msgstr ""
 "uno de ellos. No hay ninguna puerta en los trinquetes de repo un recuento de "
 "la colección."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -66953,7 +67487,7 @@ msgstr ""
 "justificación registrada en `tolerances.json`. Sólo se cierran bajo "
 "`pinned_host`, que CI nunca utiliza."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -66961,7 +67495,7 @@ msgstr ""
 "Las cargas de trabajo que lo mostraron (`retain`, `deeplist`, ...) son el "
 "corpus de mano de gc, no las 14 sondas fijas de `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -67190,14 +67724,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Compila TypeScript en un ejecutable nativo."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# O taquigrafía (detecta automáticamente la compilación):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Flag"
 
@@ -67226,7 +67761,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (predeterminado) o `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -67234,7 +67769,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "Imprime la representación intermedia HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -67246,7 +67781,7 @@ msgstr ""
 "Producir solo el objeto file, saltar el enlace; escrito en `-o` (véase "
 "[Banderas de compilador](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -67254,7 +67789,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "Conserva los archivos `.o` y `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -67262,7 +67797,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "Habilita el fallback al runtime JavaScript de V8"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -67274,8 +67809,8 @@ msgstr ""
 "Fuerza el enlazado del runtime host de WebAssembly wasmi (detectado "
 "automáticamente con el uso de `WebAssembly.*`)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -67283,16 +67818,16 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Habilita la verificación de tipos mediante tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr ""
 "Minimiza y ofusca la salida (habilitado automáticamente para `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -67300,7 +67835,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (requerido para targets de widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -67309,23 +67844,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "Agrupa extensiones TypeScript del directorio especificado"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Compilación básica"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Compilación cruzada para el simulador iOS"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Construir un complemento"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: ver representación intermedia"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Construir un widget iOS"
 
 #: src/cli/commands.md:82
@@ -67333,23 +67873,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Compila e inicia tu aplicación en un solo paso."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# Autodetectar el archivo de entrada"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Ejecutar en iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Ejecutar en Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Ejecutar en el dispositivo Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Reenviar args a su programa"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -67483,19 +68028,23 @@ msgstr ""
 "destino. Usa `--local` o `--remote` para forzar cualquiera de las rutas."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Ejecutar un programa CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Ejecutar en un simulador específico"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Forzar construcción remota"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Ejecutar el objetivo web"
 
 #: src/cli/commands.md:131
@@ -67511,19 +68060,23 @@ msgstr ""
 "en cada guardado."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# ver + reconstruir + relanzar en guardar"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# enviar args al niño"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# ver un directorio adicional"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# anular la ruta de salida"
 
 #: src/cli/commands.md:144
@@ -67662,7 +68215,7 @@ msgstr ""
 "Preservación de estado entre recompilaciones / HMR — \"reinicio rápido\" es "
 "el objetivo honesto."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -67727,19 +68280,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Incluir correcciones de confianza media"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Comprobar un solo archivo"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Comprobar con el análisis de dependencia"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Problemas de corrección automática"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Previsualizar correcciones sin aplicar"
 
 #: src/cli/commands.md:207
@@ -68035,27 +68592,33 @@ msgstr ""
 "configuración de cadena de herramientas para Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Mostrar menú de plataforma"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# Configuración de macOS (firma de credenciales)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# Configuración de iOS (firma de credenciales)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# Configuración de visionOS (firma de credenciales)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Configuración de Android (firma de credenciales)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr ""
 "# Cadena de herramientas Windows (descarga MS CRT + Windows SDK vía xwin)"
 
@@ -68086,19 +68649,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Actualizar a la última"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Comprobar sin instalar"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Ignorar la respuesta en caché"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Guarde cómo deben comportarse las actualizaciones, luego salga"
 
 #: src/cli/commands.md:333
@@ -68116,7 +68683,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` escribe `[update] mode` a `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -68234,14 +68801,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Crear el scaffolding de un nuevo paquete de bindings nativos:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"Ataduras nativas para libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "'libfoo = \"1.0\"'"
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -68783,10 +69342,21 @@ msgstr ""
 "Salida ejecutable, paquete, biblioteca compartida, archivo u ruta de objetos."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -68794,20 +69364,20 @@ msgstr ""
 "Seleccione Linux libc/linkage; `musl` actualiza el objetivo Linux "
 "correspondiente a una construcción totalmente estática sin cabeza."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr ""
 "Identificador de paquetes requerido por los objetivos del widget de pantalla "
 "doméstica."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr ""
 "Descubra y empaquete estáticamente paquetes de extensiones nativas desde un "
 "directorio."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -68815,22 +69385,22 @@ msgstr ""
 "Ejecute el verificador nativo TypeScript (`@typescript/native-preview`) "
 "antes del códice."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Establecer el piso de compatibilidad Windows PE; ignorado para objetivos no "
 "Windows."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -68838,11 +69408,11 @@ msgstr ""
 "Seleccione el subsistema Windows PE en lugar de confiar en la autodetección "
 "basada en la importación."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -68850,11 +69420,11 @@ msgstr ""
 "Para los objetivos del widget de Apple, emita fuente y metadatos SwiftUI sin "
 "invocar `swiftc`."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -68862,35 +69432,68 @@ msgstr ""
 "Seleccione el material de firma HarmonyOS HAP. Prefiere las fuentes "
 "environment/config correspondientes para secretos."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "Cadena de certificados de solicitud HarmonyOS."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "Perfil de aprovisionamiento firmado por HarmonyOS."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS keystore alias; por defecto a `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — módulo"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Activo de inserción"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -68899,11 +69502,11 @@ msgstr ""
 "el ejecutable independiente para que se ejecute sin archivos externos en el "
 "disco (#5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -68913,11 +69516,23 @@ msgstr ""
 "proyecto). Repeatable. Combinado con `perry.embed` (package.json) y "
 "`[compile] embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -68926,21 +69541,22 @@ msgstr ""
 "por debajo de `dir` a un mango estable de `$perryfs`. Repetible; se excluyen "
 "los mapas de origen."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# sirve dist/ de memoria — no se necesita dist/ carpeta"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr ""
 "Los archivos empotrados se pueden alcanzar en el tiempo de ejecución de tres "
 "maneras:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -68972,7 +69588,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -68984,7 +69600,7 @@ msgstr ""
 "`readEmbedded(path)` y `node:fs` aceptan la ruta virtual `$perryfs/<path>` o "
 "la clave relativa a la integración."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -68992,7 +69608,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -69002,7 +69618,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -69016,7 +69660,7 @@ msgstr ""
 "borde `{ type: \"file\" }` y mantiene la fuente generada en su caché en "
 "lugar de modificar la caja."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -69025,11 +69669,7 @@ msgstr ""
 "usuario de la web de origen y luego compile a partir de la raíz de paquetes "
 "de `packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -69044,7 +69684,7 @@ msgstr ""
 "resolver. Ejecute el comando de preparación para cada revisión de origen "
 "para que las entradas generadas no puedan ser rancias."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -69057,7 +69697,7 @@ msgstr ""
 "relacionada con el proyecto, el tamaño de los bytes, el digest SHA-256 y el "
 "módulo de activos generadores, cuando proceda."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -69072,7 +69712,7 @@ msgstr ""
 "real en el disco por ruta absoluta, y utilice el formulario `$perryfs/"
 "<path>` explícito cuando se refiere específicamente a la copia incrustada."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -69084,19 +69724,19 @@ msgstr ""
 "`PERRY_LLVM_CLANG` cuando el clang correspondiente no es el primero en "
 "`PATH`. Actualmente no se admite la integración de objetivos cruzados."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Flags de depuración"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "Imprimir el HIR (representación intermedia) en stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -69105,11 +69745,11 @@ msgstr ""
 "(HIR post-transformación), `llvm` (`.ll` por módulo en `.perry-trace/llvm/"
 "`), o `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -69119,7 +69759,7 @@ msgstr ""
 "`NAME`, suprimiendo el ruido de imports/exports/init. Implica `--trace hir` "
 "si no se especifica ninguna etapa"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -69133,11 +69773,11 @@ msgstr ""
 "que un `-o` no puede nombrar varios archivos. Sin `-o` que aterrizan en el "
 "directorio actual. Cada ruta se imprime como `Wrote object file: <path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -69147,15 +69787,15 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`). Ver [Configuración del proyecto](../getting-started/"
 "project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "Conservar los archivos intermedios `.o` y `.asm`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
@@ -69163,33 +69803,33 @@ msgstr ""
 "Retener symbols/DWARF (y emitir un Windows PDB) en lugar de eliminar el "
 "resultado."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Desactivar la caché de objetos por módulo para esta compilación; también "
 "`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "Anular la raíz de caché local de la máquina; véase [Directorio de caché]"
 "(cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -69197,30 +69837,30 @@ msgstr ""
 "Ejecute representación nativa reduciendo invariantes y forzar la "
 "reutilización del códice en lugar de la caché."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr "Desactivar Buffer/Uint8Array load/store para el diagnóstico de A/B."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 "Emitir un informe de evidencia tipo-reducción; implica la verificación de la "
 "región nativa."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -69231,11 +69871,11 @@ msgstr ""
 "estable para herramientas. También configurable a través de "
 "`PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -69248,7 +69888,7 @@ msgstr ""
 "requiere `PERRY_RS4GC=1`, el único motor de raíz nativa (el mapa de pila "
 "plano y los modos de puente explícito que también se nombran se han ido)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -69266,11 +69906,11 @@ msgstr ""
 "generación de código para módulos sin cambios, dejando el directorio de "
 "trazas vacío)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report` — Por qué se mantuvo en caja un valor"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -69288,11 +69928,11 @@ msgstr ""
 "representación-selección de los comentarios LLVM de `-Rpass-missed`: imprime "
 "lo que fue probado, lo que no lo fue, y qué regla hizo la llamada."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Cada valor negado lleva:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -69302,7 +69942,7 @@ msgstr ""
 "objeto literal que nunca está ligado a un local, el idioma `.map(x => "
 "({...}))`)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -69310,7 +69950,7 @@ msgstr ""
 "**La regla que lo negó**, en la propia numeración del coleccionista, para "
 "que pueda comprobarlo en el archivo fuente nombrado."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -69322,7 +69962,7 @@ msgstr ""
 "(correctamente boxeado — sin acción), o _Perry limitation_ (no su código; "
 "nombre el problema de seguimiento donde existe)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -69337,7 +69977,7 @@ msgstr ""
 "vez por elemento, por lo que la profundidad del bucle solo lo clasifica como "
 "último. Tampoco lo es un perfil, son proxies estáticos."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -69345,7 +69985,7 @@ msgstr ""
 "Las ganancias se reportan junto a las fallas, por lo que la proporción es "
 "visible en lugar de sólo las quejas."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -69360,7 +70000,7 @@ msgstr ""
 "nada que informar. El informe va a **stderr**, por lo que nunca se mezcla en "
 "una carga útil `--format json` o la salida canalizada de su programa."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -69375,15 +70015,15 @@ msgstr ""
 "un cheque CI barato contra una representación que retrocede silenciosamente "
 "a cero."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Optimización de salida"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -69406,11 +70046,11 @@ msgstr ""
 "para `generic`. Aplica al código de aplicación y la reconstrucción de "
 "runtime/stdlib optimizada automáticamente."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -69418,11 +70058,11 @@ msgstr ""
 "Definir las constantes `__feature_NAME__` de tiempo de compilación separadas "
 "por comas para la eliminación de código muerto."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -69430,28 +70070,28 @@ msgstr ""
 "Utilice el runtime/stdlib completo preconstruido en lugar de reconstruir el "
 "conjunto de características más pequeño accesible."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "Permitir la reasociación de puntos flotantes; véase [Fast-math](fast-"
 "math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr ""
 "Control fusionado multi-añadir la contracción por separado de la "
 "reasignación."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -69460,11 +70100,11 @@ msgstr ""
 "nombres de variables locales, parámetros y funciones no exportadas para "
 "obtener una salida más pequeña."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Estructuras optimizadas para el tamaño"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -69477,11 +70117,11 @@ msgstr ""
 "(requieren una compra de espacio de trabajo Perry, como el resto de auto-"
 "optimizar):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -69494,11 +70134,11 @@ msgstr ""
 "pueden correr ~2-3× más lento). Los archivos normales y optimizados en "
 "tamaño se guardan en caché de forma independiente."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -69507,11 +70147,11 @@ msgstr ""
 "reconstruidos (reconstrucción lenta, binario más pequeño). Sólo significante "
 "junto con `PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -69530,7 +70170,7 @@ msgstr ""
 "luego se aborta sin una retrotraza simbolizada — JS `throw`/`catch`, "
 "`finally`, las pilas de error y `uncaughtException` no se ven afectadas."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -69542,15 +70182,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. Los programas que usan más tiempo de "
 "ejecución se reducen menos, proporcionalmente."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Flags de pruebas"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -69558,26 +70198,26 @@ msgstr ""
 "Incrustar el servidor HTTP [Geisterhand](../testing/geisterhand.md) para "
 "pruebas de UI programáticas (puerto predeterminado 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Establecer un puerto personalizado para el servidor Geisterhand (implica `--"
 "enable-geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Flags de runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "Habilitar el runtime de JavaScript V8 para paquetes npm no compatibles"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -69587,15 +70227,15 @@ msgstr ""
 "cuando se referencia `WebAssembly.*`; solo es necesario cuando se carga "
 "mediante dlopen / FFI sin una referencia estática)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Habilitar la verificación de tipos mediante IPC de tsgo"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -69612,11 +70252,11 @@ msgstr ""
 "(package.json o perry.toml). `PERRY_ALLOW_EVAL=1` lo obliga a retirarse. "
 "Véase [Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -69640,11 +70280,11 @@ msgstr ""
 "afectadas. Véase [Limitations](../language/limitations.md#no-eval-or-dynamic-"
 "code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -69653,23 +70293,23 @@ msgstr ""
 "stdlib reconocida pero no implementada en lugar de emitir un error de tiempo "
 "de ejecución diferido."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Emite `<binary>.attest.json`; véase [Declaración binaria](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Emite el sidecar de la plataforma Sandbox; véase [Perfiles de caja de arena]"
 "(emit-sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -69677,31 +70317,31 @@ msgstr ""
 "Rechazar superficies de ejecución de código arbitrario accesibles; véase "
 "[Lockdown](lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Variables de entorno"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Clave de licencia de Perry Hub para `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Contraseña para el certificado .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -69710,62 +70350,62 @@ msgstr ""
 "valores que `--march`; el indicador y perry.toml `[build] march` ganan sobre "
 "el var env)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Deshabilitar las comprobaciones automáticas de actualizaciones"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "Lo mismo, usando la ortografía de todo el ecosistema"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` para una carrera — véase [Updates](updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL de servidor de actualizaciones personalizado"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Omitir automáticamente las comprobaciones de actualizaciones (establecido "
 "por la mayoría de los sistemas CI)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Nivel de registro de depuración (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -69773,7 +70413,7 @@ msgstr ""
 "`1`/`text` o `json` — lo mismo que `--opt-report[=json]`, para conducir el "
 "informe desde un entorno donde añadir un indicador es incómodo"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -69788,15 +70428,15 @@ msgstr ""
 "usuario — era un quinto botón de env GC sin brazo CI, y fue eliminado bajo "
 "la política de matar del pomo GC de CLAUDE.md."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "Archivos de configuración"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (proyecto)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -69876,11 +70516,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (global)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -69902,59 +70542,255 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Programa CLI simple"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# iOS aplicación para simulador"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# visionOS aplicación para simulador"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Aplicación web (WASM con puente DOM — alias: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Librería compartida de complementos"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# iOS widget con ID de paquete"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Compilación de depuración"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Compilación de verbos"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Compilación verificada por el tipo"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# Raw WASM binario (sin envoltorio HTML)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Salida web minimizada (comprime el puente JS integrado)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Comandos](commands.md) — Todos los comandos de la CLI"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr ""
 "[Descripción general de plataformas](../platforms/overview.md) — Plataformas "
 "disponibles"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"módulos\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Identidad caché"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"módulos\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"fuente\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"lodash\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"objetivos\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"funciones\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Incremento\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"caption\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -70201,15 +71037,18 @@ msgstr ""
 "de entorno sobre package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. Bandera CLI por construcción"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Entorno per-shell"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. Por proyecto package.json (más común)"
 
 #: src/cli/fast-math.md:35
@@ -70225,19 +71064,22 @@ msgid "Contraction is separate from reassociation:"
 msgstr "La contracción es independiente de la reasociación:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Permitir la contracción FMA solamente."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Permitir el modo de contracción más agresivo de la interfaz sin "
 "reasociación."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# Mantenga la reasociación de --fast-math pero bloque FMA contracción."
 
 #: src/cli/fast-math.md:55
@@ -71265,7 +72107,8 @@ msgid "Emit"
 msgstr "Emitir"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -71355,7 +72198,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"tamaño\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -72601,10 +73444,6 @@ msgstr ""
 msgid "produces:"
 msgstr "produce:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"módulos\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -72690,9 +73529,10 @@ msgstr ""
 "host se muestra bajo `<host source>`."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Devuelve un error claro si el manifiesto no existe todavía — `perry  "
 "compile` o `perry run` lo escribe en cada compilación exitosa."
@@ -74873,7 +75713,7 @@ msgstr ""
 msgid "Setting"
 msgstr "Ajuste"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "Archivo"
 
@@ -74958,15 +75798,18 @@ msgstr ""
 "config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# Configurar la firma iOS (certificado, perfil de aprovisionamiento)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Configurar la firma Android (tecla tienda, tecla Play Store)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Configurar la distribución macOS (App Store, notarialización)"
 
 #: src/cli/perry-toml.md:605
@@ -75007,8 +75850,11 @@ msgstr ""
 "credenciales en `perry.toml`:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# Ejemplo de acciones GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -76264,20 +77110,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Buques Perry **dos canales independientes de admisión voluntaria** para "
-"enviar datos a casa — nada sale de su máquina sin un `enabled = true` "
-"explícito o `on` en `~/.perry/config.toml`. Ambos honores "
-"`PERRY_NO_TELEMETRY=1` y `CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Análisis de uso genérico — `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Análisis de uso genérico — `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -76287,15 +77133,17 @@ msgstr ""
 "fondo HTTP Mensaje. Sends: nombre de comando, plataforma (`darwin`/"
 "`linux`/...), versión Perry, estado success/error, y un cliente anónimo UUID."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr ""
 "2. Informes de compatibilidad — `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -76306,16 +77154,16 @@ msgstr ""
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Tres modos:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 "`off` — nunca enviar. El fregadero ni siquiera está instalado; cero arriba."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -76324,99 +77172,99 @@ msgstr ""
 "informe una vez por sesión: `[y] just this once / [a] always / [n] not this "
 "time / [N] never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on` — siempre enviar (después de dedup + redacción). No hay señal."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**¿Qué se envía (el esquema de carga útil completo):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"código\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"categoría\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"basura-categórica\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"etapa\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"hir-lower\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:...\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"decorador\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"Nodo:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -76433,7 +77281,7 @@ msgstr ""
 "`console`, `Math`, `Promise`) → `<id1>`, `<id2>`, con un tope de 200 "
 "caracteres, con un rechazo duro si falla cualquier invariante."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -76441,32 +77289,36 @@ msgstr ""
 "Una caché local de 30 días en `~/.perry/.report-cache` evita reenviar el "
 "mismo `snippet_hash` en cada recarga."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Inspección y gestión"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# muestra el modo actual, sent/queued cuenta"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# imprimir cargas útiles editadas en la cola de esta ejecución"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# limpiar la caché de 30 días de descarga"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "Para optar por el nivel de archivo, edite `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -76475,7 +77327,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -76728,15 +77580,18 @@ msgstr ""
 "(`crates/perry-runtime/src/gc/types.rs`):"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// tamaño total del aloc, utilizado para caminar en bloque de arena"
 
 #: src/internals/memory-model.md:69
@@ -77083,7 +77938,7 @@ msgstr ""
 "bisección de benchmarks/depuración. Sin definir, `=1`, `=on` y `=true` "
 "mantienen las barreras habilitadas."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -77276,10 +78131,11 @@ msgstr ""
 "bajo `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -77515,10 +78371,24 @@ msgstr ""
 "presión."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Mapa de fuentes"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -77527,183 +78397,183 @@ msgstr ""
 "vuelve a derivarse, y cada fila de esta tabla una vez apuntaba a un `gc.rs` "
 "que ya no existe."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Tema"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Símbolo a buscar"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaN-boxing tags"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, constantes de tipo/flag"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Marcos de sombras (reducción de la raíz de retroceso)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Escáneres de raíces registrados"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Copiar menor"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Promoción de todo el bloque en el lugar"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Política de promoción"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Umbral de mantenimiento adaptativo"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Barreras de escritura"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Pinzas explícitas"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Conservador-pin predicado"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Detonadores de recogida y estimulación"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Operaciones actuales página"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Plan de diseño (histórico)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -78151,12 +79021,18 @@ msgstr ""
 "runtime/src/gc/heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "en un proceso desktop/server sin restricciones, escalado a una octava parte "
 "de un presupuesto device/container con un piso 1 MiB. El desbordamiento se "
@@ -78165,7 +79041,7 @@ msgstr ""
 "unsafe/deferred y vacía la piscina cuando la colección completa debe "
 "terminar su recuperación de arena."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -78176,108 +79052,222 @@ msgstr ""
 "más deltas incrementales, no una suma de bloques de compensación de agua "
 "alta."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Controles soportados"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 "Estos son los controles operativos más útiles para el desarrollo de "
 "colectores externos:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "reflujo de la bisección al barrido completo de marcas"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr ""
 "compile/runtime bisección de barrera; también fuerza la marca-barra completa"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr ""
 "deshabilitar la recolección directa de viveros para la comparación de "
 "estimulación"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr ""
 "revertir la promoción de bloques enteros a la evacuación de objetos por "
 "objetos"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "establecer la tapa base del vivero"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "anular el presupuesto del montón de proceso en MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "seleccionar las raíces de sombra en un objetivo nativo-raíz-capaz"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr ""
 "diagnóstico de exploración completa de pila nativa; deshabilita la copia"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "emitir registros estructurados por ciclo de seguimiento"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "emitir diagnósticos de colectores legibles por personas"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -78286,10 +79276,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "El estrés de enraizamiento utiliza `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -78304,7 +79295,7 @@ msgstr ""
 "`PERRY_STACKMAP_WALKER`, pero no son modos de colector adicionales "
 "soportados."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -78333,11 +79324,11 @@ msgstr ""
 "el comportamiento falla `cargo-test`; ninguno puede quedarse en silencio "
 "mientras esta página sigue reclamando lo viejo."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Validación y autoridad de IC"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -78349,39 +79340,39 @@ msgstr ""
 "src/testing/ci-tiers.md`; la política de nivel es `scripts/ci_plan.py`). La "
 "cobertura específica del GC se divide deliberadamente:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "donde corre"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "estado requerido"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 "La custodia del titular de la raíz, la deriva de GC-knob, y las "
 "reclamaciones path/number de esta página"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "Sí (a través de `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "unidad de tiempo de ejecución suite y `run_memory_stability_tests.sh` matriz "
 "de cuatro modos"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -78389,7 +79380,7 @@ msgstr ""
 "sí (a través de `pr-gate`; el nivel PR es diff-scoped, los niveles sweep/"
 "full ejecutan el espacio de trabajo)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -78397,27 +79388,27 @@ msgstr ""
 "CG × matriz de selección de representación, instrumentos de enraizamiento-"
 "bug, esfuerzo de barrera de escritura"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr ""
 "sí (a través de `pr-gate`; subconjunto PR en PRs, matriz completa en el "
 "barrido)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "dominio de la raíz emitido, incluyendo el estado nativo IR"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -78425,27 +79416,27 @@ msgstr ""
 "no se requiere rama; brazo PR opt-in vía `run-extended-tests`, seis horas en "
 "`main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "Colector empotrado counters/RSS/wall matriz"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "presupuesto local mechanism/policy"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Útiles comandos locales de prevuelo:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -78455,11 +79446,11 @@ msgstr ""
 "amplios de compilador y host; sus archivos de flujo de trabajo son la "
 "autoridad para órdenes exactas y filtros de relevancia."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Pruebas históricas"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -78468,7 +79459,7 @@ msgstr ""
 "generational-gc-plan.md): diseño original y registro de aterrizaje fase por "
 "fase."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -78478,7 +79469,7 @@ msgstr ""
 "statepoint-gc-experiment.md): mediciones y correcciones cronológicas de "
 "prototipos que conducen al valor predeterminado de raíz nativa."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -78487,7 +79478,7 @@ msgstr ""
 "sonido del códice, modos de verificación, puntos ciegos conocidos e "
 "instrumentos de depuración."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -78822,7 +79813,8 @@ msgstr ""
 "solución, era el costo cada vez."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "Las cinco formas en que se ha roto"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -78981,14 +79973,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` en `gc/mod.rs` en el mismo commit."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Cómo comprobar su trabajo"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. El comprobador estático — ejecute éste"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -78999,7 +80032,7 @@ msgstr ""
 "único instrumento que ve un defecto antes de que se desplome, por lo que se "
 "ejecuta primero."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -79007,7 +80040,7 @@ msgstr ""
 "**Es ciego a tres clases, todas se encuentran de la manera difícil. Un "
 "informe limpio no es evidencia para ninguno de ellos:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -79016,7 +80049,7 @@ msgstr ""
 "emitido y no puede ver una célula de tiempo de ejecución. Tell: falla 10/10 "
 "en lugar de intermitentemente."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -79026,7 +80059,7 @@ msgstr ""
 "Leía `0 violations` a ambos lados de un verdadero error cuya solución era "
 "una línea `GcSuppressScope` en el bootstrap `globalThis`."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -79045,7 +80078,7 @@ msgstr ""
 "conjuntos contra lo que el codegen realmente emite, la forma #7227 "
 "auditorías `ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -79056,7 +80089,7 @@ msgstr ""
 "registra 25 archivos de corpus curados pasando mientras 20 líneas de stock "
 "zod fallan."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -79074,30 +80107,13 @@ msgstr ""
 "sido el valor predeterminado en ningún objetivo de marco caminable desde el "
 "#7370. **Ejecutar ambos**, y sabe cuál de los dos correste:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# SHADOW (PERRY_RS4GC=0): sigue bajando en arm64_32 watchOS y ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr ""
-"# NATIVO (PERRY_RS4GC=1): el valor predeterminado en todas partes. Anclas "
-"sobre"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` alocas de raíz y LLVM inserta los puntos de seguridad "
-"más tarde, por lo que el"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -79108,11 +80124,11 @@ msgstr ""
 "falla allí, y el corpus de sombras tiene cero puntos de seguridad, por lo "
 "que `--min-statepoints` falla allí."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Lo que `--statepoints` comprueba, y cómo difiere"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -79124,7 +80140,7 @@ msgstr ""
 "punto seguro es el resultado `gc.relocate`. Así que \"la tienda de raíces "
 "debe dominar cada punto de recogida posterior\" se convierte en:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -79132,7 +80148,7 @@ msgstr ""
 "Ningún registro que nombre un objeto GC se puede utilizar por debajo de un "
 "punto seguro a menos que sea el valor reubicado."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -79147,23 +80163,23 @@ msgstr ""
 "vida como un `double`. Dos clases de veredicto, porque tienen dos arreglos "
 "diferentes:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -79171,15 +80187,15 @@ msgstr ""
 "ningún valor de `ptr addrspace(1)` en la cadena de fundición del registro "
 "está en el paquete vivo del punto seguro. Nada marca o reescribe el objeto."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "Raízala"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -79187,11 +80203,11 @@ msgstr ""
 "el objeto está en el paquete y es reubicado, pero una copia en bruto de su "
 "dirección pre-mover se utiliza a continuación"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "re-derivar del valor reubicado (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -79208,7 +80224,7 @@ msgstr ""
 "`--moving-only` clasifica contra el símbolo real en lugar de "
 "`llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -79233,15 +80249,15 @@ msgstr ""
 "colecta, por lo que una brecha en su modelo cuesta un falso positivo, nunca "
 "un error perdido."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Para un solo archivo está iterando en:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "Ambas perillas de env importan, por diferentes razones."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -79257,7 +80273,7 @@ msgstr ""
 "colección entre dos puntos de un cuerpo de bucle de otro modo inerte no "
 "puede aparecer en el corpus sin él."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -79280,7 +80296,7 @@ msgstr ""
 "`js_object_get_field_ic_miss` y `js_closure_call1`. Esos se están moviendo "
 "sin encuestas cerca de ellos."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -79288,14 +80304,14 @@ msgstr ""
 "Por lo tanto: encender la perilla, porque amplía lo que el corpus puede "
 "expresar, pero no leer una función libre de encuestas como seguro."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` es por el símbolo emitido EXACT, y que ha mordido dos "
 "veces"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -79307,7 +80323,8 @@ msgstr ""
 "clasifica nada, para siempre, y se parece exactamente a la cobertura "
 "mientras lo hace. Ahora se han medido dos rondas:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -79318,7 +80335,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -79336,7 +80353,7 @@ msgstr ""
 "`clone` de zod. El protector y el verificador no estaban de acuerdo; el "
 "verificador estaba equivocado."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -79359,7 +80376,7 @@ msgstr ""
 "entrada reales son `js_closure_callN`, que `RECEIVER_SINKS` en el mismo "
 "archivo ya escrito correctamente."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -79379,60 +80396,60 @@ msgstr ""
 "corta, por lo que la forma nunca fue capturable bajo el modo de "
 "funcionamiento CI. Replantar ese código exacto y ejecutar cada modo (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (dominio)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (la bajada que los buques)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (no filtrado)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (no filtrado)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -79444,7 +80461,7 @@ msgstr ""
 "ciegos a la bajada de la navegación. Agregar el nombre lleva los brazos "
 "saboteados a 13 y 8 y deja los brazos limpios a 2 y 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -79474,7 +80491,7 @@ msgstr ""
 "pueda, añádala a `POLL_CAPABLE_RUNTIME` en la misma confirmación.** Nada te "
 "lo pedirá."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -79485,7 +80502,7 @@ msgstr ""
 "dominance.yml` se ejecuta junto a `--audit-alloc-re` antes de la "
 "construcción."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -79512,7 +80529,7 @@ msgstr ""
 "fantasma con el codógeno símbolo realmente emite en lugar de eliminarlo — "
 "borrar convierte la auditoría en verde y deja el agujero."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -79543,21 +80560,17 @@ msgstr ""
 "más), y los comentarios y los literales de cuerda se despojan primero para "
 "que un nombre mencionado en prosa no pueda convertirse en una premisa."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "Comprobar un nombre _plausible_ no es suficiente. Confirmar contra IR "
 "emitido:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -79565,7 +80578,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` hace que cada almacén raíz el formulario de "
 "llamada `js_shadow_slot_bind` sea el ancla del verificador."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -79581,7 +80594,7 @@ msgstr ""
 "es el brazo que se basa en la lista de permisos, por lo que los casos 3 y 4 "
 "sólo superficie cuando se ejecuta este modo a mano."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -79597,7 +80610,7 @@ msgstr ""
 "a la función limpia. Encontró el `lower_call/new.rs` en línea de `this_slot` "
 "independientemente de cualquier sonda de tiempo de ejecución."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -79615,17 +80628,17 @@ msgstr ""
 "un local `Symbol` no tiene ranura de sombra en absoluto. Ejecutarlo a mano "
 "cuando toque un sitio `alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr ""
 "2. Los instrumentos de tiempo de ejecución — segundo, y la mente de la "
 "profundidad"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Desde el #7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -79640,7 +80653,7 @@ msgstr ""
 "literal de cada uno cuando la ventana que está cazando se ejecuta una sola "
 "vez — es mucho más lento."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -79649,11 +80662,12 @@ msgstr ""
 "evacuación, de modo que una falla de lectura rancio inmediatamente en lugar "
 "de leer basura plausible."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT` — ahora realmente se ejecuta."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -79661,7 +80675,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -79678,7 +80692,7 @@ msgstr ""
 "gc_schedule_fuzz.sh <binary> [seed-count]` barre semillas e imprime un "
 "comando de reproducción por fallo."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -79693,7 +80707,7 @@ msgstr ""
 "en absoluto. Variando _when_ colecciones de fuego es la única manera barata "
 "de explorar el espacio en el que el error realmente vive."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -79706,7 +80720,7 @@ msgstr ""
 "para el momento en que se desprecie. **Usa 800.** Una ejecución limpia en la "
 "profundidad predeterminada no significa nada."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -79735,7 +80749,7 @@ msgstr ""
 "acuerdo con el verificador estático, mira primero al verificador. Así fue "
 "como se resolvió el desacuerdo zod `clone`."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -79747,7 +80761,7 @@ msgstr ""
 "marco que posee el registro — el valor comúnmente llega como un argumento de "
 "un llamante que lo deja rancio."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -79759,11 +80773,11 @@ msgstr ""
 "cualquier sonda de tiempo de ejecución lo note. Estos instrumentos captan la "
 "_consecuencia, más tarde. El comprobador estático atrapa la causa, ahora."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "La imagen del espejo: una barrera de escritura faltante (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -79775,43 +80789,43 @@ msgstr ""
 "nunca es **habla de**. Las dos son duales, y —esta es la parte que sigue "
 "atrapando a la gente— **sus detectores son intercambiados**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "bug de enraizamiento"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted barrera de escritura"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "lo que sale mal"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "un valor vivo es invisible para el escaneo raíz"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "un viejo → borde joven está ausente del conjunto recordado"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "Cuando sale mal"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "en la colección, en silencio"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "no en la tienda en absoluto; en algunos _más tarde_ menor"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "el detector"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -79821,30 +80835,30 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE`), más el comprobador estático para la mitad "
 "visible IR"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **Aserción estática de IR**Y nada más"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "el punto ciego"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "el verificador estático no puede ver un caché de lado de ejecución de un "
 "puntero de montón (véase §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**cada sonda de tiempo de ejecución que tenemos**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "¿Por qué ninguna sonda de tiempo de ejecución puede verlo"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -79859,19 +80873,19 @@ msgstr ""
 "Convirtiéndolo en un fracaso observable necesita una conjunción que el "
 "programa tiene que suministrar por sí solo:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "el padre tiene que sobrevivir en la vieja generación (o ser titular) "
 "**antes** el almacén;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr ""
 "el niño tiene que estar todavía en la guardería **en el siguiente menor**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -79879,7 +80893,7 @@ msgstr ""
 "a **menor** la colección —no es un barredor de marcas completo, que retrae "
 "todo y papeles sobre toda la clase— tiene que aterrizar en esa ventana; y"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -79887,7 +80901,7 @@ msgstr ""
 "que borde tiene que ser la ruta _only_ al niño, o alguna otra raíz lo "
 "encuentra de todos modos y la colección está limpia."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -79895,7 +80909,7 @@ msgstr ""
 "Si se pierde a cualquiera y el menor recoge correctamente, el programa "
 "imprime la respuesta correcta, y la sonda reporta éxito. No se intentó nada."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -79905,7 +80919,7 @@ msgstr ""
 "ellas están dirigidas a una propiedad completamente diferente, y es fácil "
 "leer su verde como evidencia:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -79919,7 +80933,7 @@ msgstr ""
 "que no pudo reescribir. Recordar y reescribir son diferentes propiedades, y "
 "el verificador sólo pregunta sobre el segundo."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -79931,7 +80945,7 @@ msgstr ""
 "sea inaccesible. Una carrera verde aquí es la evidencia más fuerte y vacía "
 "de los tres."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -79943,7 +80957,7 @@ msgstr ""
 "raíz de la dualidad. Ellos fallan en un puntero colgando del espacio, no en "
 "un objeto vivo que nunca fue rastreado."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -79958,7 +80972,7 @@ msgstr ""
 "nombre en este documento es uno que la puerta ha confirmado que posee un "
 "analizador vivo."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -79970,7 +80984,7 @@ msgstr ""
 "observar ejecutando el programa.** No hay ejecución en la que \"la barrera "
 "no funcionó\" es un evento distinguible."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -79991,11 +81005,11 @@ msgstr ""
 "contradicción. La prueba de infrarrojos estática fue lo único que dijo que "
 "no."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "Lo que un PR que añade o mueve una tienda en una ranura de GC debe"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -80005,7 +81019,7 @@ msgstr ""
 "comportamiento. Cuatro cosas que tiene que fijar, cada una porque un "
 "sabotaje que se saltó fue _not_ atrapado:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -80015,7 +81029,7 @@ msgstr ""
 "barrera de escritura, la nota de diseño y la cadena addref. Cualquiera de "
 "los tres desaparecidos es la familia #5094 / #7511 de varados silenciosos."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -80029,7 +81043,7 @@ msgstr ""
 "muerto** que cada afirmación de contenido inspeccionado felizmente, e "
 "inicialmente pasó. La presencia de código no es prueba de que funcione."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -80039,7 +81053,7 @@ msgstr ""
 "la contabilidad. Una barrera que se filtra en ella significa que el "
 "discriminador dejó de discriminar, y la \"optimización\" no mide nada."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -80049,9 +81063,10 @@ msgstr ""
 "que la prueba se vuelve roja. Una prueba que nunca ha fallado es una prueba "
 "cuyo modo de fallo es desconocido."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -80068,36 +81083,25 @@ msgstr ""
 "class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` y "
 "`write_pic_barrier_tests.rs` son la forma."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "El marcador `GC_STORE_AUDIT`, y lo que hace y no prueba"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Cada sitio de la tienda relevante de GC en bruto lleva un marcador cercano "
 "que nombra su veredicto:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// GC_STORE_AUDIT(BARRIERED): la escritura de ranura es incondicional; la "
-"barrera"
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr ""
-"// abajo está protegido sólo por una prueba en vivo que los bits almacenados "
-"no llevan ningún montón"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// puntero, que es la primera prueba de la barrera."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -80110,7 +81114,7 @@ msgstr ""
 "marcador — por lo que un **nuevo** sitio de la tienda no puede aterrizar con "
 "la pregunta sin respuesta."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -80119,7 +81123,7 @@ msgstr ""
 "**Reclamación**, no sólo el comentario, para las dos clases donde un falso "
 "reclamo filamentos objetos:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -80161,7 +81165,7 @@ msgstr ""
 "llamada fuera de su bloque, evitar la puerta) corren en la suite contra cada "
 "tallo."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -80188,7 +81192,7 @@ msgstr ""
 "llamada de barrera en la misma función todavía pasan), y el guión imprime "
 "ese límite."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -80211,11 +81215,11 @@ msgstr ""
 "(la disciplina `gc_rekeyed_key_tables.py`), y su `--self-test` planta quince "
 "formas, cada una de las cuales debe ser adjudicada."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "El problema del corpus, y los dos cuerpos (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -80223,7 +81227,7 @@ msgstr ""
 "**Un corpus escrito a mano no puede expresar esta clase de error a escala de "
 "dependencia, y durante un tiempo nadie podía decir, porque era verde.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -80238,7 +81242,7 @@ msgstr ""
 "pone en una frase: _25 archivos curados pasan mientras que 20 líneas de "
 "stock zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -80246,40 +81250,40 @@ msgstr ""
 "Eso no es un problema de tamaño. Ambos cuerpos fueron medidos en el mismo "
 "compilador con `--stale-registers --moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "usos rancios"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "lo que domina"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "comisariado, 124 fuentes / 144 módulos"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr ""
 "ventanas de ayuda de propiedad-GET, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "de 81 módulos / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -80287,7 +81291,7 @@ msgstr ""
 "`js_object_assign_one` (difusión de objetos) 137, "
 "`js_new_function_construct` 102, `js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -80304,7 +81308,7 @@ msgstr ""
 "las formas**, por lo que un corpus sin las formas no puede expresarlos como "
 "muchos archivos que tiene."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -80312,11 +81316,12 @@ msgstr ""
 "Así que hay un segundo corpus, generado a partir de una dependencia real de "
 "npm en lugar de cualquier cosa escrita para la ocasión:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod es un package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -80330,7 +81335,7 @@ msgstr ""
 "un piso de tamaño no podría ser, ya que ~90 módulos de pantano `zod` "
 "cualquier cuenta una fuente de 40 líneas faltantes cruzaría."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -80342,11 +81347,11 @@ msgstr ""
 "de instrucciones. El presupuesto de `--stale-registers` es el caro (~5 min): "
 "su escaneo es superlineal, y 62 MB es 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "La puerta de la CI"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -80358,20 +81363,20 @@ msgstr ""
 "del compilador; las dos comprobaciones cerradas son de unos tres segundos "
 "cada una sobre ~2000 y ~12900 funciones."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "Está construido para ser capaz de fallar, contra los cuatro peligros en "
 "CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "el estado de salida del verificador es el del trabajo — ningún `continue-on-"
 "error`, ningún tubo;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -80379,7 +81384,7 @@ msgstr ""
 "`concurrency` cancela únicamente las solicitudes de retirada, por lo que las "
 "ejecuciones de `main` nunca se mueren de hambre;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -80390,7 +81395,7 @@ msgstr ""
 "imprime `checked N functions / M modules` para que una ejecución "
 "silenciosamente vacía sea visible;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -80403,7 +81408,7 @@ msgstr ""
 "verificador perdiendo silenciosamente la capacidad de leer la producción de "
 "Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -80420,11 +81425,11 @@ msgstr ""
 "entradas muertas: nueve en `ALLOC_RE` a través de dos rondas, diez en "
 "`POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "La lista de permisos, y por qué no es un número"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -80434,7 +81439,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, una entrada cada una con una huella "
 "digital, un problema y una justificación escrita."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -80447,11 +81452,11 @@ msgstr ""
 "construcción roja es aumentar el número por uno, y nada en el diff dice lo "
 "que fue concedido."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Así que el verificador impone tres propiedades:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -80462,7 +81467,7 @@ msgstr ""
 "es por eso que un insecto fijo no puede dejar una lápida que en silencio "
 "amplía la cobertura más tarde."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -80470,14 +81475,14 @@ msgstr ""
 "**una entrada suprime como máximo su `count`.** Una segunda violación de la "
 "misma forma en la misma función es nueva, y falla."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**Una violación sin entrada falla**, independientemente de cuántas entradas "
 "existen."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -80485,11 +81490,11 @@ msgstr ""
 "Agregar una entrada es un evento de revisión de código. Poner un `count` en "
 "verde una compilación es lo que este archivo existe para prevenir."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Promoviendo esta puerta"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -80498,11 +81503,11 @@ msgstr ""
 "comprobaciones requeridas por la protección de ramas**, lo que significa que "
 "no puede hacer que una fusión falle — riesgo 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Las dos condiciones #7198 nombradas se cumplen ahora:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -80512,7 +81517,7 @@ msgstr ""
 "lista de permisos (las entradas #7211 se eliminaron cuando ese predicado se "
 "fijó en \\#7226);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -80522,7 +81527,7 @@ msgstr ""
 "(#7236). Ese fue el sobresaliente: fue 98 antes de #7235, 2 después, y 0 una "
 "vez que `Type::Symbol` dejó de ser clasificado como un inmediato."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -80530,7 +81535,7 @@ msgstr ""
 "Así que el paso restante es para un **repo admin** añadir `gc-root-"
 "dominance` a los contextos de protección de sucursales requeridos:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -80544,7 +81549,7 @@ msgstr ""
 "con el paso `--unrooted-allocas` incluido — una puerta que nunca ha sido "
 "verde en su forma actual bloquea cada PR abierta el día que se requiere."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -80567,11 +81572,11 @@ msgstr ""
 "población está fija; una promoción que congela el presupuesto donde está ha "
 "comprado un número, no un invariante."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Reglas generales"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -80586,7 +81591,7 @@ msgstr ""
 "los inicializadores suministrados por el autor, nunca sobre las propias "
 "llamadas `js_object_set_field_by_name` emitidas por la bajada."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -80595,7 +81600,7 @@ msgstr ""
 "carga de una ranura raíz a través de una llamada. `rooted_handle_get` existe "
 "para esto."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -80605,7 +81610,7 @@ msgstr ""
 "operandos donde uno se materializa antes de otro se baja necesita el primero "
 "enraizado."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -80613,7 +81618,7 @@ msgstr ""
 "**`--trace llvm` y léelo.** Tres segundos del comprobador vencen a un día de "
 "biseccionar un `not a function` cinco ciclos río abajo."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -80877,6 +81882,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Ejecutarlo localmente con:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Validación en Tiempo de Compilación"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "El usuario elige motor por carga de trabajo"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -81335,7 +82509,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: String -- el nombre de registro, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -81373,36 +82548,34 @@ msgid "Three types and one rule."
 msgstr "Tres tipos y una regla."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 "/// Un registro con un valor administrado por GC que NO está arraigado."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// Toma prestado el emisor de forma inmutable. No Clone, no Copiar."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Una raíz de sombra. Supera los puntos de recogida; no se puede leer "
 "directamente."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// sólo se puede obtener de ShadowFrame::alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr "/// Un registro con algo que el GC no maneja: i32, doble, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// un índice de ranuras. Libremente clonable, sin vida, sin pedir prestado "
-"al emisor."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -81413,28 +82586,33 @@ msgstr ""
 "pueden recoger**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "/// No se puede recoger. Toma & self, tan excepcional `Raw` maneja mantener "
 "la validez."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// Puede cobrar. Toma &mut uno mismo, que termina cada `Raw` sobresaliente "
 "prestado."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// Releer la ranura. El Raw devuelto es válido hasta la siguiente emisión "
 "de &mut."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 "/// Consumir este registro en una raíz. La única manera de hacer un Rooted."
 
@@ -81453,24 +82631,22 @@ msgstr ""
 "utilizarse en un punto de recogida** — el compilador lo rechaza."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_>, préstamos e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// necesita &mut e"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERROR: préstamos en efectivo e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// que es mutablemente"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// tomado prestado arriba"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -81480,7 +82656,8 @@ msgstr ""
 "error:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// releer, corregir"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -82123,8 +83300,9 @@ msgstr ""
 "**La escotilla de escape**, mientras que cualquier persona que llama lo use."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -83776,11 +84954,15 @@ msgstr ""
 "máquina de construcción."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Este modelo de sidecar no tiene escritura de primera carrera, por lo que los "
 "directorios de instalación de sólo lectura son compatibles. Mover el "
@@ -83788,7 +84970,21 @@ msgstr ""
 "faltantes o hash-mal emparejados fallan antes de `dlopen` con un error de "
 "empaque."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -83805,7 +85001,7 @@ msgstr ""
 "archivo. Perry no elimina los atributos de cuarentena de binarios "
 "descargados no confiables en tiempo de ejecución."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -83824,11 +85020,11 @@ msgstr ""
 "en el gestor de paquetes mientras evita que un archivo `.node` host entre en "
 "un artefacto de destino."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Identidad caché"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -83837,31 +85033,31 @@ msgstr ""
 "contribuye con lo siguiente a las identidades de la caché de compilación y "
 "enlace:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "versión del esquema de política y versión anunciada de Node-API;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "Tupla objetivo y lista de permisos normalizados;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "el paquete seleccionado name/version y la ruta de entrada relativa;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 y el tamaño de cada archivo de carga útil de sidecar;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "el inventario ordenado de los símbolos exportados;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "modelo de envío (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -83877,11 +85073,11 @@ msgstr ""
 "nivel superior incluso cuando todos los archivos TypeScript y objetos no han "
 "cambiado."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -83900,22 +85096,15 @@ msgstr ""
 "cuando es necesario para la resolución binaria, pero determinísticamente "
 "informa de la instalación no apoyada."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: núcleo a través de la versión 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Puntos de entrada"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -83923,49 +85112,56 @@ msgstr "Puntos de entrada"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Almacenamiento estable por medio ambiente"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "Los valores de Singleton reciben manijas con alcance ordinario"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Acopladores Perry object/array"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -83973,11 +85169,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN-box conversiones"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -83985,37 +85181,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Longitud limitada; soporte `NAPI_AUTO_LENGTH`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "Los callbacks nativos usan registros de host"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` se instala cuando se suministra"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "Incluye funciones, externas, símbolos y distinciones bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -84023,11 +85219,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Comportamiento comprobado de type/status"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -84035,11 +85231,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "Semántica de consulta-duración y terminación NUL incluida"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -84047,19 +85243,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "El código de usuario está atrapado en la excepción"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Semántica de objeto general"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -84067,11 +85263,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "Cadena, símbolo y teclas numéricas"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -84079,11 +85275,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "Nombres UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -84091,43 +85287,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Rastreos y objetos indexados exóticos"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Datos, método y descriptores de acceso"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Sin atajo de identidad de puntero"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "General Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "La vida útil de Callback-info es la llamada nativa"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -84135,11 +85331,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Tabla de metadatos de objetos nativos"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -84147,11 +85343,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Diseño de referencia fuerte y débil arriba"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -84161,11 +85357,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Anidación estricta y validación de generación"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -84173,19 +85369,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Modelo pendiente-slot"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Disponible mientras está pendiente"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -84193,37 +85389,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Puntos de respaldo estables"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Los once tipos declarados de array tipo"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Respaldo de la identidad y de las compensaciones preservadas"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Retornos 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -84231,19 +85427,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "Los registros diferidos son raíces de propiedad ambiental"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -84251,41 +85447,41 @@ msgstr ""
 "Devuelve `napi_generic_failure`; la ejecución arbitraria de la fuente de "
 "tiempo de ejecución violaría el modelo de motor sin tiempo de ejecución"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Contabilidad de la presión del colector"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: versiones 5 a 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr ""
 "Finalización en cola después del período de sesiones del Consejo de Seguridad"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -84293,11 +85489,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Precisión arbitraria"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -84305,23 +85501,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "Comportamiento exacto de `lossless` y cuenta de palabras"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "Modo de recogida, filtro y conversión de teclas"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -84329,46 +85525,46 @@ msgstr ""
 "Un registro por entorno; sobrescribe el reemplazo sin llamar al ultimador "
 "anterior"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Existiendo propagación de desprendimiento"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "Etiqueta de 128 bits en metadatos de objetos"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Máquinas de descriptores Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: versión 9, versión 10, y experimental"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -84376,16 +85572,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "Publicidad sólo con una superficie completa de la versión-9"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -84393,11 +85589,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Requiere trabajo externo de cadena lifetime/accounting"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -84405,29 +85601,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "Alias de vía rápida de la versión 10"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "No es parte de la ABI estable anunciada"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -84435,33 +85631,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Registro del legado y ruta de abortar"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Integración de ganchos de sincronización existente"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -84469,11 +85665,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry Identidad `Buffer` y bytes estables"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -84481,15 +85677,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Máquina de estado explícito arriba"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -84497,15 +85693,15 @@ msgstr ""
 "Devuelve los componentes de Perry con cadena de liberación `perry`; no "
 "reclama una liberación de Nodo"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr "Devuelve `napi_generic_failure` y un bucle nulo; Perry no tiene libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -84513,19 +85709,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Ciclo de vida de los hilos principales"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Contexto de sincronización y anidación estricta"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -84533,11 +85729,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN respaldado por el lanzamiento de eventos"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -84545,35 +85741,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Conteo de hilos y ciclo de eventos"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "El apagado espera a que se complete"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "El medio ambiente ya registra el valor futuro"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Publicidad con la versión 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -84583,18 +85779,18 @@ msgstr ""
 "`napi_register_module_v1`; estos son buscados en el addon y no son "
 "exportaciones de host."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Puertas necesarias"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "La implementación no se completa hasta que las puertas de abajo puedan "
 "fallar de forma independiente:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -84607,7 +85803,7 @@ msgstr ""
 "generación de fallos; los scripts de auditoría de root-holder y rekey-table "
 "están limpios."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -84617,7 +85813,7 @@ msgstr ""
 "ultimador, y TSFN callback todo el retorno a través de C antes de Perry se "
 "eleva; un addon instrumentado afirma que ningún descanso entró en sus marcos."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -84627,7 +85823,7 @@ msgstr ""
 "llamada `napi_*` y la prueba demuestra que la dirección pertenece al "
 "ejecutable Perry. El número de llamadas de humo debe ser mayor que cero."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -84639,7 +85835,7 @@ msgstr ""
 "finalizers, y buffers. Las versiones NAPI, NAN/V8 y `uv_*` no soportadas "
 "afirman su diagnóstico exacto."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -84650,7 +85846,7 @@ msgstr ""
 "corrientes coalescadas idénticas; ambos lados afirman que su implementación "
 "nativa realmente funcionó."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -84660,7 +85856,7 @@ msgstr ""
 "ubicación de sólo lectura y cargar con éxito; la eliminación o mutación de "
 "un sidecar falla la comprobación de hash manifiesto."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -84668,7 +85864,7 @@ msgstr ""
 "**Puerta de caché:** cambiar sólo los bytes de addon o la política falla la "
 "caché de compilación; reconstruir las entradas sin cambios lo golpea."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -84677,7 +85873,7 @@ msgstr ""
 "addon vacío; informe el delta de host sólo para una construcción de addon y "
 "hacer cumplir el presupuesto de 0.6 MB."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -85253,28 +86449,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "Utilice comandos explícitos para alcances más amplios:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Producto feedback loop"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Cada miembro del espacio de trabajo compatible con el host (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"Paquete\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Inspeccionar o validar la arquitectura del espacio de trabajo"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -85429,7 +86611,8 @@ msgstr ""
 "construye con `--no-default-features` para biseccionar el motor textual-IR."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# Construir el producto predeterminado y su cierre de dependencia"
 
 #: src/contributing/building.md:37
@@ -85556,7 +86739,8 @@ msgstr ""
 "envoltura:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# Slim, desarrollador optimizado CLI"
 
 #: src/contributing/building.md:80
@@ -85589,26 +86773,31 @@ msgid "Build Specific Crates"
 msgstr "Compilar crates específicos"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# Tiempo de ejecución solamente (debe reconstruir stdlib también!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Los archivos estáticos .a son emitidos por cajas de envoltura separadas "
 "(#5422), así que un"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# explícitamente cuando necesita libperry_runtime.a / libperry_stdlib.a "
 "(e.g. para enlazar"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Codificadores únicamente"
 
 #: src/contributing/building.md:106
@@ -85655,17 +86844,21 @@ msgid "Run Tests"
 msgstr "Ejecutar pruebas"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Objetivos de las unidades de producto"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Inspeccione el alcance de prueba de IC nocturno (todas las cajas de prueba "
 "compatibles con Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Caja específica"
 
 #: src/contributing/building.md:137
@@ -85673,11 +86866,13 @@ msgid "Compile and Run TypeScript"
 msgstr "Compilar y ejecutar TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Compilar un archivo TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Depuración: imprimir HIR"
 
 #: src/contributing/building.md:148
@@ -85746,19 +86941,23 @@ msgstr ""
 "registro público difiere."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Confirme que el checkout es actual y limpio."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# debe imprimir 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# no debe imprimir nada"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Control rápido de políticas y scripts."
 
 #: src/contributing/releasing.md:23
@@ -85766,7 +86965,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Controles de comportamiento manejables por los anfitriones. Estos mejoran "
 "la respuesta, pero no lo hacen"
@@ -85793,7 +86994,8 @@ msgstr ""
 "del proceso de fusión normal."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Sustituir la versión ya presente en Cargo.toml."
 
 #: src/contributing/releasing.md:48
@@ -85813,7 +87015,8 @@ msgid "'[0-9]*.md'"
 msgstr "«[0-9]*.md»"
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # no debe imprimir nada"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -85921,9 +87124,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "medidas permitidas: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -85956,22 +87160,15 @@ msgstr ""
 "intencionalmente un conjunto parcial."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# un paquete de lanzamiento ejecuta: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # publicar + verificar todos los 9 a través de "
-"la OIDC, a continuación, crear"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + el último lanzamiento de GitHub"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# inspeccionar el recibo commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -86193,11 +87390,13 @@ msgstr ""
 "humano:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# Compilación para el simulador"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr ""
 "# Arranque un dispositivo (una vez; reutilice el UDID a través de las "
 "carreras)"
@@ -86207,22 +87406,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Instalar + lanzamiento con modo de prueba"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# La aplicación sale 0 después de la renderización; la captura de pantalla "
-"aterriza en el contador-ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -86496,6 +87682,10 @@ msgid "patch distance"
 msgstr "distancia del parche"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -86531,15 +87721,18 @@ msgstr ""
 "cierra a sí mismo una vez que el registro ha alcanzado."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# prueba que puede fallar"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# registro real, ningún problema escribe"
 
 #: src/contributing/releasing.md:289
@@ -86599,6 +87792,378 @@ msgstr ""
 "distribución de paquetes de liberación heredados, envíelo con "
 "`existing_tag=vX.Y.Z`; añada `publish_npm=true` sólo cuando la pierna "
 "idempotente npm también necesite volver a intentarlo."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "«pdfium-render = \"0.8\"»"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# Editar src/lib.rs — añadir sus funciones `js_*`, todos utilizando sólo"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr ""
+#~ "# Editar src/index.ts — declarar las importaciones de código de usuario "
+#~ "de superficie TS"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# Editar package.json — lista cada exportación js_* en el"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# Manifiesto que coincide con la lib estática"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# el andamio release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # construye preconstruidos para todos "
+#~ "los objetivos"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # y los une a la liberación"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Encuadernaciones nativas para <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string` — extraer el texto de un buffer PDF."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "///# Seguridad"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` debe ser nulo o válido para los bytes `buf_len`. Perry pasa"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// este par de un parámetro de manifiesto `buffer+len`."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const result = fail spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Relleno e insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 rebanada (objetivo predeterminado del dispositivo)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. alinear minos + fusible"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => brazo arm64_3264"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"plataformas;android-35\" \"herramientas de construcción;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "«imágenes del sistema;android-34;confección de android;arm64-v8a»"
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. El objetivo transversal Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Crear + arrancar un emulador Wear OS (reloj redondo)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Paquetes npm adicionales y APIs de Node.js compatibles con Perry. Todo lo "
+#~ "listado aquí está conectado a través del registro de bindings nativos "
+#~ "bien conocidos de Perry (#466) y compila a código nativo sin ninguna "
+#~ "participación del runtime de JavaScript."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr ""
+#~ "# 3) Sanidad-comprobar la firma localmente antes de subir el manifiesto —"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    aquí predice una verificación de paso en el cliente."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Lanzamiento CI firma el manifiesto CLI, encuadernando su URL de "
+#~ "archivo, plataforma,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// Detectar objetivo: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos "
+#~ "SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// Compilar: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// Enlace: carga:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "«Tipo de contenido: application/json»"
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "'{\"texto\":\"hola mundo\"}"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "«{\"valor\":0.75}»"
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "«{\"valor\":42}»"
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "'{\"Shortcut\":\"s\"}"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Déjalo correr durante 30 segundos"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Comprobar estadísticas"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"correr\":true,\"events_fired\":600,\"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Toma una captura de pantalla para ver el estado final"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Detener el caos"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Compruebe que la aplicación sigue viva"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Construcción para iOS (compilación cruzada)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "'.jobs[] | select(.status==\"in_progress\") | (.etiquetas|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# Qué tan profunda es la cola, y en qué piscinas:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "'.jobs[] | select(.status==\"queued\") | (.etiquetas|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"Ataduras nativas para libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "'libfoo = \"1.0\"'"
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Buques Perry **dos canales independientes de admisión voluntaria** para "
+#~ "enviar datos a casa — nada sale de su máquina sin un `enabled = true` "
+#~ "explícito o `on` en `~/.perry/config.toml`. Ambos honores "
+#~ "`PERRY_NO_TELEMETRY=1` y `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "emitir diagnósticos de colectores legibles por personas"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr ""
+#~ "# NATIVO (PERRY_RS4GC=1): el valor predeterminado en todas partes. Anclas "
+#~ "sobre"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` alocas de raíz y LLVM inserta los puntos de "
+#~ "seguridad más tarde, por lo que el"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): la escritura de ranura es incondicional; la "
+#~ "barrera"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// abajo está protegido sólo por una prueba en vivo que los bits "
+#~ "almacenados no llevan ningún montón"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// puntero, que es la primera prueba de la barrera."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr ""
+#~ "/// Toma prestado el emisor de forma inmutable. No Clone, no Copiar."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// un índice de ranuras. Libremente clonable, sin vida, sin pedir "
+#~ "prestado al emisor."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERROR: préstamos en efectivo e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// que es mutablemente"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// tomado prestado arriba"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"Paquete\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Inspeccionar o validar la arquitectura del espacio de trabajo"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# un paquete de lanzamiento ejecuta: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # publicar + verificar todos los 9 a través "
+#~ "de la OIDC, a continuación, crear"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr ""
+#~ "                            # v0.x.y + el último lanzamiento de GitHub"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# La aplicación sale 0 después de la renderización; la captura de "
+#~ "pantalla aterriza en el contador-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -87668,9 +89233,6 @@ msgstr ""
 
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "Variables de entorno `LANG` / `LC_ALL` / `LC_MESSAGES`"
-
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Validación en Tiempo de Compilación"
 
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""

--- a/docs/po/fr.po
+++ b/docs/po/fr.po
@@ -214,7 +214,7 @@ msgstr "Hooks"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Exemples"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "Niveaux de CI (contrôle de PR / balayage / suite complète)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Planification des contrôles CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "Référence CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Commandes"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Drapeaux du compilateur"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Répertoire de cache"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dispatch Dynamique de la Bibliothèque Standard"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "Activation du Runtime JS"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar d'attestation binaire)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Liste d'autorisation de sortie (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Capacités par paquet (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Liste d'autorisation hôte (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "Référence perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Recherche de mises à jour dans vos applications"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Confidentialité et télémétrie"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Internals"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Modèle Mémoire"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Ramasse-miettes"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Gestion explicite de la mémoire"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "L’invariant d’enracinement du GC (génération de code)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Preuves de type pour les liaisons locales"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Limites des étapes du GC incrémental"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC : enracinement par construction"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Contribuer"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Architecture"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Politique des crates"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Compiler depuis les sources"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Publier une version de Perry"
 
@@ -936,7 +944,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Ouvre une fenêtre macOS/Windows/Linux native"
 
 #: src/introduction.md:79
@@ -970,11 +979,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -983,9 +992,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -995,7 +1004,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Étapes suivantes"
@@ -1071,27 +1080,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Chaîne d'outils de liaison Linux par distribution:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint est un logiciel de mise à jour"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS est en cours d'exécution"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# À base de mousse alpine"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Nul Linux"
 
 #: src/getting-started/installation.md:41
@@ -1133,15 +1148,18 @@ msgstr ""
 "Windows x64) avec une seule commande:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Projet-local (pins la version de Perry à côté de vos dépôts)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Installation à zéro, une prise"
 
 #: src/getting-started/installation.md:66
@@ -1341,7 +1359,8 @@ msgstr ""
 "Le binaire se trouve dans `target/release/perry`. Ajoutez-le à votre PATH :"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Ajouter à ~/.zshrc ou ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1481,16 +1500,14 @@ msgstr ""
 "plateformes ne les requiert pas.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu ou Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2182,25 +2199,30 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "Le même code s'exécute sur les 6 plateformes :"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (par défaut)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# Simulateur iOS"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr ""
 "# Web (compile vers WebAssembly + pont DOM dans un fichier HTML autonome)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# Alias: --target était"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Autres plateformes"
 
 #: src/getting-started/first-app.md:138
@@ -2448,7 +2470,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2466,7 +2488,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2694,7 +2716,8 @@ msgstr ""
 "générateur :"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2726,7 +2749,8 @@ msgid "\"port\""
 msgstr "\"port\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// source autonome"
 
 #: src/getting-started/project-config.md:122
@@ -2975,19 +2999,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Champ"
 
@@ -3002,9 +3027,9 @@ msgstr "Champ"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3126,11 +3151,13 @@ msgstr ""
 "aucune configuration :"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3185,7 +3212,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3194,7 +3221,7 @@ msgstr ""
 "de Perry. Voir [Bibliothèque standard](../stdlib/overview.md) pour la liste "
 "complète."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3203,46 +3230,49 @@ msgstr ""
 "pour les packages TS/JS purs, ou le repli sur le runtime JavaScript pour les "
 "packages complexes."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Structure du projet"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry est flexible quant à la structure du projet. Modèles courants :"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Pour les applications UI :"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Compilation"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Compiler un fichier"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# Compiler avec une cible spécifique"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Débogage: représentation intermédiaire d'impression"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "Voir [Commandes CLI](../cli/commands.md) pour toutes les options."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 "[Commandes CLI](../cli/commands.md) — Toutes les commandes et options du "
 "compilateur"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3250,7 +3280,7 @@ msgstr ""
 "[Fonctionnalités prises en charge](../language/supported-features.md) — "
 "Quelles fonctionnalités TypeScript fonctionnent"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr ""
 "[Bibliothèque standard](../stdlib/overview.md) — Packages npm pris en charge"
@@ -3391,32 +3421,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Classes"
 
@@ -5479,6 +5510,7 @@ msgstr ""
 "et prend en charge deux chemins :"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5488,7 +5520,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Les décorateurs de classe hérités, les décorateurs de méthode, les "
 "décorateurs de propriété, les décorateurs de paramètre de constructeur et "
@@ -5501,7 +5537,7 @@ msgstr ""
 "Perry émet `design:paramtypes` pour les classes/méthodes décorées et "
 "`design:type` pour les propriétés décorées."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5514,15 +5550,15 @@ msgstr ""
 "aucun mécanisme de décorateur à l'exécution. Voir `crates/perry-hir/src/"
 "decorator_log.rs` pour l'implémentation."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Ce qui ne fonctionne pas"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Les décorateurs d'accesseur et le remplacement de descripteur"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5539,17 +5575,17 @@ msgstr ""
 "la classe abaissée est fixée dans l'IR et ne peut pas être remplacée à "
 "l'exécution."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Les appels généraux à `Reflect.metadata(...)` en dehors de la syntaxe des "
 "décorateurs"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` comme clé de métadonnée"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5557,7 +5593,7 @@ msgstr ""
 "`emitDecoratorMetadata` au-delà de `design:paramtypes` pour les classes/"
 "méthodes et `design:type` pour les propriétés"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5567,13 +5603,13 @@ msgstr ""
 "delà du canari de constructeur de classe réduit (`tsyringe`, comportement "
 "complet de l'injecteur NestJS, injecteur racine d'Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "Les flux de métadonnées à l'exécution de `class-validator`, `type-graphql`, "
 "`TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5583,11 +5619,11 @@ msgstr ""
 "câblage explicite ou une transformation AOT dédiée, et non l'utilisation du "
 "runtime complet des décorateurs TypeScript hérités."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Motif recommandé : construction explicite"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5600,7 +5636,7 @@ msgstr ""
 "fonctionnent déjà les frameworks TS sans décorateurs (Hono, serveurs tRPC, "
 "applications Drizzle)."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5616,7 +5652,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5626,11 +5662,11 @@ msgstr ""
 "— l'ordre de construction _est_ le graphe de dépendances, et il est vérifié "
 "par le compilateur TypeScript."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Recette de migration : un service Angular"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5640,19 +5676,19 @@ msgstr ""
 "services/rating.service.ts`, environ 80 lignes), présenté dans sa forme "
 "Angular originale puis porté vers Perry."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Avant — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Après — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Trois changements mécaniques :"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5660,7 +5696,7 @@ msgstr ""
 "**Supprimez `@Injectable`.** Il ne portait aucune information que la forme "
 "de la classe ne porte pas déjà."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5671,7 +5707,7 @@ msgstr ""
 "comportent comme des Promises. (Pour des flux à valeurs multiples, utilisez "
 "`AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5684,11 +5720,11 @@ msgstr ""
 "plus clairement lorsque la classe est instanciée à la main plutôt que par un "
 "conteneur."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Câblage"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5708,7 +5744,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5726,7 +5762,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5736,13 +5772,13 @@ msgstr ""
 "'root'`, la recherche implicite dans le conteneur — tout cela se résume en "
 "une seule ligne `new RatingService(api)` dans `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr ""
 "Qu'en est-il des composants Angular, des contrôleurs NestJS, des entités "
 "TypeORM ?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5766,11 +5802,11 @@ msgstr ""
 "enregistrer des itinéraires ou des schémas comme des appels de fonction "
 "simples / constantes au niveau du module."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Orientation future"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6497,12 +6533,13 @@ msgstr ""
 "et n'a besoin de rien au moment de la liaison."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Appels statiques littéraux** (`WebAssembly.instantiate(bytes)` écrit "
@@ -8108,58 +8145,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Créer un binding — le tour en 60 secondes"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"Bindings de rendu PDF\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\""
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# Modifier src/lib.rs  ajouter vos fonctions `js_*`, tous en utilisant "
-"uniquement"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr ""
-"# Modifier src/index.ts  déclarer le code d'importation de l'utilisateur de "
-"surface TS"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# Modifier package.json  liste de toutes les exportations js_* dans le"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ le manifeste correspond à la clé statique"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# l'échafaudage release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # construit des pré-constructions pour "
-"toutes les cibles"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # et les attache à la décharge"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8562,7 +8554,7 @@ msgstr "Statut actuel"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8582,7 +8574,7 @@ msgstr "En attente de déménagement"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8634,7 +8626,7 @@ msgstr "En attente de migration"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8694,7 +8686,7 @@ msgstr "Compiler la source du paquet en amont"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8702,7 +8694,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8710,7 +8702,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8718,7 +8710,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8750,7 +8742,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8758,7 +8750,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8766,7 +8758,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8798,7 +8790,7 @@ msgstr "En paquet; conservés"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8806,7 +8798,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8838,7 +8830,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8846,7 +8838,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8854,7 +8846,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8862,7 +8854,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8878,7 +8870,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8886,7 +8878,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8894,7 +8886,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8902,7 +8894,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8926,7 +8918,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8934,7 +8926,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8942,7 +8934,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8950,7 +8942,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8958,7 +8950,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8966,7 +8958,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8974,7 +8966,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8982,7 +8974,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8990,7 +8982,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8998,7 +8990,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -9006,7 +8998,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -9014,7 +9006,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -9069,14 +9061,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr "1. Scaffolding"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Réservations natives pour <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Cela crée :"
@@ -9109,28 +9093,21 @@ msgstr ""
 "`perry_ffi` :"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  extraire du texte d'un tampon PDF."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # Sécurité"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr` doit être nul ou valide pour les octets `buf_len`. Perry est "
-"passé"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// cette paire à partir d'un paramètre de manifestation `buffer+len`."
+"/// `pdf.parse(buf) -> string` — extrait le texte d'un tampon PDF.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` doit être null ou valide pour `buf_len` octets. Perry "
+"transmet\n"
+"/// cette paire depuis un paramètre manifeste `buffer+len`.\n"
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9265,7 +9242,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"Bonne\""
 
@@ -9507,7 +9484,8 @@ msgid "In a separate directory:"
 msgstr "Dans un répertoire séparé :"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# ou n'importe quel chemin que votre outil supporte"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9905,7 +9883,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Écouteurs d'événements (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr ""
 "// les pointeurs de fermeture, maintenus en vie par le scanner GC ci-dessous"
 
@@ -10359,7 +10338,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr ""
 "// ... lire le fichier, régler les environnements, retourner 1.0 / 0.0 "
 
@@ -10670,8 +10650,8 @@ msgstr "Requis"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Notes"
 
@@ -10729,14 +10709,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12487,34 +12467,41 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Les outils  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Provision ou bouton d'une broche vers une version spécifique (par défaut: "
 "dernière stable)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# Prévoir chaque liaison actuellement non fixée à sa dernière stable"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Porte hors ligne (CI): épingles présentes, verrouillées, des caisses "
 "existent. Sortie 1 sur n'importe quelle"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Avis: en outre, les épingles de drapeau dont la sortie stable en amont est "
 "plus récente"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# Matérialiser le repo en amont au ref fixé dans gitignored en amont/<name>"
 
@@ -12755,15 +12742,15 @@ msgstr ""
 "Pour les CI qui ne doivent jamais remplacer un emballage partiel, définir:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12920,7 +12907,7 @@ msgstr "Réalité"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12937,7 +12924,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14937,19 +14924,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Comparaison avec les worker_threads de Node.js"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~15 lignes, un fichier séparé est nécessaire ────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14969,12 +14956,11 @@ msgid "/* handle */"
 msgstr "/* le manche */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// ── Perry: 1 ligne ──────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const résultat = attendre spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -15189,13 +15175,14 @@ msgid "Mental Model"
 msgstr "Modèle mental"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "L'interface utilisateur de Perry suit le même modèle que SwiftUI et "
 "Flutter : vous composez des widgets natifs à l'aide de conteneurs de mise en "
@@ -15284,7 +15271,7 @@ msgstr ""
 msgid "Property"
 msgstr "Propriété"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15737,7 +15724,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15761,7 +15748,7 @@ msgstr ""
 "Le comportement spécifique à chaque plateforme est indiqué sur la page de "
 "documentation de chaque widget."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17390,7 +17377,8 @@ msgid "Double-click handler"
 msgstr "Gestionnaire de double-clic"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17454,12 +17442,13 @@ msgstr ""
 "chaque PR."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Les aides de mise en page sont des fonctions gratuites: "
 "`widgetAddChild(parent, child)`, `stackSetAlignment(stack, value)`, "
@@ -17942,7 +17931,7 @@ msgstr "Effet"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17955,7 +17944,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "Les enfants s'alignent sur le bord de début (gauche)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17968,7 +17957,7 @@ msgid "Children centered horizontally"
 msgstr "Enfants centrés horizontalement"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17989,7 +17978,7 @@ msgstr "**Alignement HStack** (axe transversal = vertical) :"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -18016,8 +18005,8 @@ msgstr "Enfants centrés verticalement"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -18071,9 +18060,9 @@ msgstr "Comportement"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -18096,11 +18085,11 @@ msgstr "Tous les enfants ont la même taille"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18305,9 +18294,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Piles avec rembourrage intégré"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Créez une pile avec un rembourrage en un seul appel. L'ordre est **haut, "
 "gauche, bas, droite** (style abrégé CSS), et non haut/droite/bas/gauche :"
@@ -18331,11 +18321,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` est la contrepartie "
 "horizontale. Équivalent à la création d'une pile suivie d'un appel à "
@@ -18625,8 +18616,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -19013,6 +19005,7 @@ msgstr ""
 "compiler accepte."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -19024,7 +19017,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -19052,11 +19044,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Couleurs"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -19072,11 +19064,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Polices"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -19092,15 +19084,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Utilisez `\"monospaced\"` pour la police monospace système."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Rayon de coin"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -19112,21 +19104,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Bordures"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Rembourrage et marges internes"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Rembourrage"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -19136,11 +19128,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Dimensionnement"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -19156,11 +19156,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Opacité"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -19172,11 +19172,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Dégradé d'arrière-plan"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -19198,11 +19198,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Taille du contrôle"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -19214,7 +19214,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -19222,11 +19222,11 @@ msgstr ""
 "**macOS** : Correspond à `NSControl.ControlSize`. Les autres plateformes "
 "peuvent l'interpréter différemment."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Info-bulles"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -19238,7 +19238,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -19246,11 +19246,11 @@ msgstr ""
 "**macOS/Windows/Linux** : Info-bulles natives. **iOS/Android** : Pas de "
 "support des info-bulles. **Web** : Attribut HTML `title`."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Activé/Désactivé"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -19262,11 +19262,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Exemple impératif complet"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -19286,7 +19287,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19314,10 +19315,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19390,15 +19391,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Composition de styles (fonctions utilitaires impératives)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Réduisez les répétitions en créant des fonctions utilitaires :"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19408,11 +19409,11 @@ msgstr ""
 "définir des tokens de design en JSON et générer un fichier de thème typé. "
 "Voir [Thématisation](theming.md) pour le flux de travail complet."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Support des plateformes"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19423,7 +19424,7 @@ msgstr ""
 "src/styling_matrix.rs` et vérifiée en CI par rapport aux exports `lib.rs` de "
 "chaque backend à chaque PR."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19443,15 +19444,15 @@ msgstr ""
 "dans une autre table manuelle; consulter la matrice afin que la "
 "documentation ne puisse pas dériver de l'inventaire backend."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Mise en page](layout.md) — Conteneurs de mise en page"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — Animer les changements de style"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr ""
 "[Thématisation](theming.md) — Tokens de design via le package `perry-styling`"
@@ -20804,8 +20805,8 @@ msgstr "Implémentation"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Statut"
 
@@ -24383,7 +24384,7 @@ msgstr ""
 msgid "Options"
 msgstr "Options"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25994,7 +25995,7 @@ msgstr "Équivalence avec ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26721,15 +26722,18 @@ msgid "Cross-Compilation"
 msgstr "Compilation croisée"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# Par défaut: compilation pour la plateforme actuelle"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# Compiler pour une cible spécifique"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  Android sur une montre"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26945,7 +26949,8 @@ msgid "Building"
 msgstr "Compilation"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS est la cible par défaut"
 
 #: src/platforms/macos.md:18
@@ -27050,7 +27055,8 @@ msgid "App Store Distribution"
 msgstr "Distribution sur l'App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Signer avec le certificat App Store"
 
 #: src/platforms/macos.md:60
@@ -27058,7 +27064,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -27194,15 +27201,18 @@ msgstr ""
 "La façon la plus simple de compiler et d'exécuter sur iOS est `perry run` :"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# Détection automatique device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# En direct stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Utilisez le serveur de compilation Perry Hub"
 
 #: src/platforms/ios.md:40
@@ -27865,7 +27875,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Cela produit un binaire ARM64 pour le matériel Apple TV physique."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Détection automatique du simulateur Apple TV démarré"
 
 #: src/platforms/tvos.md:39
@@ -28360,11 +28371,13 @@ msgstr ""
 "dispositif](#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# Simulateur (niveau 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28476,20 +28489,14 @@ msgstr ""
 "la source une fois, puis pointez `PERRY_RUNTIME_DIR` vers elles:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (série 9+ / watchOS 26+)  la cible du dispositif par défaut"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (série 4-8 / SE)  opt-in avec PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28506,7 +28513,7 @@ msgid "Build environment variables"
 msgstr "Créer des variables d'environnement"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Variable"
@@ -28627,7 +28634,8 @@ msgstr ""
 "`TypeError` résultante a déréférencé la fermeture en tant qu'objet."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Simulateur de montre détecté automatiquement"
 
 #: src/platforms/watchos.md:126
@@ -29237,36 +29245,13 @@ msgstr ""
 "ensemble:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 tranche à la cible de déploiement partagé (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. tranche arm64 (cible du dispositif par défaut)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. aligner les minos + fusible"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -29389,19 +29374,8 @@ msgstr ""
 "**enregistrement de nouvelle application propre** dans App Store Connect."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Distribution Apple: <Team>\" est une vidéo"
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -29414,6 +29388,10 @@ msgid ""
 msgstr ""
 "`altool` ne peut pas télécharger les applications de surveillance (\"ne peut "
 "pas déterminer la plateforme\"). Utilisez le Transporteur:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29774,19 +29752,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Configuration unique (exemple macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (`gradle` de Homebrew peut être 9.x  pin 8.x si tel "
 "est le cas)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# ou tout Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 "# 2. Pointez l' env sur le SDK / NDK / JDK 17 (ajouter à votre profil de "
 "shell)"
@@ -29796,7 +29777,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr ""
 "\"$ANDROID_HOME/ndk/<installed-version>\" est le numéro e.g. 28.2.13676358"
 
@@ -29809,32 +29791,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. Les paquets SDK + une image Wear OS arm64"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"outils de plateforme\" \"émulateur\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"plateformes;android-35\" \"outils de construction;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\" est le nom du code"
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"Images du système;android-34;android-wear;arm64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. La cible croisée Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Créer + démarrer un émulateur Wear OS (ronde de surveillance)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29860,7 +29823,8 @@ msgstr ""
 "produit au moment de l'exécution (ci-dessous)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr ""
 "# Détecter automatiquement une montre connectée / émulateur Wear démarré"
 
@@ -31900,7 +31864,8 @@ msgstr ""
 "capture fidèle au pixel."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# Dans un autre terminal:"
 
 #: src/platforms/linux.md:82
@@ -31920,7 +31885,8 @@ msgstr ""
 "pont JavaScript pour les widgets DOM."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# même sortie que --target wasm"
 
 #: src/platforms/web.md:10
@@ -31999,15 +31965,18 @@ msgstr ""
 "imports FFI et du threading Web Worker \"gratuitement\"."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML autonome (par défaut)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# C' est la même chose"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm binaire (sans enveloppe HTML)"
 
 #: src/platforms/wasm.md:21
@@ -32333,11 +32302,13 @@ msgid "Provide them when instantiating:"
 msgstr "Fournissez-les lors de l'instanciation :"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Via __ffiImports global (défini avant le démarrage)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// Ou via le deuxième argument bootPerryWasm"
 
 #: src/platforms/wasm.md:95
@@ -32896,7 +32867,7 @@ msgstr "stdlib complète"
 msgid "The compiler links only the required runtime components."
 msgstr "Le compilateur ne lie que les composants runtime nécessaires."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Bindings natifs externes"
 
@@ -33010,7 +32981,7 @@ msgstr "[Système de fichiers](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Réseau](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Bases de données](database.md)"
 
@@ -33235,8 +33206,8 @@ msgstr ""
 "Passez les chemins de fichiers à travers les frontières de threads et "
 "rouvrez les fichiers dans le worker."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Vue d'ensemble](overview.md) — Tous les modules stdlib"
 
@@ -33336,10 +33307,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Il est pris en charge sur `IncomingMessage`: `.method`, `.url`, `.headers`, "
@@ -33348,10 +33320,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33951,10 +33924,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / Stockage objet compatible S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33970,11 +33969,11 @@ msgstr ""
 "sans aucun patch — vérifié avec une URL présignée SigV4 identique octet par "
 "octet à `bun` (issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -34048,78 +34047,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "Le même code fonctionne avec n'importe quel service compatible S3 — seul "
 "`endPoint` change :"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Service"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (tests)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -34136,7 +34135,7 @@ msgstr ""
 "identiques à `bun` sur des vecteurs de test épinglés et s'authentifieront "
 "correctement auprès d'un vrai S3."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -34149,7 +34148,7 @@ msgstr ""
 "selon #562 — ce chemin se compile mais n'est pas vérifié indépendamment sur "
 "des vecteurs épinglés ici."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34798,9 +34797,10 @@ msgstr ""
 "`inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Utiliser des importations nommées: le formulaire de récepteur d'importation "
@@ -35016,20 +35016,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Packages npm supplémentaires et API Node.js pris en charge par Perry. Tous "
-"ceux listés ici sont connectés via le registre de bindings natifs bien "
-"connus de Perry (#466) et compilent en code natif sans aucune implication "
-"d'un runtime JavaScript."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Traitement d'images)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -35038,7 +35033,7 @@ msgstr ""
 "conversion de format, ainsi que la sortie vers buffer ou fichier "
 "fonctionnent tous."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -35088,15 +35083,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (Analyse HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Bindings natifs via `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -35114,11 +35109,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (E-mail)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -35158,15 +35153,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Compression)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Bindings natifs via `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -35184,11 +35179,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Planification de tâches)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -35196,7 +35191,7 @@ msgstr ""
 "Bindings natifs via `perry-ext-cron` (v0.5.564). Les noms de packages `cron` "
 "et `node-cron` sont tous deux routés vers le même backend."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -35216,11 +35211,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -35230,7 +35225,7 @@ msgstr ""
 "plomberie ABI de style [`ethers-rs`](https://github.com/gakonst/ethers-rs) "
 "via les surfaces BigInt + Buffer de `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -35248,11 +35243,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -35260,7 +35255,7 @@ msgstr ""
 "Bindings natifs via `perry-ext-events` (v0.5.546). La forme `EventEmitter` "
 "correspond à Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -35278,15 +35273,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Logique de nouvelles tentatives)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Bindings natifs via `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -35308,11 +35303,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Précision arbitraire)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -35321,7 +35316,7 @@ msgstr ""
 "packages sont routés vers le même backend — `Decimal` et `BigNumber` sont "
 "tous deux exposés."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -35357,11 +35352,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Manipulation de dates)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -35370,7 +35365,7 @@ msgstr ""
 "sont routés vers le même backend Rust — même surface d'analyse, de formatage "
 "et de calcul de différences."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -35388,11 +35383,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Date héritée)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -35402,7 +35397,7 @@ msgstr ""
 "maintenance en amont — préférez `dayjs` pour le nouveau code, mais Perry "
 "prend en charge les deux pour les bases de code existantes."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -35418,11 +35413,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -35431,7 +35426,7 @@ msgstr ""
 "est connecté ; les backends Redis et cluster feront l'objet de "
 "développements ultérieurs."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -35455,11 +35450,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -35478,7 +35473,7 @@ msgstr ""
 "`parallelFilter` / `spawn` de `perry/thread` reste l'interface la plus "
 "simple (voir [Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -35516,14 +35511,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Les URL du module Web Worker sont détectées par rapport au fichier source "
 "d'importation:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -35556,10 +35551,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (analyse CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35601,11 +35769,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35628,7 +35796,7 @@ msgstr ""
 "`sizeCalculation`, `dispose`, `fetch`, `allowStale` et la surface de "
 "l'itérateur ne sont pas encore implémentés."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35658,11 +35826,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35712,11 +35880,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35731,7 +35899,7 @@ msgstr ""
 "pour le moment (macOS + Linux); sur d'autres hôtes `spawn` lance, ce qui "
 "déclenche les chemins de secours non vides des consommateurs."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35744,7 +35912,7 @@ msgstr ""
 "`undefined` autrement; `kill()` par défaut à `SIGHUP` comme node-pty. Le "
 "`TERM` chez l'enfant provient du `name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35790,11 +35958,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35810,7 +35978,7 @@ msgstr ""
 "au moment de la compilation. Le comportement a été vérifié par `@parcel/"
 "watcher` 2.5.1."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35831,7 +35999,7 @@ msgstr ""
 "notifications overflow/rescan du backend déclenchent un nouvel instantané "
 "d'arbre et émettent sa différence."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35852,7 +36020,7 @@ msgstr ""
 "la même sémantique de différence d'instantané que la récupération de "
 "débordement."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35863,7 +36031,7 @@ msgstr ""
 "package npm, mais sont adossés à Rust et compilés nativement via `perry-"
 "ffi` :"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35871,7 +36039,7 @@ msgstr ""
 "**`@perryts/tursodb`** — Client de base de données Turso (fork libSQL). Voir "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35879,11 +36047,11 @@ msgstr ""
 "**`@perryts/iroh`** — Réseau pair-à-pair Iroh. Voir [PerryTS/iroh-bindings]"
 "(https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "Drivers TypeScript purs compilés via `compilePackages` :"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35893,7 +36061,7 @@ msgstr ""
 "**`@perryts/redis`** — Clients de protocole wire qui fonctionnent également "
 "sur Node.js et Bun sans modification."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35901,11 +36069,11 @@ msgstr ""
 "Voir [Bindings Natifs — Vue d'ensemble](../native-libraries/overview.md) "
 "pour le contrat que suivent ces packages externes."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[Système de fichiers](fs.md) — APIs fs et path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[Bindings Natifs](../native-libraries/overview.md) — Créer les vôtres"
 
@@ -35929,7 +36097,8 @@ msgstr ""
 "l'exécution sur la cible choisie."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Au total: 3019 entrées dans 138 modules."
 
 #: src/api/reference.md:9
@@ -36026,4831 +36195,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Méthodes"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — module"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Propriétés"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "Module `__nativeEventCount`"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "Module `getEventsSince`"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — module"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — module"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "Module `writeSnapshot`"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — module"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — module"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — module"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — module"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — module"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — instance"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — instance"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — instance"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — instance"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — instance"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — instance"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — instance"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — module"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — module"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — module"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — module"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — module"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — module"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — module"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — module"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — module"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — module"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — module"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — module"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — module"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — module"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — module"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — module"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — module"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — module"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — module"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — module"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — module"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "Module `throws`"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — instance _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — module _(classe : `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — module _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — instance _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — module"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — instance"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — instance _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — instance _(classe : `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — instance"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — module"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — module"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — instance"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — instance"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — instance"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — instance _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — module _(classe : `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — module"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(classe : `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — module"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — module"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — module"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — module"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — module"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — module"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — module"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — module"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — module"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — module"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — module"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — instance"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — instance"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — instance"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — instance"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — instance"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — instance"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — instance"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — instance"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — instance"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — instance"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — instance"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — module"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — module"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — module"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — module"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — module"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — module"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Transfert"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "Module `Glob`"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — module"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — module"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — module"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — module"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — module"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — module"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "Module `file`"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — module"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — module"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — module"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — module"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — module"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — instance _(classe : `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(classe : `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — module"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "Module `stringWidth`"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — module"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(classe : `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction`  instance _ ((classe: `Database`) _"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "Module `unsupported`"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — module"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — module"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — module"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — module"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — module"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "Module `CFunction`"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "Module `CString`"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "Module `JSCallback`"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — module"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "Module `linkSymbols`"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "Module `ptr`"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "Module `toArrayBuffer`"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "Module `toBuffer`"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "Module `viewSource`"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — module"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "Module `Database`"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction`  instance _ ((classe: `Database`) _"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values`  instance _ ((classe: `Statement`) _"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — instance"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — instance"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — instance"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — instance"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — instance"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — instance"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — instance"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — instance"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — instance"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — module"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — instance"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — instance"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — instance"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — module"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — module"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — module"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — module"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — module"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — module"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — module"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — module"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — module"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — module"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — instance"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  une instance"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  une instance"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — instance"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — instance"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — instance"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — instance"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — instance"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — instance"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — instance"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — instance"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — module"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — module"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — module"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — module"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — module"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — module"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — module"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — module"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — module"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — module"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — module"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — module"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — module"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — module"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — module"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — module"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — module"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — module"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — module"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — module"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — module"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — module"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — module"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — module"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — module"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — instance"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — instance"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — module"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — instance"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — instance"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — module"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — module"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — module"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — module"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — module"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — module"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — module"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — module"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — module"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — module"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — module"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — module"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — module"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — module"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — module"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — module"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — module"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — module"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — module"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — module"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — module"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — module"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — module"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — module"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — module"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — module"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — module"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — module"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — module"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — module"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — module"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — module"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — module"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — module"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — module"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — module"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — module"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — module"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — module"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — module"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — module"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — module"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — module"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — module"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — module"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — module"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — module"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — module"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — module"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — module"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — module"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — module"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — module"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — module"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — module"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — module"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — module"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — module"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — module"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — module"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — module"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — module"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — module"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — module"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — module"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — module"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — module"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — module"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — instance"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — instance"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — instance"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — instance"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — module"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — instance"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — instance"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — instance"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — instance"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — instance"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — instance"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — instance"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — instance"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — instance"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — instance"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — instance"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — instance"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — instance"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — instance"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — instance"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — instance"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — instance"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — instance"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — instance"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — instance"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — instance"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — instance"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — instance"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — instance"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — instance"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — instance"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — instance"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — instance"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — instance"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — instance"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — instance"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — instance"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — instance"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — instance"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — instance"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — instance"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — instance"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — instance"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — instance"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — instance"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — instance"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — module"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — module"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — module"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — module"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — module"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — module"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — module"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — module"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — module"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — module"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — module"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — module"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — module"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — module"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — module"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — module"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — module"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — module"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — module"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — module"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — module"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — module"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — module"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — module"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — module"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — module"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — module"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — module"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — instance _(classe : `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — module"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — instance"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — instance"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — module"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — instance"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — instance"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — instance"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — instance"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — instance"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — module"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — module"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — module _(class : `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — module"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — module"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — module"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — module"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — module"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — module"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — module"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — module"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — instance _(class : `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — instance _(class : `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — instance"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class : `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — instance"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — module"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — instance"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — module"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — module"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — instance"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — module"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — instance"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — instance"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — module"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — instance"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — module"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — instance"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — instance"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — instance"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — instance"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — instance"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — instance"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — module"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(class : `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — module"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — instance"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — instance"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — instance"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — instance"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — instance"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — instance"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — instance"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — instance"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — instance"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — instance"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — instance"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — instance"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — instance"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — instance"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — instance"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — instance"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — instance"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — instance"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — instance"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — instance"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — instance"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — instance"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — instance"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — instance"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — instance"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — instance"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — instance"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — instance"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "Module `getRawPointer`"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "Module `toString`"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — module"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — module"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — module"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — module"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — module"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — module"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — module"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — module"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — module"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — module"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — module"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — module"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — module"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — module"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — module"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — module"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — module"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — module"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — module"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — module"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — module"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — module"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — module"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — module"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — module"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — module"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — module"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — module"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — module"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — module"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — module"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — module"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — module"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — module"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — module"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — module"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — module"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — module"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — module"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — module"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — module"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — module"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — module"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — module"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — module"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — module"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — module"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — module"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — module"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — module"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — module"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — module"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — module"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — module"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — module"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — module"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — module"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — module"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — module"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — module"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — module"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — module"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — module"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — module"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — module"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — module"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — module"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — module"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — module"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — module"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — module"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — module"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — module"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — module"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — module"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — module"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — module"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — module"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — module"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — module"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — module"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — module"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — module"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — module"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — module"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — module"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — module"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — module"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — module"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — module"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — module"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — module"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — module"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — module"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — instance _(class : `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — instance _(class : `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — instance _(class : `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — module"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — module"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — instance _(class : `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening`  instance _ ((classe: `HttpServer`) _"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — instance _(class : `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — instance _(class : `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — instance _(class : `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — instance _(class : `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — module"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — module"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40859,103 +41175,103 @@ msgstr ""
 "possède la piscine de maintien en vie; les crochets par prise sont "
 "interdits, prévient une fois (#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening`  instance _ ((classe: `HttpServer`) _"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once`  instance _ ((classe: `ClientRequest`) _"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref`  instance _ ((classe: `HttpServer`) _"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40964,375 +41280,369 @@ msgstr ""
 "la piscine de maintien en vie; les crochets par prise sont interdits, "
 "prévient une fois (#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — module"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — module"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket`  instance _ ((classe: `IncomingMessage`) _"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — instance _(classe : `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — instance _(classe : `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — instance _(classe : `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref`  instance _ ((classe: `HttpServer`) _"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — instance _(classe : `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — module"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — module"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — instance _(classe : `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — module"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — module"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — module"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — module"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — module"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — module"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening`  instance _ ((classe: `HttpsServer`) _"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening`  instance _ ((classe: `HttpsServer`) _"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref`  instance _ ((classe: `HttpsServer`) _"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — instance _(classe : `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref`  instance _ ((classe: `HttpsServer`) _"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — module"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  module _ ((classe: `console`)"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  module _ ((classe: `console`)"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  module _ ((classe: `console`)"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  module _ ((classe: `console`)"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -41341,7 +41651,7 @@ msgstr ""
 "point final de l'inspecteur WebSocket; les sessions sont des faux en cours "
 "(#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -41352,7 +41662,7 @@ msgstr ""
 "répondent; toutes les autres méthodes de protocole lancent l'erreur "
 "d'inspecteur -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -41360,7 +41670,7 @@ msgstr ""
 "`url`  module **ébauche** toujours indéfini: Perry n'expose jamais un "
 "véritable point final de l'inspecteur (#4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -41368,3285 +41678,3276 @@ msgstr ""
 "`waitForDebugger`  module **ébauche** retourne immédiatement après open(); "
 "il n'y a pas de débogueur à attendre (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  module _ ((classe: `console`)"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — instance _(classe : `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — instance"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — module"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — instance"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — instance"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — instance"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — instance"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — instance"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — instance"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — instance"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — instance"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — instance"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — instance"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — module"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — instance"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — instance"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — instance"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — instance"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — instance"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — instance"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — module"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — module"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — module"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — module"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — module"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — module"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — module"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — module"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — module"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — module"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — module"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — module"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — module"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — module"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — module"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — module"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — module"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — module"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — module"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — module"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — module"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — module"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — module"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — module"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — module"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — module"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — module"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — instance"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — instance"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  une instance"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — instance"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — module"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — module"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — module"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — module"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — module"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — module"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — module"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — module"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — module"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — module"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — module"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — module"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — module"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — module"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — module"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — module"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — module"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — module"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — module"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — module"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — module"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — module"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — module"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  une instance"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  une instance"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — module"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  une instance"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — instance"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — instance"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — instance"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — instance"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — instance"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — instance"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — instance"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — instance"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — instance"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — instance"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — instance"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — instance"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — module"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — module"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — instance _(classe : `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — instance"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — instance _(classe : `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — instance _(classe : `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — instance"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — instance"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — instance _(classe : `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — instance _(classe : `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — instance"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — instance"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — module"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — module"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — module"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — module"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — module"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — module"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — instance _(classe : `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — instance _(classe : `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — instance _(classe : `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — module _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — module"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — module"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — module"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — module _(classe : `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — instance _(classe : `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert`  instance _ ((classe: `Socket`) _"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — instance _(classe : `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — instance _(classe : `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "Module `certificateFromPem`"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "Module `certificateToPem`"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "Module `createCertificate`"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "Module `privateKeyFromPem`"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "Module `privateKeyToPem`"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "Module `publicKeyToPem`"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions`  instance _ ((classe: `Certificate`) _"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer`  instance _ ((classe: `Certificate`) _"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject`  instance _ ((classe: `Certificate`) _"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign`  instance _ ((classe: `Certificate`) _"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — module"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — instance"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — instance"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — module"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — module"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — module"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — module"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — module"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — module"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — module"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — module"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — module"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — module"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — module"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — module"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — module"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — module"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — module"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — module"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — module"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — module"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — module"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — module"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — module"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — module"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — module"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — module"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — module"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — module"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — module"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — module"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — module"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — module"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — module"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — instance _(classe : `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "Module `eventLoopUtilization`"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — module"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — instance _(classe : `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — instance _(classe : `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — module"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "Module `embeddedFiles`"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "Module `readEmbedded`"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — module"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — module"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — module"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — module"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "Module `js_ads_request_consent`"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — module"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — module"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — module"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — module"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — module"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — module"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — module"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — module"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — module"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — module"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — module"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — module"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — module"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — module"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — module"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — module"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — module"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — module"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — module"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — module"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — module"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — module"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — module"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — module"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — module"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — module"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — module"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — module"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — module"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — module"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — module"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — module"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — module"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — module"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — module"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — module"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — module"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — module"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — module"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — module"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — module"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — module"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — module"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — module"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — module"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — module"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — module"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — module"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — module"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — module"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — module"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — module"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "Module `collect`"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "Module `idleHint`"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "Module `minor`"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — module"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — module"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — module"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — module"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — module"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — module"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — module"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — module"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "Module `createLanguageModelSession`"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "Module `destroyLanguageModelSession`"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "Module `foundationModelAvailability`"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "Module `getLayoutEnvironment`"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "Module `offLayoutChange`"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "Module `onLayoutChange`"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "Module `respond`"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — module"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — module"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — module"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — module"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — module"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — module"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — module"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — module"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  module _ ((intrinsèque)"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "Module `f32`"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "Module `f64`"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "Module `i16`"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "Module `i32`"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "Module `i64`"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "Module `i8`"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "Module `isize`"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  module _ ((intrinsèque)"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  module _ ((intrinsèque)"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "Module `u16`"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "Module `u32`"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "Module `u64`"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "Module `u8`"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "Module `usize`"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — module"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — module"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — module"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — module"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — module"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — module"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — module"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — module"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — module"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — module"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — module"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — module"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — module"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — module"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — module"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — module"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — module"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — module"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — module"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — module"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — module"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — module"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — module"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — module"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — module"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — module"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — module"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — module"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — module"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — module"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — module"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — module"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — module"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — module"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — module"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — module"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — module"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — module"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — module"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — module"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "Module `hapticPlay`"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — module"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — module"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — module"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — module"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — module"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — module"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — module"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — module"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — module"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — module"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — module"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — module"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — module"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — module"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — module"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — module"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — module"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — module"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — module"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — module"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — module"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — module"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — module"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — module"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — module"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — module"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — module"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — module"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — module"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — module"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — module"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — module"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — module"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — module"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — module"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — module"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — module"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — module"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — module"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — module"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — module"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — module"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — module"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — module"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — module"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — module"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — module"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — module"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — module"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — module"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — instance _(classe : `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — module"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — module"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — instance _(classe : `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — module"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — instance _(classe : `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — module"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — instance _(classe : `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — module"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — instance _(classe : `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — instance _(classe : `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — instance _(classe : `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — module"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — instance _(classe : `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — instance _(classe : `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — instance _(classe : `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — module"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — module"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — module"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — module"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — module"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — module"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — module"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — module"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — module"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — module"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — module"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — module"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — module"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — instance _(classe : `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — instance _(classe : `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — module"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — module"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "Module `BloomView`"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — module"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — module"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — module"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — module"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — module"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — module"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — module"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — module"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — module"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — module"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — module"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — module"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — module"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — module"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — module"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — module"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — module"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — module"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — module"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — module"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — module"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — module"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — module"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — module"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — module"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — module"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — module"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — module"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "Module `WheelPicker`"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — module"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — module"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — module"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — module"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — module"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "Module `appSetActivationPolicy`"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — module"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — module"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — module"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — module"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — module"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "Module `bloomViewGetHwnd`"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "Module `bloomViewGetNativeHandle`"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — module"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — module"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — module"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — module"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — module"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — module"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — module"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — module"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — module"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — module"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — module"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — module"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — module"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — module"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — module"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — module"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — module"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — module"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — module"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — module"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — module"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — module"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — module"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — module"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — module"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — module"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — module"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — module"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — module"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — module"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — module"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — module"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — module"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — module"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — module"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — module"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — module"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — module"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — module"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — module"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — module"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — module"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — module"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — module"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — module"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — module"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — module"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — module"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — module"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — module"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — module"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — module"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — module"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — module"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — module"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — module"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — module"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — module"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — module"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — module"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — module"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — module"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — module"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — module"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — module"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — module"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — module"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — module"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "Module `wheelPickerAddItem`"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "Module `wheelPickerGetSelected`"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "Module `wheelPickerSetSelected`"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — module"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — module"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — module"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "Module `embeddedCheckHeaders`"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "Module `embeddedCheckUrl`"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "Module `embeddedRefreshDue`"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — module"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "Module `getEmbeddedConfig`"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — module"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — module"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — module"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — module"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — module"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "Module `recordEmbeddedResponse`"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — module"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — module"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — module"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — module"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — module"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — module"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — module"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — module"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — module"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — module"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "Module `calculateLayout`"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "Module `childCount`"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "Module `getComputed`"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "Module `getComputedEdge`"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "Module `insertChild`"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "Module `nodeFree`"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "Module `nodeNew`"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "Module `removeChild`"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "Module `setEdge`"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "Module `setEnum`"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "Module `setGap`"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "Module `setMeasureFunc`"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "Module `setNumber`"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "Module `unsetMeasureFunc`"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — module"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — instance _(classe : `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — module"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — module"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — module"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — module"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — module"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — module"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — module"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — module"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — module"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — module"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — module"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — module"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — module"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — module"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — module"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — module"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — module"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — module"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — module"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — module"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — module"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — module"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — module"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — module"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — module"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — module"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — module"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — module"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — module"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — module"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — module"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — module"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — module"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — module"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — module"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — module"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — module"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — module"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — module"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — module"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — module"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — module"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — module"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — module"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — module"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — module"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — module"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — module"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — module"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — module"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — module"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — module"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  une instance"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  une instance"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  une instance"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  une instance"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — module"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — module"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — module"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — module"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — module"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — instance"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — instance"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — instance"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — instance"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — module"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — instance"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — instance"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — instance"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — instance"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — instance"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — instance"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — instance"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44657,43 +44958,43 @@ msgstr ""
 "les recherches contextuelles et un seul '+'; pas de vraie boucle "
 "d'évaluation JS (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — module"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44704,1459 +45005,1459 @@ msgstr ""
 "recherches contextuelles et un seul '+'; pas de vraie boucle d'évaluation JS "
 "(#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — instance _(classe : `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — module"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — module"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — module"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — module"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — module"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  une instance"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  une instance"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — instance"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  une instance"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  une instance"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  une instance"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — instance"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — instance"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — instance"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — instance"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — instance"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — instance"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — instance"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — instance"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — instance"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — module"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  une instance"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — instance"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — instance"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  une instance"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — instance"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — instance"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — instance"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — module"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — module"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — instance"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — instance _(classe : `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — instance"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — module"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — instance"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — instance"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — instance _(classe : `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  une instance"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — instance _(classe : `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — instance"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — instance"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — instance _(classe : `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — instance"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — instance"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — instance"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — instance"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — instance"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — instance"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — instance"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  une instance"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — instance"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — instance"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — instance _(classe : `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — instance"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — instance"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — instance _(classe : `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — instance"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — module"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — module"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — module"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — module"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — instance"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — instance"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — module"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — instance"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — instance"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — instance"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — module"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — instance"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — module"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — module"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — module"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — module"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — module"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — instance"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — module"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — module"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — instance"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — module"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — instance"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — instance"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — instance"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — instance"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — instance"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — instance"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — instance"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — instance"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — instance"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — instance"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — instance"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — module"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — instance"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — instance"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — instance"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — instance"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — instance"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — instance"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — instance"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — instance"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — instance"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — instance"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — instance"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — instance"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — module"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — module"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — module"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — module"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — module"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — module"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — instance _(classe : `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — instance _(classe : `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — module"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — module"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — module"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — module"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — module"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — module"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — module"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — module"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — module"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — module"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — module"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — module"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — module"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — module"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — module"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — module"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — module"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — module"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — module"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — module"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — module"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — module"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — module"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — module"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — module"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — module"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — module"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — module"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — module"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — module"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — module"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — module"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — module _(classe : `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — module"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — module"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — module"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — module _(classe : `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — module _(classe : `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — module _(classe : `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — module _(classe : `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — module _(classe : `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — module"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — module"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — module"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — module _(classe : `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — module"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — module"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — module"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — module"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — module"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — module"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — module"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — module"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — module"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — module"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — module"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — module"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — module"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — module"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — module"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "Module `convertALPNProtocols`"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — module"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — module"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "Module `getCertificateCompressionAlgorithms`"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — module"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — instance _(classe : `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — module"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — module"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — module"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — instance _(classe : `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — instance _(classe : `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — instance"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — instance"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — instance"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — instance"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — instance"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "Module `flattenDiagnosticMessageText`"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "Module `transpileModule`"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "Module `ProxyAgent`"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close`  instance _ ((classe: `ProxyAgent`) _"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy`  instance _ ((classe: `ProxyAgent`) _"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "Module `fetch`"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "Module `getGlobalDispatcher`"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "Module `setGlobalDispatcher`"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — module"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — module"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — module"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — instance _(classe : `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — module"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — module"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — instance _(classe : `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — module"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — module"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — module"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — module"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — module"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — module"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — module"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — module"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — module"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — module"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — module"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — module"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — module"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — module"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — module"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — module"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — module"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — module"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — module"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — module"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — module"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — module"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — module"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — module"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — module"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — module"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — module"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — module"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — module"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — module"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — module"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — module"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — module"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — module"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — module"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — module"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — module"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — module"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — module"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — module"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — module"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — module"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — module"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — module"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — module"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "Module `v3`"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — module"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "Module `v5`"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — module"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — instance _(classe : `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — instance _(classe : `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — module"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — instance _(classe : `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — module"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — module"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -46164,11 +46465,11 @@ msgstr ""
 "`getHeapCodeStatistics`  module **ébauche** tous les champs 0; Perry compile "
 "AOT, il n'existe pas de pile de code JIT (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — module"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -46178,7 +46479,7 @@ msgstr ""
 "toute l'utilisation en direct attribuée à old_space depuis les arènes Perry; "
 "les autres espaces rapportent 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -46192,87 +46493,87 @@ msgstr ""
 "appliqué); \\*\\_exécutable, external_memory, global-handles et champs zap "
 "sont 0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — instance _(classe : `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — module"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — instance _(classe : `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — instance _(classe : `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — instance _(classe : `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — instance _(classe : `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — module"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — instance _(classe : `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — module"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — instance _(classe : `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — module"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — module"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — instance _(classe : `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — module"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -46280,459 +46581,469 @@ msgstr ""
 "`stop`  instance _ ((classe: `GCProfiler`) _ **ébauche** le rapport a la "
 "forme du nœud mais le tableau des statistiques est toujours vide (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — module"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — module"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — module"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — instance _(classe : `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — module"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — module"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — module"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — module"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — module"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — module"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — instance"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — module"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — module"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — instance"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — instance"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — instance"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — instance"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — instance"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — instance"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — instance"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — module"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — instance"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — instance"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — module"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — instance"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — instance"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — module"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — module"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — module"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — instance"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — module"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — instance _(classe : `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — instance _(classe : `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — instance _(classe : `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — instance _(classe : `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — module"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — module"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  une instance"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — module"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — module"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — module"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — module"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — module"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — module"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — module"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload`  instance _ ((classe: `Worker`) _"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  une instance"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — module"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — instance _(classe : `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — module"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — instance _(classe : `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — instance"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — instance"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — instance _(classe : `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — module"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — instance"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — instance _(classe : `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  une instance"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — instance _(classe : `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — module"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — module"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — module"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — module"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — module"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — module"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46740,7 +47051,7 @@ msgstr ""
 "`createBrotliCompress`  module **ébauche** Options params/quality acceptées "
 "mais ignorées, prévient une fois (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46748,7 +47059,7 @@ msgstr ""
 "`createBrotliDecompress`  module **ébauche** Options params/quality "
 "acceptées mais ignorées, prévient une fois (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46756,7 +47067,7 @@ msgstr ""
 "`createDeflate`  module **ébauche** niveau respecté; strategy/memLevel "
 "validé mais non appliqué (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46764,11 +47075,11 @@ msgstr ""
 "`createDeflateRaw`  module **ébauche** niveau respecté; strategy/memLevel "
 "validé mais non appliqué (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — module"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46776,19 +47087,19 @@ msgstr ""
 "`createGzip`  module **ébauche** niveau respecté; strategy/memLevel validé "
 "mais non appliqué (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — module"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — module"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — module"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46796,7 +47107,7 @@ msgstr ""
 "`createZstdCompress`  module **ébauche** Options params/quality acceptées "
 "mais ignorées, prévient une fois (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46804,79 +47115,71 @@ msgstr ""
 "`createZstdDecompress`  module **ébauche** Options params/quality acceptées "
 "mais ignorées, prévient une fois (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — module"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — module"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — module"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — module"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — module"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — module"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — module"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — module"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — module"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — module"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — module"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — module"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — module"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — module"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — module"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — module"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — module"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — module"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -47417,9 +47720,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "Vous utiliseriez sinon un fichier `docker-compose.yaml`."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "Les deux modules partagent un temps d'exécution; vous pouvez les mélanger "
@@ -47956,12 +48260,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` équivaut à `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Note sur les formes de retour `logs` et `exec`:** Aujourd'hui, le FFI "
 "renvoie une poignée de registre-id dans un `Vec<ContainerLogs>` plutôt qu'un "
@@ -48090,9 +48395,10 @@ msgstr ""
 "cache et retournent instantanément."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` est asynchrone et renvoie un tableau JSON de chaque "
@@ -48856,9 +49162,10 @@ msgstr ""
 "opérationnelle :"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Utiliser le bloc `healthcheck` sur le service** (Introduit, le temps "
@@ -49243,8 +49550,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "L'exemple Forgejo utilise ce modèle portable (`container_name:  'forgejo-"
@@ -49318,8 +49626,9 @@ msgid "Single-network shorthand"
 msgstr "Raccourci réseau unique"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49737,9 +50046,10 @@ msgid "External volumes"
 msgstr "Volumes externes"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Marquez un volume `external: true` pour le partager entre les piles ou pour "
@@ -49761,8 +50071,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49833,15 +50144,18 @@ msgstr ""
 "runtime sous-jacent :"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# Liste des volumes préfixes à l'application"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# point de montage, conducteur, étiquettes"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# Monter + inspecter le contenu"
 
 #: src/container/volumes.md:160
@@ -50013,9 +50327,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -50205,8 +50520,9 @@ msgstr ""
 "ultérieures sur le même digest sont gratuites."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -50477,8 +50793,9 @@ msgstr ""
 "**Exécuter en tant que non-root** (`user: \"nobody\"` ou UID numérique)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Retirez toutes les capacités, ajoutez celles spécifiques** (`cap_drop:  "
@@ -50634,7 +50951,8 @@ msgstr ""
 "démonter »."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 "Sortie 0. Les conteneurs fonctionnent grâce à `restart:  unless-stopped`."
 
@@ -50857,11 +51175,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Démarrage des dépendances conditionné par le healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres prend ~510 secondes pour s'initialiser lors de la première "
 "exécution (initdb + listener bind). Sans passerelle, Forgejo démarre "
@@ -51035,7 +51354,8 @@ msgstr ""
 "fichier `.env` ou un gestionnaire de secrets :"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -51048,7 +51368,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -51111,11 +51432,13 @@ msgstr ""
 "`--down` explicite :"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# les volumes de conservation"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# redéployer avec la nouvelle version"
 
 #: src/container/production-patterns.md:268
@@ -51133,35 +51456,42 @@ msgid "Running it"
 msgstr "Exécution"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Construisez Perry une fois"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Donnez l'exemple"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Back-end: le docker"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Visitez http://localhost:3000/ dans un navigateur."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Arrêter (conserve les volumes pour le redéploiement) :"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Détruire + déposer des volumes (données de DÉTRUCTION):"
 
 #: src/container/production-patterns.md:300
@@ -51478,19 +51808,23 @@ msgstr ""
 "backends  les valeurs divergent."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// testé + émis tel quel"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// le moteur émule le côté hôte"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// abandonné + avertissement"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// sous-ensemble limité; raison documentée"
 
 #: src/container/determinism.md:156
@@ -51616,7 +51950,8 @@ msgstr ""
 "`capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "Les constructeurs d'arcs"
 
 #: src/container/determinism.md:192
@@ -51644,7 +51979,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\" champ de spécifications dropped/translated pour le back-end \""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- spécification propre"
 
 #: src/container/determinism.md:212
@@ -51657,15 +51993,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// champ supprimé"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// correspondant à l'équivalent"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// le moteur émule à la place"
 
 #: src/container/determinism.md:231
@@ -51674,15 +52013,18 @@ msgstr ""
 "3. Mode d'exécution  choisir la façon dont les avertissements apparaissent"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// par défaut  suivi silencieux:: avertissement !"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// surface à TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// champ non pris en charge → défaillance de hard up()"
 
 #: src/container/determinism.md:241
@@ -51745,7 +52087,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "Normalité de sortie  même forme indépendamment du backend"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// forme Docker (ligne NDJSON)"
 
 #: src/container/determinism.md:292
@@ -51753,7 +52096,8 @@ msgid "/* docker JSON */"
 msgstr "/* docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// la forme de pomme (matrice JSON des objets `configuration`-wrapped)"
 
 #: src/container/determinism.md:294
@@ -51761,7 +52105,8 @@ msgid "/* apple JSON */"
 msgstr "/* pomme JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// Les deux produisent ContainerInfo avec la même sémantique de champ:"
 
 #: src/container/determinism.md:301
@@ -52108,7 +52453,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -52121,7 +52467,8 @@ msgid "\"Back\""
 msgstr "\"Retour\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (valeurs vides = besoin de traduction)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -52355,7 +52702,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -52480,7 +52828,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Vous avez {count} Article\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (en polonais: un, quelques, beaucoup)"
 
 #: src/i18n/interpolation.md:65
@@ -53266,21 +53615,25 @@ msgid "Typical translation workflow:"
 msgstr "Workflow de traduction typique :"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Écrire du code avec des chaînes en anglais"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Extraire des chaînes dans les fichiers locaux"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 "# 3. Envoyer locales/de.json aux traducteurs (les valeurs vides doivent être "
 "remplies)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Construire  Perry valide tout"
 
 #: src/i18n/cli.md:49
@@ -53969,58 +54322,25 @@ msgstr ""
 "manifeste authentifié consommé par `perry update`."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr ""
 "# 1) Génération unique de paires de clés. Enregistrer kp.json avec le mode "
 "0600 et"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr ""
 "# 2) Signature par version. L'enveloppe JSON de sortie contient tous les"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr ""
-"# 3) Vérifiez la santé mentale de la signature avant de télécharger le "
-"manifeste"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    ici prédit une vérification de passage sur le client."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) Release CI signe le manifeste CLI, liant son URL d'archive, plateforme,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Rédiger un manifeste final en passant la sortie `sign` par `jq` pour chaque "
@@ -55678,9 +55998,10 @@ msgstr ""
 "même (ex. : plusieurs coups de feu, plusieurs pas)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** un groupe de mélangeurs. Les sons passent par un bus, les bus "
@@ -56698,6 +57019,7 @@ msgstr ""
 "d'horloge murale."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -56707,7 +57029,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57929,23 +58251,28 @@ msgstr ""
 "requise."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# Extension iOS WidgetKit"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Le widget de l'application Android"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS Complication"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# Simulateur watchOS"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS Carreaux"
 
 #: src/widgets/overview.md:60
@@ -58880,10 +59207,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Rembourrage"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Cadre"
@@ -59489,11 +59812,13 @@ msgid "Build Commands"
 msgstr "Commandes de build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -60396,19 +60721,23 @@ msgid "Build Instructions"
 msgstr "Instructions de build"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# Copiez les fichiers .kt à app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# Fusionner AndroidManifest_snippet.xml avec AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Copiez les fichiers .kt dans le module Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# Fusionner AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -60601,11 +60930,13 @@ msgstr ""
 "Le rafraîchissement en arrière-plan utilise le framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Pour l' Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Pour Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -62239,11 +62570,13 @@ msgstr ""
 "déclarées avec `#[no_mangle] pub extern \"C\"` :"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry à l'heure d'exécution"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... appeler la plateforme API, résoudre la promesse quand fait ..."
 
 #: src/plugins/native-extensions.md:200
@@ -62374,25 +62707,17 @@ msgstr ""
 "l'aide de `swiftc`, en ciblant le SDK de la bonne plateforme :"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (simplifié)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// Détectez la cible: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// Compilé: rapidc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// lien: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -62419,7 +62744,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Résoudre la Promise Perry avec le résultat"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Obtenez l'activité de PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -62435,7 +62761,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "Appelez les API de la plateforme via JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -63070,15 +63397,18 @@ msgstr ""
 "construction."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# la porte"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# ce qui est dans le champ d'application et ce qui ne l'est pas"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# prouve que la porte peut encore échouer"
 
 #: src/testing/test-registration.md:18
@@ -63439,33 +63769,40 @@ msgstr ""
 "lorsque vous compilez avec `--enable-geisterhand`."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Compiler avec geisterhand activé (libs auto-construire à la première "
 "utilisation)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Exécutez l' application"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. Dans un autre terminal  interagir avec l'application"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Liste des widgets"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Cliquez sur le bouton avec la poignée 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Capture d'écran de la fenêtre"
 
 #: src/testing/geisterhand.md:25
@@ -63482,7 +63819,8 @@ msgstr ""
 "des deux flags) :"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# ou avec Perry Run:"
 
 #: src/testing/geisterhand.md:35
@@ -63629,8 +63967,8 @@ msgid "Menu item"
 msgstr "Élément de menu"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -63642,8 +63980,8 @@ msgstr "Raccourci clavier"
 msgid "Data table"
 msgstr "Tableau de données"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -63758,17 +64096,6 @@ msgstr ""
 "Définit le contenu du champ texte et déclenche son callback `onChange` avec "
 "le nouveau texte sous forme de chaîne NaN-boxed."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"Type de contenu: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "Je ne sais pas"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Déplacer un curseur"
@@ -63794,10 +64121,6 @@ msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr ""
 "Définit la position du curseur et déclenche `onChange` avec la valeur "
 "numérique."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"valeur\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -63850,10 +64173,6 @@ msgstr ""
 "callbacks des widgets. Cela déclenche toutes les liaisons réactives "
 "attachées à l'état (libellés de texte liés, visibilité, boucles forEach, "
 "etc.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "\"{\"valeur\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -63931,10 +64250,6 @@ msgstr ""
 "et correspondent à la chaîne de touche passée à `menuAddItem` (par ex., "
 "`\"s\"` pour Cmd+S, `\"S\"` pour Cmd+Maj+S, `\"n\"` pour Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "Je ne sais pas"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63969,10 +64284,6 @@ msgid ""
 msgstr ""
 "Définit le décalage de défilement d'un widget ScrollView. `x` et `y` sont "
 "exprimés en points."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -64074,12 +64385,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Tirez des entrées aléatoires toutes les 200 ms"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -64221,12 +64529,16 @@ msgstr ""
 "`libimobiledevice` :"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Installer et lancer par Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP de la personne:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -64254,7 +64566,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Package dans APK et installer"
 
 #: src/testing/geisterhand.md:381
@@ -64262,7 +64575,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Installez d'abord les bibliothèques de développement GTK4 :"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -64286,15 +64600,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Un test de bout en bout simple utilisant bash :"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Construire avec la main de l'esprit"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Démarrer l'application en arrière-plan"
 
 #: src/testing/geisterhand.md:419
@@ -64306,33 +64623,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"exécuter $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Attendez que l'application soit prête"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Obtenez des widgets"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\" widgets enregistrés: $WIDGETS \""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Trouvez le bouton \" Soumettre \""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Cliquez dessus "
 
 #: src/testing/geisterhand.md:436
@@ -64340,7 +64661,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Prenez une capture d'écran après l'interaction"
 
 #: src/testing/geisterhand.md:441
@@ -64352,7 +64674,8 @@ msgid "Python Test Example"
 msgstr "Exemple de test Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# Démarrer l' application"
 
 #: src/testing/geisterhand.md:450
@@ -64360,11 +64683,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Attendez le démarrage"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Widgets de liste"
 
 #: src/testing/geisterhand.md:455
@@ -64372,11 +64697,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Trouver les widgets par étiquette"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# Tapez dans le premier champ de texte"
 
 #: src/testing/geisterhand.md:464
@@ -64396,7 +64723,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Cliquez sur le premier bouton"
 
 #: src/testing/geisterhand.md:470
@@ -64404,7 +64732,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Capture d'écran pour régression visuelle"
 
 #: src/testing/geisterhand.md:473
@@ -64420,7 +64749,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Assurez-vous que l'application est toujours en bon état"
 
 #: src/testing/geisterhand.md:478
@@ -64452,42 +64782,14 @@ msgstr ""
 "les gels ou les états inattendus :"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Construire et lancer"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Commencez le chaos agressif (toutes les 50 ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Laissez-le tourner pendant 30 secondes"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Vérifiez les statistiques"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr ""
-"# Je suis en train de courirevents_fired\"600,\" Je suis "
-"désoléuptime_secs\"30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Prenez une capture d'écran pour voir l'état final"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Arrêtez le chaos"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Vérifiez que l'application est toujours en vie"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -64501,11 +64803,13 @@ msgstr ""
 "aux références :"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# État initial"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -64513,24 +64817,25 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "Je vous salue"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Capture après interaction"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# Comparer (en utilisant ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "Intégration dans un pipeline CI"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# Exemple d'action GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr "# Exemple d'action GitHub"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -64579,7 +64884,8 @@ msgid "Run UI tests"
 msgstr "Run UI tests"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Exécutez votre script de test"
 
 #: src/testing/geisterhand.md:568
@@ -64757,20 +65063,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Après compilation avec `--enable-geisterhand` et exécution :"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Voir tous les widgets interactifs"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Incrémentation\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   Je ne sais paswidget_type\"0,\"callback_kind\"0,\"étiquette\":"
 "\"Réinitialiser\"},"
@@ -64780,8 +65089,9 @@ msgid "\"Enter your name\""
 msgstr "\"Entrez votre nom\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"main\":6,\"widget_type\":2,\"callback_kind\":1,\"étiquette\":\"\"},"
 
@@ -64790,19 +65100,22 @@ msgid "\"Dark Mode\""
 msgstr "Le mode sombre"
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Cliquez sur Incrémentation 3 fois"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# L'étiquette du compteur indique maintenant \"Count: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Tapez un nom"
 
 #: src/testing/geisterhand.md:669
@@ -64810,7 +65123,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "\"{\"texte\":\"Perry\"}\" Je suis désolée"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Réglez le curseur à 80%"
 
 #: src/testing/geisterhand.md:672
@@ -64818,11 +65132,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "\"{\"valeur\":0.8}\""
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Activer le mode sombre"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -65139,16 +65455,13 @@ msgstr ""
 "compilation croisée manuellement :"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Créez des libs pour macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Construire pour iOS (compilation croisée)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -65346,15 +65659,18 @@ msgstr ""
 "Perry compilation + exécutions. Rétrécissez plus loin:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# quelques modules"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# uniquement ces exportations"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# le formulaire combiné mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -65375,15 +65691,18 @@ msgid "Full sweep and the CI gate"
 msgstr "Vérifier la porte d'entrée "
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# Matrice complète + tableau de synthèse"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# sortie 1 sur les régressions par rapport à la ligne de base"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# réécrire la ligne de base engagée"
 
 #: src/testing/node-compat-matrix.md:43
@@ -65677,7 +65996,7 @@ msgstr ""
 "autres emplois sont `needs: plan` et encadrés par "
 "`fromJSON(needs.plan.outputs.plan).jobs.<name>`."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -65773,11 +66092,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -65802,96 +66121,109 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6 fois plus rapide"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3 fois plus vite"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8 fois plein"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "Uniquement pour les dépôts"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr ""
 "Dans le cadre de la **pr** la liste des fichiers modifiés réduit encore le "
 "plan:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -65900,7 +66232,7 @@ msgstr ""
 "`npm/`, `packaging/`, `.claude/`, ...  voir `NON_CORE_GLOBS` dans "
 "`ci_plan.py`) → seulement `lint` fonctionne."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -65908,7 +66240,7 @@ msgstr ""
 "**le noyau** (tout ce qui peut modifier le compilateur, le runtime, ou un "
 "résultat de test) → le niveau PR entier."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -65917,7 +66249,7 @@ msgstr ""
 "`package.json`, `.claude/`, `skills/`, ...) → en plus le flux de travail "
 "réutilisable `security-audit`."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -65932,7 +66264,7 @@ msgstr ""
 "correctifs effectués dans HIR, transform, ou une autre dépendance sans "
 "ajouter la configuration Rust aux PR de docs uniquement."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -65942,11 +66274,11 @@ msgstr ""
 "travail `plan` échoué échoue le portail tout à fait  un planificateur "
 "défectueux ne doit jamais se transformer en \"tout sauté, donc vert\"."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "Pourquoi cela ressemble-t-il à cela (mesuré 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -65959,13 +66291,13 @@ msgstr ""
 "travail / 48 emplois / ~ 650 minutes de course**, et `main` a vu ~ 66 push "
 "PR et ~ 58 fusions par jour. C'est 1.5 2 × capacité totale, donc:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "les temps d'attente dans les files d'attente pour les tâches ont été de 37 h "
 "(`conformance-smoke` shards: médiane de 4 h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -65974,7 +66306,7 @@ msgstr ""
 "dans la fenêtre d'échantillonnage  8 ont échoué, 56 ont été annulées par la "
 "prochaine pression;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -65987,7 +66319,7 @@ msgstr ""
 "fusions a été un bypass administratif** avec `lint` et `cargo-test` toujours "
 "en attente."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -66002,11 +66334,11 @@ msgstr ""
 "transmettre Linux, et # 8187 a remplacé la liste de contexte requis "
 "fragmentée par le fan-in `pr-gate` unique décrit ci-dessus."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Deux coûts spécifiques ont dominé:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -66028,7 +66360,7 @@ msgstr ""
 "automatique de 8 fragments est maintenu dans le niveau complet car c'est le "
 "seul bras qui voit les bugs de liens d'optimisation automatique."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -66044,7 +66376,19 @@ msgstr ""
 "principale. `cache-warm.yml` a disparu: le balayage est la compilation de "
 "production de cache sur `main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -66068,75 +66412,75 @@ msgstr ""
 "étiqueté reçoit toujours une course de chaque  avec chaque job sauté, ce qui "
 "ne coûte pas de place de coureur."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "emplois typiques"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "minutes de course typiques"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "l'horloge murale cible"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (noyau)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 éclats de débris)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 min une fois en file d'attente"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (seulement pour les documents)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 minutes"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "pas une cible  il fusionne"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "pas une cible"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -66168,11 +66512,20 @@ msgstr ""
 "est par fenêtre (`previous sweep SHA .. this sweep SHA`), exactement comme "
 "pour les portes de six heures."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Opter pour une relation publique dans plus"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -66187,7 +66540,7 @@ msgstr ""
 "L'application de l'étiquette déclenche à nouveau les exécutions (déclencheur "
 "`labeled`)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -66196,7 +66549,7 @@ msgstr ""
 "`lint` (une modification de `crates/` doit autrement ajouter un fragment de "
 "`changelog.d/<PR>-<slug>.md`)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -66204,11 +66557,11 @@ msgstr ""
 "**`workflow_dispatch`** sur toute succursale: `tier` (`pr` / `sweep` / "
 "`full`) et `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Rééquilibrer l'écart instantané"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -66221,15 +66574,17 @@ msgstr ""
 "changement d'oracle), le régénérer **de CI**, non à partir d'un ordinateur "
 "portable (la ligne de base requise est le mode Linux, `fast`):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# Attendez la course, alors:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# remplir `issue` / `reason` pour chaque nouvelle entrée, puis engager"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -66239,11 +66594,11 @@ msgstr ""
 "à chacune une question et une raison avant de fusionner. Un crash ne peut "
 "jamais être garé dans l'instantané (`run_gap_tests.sh` refuse)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Protection des branches"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -66260,11 +66615,11 @@ msgstr ""
 "_completed_ dans son budget; la propre exécution de la passerelle porte si "
 "ce résultat est passé ou échoué."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -66277,7 +66632,7 @@ msgstr ""
 "de niveau PR sur le même SHA ne compte pas. Voir [Releasing](../contributing/"
 "releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -66294,6 +66649,173 @@ msgstr ""
 "s'exécutent une fois dans `parity-aggregate` sur le rapport fusionné "
 "(`scripts/parity_report_merge.py`, qui refuse un fragment manquant plutôt "
 "que de réduire la suite)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Ce qu'un chèque envoie"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Exécutez-le localement avec:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"commande\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -66416,7 +66938,8 @@ msgid "Reproduce the core of it with:"
 msgstr "Reproduisez le noyau avec:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr ""
 "# Ce qui est en train de se passer, à l'échelle de l'entreprise, au niveau "
 "du travail:"
@@ -66424,31 +66947,6 @@ msgstr ""
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\"workflow_runs[].id\" est le code de l'appareil"
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr ""
-"Les emplois | select(.status==\"in_progress\") | (étiquettes|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Quelle est la profondeur de la file d'attente, et sur quels bassins:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "Les emplois | select(.status==\"queued\") | (étiquettes|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -66641,24 +67139,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# inchangé  chaque PR est toujours mesurée"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # échelonné; voir le tableau ci-dessous"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -66669,12 +67165,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# les décharges restent individuellement fermées"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -66956,11 +67451,13 @@ msgstr ""
 "sécurité; un appelant qui saute même l'un des cinq n'est pas."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# prouve qu'il peut encore échouer"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# réelle API, aucun problème écrit"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -66995,10 +67492,49 @@ msgstr ""
 "détecteur fonctionne, pas que rien n'a été essayé."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "La file d'attente devant le calendrier (# 7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -67007,57 +67543,57 @@ msgstr ""
 "que six heures. Le 12 août 2026 ce n'était pas le cas, et la raison n'était "
 "pas les portes:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "les trajets en file d'attente"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "les essais simultanés observés"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "en file d'attente par événement"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "branches principales distinctes parmi les séries PR en file d'attente"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**des branches qui existaient encore**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -67076,11 +67612,12 @@ msgstr ""
 "Aucune quantité de cadence de planification ne peut en être récupérée; les "
 "ordures doivent être éliminées."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -67097,7 +67634,7 @@ msgstr ""
 "ce qui assure la sécurité des PR de la fourchette  la branche principale "
 "d'une fourchette n'apparaît jamais dans les références de ce repo."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -67110,7 +67647,7 @@ msgstr ""
 "manuel (la sécheresse est par défaut); le calendrier le maintient libre par "
 "la suite."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
@@ -67118,7 +67655,7 @@ msgstr ""
 "Pourquoi \"la porte était sombre\" n'est pas la même chose que \"la porte "
 "l'aurait attrapé\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -67130,7 +67667,7 @@ msgstr ""
 "sombre l'a laissé passer  ne survit pas à la vérification et à "
 "l'enregistrement des raisons qui comptent plus que l'incident:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -67143,7 +67680,7 @@ msgstr ""
 "(`collection_kind: \"full\"` 0 → 2) n'est pas l'un d'entre eux. Aucune porte "
 "dans le référentiel n'affiche un nombre de collection-_kind_."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -67155,7 +67692,7 @@ msgstr ""
 "justification enregistrée dans `tolerances.json`. Ils utilisent seulement le "
 "code `pinned_host`, que CI n'utilise jamais."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -67163,7 +67700,7 @@ msgstr ""
 "Les charges de travail qui l'ont montré (`retain`, `deeplist`, ...) sont le "
 "corpus de transfert gc, pas les 14 sondes fixes de `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -67393,14 +67930,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Compiler du TypeScript en un exécutable natif."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# Ou un raccourci:"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Option"
 
@@ -67429,7 +67967,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (défaut) ou `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -67437,7 +67975,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "Afficher la représentation intermédiaire HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -67449,7 +67987,7 @@ msgstr ""
 "Produire l'objet file ((s) seulement, sauter le lien; écrit à `-o` (voir "
 "[Balises du compilateur](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -67457,7 +67995,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "Conserver les fichiers `.o` et `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -67465,7 +68003,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "Activer le runtime de secours JavaScript V8"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -67477,8 +68015,8 @@ msgstr ""
 "Force l'édition de liens avec le runtime hôte WebAssembly wasmi (détecté "
 "automatiquement lors de l'utilisation de `WebAssembly.*`)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -67486,16 +68024,16 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Activer la vérification de types via tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr ""
 "Minifier et obscurcir la sortie (activé automatiquement pour `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -67503,7 +68041,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (requis pour les cibles widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -67512,23 +68050,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "Intégrer les extensions TypeScript depuis un répertoire"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Compilation de base"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Compilation croisée pour le simulateur iOS"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Créez un plugin"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Débogage: afficher la représentation intermédiaire"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Créez un widget iOS"
 
 #: src/cli/commands.md:82
@@ -67536,23 +68079,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Compiler et lancer votre application en une seule étape."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# Fichier d'entrée détecté automatiquement"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Exécutez sur iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Exécutez sur Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Exécuter sur le périphérique Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Envoyez les args à votre programme"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -67687,19 +68235,23 @@ msgstr ""
 "remote` pour forcer l'un ou l'autre chemin."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Exécutez un programme CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Exécuter sur un simulateur spécifique"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Forcer la construction à distance"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Exécuter la cible web"
 
 #: src/cli/commands.md:131
@@ -67715,19 +68267,23 @@ msgstr ""
 "automatiquement à chaque sauvegarde."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# Regardez + reconstruisez + relancez sur sauvegarde"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# Argues avant à l'enfant"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# regarder un répertoire supplémentaire"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# le chemin de sortie est annulé"
 
 #: src/cli/commands.md:144
@@ -67874,7 +68430,7 @@ msgstr ""
 "Préservation de l'état entre les reconstructions / HMR — « redémarrage "
 "rapide » est l'objectif honnête."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -67939,19 +68495,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Inclure les corrections à confiance moyenne"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Vérifiez un seul fichier"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Vérifiez avec l'analyse de dépendance"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Problèmes de correction automatique"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Prévisualisation des correctifs sans application"
 
 #: src/cli/commands.md:207
@@ -68248,27 +68808,33 @@ msgstr ""
 "Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Afficher le menu de la plateforme"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# Configuration de macOS (identifiants de signature)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# Configuration de iOS (identifiants de signature)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# Configuration de visionOS (identifiants de signature)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Configuration de Android (identifiants de signature)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Chaîne d'outils Windows (télécharge MS CRT + Windows SDK via xwin)"
 
 #: src/cli/commands.md:318
@@ -68299,19 +68865,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Mise à jour à la dernière"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Vérifiez sans installer"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Ignorez la réponse en cache"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Enregistrez le comportement des mises à jour, puis sortez"
 
 #: src/cli/commands.md:333
@@ -68329,7 +68899,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` écrit `[update] mode` à `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -68445,14 +69015,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Initialiser un nouveau package de liaisons natives :"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"Réservations natives pour libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -68994,10 +69556,21 @@ msgstr ""
 "d'objet."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -69005,18 +69578,18 @@ msgstr ""
 "Sélectionnez Linux libc/linkage; `musl` met à niveau la cible Linux "
 "correspondante vers une version entièrement statique sans tête."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr ""
 "Identifiant de groupe requis par les widgets cibles de l'écran d'accueil."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr ""
 "Découvrez et regroupez statiquement les extensions natives d'un répertoire."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -69024,22 +69597,22 @@ msgstr ""
 "Exécutez le vérificateur natif TypeScript (`@typescript/native-preview`) "
 "avant le codegen."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Définir le niveau de compatibilité Windows PE; ignoré pour les cibles autres "
 "que Windows."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -69047,11 +69620,11 @@ msgstr ""
 "Sélectionnez le sous-système Windows PE au lieu de compter sur la détection "
 "automatique basée sur l'importation."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -69059,11 +69632,11 @@ msgstr ""
 "Pour les cibles des widgets Apple, émettre les sources et les métadonnées "
 "SwiftUI sans invoquer `swiftc`."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -69071,35 +69644,68 @@ msgstr ""
 "Sélectionnez HarmonyOS matériel de signature HAP. Préférer les sources "
 "environment/config correspondantes pour les secrets."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "Chaîne de certificats d'application HarmonyOS."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS signé profil de mise à disposition."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS alias du magasin de clés; par défaut `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — module"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Intégration d'actifs"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -69108,11 +69714,11 @@ msgstr ""
 "polices, ...) dans l'exécutable autonome afin qu'il fonctionne sans fichiers "
 "externes sur le disque (# 5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -69122,11 +69728,23 @@ msgstr ""
 "racine du projet). Repeatable. Fusionné avec `perry.embed` (package.json) et "
 "`[compile] embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -69135,20 +69753,21 @@ msgstr ""
 "fichier inférieur à `dir` à une poignée stable `$perryfs`. Répétable; les "
 "cartes sources sont exclues."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# sert dist/ de la mémoire  pas besoin de dist/ dossier"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr ""
 "Les fichiers intégrés sont accessibles en temps d'exécution de trois façons:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -69180,7 +69799,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -69192,7 +69811,7 @@ msgstr ""
 "résultat. `readEmbedded(path)` et `node:fs` acceptent soit le chemin virtuel "
 "`$perryfs/<path>`, soit la clé relative à l'intégration."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -69200,7 +69819,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -69210,7 +69829,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -69224,7 +69871,7 @@ msgstr ""
 "chaque bord `{ type: \"file\" }`, et garde la source générée dans son cache "
 "plutôt que de modifier la sortie."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -69233,11 +69880,7 @@ msgstr ""
 "utilisateur Web en amont, puis compilez à partir de la racine du paquet "
 "`packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -69252,7 +69895,7 @@ msgstr ""
 "Exécutez la commande de préparation pour chaque révision de source afin que "
 "les entrées générées ne puissent pas être obsolètes."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -69265,7 +69908,7 @@ msgstr ""
 "source relative au projet, la taille des octets, le résumé SHA-256 et le "
 "module d'actif générateur, le cas échéant."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -69281,7 +69924,7 @@ msgstr ""
 "explicite `$perryfs/<path>` lorsque vous voulez spécifiquement dire la copie "
 "intégrée."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -69294,19 +69937,19 @@ msgstr ""
 "le premier sur `PATH`. L'intégration de cibles croisées n'est pas "
 "actuellement prise en charge."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Options de débogage"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "Affiche la HIR (représentation intermédiaire) sur stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -69315,11 +69958,11 @@ msgstr ""
 "virgules : `hir` (HIR post-transformation), `llvm` (fichiers `.ll` par "
 "module dans `.perry-trace/llvm/`), ou `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -69329,7 +69972,7 @@ msgstr ""
 "`NAME`, en supprimant le bruit des imports/exports/inits. Implique `--trace "
 "hir` si aucune étape n'est spécifiée"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -69344,11 +69987,11 @@ msgstr ""
 "répertoire actuel. Chaque chemin est imprimé comme `Wrote object file: "
 "<path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -69358,15 +70001,15 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`). Voir [Configuration du projet](../getting-started/"
 "project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "Conserve les fichiers intermédiaires `.o` et `.asm`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
@@ -69374,33 +70017,33 @@ msgstr ""
 "Retenir symbols/DWARF (et émettre un PDB Windows) au lieu de supprimer le "
 "résultat."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Désactiver le cache objet par module pour cette compilation; également "
 "`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "Supprimer la racine du cache local de la machine; voir [Répertoire de cache]"
 "(cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -69408,32 +70051,32 @@ msgstr ""
 "Exécutez des invariants de réduction de représentation native et forcez "
 "codegen au lieu de réutiliser le cache."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 "Désactiver la réduction native Buffer/Uint8Array load/store pour le "
 "diagnostic A/B."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 "Émettre un rapport de preuve de réduction de type; implique une vérification "
 "de la région d'origine."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -69444,11 +70087,11 @@ msgstr ""
 "opt-report=json` émet un schéma stable pour les outils. Également réglable "
 "via `PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -69461,7 +70104,7 @@ msgstr ""
 "uniquement; nécessite `PERRY_RS4GC=1`, le backend natif de la racine (les "
 "modes de stack-map et de pont explicite qu'il a également nommés sont partis)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -69479,11 +70122,11 @@ msgstr ""
 "génération de code pour les modules inchangés, laissant le répertoire de "
 "trace vide)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  pourquoi une valeur est restée dans la case"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -69502,11 +70145,11 @@ msgstr ""
 "missed` de LLVM: il imprime ce qui a été prouvé, ce qui ne l'a pas été et "
 "quelle règle a effectué l'appel."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Chaque valeur refusée porte:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -69516,7 +70159,7 @@ msgstr ""
 "site` (un objet littéral qui n'est jamais lié à un local, le langage `.map(x "
 "=> ({...}))`)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -69524,7 +70167,7 @@ msgstr ""
 "**La règle qui l' a niée**, dans la numérotation du collectionneur, pour que "
 "vous puissiez la comparer au fichier source nommé."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -69536,7 +70179,7 @@ msgstr ""
 "(correctement encadré  aucune action), ou _Perry limitation_ (pas votre "
 "code; nomme le problème de suivi où il existe un)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -69552,7 +70195,7 @@ msgstr ""
 "seule la classe en dernier. Ce n'est pas non plus un profil  ce sont des "
 "proxies statiques."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -69560,7 +70203,7 @@ msgstr ""
 "Les gains sont rapportés avec les échecs, de sorte que le ratio est visible "
 "plutôt que les plaintes."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -69576,7 +70219,7 @@ msgstr ""
 "ne se mélange jamais à une charge utile `--format json` ou à la sortie de "
 "votre programme."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -69591,15 +70234,15 @@ msgstr ""
 "builds' JSON est une vérification CI bon marché contre une représentation en "
 "régression silencieuse à zéro."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Optimisation de la sortie"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -69622,11 +70265,11 @@ msgstr ""
 "au code de l'application et à la reconstruction runtime/stdlib optimisée "
 "automatiquement."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -69634,11 +70277,11 @@ msgstr ""
 "Définir les constantes `__feature_NAME__` séparées par des virgules au "
 "moment de la compilation pour éliminer le code mort."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -69646,28 +70289,28 @@ msgstr ""
 "Utilisez le runtime/stdlib complet préconstruit au lieu de reconstruire le "
 "plus petit ensemble de fonctionnalités accessibles."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "Permettre la réassociation en virgule flottante; voir [Fast-math](fast-"
 "math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr ""
 "Contrôle fusionné multipliez-ajoutez la contraction séparément de la "
 "réassociation."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -69676,11 +70319,11 @@ msgstr ""
 "noms de variables locales, de paramètres et de fonctions non exportées pour "
 "réduire la taille de la sortie."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Constructions optimisées pour la taille"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -69693,11 +70336,11 @@ msgstr ""
 "nécessitent une vérification de l'espace de travail Perry, comme le reste de "
 "l'optimisation automatique):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -69710,11 +70353,11 @@ msgstr ""
 "fonctionner ~ 2-3 fois plus lentement). Les archives normales et les "
 "archives de taille optimisée sont mises en cache indépendamment."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -69723,11 +70366,11 @@ msgstr ""
 "reconstruites (reconstruction plus lente, binaire plus petit). Uniquement "
 "significatif avec `PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -69747,7 +70390,7 @@ msgstr ""
 "`catch`, `finally`, piles d'erreurs et `uncaughtException` ne sont pas "
 "affectées."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -69759,15 +70402,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. Les programmes qui utilisent plus de "
 "temps d'exécution rétrécissent moins, proportionnellement."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Options de test"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -69775,27 +70418,27 @@ msgstr ""
 "Intègre le serveur HTTP [Geisterhand](../testing/geisterhand.md) pour les "
 "tests UI programmatiques (port par défaut 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Définit un port personnalisé pour le serveur Geisterhand (implique `--enable-"
 "geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Options runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr ""
 "Active le runtime JavaScript V8 pour les packages npm non pris en charge"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -69805,15 +70448,15 @@ msgstr ""
 "automatiquement lorsque `WebAssembly.*` est référencé ; nécessaire "
 "uniquement lors du chargement via dlopen / FFI sans référence statique)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Active la vérification de types via IPC tsgo"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -69830,11 +70473,11 @@ msgstr ""
 "perry.toml). `PERRY_ALLOW_EVAL=1` le force à s'éteindre. Voir [Limitations]"
 "(../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -69858,11 +70501,11 @@ msgstr ""
 "affectées. Voir [Limitations](../language/limitations.md#no-eval-or-dynamic-"
 "code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -69871,23 +70514,23 @@ msgstr ""
 "non implémentée est référencée au lieu d'émettre une erreur d'exécution "
 "différée."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Émettre `<binary>.attest.json`; voir [Attestation binaire](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Émettre le sidecar de la plateforme sandbox; voir [Profiles de sable](emit-"
 "sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -69895,31 +70538,31 @@ msgstr ""
 "Rejeter les surfaces d'exécution de code arbitraire accessibles; voir "
 "[Lockdown](lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Variables d'environnement"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Clé de licence Perry Hub pour `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Mot de passe du certificat .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -69928,63 +70571,63 @@ msgstr ""
 "mêmes valeurs que `--march`; le drapeau et perry.toml `[build] march` "
 "gagnent sur l'environnement)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Désactive les vérifications automatiques de mises à jour"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "La même chose, en utilisant l'orthographe de l'écosystème"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` pour une seule série  voir [Updates]"
 "(updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL du serveur de mise à jour personnalisé"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Ignore automatiquement les vérifications de mises à jour (défini par la "
 "plupart des systèmes CI)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Niveau de journalisation de débogage (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -69992,7 +70635,7 @@ msgstr ""
 "`1`/`text` ou `json`  identique à `--opt-report[=json]`, pour exécuter le "
 "rapport à partir d'un environnement où l'ajout d'un indicateur est gênant"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -70008,15 +70651,15 @@ msgstr ""
 "été supprimé en vertu de la politique de suppression du bouton GC de "
 "CLAUDE.md."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "Fichiers de configuration"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (projet)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -70096,11 +70739,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (global)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -70122,58 +70765,254 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Un simple programme de CLI"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# Application iOS pour le simulateur"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# Application visionOS pour le simulateur"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Application Web (WASM avec le pont DOM  alias: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Bibliothèque partagée de plugins"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# Widget iOS avec identifiant du paquet"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Compilation de débogage"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Compilation de mots"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Compilation vérifiée par type"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# WASM binaire brut (sans enveloppe HTML)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Sortie Web minifiée (comprime le pont JS intégré)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Commandes](commands.md) — Toutes les commandes CLI"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr ""
 "[Aperçu des plateformes](../platforms/overview.md) — Cibles de plateforme"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"modules\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Identité du cache"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"modules\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"source\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"Lodash\" est un mot"
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"objectifs\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"fonctions\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Incrémentation\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"sous-titre\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -70424,15 +71263,18 @@ msgstr ""
 "d'environnement l'emporte sur package.json :"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. Indicateur de CLI par construction"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Environnement par shell"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. package.json par projet (le plus courant)"
 
 #: src/cli/fast-math.md:35
@@ -70448,19 +71290,22 @@ msgid "Contraction is separate from reassociation:"
 msgstr "La contraction est indépendante de la réassociation :"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Permettez uniquement la contraction de la FMA."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Permettez le mode de contraction le plus agressif du front-end sans "
 "réassociation."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr ""
 "# Gardez la réassociation de --fast-math mais bloquez la contraction FMA."
 
@@ -71485,7 +72330,8 @@ msgid "Emit"
 msgstr "Émission"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -71574,7 +72420,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"taille\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -72824,10 +73670,6 @@ msgstr ""
 msgid "produces:"
 msgstr "produit :"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"modules\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -72910,9 +73752,10 @@ msgstr ""
 "hôte est signalé sous `<host source>`."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Renvoie une erreur claire si le manifeste n'existe pas encore  `perry  "
 "compile` ou `perry run` l'écrit sur chaque build réussi."
@@ -75100,7 +75943,7 @@ msgstr ""
 msgid "Setting"
 msgstr "Paramètre"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "Fichier"
 
@@ -75185,17 +76028,20 @@ msgstr ""
 "config.toml` :"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr ""
 "# Configurer la signature iOS (certificat, profil de mise à disposition)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr ""
 "# Configurer la signature Android (clés du magasin, clés du Play Store)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Configurer la distribution macOS (App Store, certification notariée)"
 
 #: src/cli/perry-toml.md:605
@@ -75237,8 +76083,11 @@ msgstr ""
 "que de stocker les identifiants dans `perry.toml` :"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# Exemple d'action GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -76505,20 +77354,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Les navires Perry **deux canaux indépendants de participation facultative** "
-"pour envoyer des données à la maison  rien ne quitte votre machine sans un "
-"`enabled = true` ou `on` explicite dans `~/.perry/config.toml`. Les deux "
-"respectent `PERRY_NO_TELEMETRY=1` et `CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Analyse générique de l'utilisation  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Analyse générique de l'utilisation  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -76528,14 +77377,16 @@ msgstr ""
 "POST HTTP en arrière-plan. Envoie: nom de commande, plateforme (`darwin`/"
 "`linux`/...), version Perry, statut success/error et UUID de client anonyme."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. Rapports de compatibilité  `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -76546,17 +77397,17 @@ msgstr ""
 "`UnsupportedExpression`, `UnsupportedStatement`, `DynamicPropertyAccess`, "
 "`ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Trois modes:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 "`off`  ne doit jamais être envoyé. L'évier n'est même pas installé, aucun "
 "frais."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -76565,101 +77416,101 @@ msgstr ""
 "fois par session: `[y] just this once / [a] always / [n] not this time / [N] "
 "never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr ""
 "`on`  toujours envoyer (après déduction + rédaction). Il n'y a pas "
 "d'instruction."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**Ce qui est envoyé (tout le schéma de charge utile):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"oui\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"code\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"catégorie\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"Gap-catégorique\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"étape\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"Hir-inférieur\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:... \" Je suis désolé"
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"décorateur\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"nœud:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"nous\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"Darwin-arm64\" est un jeu de mots"
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -76676,7 +77527,7 @@ msgstr ""
 "intégrés tels que `console`, `Math`, `Promise`) → `<id1>`, `<id2>`, plafonné "
 "à 200 caractères, avec un rejet dur si une invariante échoue."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -76684,34 +77535,38 @@ msgstr ""
 "Un cache local de déduplication de 30 jours à `~/.perry/.report-cache` "
 "empêche de renvoyer le même `snippet_hash` à chaque rechargement."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Inspection et gestion"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# montre le mode courant, compte sent/queued"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr ""
 "# Imprimer les charges utiles éditées dans la file d'attente de cette course"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# effacer le cache de déduplication de 30 jours"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr ""
 "Pour vous désabonner au niveau du fichier, modifiez `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -76720,7 +77575,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -76974,15 +77829,18 @@ msgstr ""
 "(`crates/perry-runtime/src/gc/types.rs`) de 8 octets:"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// Marqué | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr ""
 "// taille totale de l'allocation, utilisée pour la marche du bloc de l'arène"
 
@@ -77333,7 +78191,7 @@ msgstr ""
 "bissection benchmark/debug. Non défini, `=1`, `=on` et `=true` maintiennent "
 "les barrières activées."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -77527,10 +78385,11 @@ msgstr ""
 "protect] retired_set=#N` sous `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -77768,10 +78627,24 @@ msgstr ""
 "pression."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Carte des sources"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -77780,183 +78653,183 @@ msgstr ""
 "rien ne dérive, et chaque ligne de ce tableau une fois pointé dans un "
 "`gc.rs` qui n'existe plus."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Sujet"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Symbole à rechercher"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "Les étiquettes NaN-boxing"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, constantes de type/flag"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Cadres d'ombre (abaissement de la racine en cas de chute)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Scanners de racines enregistrés"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Copie mineure"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Promotion sur place dans tout le bloc"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Politique de promotion"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Seuil de durée de vie adaptatif"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Écrire des barrières"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Pinning explicite"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Prédicat à broche conservatrice"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Les déclencheurs de collecte et le rythme"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Page des opérations en cours"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Plan de conception (historique)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -78408,12 +79281,18 @@ msgstr ""
 "runtime/src/gc/heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "sur un processus desktop/server sans contrainte, réduit à un huitième d'un "
 "budget device/container avec un plancher de 1 MiB. Le débordement est "
@@ -78422,7 +79301,7 @@ msgstr ""
 "périodes unsafe/deferred et vide le pool lorsque la collecte complète due "
 "termine sa récupération de l'arène."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -78433,109 +79312,223 @@ msgstr ""
 "collecte **recensement vivant** plus les delta incrémentiels, pas la somme "
 "des décalages de haute eau de bloc."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Contrôle soutenu"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 "Ce sont les contrôles opérationnels les plus utiles en dehors du "
 "développement du collecteur:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "La réaction de la bisection à la balayage complet de la marque"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr ""
 "compile/runtime bisection de barrière; aussi forcer le balayage complet de "
 "la marque"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr ""
 "désactiver le ramassage direct de la pépinière pour la comparaison du rythme"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr ""
 "Retourner à l'évacuation de l'ensemble du bloc à l'évacuation d'objet par "
 "objet"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "Mettez le capuchon de base de la crèche"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "Supprimer le budget du tas de processus dans MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr ""
 "sélectionnez les racines d'ombre sur une cible capable de générer des "
 "racines natives"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "Scanner de pile native complet pour le diagnostic; désactive la copie"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "émettent des enregistrements de trace structurés par cycle"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "émettent un diagnostic collecteur lisible par l'homme"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -78544,10 +79537,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "Le stress d'enracinement utilise `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -78562,7 +79556,7 @@ msgstr ""
 "`PERRY_GC_SAFEPOINT_ONLY` et `PERRY_STACKMAP_WALKER` sont acceptées mais ne "
 "sont pas des modes de collecteur supplémentaires pris en charge."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -78592,11 +79586,11 @@ msgstr ""
 "l'un ni l'autre ne peut rester silencieux pendant que cette page continue à "
 "revendiquer l'ancienne chose."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Autorités de validation et d'IC"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -78608,39 +79602,39 @@ msgstr ""
 "`docs/src/testing/ci-tiers.md`; la stratégie du niveau est `scripts/"
 "ci_plan.py`). La couverture spécifique à la GC est délibérément divisée:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "où il coule"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "statut requis"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 "dépôt de détenteur racine, dérivation du bouton GC et revendications path/"
 "number de cette page"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "Oui (par le biais de `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "suite d'unités d'exécution et matrice en quatre modes "
 "`run_memory_stability_tests.sh`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -78648,7 +79642,7 @@ msgstr ""
 "oui (via `pr-gate`; le niveau PR est diff-scopé, les niveaux sweep/full "
 "exécutent l'espace de travail)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -78656,27 +79650,27 @@ msgstr ""
 "GC × matrice de sélection de représentation, instruments de détection des "
 "erreurs, contraintes de barrière d'écriture"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr ""
 "Oui (via `pr-gate`; sous-ensemble PR sur les PR, matrice complète dans le "
 "balayage)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "dominance racine émise, y compris IR de point d'état natif"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -78684,27 +79678,27 @@ msgstr ""
 "ne sont pas exigées par la succursale; prise en charge de la branche PR par "
 "`run-extended-tests`, toutes les six heures sur `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "Matrice counters/RSS/wall pour le collecteur pincé"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "le budget mechanism/policy du fil local"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Commandes locales utiles avant le vol:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -78714,11 +79708,11 @@ msgstr ""
 "pour le compilateur et l'hôte; leurs fichiers de flux de travail sont "
 "l'autorité pour les commandes exactes et les filtres de pertinence."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Des preuves historiques"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -78727,7 +79721,7 @@ msgstr ""
 "blob/main/docs/generational-gc-plan.md): conception originale et journal "
 "d'atterrissage par étape."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -78737,7 +79731,7 @@ msgstr ""
 "main/docs/statepoint-gc-experiment.md): mesures chronologiques du prototype "
 "et corrections menant à la racine native par défaut."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -78746,7 +79740,7 @@ msgstr ""
 "solidité du code, modes de vérification, points morts connus et instruments "
 "de débogage."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -79080,7 +80074,8 @@ msgstr ""
 "pas la correction, était le coût à chaque fois."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "Les cinq façons dont il s'est brisé"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -79241,14 +80236,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` dans `gc/mod.rs` dans le même commit."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Comment vérifier votre travail"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. Le vérificateur statique  exécute celui-ci"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -79259,7 +80295,7 @@ msgstr ""
 "domaine, c'est le seul instrument qui détecte un défaut avant de s'écraser, "
 "c'est pourquoi il fonctionne en premier."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -79267,7 +80303,7 @@ msgstr ""
 "**Il est aveugle à trois classes, toutes trouvées à la dure. Un rapport "
 "propre n'est pas une preuve pour l'un d'eux:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -79276,7 +80312,7 @@ msgstr ""
 "et ne peut pas voir une cellule d'exécution. Dites: échoue 10/10 plutôt que "
 "de façon intermittente."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -79286,7 +80322,7 @@ msgstr ""
 "Il disait `0 violations` des deux côtés d'un vrai bug dont la correction "
 "était une ligne `GcSuppressScope` dans le bootstrap `globalThis`."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -79305,7 +80341,7 @@ msgstr ""
 "ces ensembles par rapport à ce que le code générateur émet réellement, de la "
 "même manière que le numéro 7227 audite `ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -79316,7 +80352,7 @@ msgstr ""
 "#7280 enregistre 25 fichiers de corpus sélectionnés qui passent tandis que "
 "20 lignes de stock zod échouent."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -79335,29 +80371,14 @@ msgstr ""
 "walkable depuis # 7370. **Faites les deux **, et sachez lequel vous avez "
 "couru:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr ""
 "# Shadow (PERRY_RS4GC=0): toujours la baisse sur arm64_32 watchOS et ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# NATIVE (PERRY_RS4GC=1): par défaut partout ailleurs. Ancres sur"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\" est le nom de l'appareil"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` attribue les racines et LLVM insère les points de "
-"sécurité plus tard, de sorte que le"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -79367,11 +80388,11 @@ msgstr ""
 "corpus natif a zéro stockage racine, donc `--min-binds` échoue là, et le "
 "corpus ombre a zéro point de sécurité, donc `--min-statepoints` échoue là."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Qu'est-ce que `--statepoints` vérifie, et en quoi il diffère"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -79384,7 +80405,7 @@ msgstr ""
 "\"le stockage racine doit dominer chaque point de collecte ultérieur\" "
 "devient:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -79392,7 +80413,7 @@ msgstr ""
 "Aucun registre nommant un objet GC ne peut être Utilisé en dessous d'un "
 "point de sécurité, sauf s'il s'agit de la valeur déplacée."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -79407,23 +80428,23 @@ msgstr ""
 "partie de sa vie en tant que `double`. Deux catégories de verdict, parce "
 "qu'ils ont deux solutions différentes:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -79432,15 +80453,15 @@ msgstr ""
 "dans le paquet en direct du point de sécurité. Rien ne marque ou réécrit "
 "l'objet."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "Il faut le déraciner"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -79448,11 +80469,11 @@ msgstr ""
 "l'objet est dans le paquet et est déplacé, mais une copie brute de son "
 "adresse avant le déplacement est utilisée ci-dessous"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "dériver à nouveau de la valeur déplacée (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -79469,7 +80490,7 @@ msgstr ""
 "enveloppé**, donc `--moving-only` est classé par rapport au symbole réel "
 "plutôt qu'à `llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -79494,16 +80515,16 @@ msgstr ""
 "comme une collecte, donc une faille dans son modèle coûte un faux positif, "
 "jamais un bug manqué."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Pour un seul fichier que vous êtes en train d' itérer:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr ""
 "Les deux boutons environnementaux comptent, pour des raisons différentes."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -79519,7 +80540,7 @@ msgstr ""
 "collection entre deux points d'un corps de boucle inerte ne peut pas "
 "apparaître dans le corpus sans cela."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -79542,7 +80563,7 @@ msgstr ""
 "`js_object_set_field_by_name`, `js_object_get_field_ic_miss` et "
 "`js_closure_call1`. Ils se déplacent sans aucune enquête."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -79550,13 +80571,13 @@ msgstr ""
 "Donc: allumez le bouton, car il élargit ce que le corpus peut exprimer, mais "
 "ne lisez pas une fonction sans sondage comme sûre."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` est par EXACT émis symbole, et qui a mordu deux fois"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -79568,7 +80589,8 @@ msgstr ""
 "toujours, et ressemble exactement à une couverture tout en le faisant. Deux "
 "cycles ont été mesurés:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -79579,7 +80601,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -79596,7 +80618,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` à `clone` de zod. Le protecteur et le "
 "contrôleur n'étaient pas d'accord; le contrôleur avait tort."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -79619,7 +80641,7 @@ msgstr ""
 "points d'entrée sont `js_closure_callN`, que `RECEIVER_SINKS` dans le même "
 "fichier a déjà orthographié correctement."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -79640,60 +80662,60 @@ msgstr ""
 "que la forme n'a jamais été attrapable sous le mode CI. Replantant ce code "
 "exact et exécutant chaque mode (# 7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (dominance)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (l'abaissement qui envoie)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (non filtré)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (non filtré)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -79705,7 +80727,7 @@ msgstr ""
 "étaient aveugles à l'abaissement de l'expédition. En ajoutant un nom, les "
 "bras sabotés sont 13 et 8 et les bras propres sont 2 et 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -79735,7 +80757,7 @@ msgstr ""
 "un chemin qui peut, ajoutez-le à `POLL_CAPABLE_RUNTIME` dans le même "
 "commit.** Rien ne vous le demandera."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -79746,7 +80768,7 @@ msgstr ""
 "dominance.yml` fonctionne à la fois avec `--audit-alloc-re` avant la "
 "compilation."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -79773,7 +80795,7 @@ msgstr ""
 "devient rouge, **remplacer** le fantôme avec le symbole codegen émet en fait "
 "plutôt que de le supprimer  supprimer rend l'audit vert et laisse le trou."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -79804,21 +80826,17 @@ msgstr ""
 "commentaires et les littéraux de chaîne sont supprimés en premier afin qu'un "
 "nom mentionné en prose ne puisse pas devenir une prémisse."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "Il ne suffit pas de vérifier un nom plausible. Confirmer par rapport à l'IR "
 "émise:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -79826,7 +80844,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` rend chaque stockage racine le formulaire "
 "d'appel `js_shadow_slot_bind` les ancres de vérification sur."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -79843,7 +80861,7 @@ msgstr ""
 "d'autorisation, de sorte que les cas 3 et 4 ne surface que lorsque vous "
 "exécutez ce mode à la main."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -79860,7 +80878,7 @@ msgstr ""
 "ligne `lower_call/new.rs` `this_slot` indépendamment de toute sonde "
 "d'exécution."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -79878,15 +80896,15 @@ msgstr ""
 "`Symbol` n'a pas de fente d'ombre du tout. Exécutez-le manuellement lorsque "
 "vous touchez un site `alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. Les instruments d'exécution  seconde, et attention à la profondeur"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Du numéro 7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -79901,7 +80919,7 @@ msgstr ""
 "mode littéral every-poll lorsque la fenêtre que vous recherchez n'est "
 "exécutée qu'une seule fois  c'est beaucoup plus lent."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -79910,11 +80928,12 @@ msgstr ""
 "l'évacuation, donc une erreur de lecture obsolète immédiatement au lieu de "
 "lire des ordures plausibles."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT`  s'exécute désormais."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -79922,7 +80941,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -79939,7 +80958,7 @@ msgstr ""
 "gc_schedule_fuzz.sh <binary> [seed-count]` balaie les graines et imprime une "
 "commande de reproduction par défaillance."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -79954,7 +80973,7 @@ msgstr ""
 "le feu est le seul moyen bon marché d'explorer l'espace dans lequel vit le "
 "bug."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -79967,7 +80986,7 @@ msgstr ""
 "moment où il est dérivé. **Utilisez le 800.** Une course propre à la "
 "profondeur par défaut ne signifie rien."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -79997,7 +81016,7 @@ msgstr ""
 "le vérificateur statique, regardez le vérificateur en premier. C'est ainsi "
 "que le désaccord zod `clone` a été réglé."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -80009,7 +81028,7 @@ msgstr ""
 "pas la trame qui possède le registre  la valeur arrive généralement comme un "
 "argument d'un appelant qui la laisse obsolète."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -80021,11 +81040,11 @@ msgstr ""
 "toute sonde d'exécution à remarquer. Ces instruments capteront les "
 "conséquences plus tard. Le vérificateur statique capte la cause, maintenant."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "L'image miroir: une barrière d'écriture manquante (# 8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -80037,43 +81056,43 @@ msgstr ""
 "jamais **Il m'a parlé de**. Les deux sont des doubles, et  c'est la partie "
 "qui continue à attraper les gens **Leurs détecteurs sont échangés**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "insecte des racines"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "Barrière d'écriture missing/deleted"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "Ce qui ne va pas"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "une valeur en direct est invisible à l'analyse racine"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "un bord old→young est absent de l'ensemble mémorisé"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "quand ça tourne mal"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "à la collecte, silencieusement"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "pas du tout au magasin; à un mineur plus tard"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "le détecteur"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -80083,30 +81102,30 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE`), ainsi que le vérificateur statique de la "
 "moitié visible IR"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **affirmation IR statique**, et rien d'autre"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "le point mort"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "le vérificateur statique ne peut pas voir un cache côté exécution d'un "
 "pointeur de heap (voir §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**chaque sonde en cours d'exécution que nous avons**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "Pourquoi aucune sonde ne peut le voir "
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -80121,18 +81140,18 @@ msgstr ""
 "une défaillance observable nécessite une conjonction que le programme doit "
 "fournir par lui-même:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "le parent doit survivre à la vieillesse (ou être titulaire) **avant** le "
 "magasin;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "l'enfant doit encore être à la maternelle **à la prochaine mineure**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -80141,7 +81160,7 @@ msgstr ""
 "tout et les papiers sur l'ensemble de la classe  doit atterrir dans cette "
 "fenêtre; et"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -80149,7 +81168,7 @@ msgstr ""
 "cette bordure doit être le seul chemin vers l'enfant, ou une autre racine le "
 "trouve de toute façon et la collection est propre."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -80157,7 +81176,7 @@ msgstr ""
 "Le mineur collecte correctement, le programme imprime la bonne réponse, et "
 "la sonde rapporte le succès. Rien n'a été essayé."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -80167,7 +81186,7 @@ msgstr ""
 "eux visent une propriété complètement différente, et il est facile de lire "
 "leur vert comme preuve:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -80181,7 +81200,7 @@ msgstr ""
 "pas une fente qu'il a échoué à réécrire. Se souvenir et réécrire sont des "
 "propriétés différentes, et le vérificateur ne demande que la seconde."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -80193,7 +81212,7 @@ msgstr ""
 "inaccessible. Une course verte ici est la preuve la plus forte et la plus "
 "vide des trois."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -80205,7 +81224,7 @@ msgstr ""
 "enracinement de la dualité. C'est un pointeur suspendu dans l'espace, pas un "
 "objet vivant qui n'a jamais été retrouvé."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -80220,7 +81239,7 @@ msgstr ""
 "Chaque nom dans ce document est celui que la passerelle a confirmé posséder "
 "par un analyseur en direct."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -80232,7 +81251,7 @@ msgstr ""
 "être observée en exécutant le programme.** Il n'y a pas d'exécution dans "
 "laquelle \"la barrière n'a pas couru\" est un événement distinctif."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -80253,12 +81272,12 @@ msgstr ""
 "grand dispositif d'adversité. Le test IR statique était la seule chose qui a "
 "dit non."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr ""
 "Qu'est-ce qu'un PR qui ajoute ou déplace un magasin sur une fente GC doit"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -80268,7 +81287,7 @@ msgstr ""
 "test comportemental. Quatre choses qu'il doit fixer, chacune parce qu'un "
 "sabotage qui l'a sauté n'a pas été attrapé:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -80279,7 +81298,7 @@ msgstr ""
 "addref. Si l'un des trois disparaît, c'est la famille 5094/7511 de Silent "
 "Stranding."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -80292,7 +81311,7 @@ msgstr ""
 "de contenu heureusement inspecté, et initialement passé. La présence d'un "
 "code ne prouve pas qu'il fonctionne."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -80302,7 +81321,7 @@ msgstr ""
 "la comptabilité. Une barrière qui s'échappe signifie que le discriminateur a "
 "cessé de discriminer, et l'\"optimisation\" ne mesure rien."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -80312,9 +81331,10 @@ msgstr ""
 "et notez que le test devient rouge. Un test qui n'a jamais échoué est un "
 "test dont le mode d'échec est inconnu."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -80331,36 +81351,25 @@ msgstr ""
 "class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` et "
 "`write_pic_barrier_tests.rs` sont la forme."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "Le marqueur `GC_STORE_AUDIT`, et ce qu'il fait et ne prouve pas"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Tous les magasins en matière de GC contiennent un marqueur à proximité "
 "indiquant son verdict:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// GC_STORE_AUDIT(BARRIERED): l'écriture de l'emplacement est "
-"inconditionnelle; la barrière"
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr ""
-"// ci-dessous est gardé seulement par un test en direct que les bits stockés "
-"ne portent pas de tas"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// pointer, qui est le premier test de la barrière."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -80373,7 +81382,7 @@ msgstr ""
 "pas de marqueur  donc un **nouveau** Le site du magasin ne peut pas atterrir "
 "sans réponse à la question."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -80382,7 +81391,7 @@ msgstr ""
 "le **réclamation**, non seulement le commentaire, pour les deux classes où "
 "une fausse revendication enchaîne les objets:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -80424,7 +81433,7 @@ msgstr ""
 "(supprimer l'appel, câbler la porte, déplacer l'appel hors de son bloc, "
 "contourner la porte) effectués dans la suite contre chaque tige."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -80452,7 +81461,7 @@ msgstr ""
 "de barrière dans la même fonction passent toujours), et le script imprime "
 "cette limite."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -80476,11 +81485,11 @@ msgstr ""
 "(le `gc_rekeyed_key_tables.py` Il s'agit d'une discipline `--self-test` Les "
 "plantes ont quinze formes, dont chacune doit être jugée."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "Le problème du corpus, et les deux corpus (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -80489,7 +81498,7 @@ msgstr ""
 "l'échelle de dépendance, et pendant un moment personne ne pouvait le dire, "
 "parce qu'il était vert.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -80504,7 +81513,7 @@ msgstr ""
 "# 7280 le met en une phrase: _25 fichiers sélectionnés passer tandis que 20 "
 "lignes de stock zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -80512,40 +81521,40 @@ msgstr ""
 "Ce n'est pas un problème de taille. Les deux corps ont été mesurés sur le "
 "même compilateur avec `--stale-registers --moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "utilisations périmées"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "ce qui domine"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "Les résultats de l'étude sont publiés dans les pages suivantes:"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr ""
 "fenêtres de l'aide propriété-GET, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "échelle de dépendance, 81 modules / 62 Mo"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -80553,7 +81562,7 @@ msgstr ""
 "`js_object_assign_one` Je ne sais pas `js_new_function_construct` 102, "
 "`js_closure_call*` 30 ans"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -80570,7 +81579,7 @@ msgstr ""
 "dangers de l'enracinement vivent dans les formes**, donc un corpus sans les "
 "formes ne peut pas les exprimer, peu importe le nombre de fichiers qu'il a."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -80578,11 +81587,12 @@ msgstr ""
 "Il y a donc un deuxième corpus, généré à partir d'une dépendance npm réelle "
 "plutôt que de quelque chose écrit pour l'occasion:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod est un package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -80597,7 +81607,7 @@ msgstr ""
 "puisque ~ 90 modules de `zod` marécage n'importe quel compte une source "
 "manquante de lignes 40 traverserait."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -80610,11 +81620,11 @@ msgstr ""
 "le plus cher (~ 5 min): son balayage est superlinéaire, et 62 MB est de 62 "
 "MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "La porte CI"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -80627,19 +81637,19 @@ msgstr ""
 "fermées sont d'environ trois secondes chacune sur ~ 2000 et ~ 12900 "
 "fonctions."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "Il est conçu pour être en mesure d'échouer, contre les quatre dangers de "
 "CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "l'état de sortie du vérificateur est  sans `continue-on-error`, sans tuyau;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -80647,7 +81657,7 @@ msgstr ""
 "`concurrency` annule uniquement les exécutions de pull-request, de sorte que "
 "les exécutions `main` ne sont jamais épuisées;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -80658,7 +81668,7 @@ msgstr ""
 "`checked N functions / M modules` afin qu'une course silencieuse vide soit "
 "visible;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -80671,7 +81681,7 @@ msgstr ""
 "attrape le vérificateur en perdant silencieusement la capacité de lire la "
 "sortie de Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -80688,11 +81698,11 @@ msgstr ""
 "expédié des entrées mortes: neuf dans `ALLOC_RE` à travers deux tours, dix "
 "dans `POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "La liste des autorisations, et pourquoi ce n'est pas un nombre"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -80702,7 +81712,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, une entrée avec une empreinte digitale, "
 "un problème et une justification écrite."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -80715,11 +81725,11 @@ msgstr ""
 "le moins cher de verdir une construction rouge est d'augmenter le nombre "
 "d'un, et rien dans la différence ne dit ce qui a été concédé."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Donc le contrôleur applique trois propriétés:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -80730,7 +81740,7 @@ msgstr ""
 "c'est pourquoi un bug fixe ne peut pas laisser une pierre tombale qui "
 "élargit discrètement la couverture plus tard."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -80738,13 +81748,13 @@ msgstr ""
 "**une entrée supprime tout au plus son `count`.** Une deuxième violation de "
 "la même forme dans la même fonction est nouvelle et échoue."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**une violation sans échec d'entrée**, quel que soit le nombre d'entrées."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -80753,11 +81763,11 @@ msgstr ""
 "`count` pour verser une compilation est exactement la chose que ce fichier "
 "existe pour empêcher."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Promouvoir cette porte"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -80766,11 +81776,11 @@ msgstr ""
 "exigées par la protection de branche**, ce qui signifie qu'il ne peut pas "
 "faire échouer une fusion — risque 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Les deux conditions nommées #7198 sont maintenant remplies:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -80780,7 +81790,7 @@ msgstr ""
 "un **vide** allowlist (les entrées #7211 ont été supprimées lorsque ce "
 "prédicat a été fixé dans \\#7226);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -80790,7 +81800,7 @@ msgstr ""
 "travail (# 7236). C'était le plus remarquable: il était 98 avant #7235, 2 "
 "après, et 0 une fois que `Type::Symbol` a cessé d'être classé comme immédiat."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -80798,7 +81808,7 @@ msgstr ""
 "Donc l'étape restante est pour un **Réserver le compte** pour ajouter `gc-"
 "root-dominance` aux contextes requis de la protection des branches:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -80813,7 +81823,7 @@ msgstr ""
 "jamais été verte dans sa forme actuelle bloque chaque PR ouvert le jour où "
 "il devient nécessaire."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -80836,11 +81846,11 @@ msgstr ""
 "la population est fixe; une promotion qui congèle le budget là où il est a "
 "acheté un nombre, pas un invariant."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Règles de base"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -80855,7 +81865,7 @@ msgstr ""
 "initialisateurs fournis par l'auteur, jamais sur les appels "
 "`js_object_set_field_by_name` émis par l'abaissement."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -80864,7 +81874,7 @@ msgstr ""
 "charge à partir d'une fente racine pendant un appel. `rooted_handle_get` "
 "existe pour cela."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -80874,7 +81884,7 @@ msgstr ""
 "plusieurs opérandes où l'un est matérialisé avant qu'un autre ne soit "
 "abaissé nécessite que le premier soit enraciné."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -80882,7 +81892,7 @@ msgstr ""
 "**`--trace llvm` et lisez-le.** Trois secondes d'épreuve sont meilleures "
 "qu'une journée de fractionnement d'un `not a function` cinq cycles en aval."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -81151,6 +82161,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Exécutez-le localement avec:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Validation à la compilation"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "Utilisateur choisit le back-end par charge de travail"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -81618,7 +82797,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: chaîne -- le nom du registre, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -81657,38 +82837,36 @@ msgid "Three types and one rule."
 msgstr "Trois types et une règle."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 "/// Un registre contenant une valeur gérée par GC qui n'est PAS rootée."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// emprunte l'émetteur invariablement. Ni le clone, ni le copier."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Une racine d'ombre. Survit aux points de collecte; ne peut pas être lu "
 "directement."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// uniquement disponible à partir de ShadowFrame:: alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 "/// Un registre contenant quelque chose que le GC ne gère pas: i32, double, "
 "bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// un index de fente. Clonable librement, pas de durée de vie, pas "
-"d'emetteur emprunté."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -81699,28 +82877,33 @@ msgstr ""
 "fonction de leur capacité à collecter**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "Je ne peux pas récupérer. Prend &self, donc les poignées `Raw` en suspens "
 "restent valides."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// peut recueillir. Prend &mut lui-même, ce qui met fin à chaque emprunt "
 "`Raw` en souffrance."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "Relisez le slot. Le RAW renvoyé est valide jusqu'à l'émission suivante de "
 "&mut."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 "Consommez ce registre dans une racine. C'est la seule façon de faire un "
 "Rooted."
@@ -81740,24 +82923,22 @@ msgstr ""
 "être utilisé à travers un point de collecte** le compilateur le rejette."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_>, emprunte le"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// besoins et besoins"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERROR: obj emprunte le e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// qui est mutable"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// emprunté ci-dessus"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -81767,7 +82948,8 @@ msgstr ""
 "sortir de l'erreur:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// ré-lire, correcte"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -82416,8 +83598,9 @@ msgstr ""
 "**La trappe d'évacuation**, tant que n'importe quel appelant l'utilise."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -84091,11 +85274,15 @@ msgstr ""
 "de construction."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Ce modèle de sidecar n'a pas d'écriture de première exécution, de sorte que "
 "les répertoires d'installation en lecture seule sont pris en charge. Pour "
@@ -84103,7 +85290,21 @@ msgstr ""
 "fichiers manquants ou dématchées par hachage échouent avant `dlopen` avec "
 "une erreur d'emballage."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -84121,7 +85322,7 @@ msgstr ""
 "les attributs de quarantaine des fichiers binaires téléchargés non fiables à "
 "l'exécution."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -84140,11 +85341,11 @@ msgstr ""
 "dépendances dans le gestionnaire de paquets tout en empêchant un fichier "
 "hôte `.node` d'entrer dans un artefact cible."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Identité du cache"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -84153,32 +85354,32 @@ msgstr ""
 "déterministe et contribue aux identités de build et de cache de lien "
 "suivantes:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr ""
 "la version du schéma de stratégie et la version annoncée de l'API de nœud;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "tuple cible et liste d'admissibilité normalisée;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "le paquet name/version sélectionné et le chemin d'entrée relatif;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 et taille de chaque fichier de charge utile de sidecar;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "l'inventaire des symboles exportés commandés;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "le modèle d'expédition (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -84193,11 +85394,11 @@ msgstr ""
 "manquer le cache de compilation de haut niveau même lorsque tous les "
 "fichiers TypeScript et les fichiers d'objets ne sont pas modifiés."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -84216,22 +85417,15 @@ msgstr ""
 "lorsque cela est nécessaire pour la résolution binaire, mais il indique de "
 "manière déterministe la fonctionnalité non prise en charge indiquée."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: noyau jusqu'à la version 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Points d'entrée"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -84239,49 +85433,56 @@ msgstr "Points d'entrée"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Stockage stable dans l'environnement"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "Les valeurs singleton reçoivent des poignées de portée ordinaires"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Les allocateurs Perry object/array"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -84289,11 +85490,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN-conversions de boîtes"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -84301,38 +85502,38 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Limité en longueur; `NAPI_AUTO_LENGTH` pris en charge"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "Les rappels natifs utilisent des enregistrements d'hôte"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` est installé lorsque fourni"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr ""
 "Inclut les distinctions fonctionnelles, externes, symboliques et bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -84340,11 +85541,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Comportement type/status vérifié"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -84352,12 +85553,12 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr ""
 "La sémantique de la longueur de requête et de la terminaison NUL est incluse"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -84365,19 +85566,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "Le code de l'utilisateur est pris au piège par une exception"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Sémantique générale des objets"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -84385,11 +85586,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "Chaîne, symbole et touches numériques"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -84397,11 +85598,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "Les noms UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -84409,43 +85610,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Arrays et objets indexés exotiques"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Les descripteurs des données, des méthodes et des accessoires"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Aucun raccourci pour l'identité du pointeur"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "Le code Perry est le code dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "L'appel de retour-info à vie est l'appel natif"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -84453,11 +85654,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Tableau de métadonnées d'objets natifs"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -84465,11 +85666,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Conception de référence forte et faible ci-dessus"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -84479,11 +85680,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Validation stricte de la nidification et de la génération"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -84491,19 +85692,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Modèle de fente en attente"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Disponible en attente"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -84511,37 +85712,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Pointers de soutien stables"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Tous les onze types de table classés déclarés"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Identification de la garantie et compensation conservées"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Retours 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -84549,20 +85750,20 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr ""
 "Les enregistrements diffusés sont des racines appartenant à l'environnement"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -84570,40 +85771,40 @@ msgstr ""
 "Renvoie `napi_generic_failure`; l'exécution de la source en temps "
 "d'exécution arbitraire violerait le modèle de moteur en temps d'exécution"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Comptabilisation de la pression du collecteur"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: les versions 5 à 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "Finalisation post-GC en file d'attente"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -84611,11 +85812,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Précision arbitraire"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -84623,24 +85824,24 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "`lossless` exact et comportement de comptage des mots"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr ""
 "Le mode de collecte, le filtre et la conversion des clés sont respectés"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -84648,46 +85849,46 @@ msgstr ""
 "Un enregistrement par environnement; remplacement est écrasé sans appeler le "
 "finalizateur précédent"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Propagation des détachements existants"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "Étiquette de 128 bits dans les métadonnées d'objet"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Le détecteur Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: version 9, version 10 et expérimental"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -84695,18 +85896,18 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr ""
 "La publicité doit être réalisée uniquement avec une surface de version 9 "
 "complète"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -84714,11 +85915,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Requiert un travail de chaîne externe lifetime/accounting"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -84726,29 +85927,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "Les alias de voie rapide de la version 10"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "Ne fait pas partie de l'ABI stable annoncé"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -84756,33 +85957,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Enregistrement d'ancienneté et chemin d'arrêt"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Intégration des crochets asynchrones existants"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -84790,11 +85991,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` identité et octets stables"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -84802,15 +86003,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Machine d'état explicite ci-dessus"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -84818,16 +86019,16 @@ msgstr ""
 "Retourne les composants semver de Perry avec la chaîne de sortie `perry`; il "
 "ne demande pas une sortie de nœud"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "Renvoie `napi_generic_failure` et une boucle nulle; Perry n'a pas de libv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -84835,19 +86036,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Cycle de vie du fil principal"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Contextes asynchrones et niches strictes"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -84855,11 +86056,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN à pompe à événement"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -84867,35 +86068,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Nombre de fils et durée de vie de la boucle d'événement"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "La fermeture est en attente d' achèvement "
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "L'environnement enregistre déjà la valeur future"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Publicité avec la version 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -84905,18 +86106,18 @@ msgstr ""
 "`napi_register_module_v1`; ceux-ci sont recherchés dans l'addon et ne sont "
 "pas des exportations d'hôte."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Portes requises"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "La mise en œuvre n'est pas complète tant que les portes ci-dessous ne "
 "peuvent pas échouer indépendamment:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -84929,7 +86130,7 @@ msgstr ""
 "les poignées obsolètes échouent à la validation de la génération; les "
 "scripts d'audit de root-holder et de rekey-table sont propres."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -84940,7 +86141,7 @@ msgstr ""
 "C avant que Perry ne se lève; un addon instrumenté affirme qu'aucun dérapage "
 "n'est entré dans ses trames."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -84950,7 +86151,7 @@ msgstr ""
 "fonction appelée `napi_*` et le test prouve que l'adresse appartient à "
 "l'exécutable Perry. Le nombre d'appels de fumée doit être supérieur à zéro."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -84962,7 +86163,7 @@ msgstr ""
 "d'instance, wrap/finalizers et les tampons. La version NAPI non prise en "
 "charge, les appareils NAN/V8 et `uv_*` affirment leur diagnostic exact."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -84973,7 +86174,7 @@ msgstr ""
 "flux fusionnés identiques; les deux parties affirment que leur mise en œuvre "
 "native s'est effectivement déroulée."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -84983,7 +86184,7 @@ msgstr ""
 "vers un emplacement en lecture seule et charger avec succès; la suppression "
 "ou la mutation d'un sidecar échoue à la vérification de hachage du manifeste."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -84992,7 +86193,7 @@ msgstr ""
 "manque le cache de construction; reconstruire les entrées inchangées le "
 "frappe."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -85001,7 +86202,7 @@ msgstr ""
 "graphique addon vide; indiquer le delta réservé aux hôtes pour une "
 "compilation addon et appliquer le budget 0.6 MB."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -85585,28 +86786,14 @@ msgstr ""
 "Utilisez des commandes explicites pour des champs d'application plus larges:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Le produit feedback"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Chaque membre de l'espace de travail compatible avec l'hôte (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$package\" est le numéro de téléphone de l'équipe"
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Inspecter ou valider l'architecture de l'espace de travail"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -85763,7 +86950,8 @@ msgstr ""
 "bisecter le backend IR textuel."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# Construire le produit par défaut et sa fermeture de dépendance"
 
 #: src/contributing/building.md:37
@@ -85890,7 +87078,8 @@ msgstr ""
 "Cargo dans l'enveloppe:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# CLI pour développeur mince et optimisé"
 
 #: src/contributing/building.md:80
@@ -85925,26 +87114,31 @@ msgid "Build Specific Crates"
 msgstr "Compiler des crates spécifiques"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# En temps d'exécution seulement (il faut aussi reconstruire stdlib!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Les archives statiques .a sont émises par des boîtes d'emballage séparées "
 "(#5422), de sorte qu'une"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# explicitement lorsque vous avez besoin de libperry_runtime.a / "
 "libperry_stdlib.a (e.g. pour lier"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Uniquement Codegen"
 
 #: src/contributing/building.md:106
@@ -85991,17 +87185,21 @@ msgid "Run Tests"
 msgstr "Lancer les tests"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Objectifs de l'unité de produit"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Inspecter la portée de test de l'IC nocturne (toutes les caisses de test "
 "compatibles avec Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Caisse spécifique"
 
 #: src/contributing/building.md:137
@@ -86009,11 +87207,13 @@ msgid "Compile and Run TypeScript"
 msgstr "Compiler et exécuter TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Compiler un fichier TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Débogage: imprimer HIR"
 
 #: src/contributing/building.md:148
@@ -86084,19 +87284,23 @@ msgstr ""
 "un registre public diffère."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Vérifiez que la caisse est propre."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# doit imprimer 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# Il ne faut rien imprimer"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Vérification rapide des politiques et des scripts."
 
 #: src/contributing/releasing.md:23
@@ -86104,7 +87308,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Des contrôles comportementaux exécutables par l'hôte. Ces mesures "
 "améliorent le chiffre d'affaires, mais ne"
@@ -86131,7 +87337,8 @@ msgstr ""
 "processus de fusion normal."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Remplacer la version déjà présente dans Cargo.toml."
 
 #: src/contributing/releasing.md:48
@@ -86151,7 +87358,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # ne doit rien imprimer"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -86259,9 +87467,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "action autorisée: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -86294,22 +87503,15 @@ msgstr ""
 "partiel."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# une mise en route de paquets de mise à jour: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # publier + vérifier tous les 9 via OIDC, puis "
-"créer"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + la dernière version de GitHub"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# vérifier le reçu commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -86533,11 +87735,13 @@ msgstr ""
 "humain:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# Compilé pour le simulateur"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr ""
 "# Démarrer un appareil (à usage unique; réutiliser l'UDID à travers les "
 "exécutions)"
@@ -86547,22 +87751,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Installation + lancement en mode test"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# Application sort 0 après le rendu; capture d'écran atterrit au compteur-"
-"ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -86840,6 +88031,10 @@ msgid "patch distance"
 msgstr "Distance du patch"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -86874,15 +88069,18 @@ msgstr ""
 "ferme une fois que le registre a rattrapé."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# prouve qu'il peut échouer"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# Enregistrement réel, pas de problème écrit"
 
 #: src/contributing/releasing.md:289
@@ -86942,6 +88140,386 @@ msgstr ""
 "paquets de version héritées, envoyez-les avec `existing_tag=vX.Y.Z`; ajoutez "
 "`publish_npm=true` uniquement lorsque la patte npm idempotente elle-même "
 "doit également être réessayée."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\""
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# Modifier src/lib.rs  ajouter vos fonctions `js_*`, tous en utilisant "
+#~ "uniquement"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr ""
+#~ "# Modifier src/index.ts  déclarer le code d'importation de l'utilisateur "
+#~ "de surface TS"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr ""
+#~ "# Modifier package.json  liste de toutes les exportations js_* dans le"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ le manifeste correspond à la clé statique"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# l'échafaudage release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # construit des pré-constructions "
+#~ "pour toutes les cibles"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # et les attache à la décharge"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Réservations natives pour <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  extraire du texte d'un tampon PDF."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # Sécurité"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` doit être nul ou valide pour les octets `buf_len`. Perry "
+#~ "est passé"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr ""
+#~ "/// cette paire à partir d'un paramètre de manifestation `buffer+len`."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr ""
+#~ "// const résultat = attendre spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Rembourrage et marges internes"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. tranche arm64 (cible du dispositif par défaut)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. aligner les minos + fusible"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"plateformes;android-35\" \"outils de construction;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\" est le nom du code"
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"Images du système;android-34;android-wear;arm64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. La cible croisée Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Créer + démarrer un émulateur Wear OS (ronde de surveillance)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Packages npm supplémentaires et API Node.js pris en charge par Perry. "
+#~ "Tous ceux listés ici sont connectés via le registre de bindings natifs "
+#~ "bien connus de Perry (#466) et compilent en code natif sans aucune "
+#~ "implication d'un runtime JavaScript."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr ""
+#~ "# 3) Vérifiez la santé mentale de la signature avant de télécharger le "
+#~ "manifeste"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    ici prédit une vérification de passage sur le client."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Release CI signe le manifeste CLI, liant son URL d'archive, "
+#~ "plateforme,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// Détectez la cible: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos "
+#~ "SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// Compilé: rapidc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// lien: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"Type de contenu: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "Je ne sais pas"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"valeur\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "\"{\"valeur\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "Je ne sais pas"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP de la personne:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Laissez-le tourner pendant 30 secondes"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Vérifiez les statistiques"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr ""
+#~ "# Je suis en train de courirevents_fired\"600,\" Je suis "
+#~ "désoléuptime_secs\"30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Prenez une capture d'écran pour voir l'état final"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Arrêtez le chaos"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Vérifiez que l'application est toujours en vie"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Construire pour iOS (compilation croisée)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\"workflow_runs[].id\" est le code de l'appareil"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "Les emplois | select(.status==\"in_progress\") | (étiquettes|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr ""
+#~ "# Quelle est la profondeur de la file d'attente, et sur quels bassins:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "Les emplois | select(.status==\"queued\") | (étiquettes|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"Réservations natives pour libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Les navires Perry **deux canaux indépendants de participation "
+#~ "facultative** pour envoyer des données à la maison  rien ne quitte votre "
+#~ "machine sans un `enabled = true` ou `on` explicite dans `~/.perry/"
+#~ "config.toml`. Les deux respectent `PERRY_NO_TELEMETRY=1` et `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "émettent un diagnostic collecteur lisible par l'homme"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# NATIVE (PERRY_RS4GC=1): par défaut partout ailleurs. Ancres sur"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\" est le nom de l'appareil"
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` attribue les racines et LLVM insère les points de "
+#~ "sécurité plus tard, de sorte que le"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): l'écriture de l'emplacement est "
+#~ "inconditionnelle; la barrière"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// ci-dessous est gardé seulement par un test en direct que les bits "
+#~ "stockés ne portent pas de tas"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// pointer, qui est le premier test de la barrière."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// emprunte l'émetteur invariablement. Ni le clone, ni le copier."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// un index de fente. Clonable librement, pas de durée de vie, pas "
+#~ "d'emetteur emprunté."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERROR: obj emprunte le e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// qui est mutable"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// emprunté ci-dessus"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$package\" est le numéro de téléphone de l'équipe"
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Inspecter ou valider l'architecture de l'espace de travail"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr ""
+#~ "# une mise en route de paquets de mise à jour: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # publier + vérifier tous les 9 via OIDC, "
+#~ "puis créer"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr ""
+#~ "                            # v0.x.y + la dernière version de GitHub"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# Application sort 0 après le rendu; capture d'écran atterrit au compteur-"
+#~ "ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -87732,22 +89310,6 @@ msgstr ""
 #~ "lookbehind (`(?<=…)` / `(?<!…)`)."
 
 #~ msgid ""
-#~ "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
-#~ "///\n"
-#~ "/// # Safety\n"
-#~ "///\n"
-#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
-#~ "/// this pair from a `buffer+len` manifest parameter.\n"
-#~ msgstr ""
-#~ "/// `pdf.parse(buf) -> string` — extrait le texte d'un tampon PDF.\n"
-#~ "///\n"
-#~ "/// # Safety\n"
-#~ "///\n"
-#~ "/// `buf_ptr` doit être null ou valide pour `buf_len` octets. Perry "
-#~ "transmet\n"
-#~ "/// cette paire depuis un paramètre manifeste `buffer+len`.\n"
-
-#~ msgid ""
 #~ "Current state (issue [\\#185](https://github.com/PerryTS/perry/issues/"
 #~ "185)):"
 #~ msgstr ""
@@ -88023,9 +89585,6 @@ msgstr ""
 #~ "**Détection de locale native à la plateforme** : utilise les API du "
 #~ "système d'exploitation sur chaque plateforme (aucune variable "
 #~ "d'environnement nécessaire sur mobile)"
-
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Validation à la compilation"
 
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""

--- a/docs/po/id.po
+++ b/docs/po/id.po
@@ -214,7 +214,7 @@ msgstr "Hook"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Contoh"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "Tingkat CI (pemeriksaan PR / sweep / rangkaian lengkap)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Penjadwalan pemeriksaan CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "Referensi CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Perintah"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Flag Compiler"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Direktori cache"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dynamic Stdlib Dispatch"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS Runtime Opt-In"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar atestasi biner)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Daftar Izin Egress (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Kapabilitas Per-Paket (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Daftar Izin Host (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "Referensi perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Pemeriksaan pembaruan di aplikasi Anda"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Privasi & Telemetri"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Internal"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Model Memori"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Pengumpul sampah"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Manajemen memori eksplisit"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "Invarian rooting GC (pembuatan kode)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Bukti tipe untuk binding lokal"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Batas langkah GC inkremental"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: rooting melalui konstruksi"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Berkontribusi"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Arsitektur"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Kebijakan crate"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Build dari Source"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Merilis Perry"
 
@@ -934,7 +942,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Membuka jendela macOS/Windows/Linux asli"
 
 #: src/introduction.md:79
@@ -967,11 +976,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -980,9 +989,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -992,7 +1001,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Langkah Berikutnya"
@@ -1066,27 +1075,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux linker toolchain menurut distribusi:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS Stream"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# Berbasis Alpine / musl"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Tidak sah Linux"
 
 #: src/getting-started/installation.md:41
@@ -1128,15 +1143,18 @@ msgstr ""
 "satu perintah:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Proyek-lokal (pin versi Perry di samping deps Anda)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Zero-install, satu tembakan"
 
 #: src/getting-started/installation.md:66
@@ -1334,7 +1352,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "Binary berada di `target/release/perry`. Tambahkan ke PATH Anda:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Tambahkan ke ~/.zshrc atau ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1472,16 +1491,14 @@ msgstr ""
 "murni / cross-compile ke platform lain tidak memerlukannya.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2166,25 +2183,30 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "Kode yang sama berjalan di semua 6 platform:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (default)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOS Simulator"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr ""
 "# Web (mengkompilasi ke WebAssembly + Jembatan DOM dalam file HTML mandiri)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# alias: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Platform lainnya"
 
 #: src/getting-started/first-app.md:138
@@ -2427,7 +2449,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2445,7 +2467,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2668,7 +2690,8 @@ msgstr ""
 "validator yang sama sebagai sumber biasa. Skrip generator:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2700,7 +2723,8 @@ msgid "\"port\""
 msgstr "Pelabuhan"
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// sumber mandiri"
 
 #: src/getting-started/project-config.md:122
@@ -2946,19 +2970,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Field"
 
@@ -2973,9 +2998,9 @@ msgstr "Field"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3095,11 +3120,13 @@ msgstr ""
 "pun:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3154,7 +3181,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3163,7 +3190,7 @@ msgstr ""
 "Perry. Lihat [Standard Library](../stdlib/overview.md) untuk daftar "
 "lengkapnya."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3172,45 +3199,48 @@ msgstr ""
 "untuk paket TS/JS murni, atau fallback runtime JavaScript untuk paket yang "
 "kompleks."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Struktur Proyek"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry fleksibel terhadap struktur proyek. Pola umum:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Untuk aplikasi UI:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Kompilasi"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Mengkompilasi file"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# Mengkompilasi dengan target tertentu"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Debug: representasi print intermediate"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "Lihat [CLI Commands](../cli/commands.md) untuk semua opsi."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 "[CLI Commands](../cli/commands.md) — Semua perintah dan flag kompilator"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3218,7 +3248,7 @@ msgstr ""
 "[Supported Features](../language/supported-features.md) — Fitur TypeScript "
 "apa saja yang berfungsi"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Standard Library](../stdlib/overview.md) — Paket npm yang didukung"
 
@@ -3357,32 +3387,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Kelas"
 
@@ -5418,6 +5449,7 @@ msgstr ""
 "mendukung dua jalur:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5427,7 +5459,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Decorator kelas legacy, decorator method, decorator properti, decorator "
 "parameter konstruktor, dan decorator parameter method** untuk DI bergaya "
@@ -5439,7 +5475,7 @@ msgstr ""
 "untuk kelas/method yang didekorasi dan `design:type` untuk properti yang "
 "didekorasi."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5452,15 +5488,15 @@ msgstr ""
 "runtime sama sekali. Lihat `crates/perry-hir/src/decorator_log.rs` untuk "
 "implementasinya."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Apa yang tidak berfungsi"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Decorator accessor dan penggantian descriptor"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5476,16 +5512,16 @@ msgstr ""
 "dibungkus memerlukan port yang kompatibel dengan Perry — kelas yang "
 "diturunkan sudah tetap di IR dan tidak dapat diganti saat runtime."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Pemanggilan helper `Reflect.metadata(...)` umum di luar sintaks decorator"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` sebagai kunci metadata"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5493,7 +5529,7 @@ msgstr ""
 "`emitDecoratorMetadata` di luar `design:paramtypes` kelas/method dan "
 "`design:type` properti"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5503,11 +5539,11 @@ msgstr ""
 "canary konstruktor kelas yang disederhanakan (`tsyringe`, perilaku injector "
 "NestJS penuh, injector root Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr "Aliran metadata runtime `class-validator`, `type-graphql`, `TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5517,11 +5553,11 @@ msgstr ""
 "pengkabelan eksplisit atau transform AOT khusus, bukan mengandalkan runtime "
 "decorator TypeScript legacy yang lengkap."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Pola yang direkomendasikan: konstruksi eksplisit"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5533,7 +5569,7 @@ msgstr ""
 "Rust menyusun layanan, dan ini juga cara framework TS tanpa-decorator (Hono, "
 "server tRPC, aplikasi Drizzle) sudah bekerja."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5549,7 +5585,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5559,11 +5595,11 @@ msgstr ""
 "— urutan konstruksi _adalah_ graf dependensi, dan ia diperiksa oleh "
 "kompilator TypeScript."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Resep migrasi: sebuah service Angular"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5573,19 +5609,19 @@ msgstr ""
 "rating.service.ts`, ~80 baris), ditampilkan dalam bentuk Angular aslinya dan "
 "diporting ke Perry."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Sebelum — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Sesudah — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Tiga perubahan mekanis:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5593,7 +5629,7 @@ msgstr ""
 "**Hapus `@Injectable`.** Decorator ini tidak membawa informasi yang belum "
 "dibawa oleh bentuk class itu sendiri."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5603,7 +5639,7 @@ msgstr ""
 "besar Observable-dari-HTTP di Angular bernilai tunggal dan berperilaku "
 "seperti Promise. (Untuk stream multi-nilai, gunakan `AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5615,11 +5651,11 @@ msgstr ""
 "eksplisit lebih mudah dibaca ketika class diinstansiasi secara manual alih-"
 "alih oleh container."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Wiring"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5639,7 +5675,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5657,7 +5693,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5667,11 +5703,11 @@ msgstr ""
 "'root'`, lookup container implisit — semuanya ringkas menjadi satu baris "
 "`new RatingService(api)` di `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "Bagaimana dengan komponen Angular, controller NestJS, entitas TypeORM?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5693,11 +5729,11 @@ msgstr ""
 "jika memungkinkan, tulis konstruksi eksplisit yang setara, daftar rute atau "
 "skema sebagai panggilan fungsi biasa / konstanta tingkat modul."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Arah ke depan"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6409,12 +6445,13 @@ msgstr ""
 "menggunakan permukaan anggun di atas dan tidak perlu apa-apa pada waktu link."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Panggilan statis literal** (`WebAssembly.instantiate(bytes)` ditulis "
@@ -7987,56 +8024,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Menulis binding — tur 60 detik"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"Binding rendering PDF\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# Mengedit src/lib.rs  menambahkan fungsi `js_*` Anda, semua menggunakan "
-"hanya"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# Edit src/index.ts  menyatakan kode pengguna permukaan TS impor"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# Edit package.json  daftar setiap js_* ekspor di"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ manifest cocok dengan staticlib"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# Scaffolded release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # Membangun prebuilds untuk semua target"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr ""
-"                                    # dan mengikat mereka dengan pelepasan"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8428,7 +8422,7 @@ msgstr "Status saat ini"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8448,7 +8442,7 @@ msgstr "Dikumpulkan; menunggu pemindahan"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8500,7 +8494,7 @@ msgstr "Dikumpulkan; pending migrasi"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8560,7 +8554,7 @@ msgstr "Mengkompilasi sumber paket hulu"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8568,7 +8562,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8576,7 +8570,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8584,7 +8578,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8616,7 +8610,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8624,7 +8618,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8632,7 +8626,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8664,7 +8658,7 @@ msgstr "Dikemas; disimpan"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8672,7 +8666,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8704,7 +8698,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8712,7 +8706,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8720,7 +8714,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8728,7 +8722,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8744,7 +8738,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8752,7 +8746,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8760,7 +8754,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8768,7 +8762,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8792,7 +8786,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8800,7 +8794,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8808,7 +8802,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8816,7 +8810,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8824,7 +8818,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8832,7 +8826,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8840,7 +8834,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8848,7 +8842,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8856,7 +8850,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8864,7 +8858,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8872,7 +8866,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8880,7 +8874,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8933,14 +8927,6 @@ msgstr "Akun GitHub jika Anda ingin scaffold release-CI prebuild Just Work."
 msgid "1. Scaffold"
 msgstr "1. Scaffold"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Pengikat asli untuk <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Ini membuat:"
@@ -8972,26 +8958,14 @@ msgstr ""
 "terlihat dari TypeScript, menggunakan **hanya** tipe dari `perry_ffi`:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  ekstrak teks dari buffer PDF."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # Keamanan"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
-msgstr "/// `buf_ptr` harus null atau valid untuk `buf_len` byte. Perry lulus"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// pasangan ini dari `buffer+len` manifest parameter."
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
+msgstr ""
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9125,7 +9099,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"Kasih sayang\""
 
@@ -9366,7 +9340,8 @@ msgid "In a separate directory:"
 msgstr "Di direktori terpisah:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# atau jalur apa pun yang didukung alat Anda"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9757,7 +9732,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Event listener (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// penunjuk penutupan, disimpan hidup oleh GC scanner di bawah"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10198,7 +10174,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... membaca file, mengatur lingkungan, kembali 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10503,8 +10480,8 @@ msgstr "Wajib"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Catatan"
 
@@ -10562,14 +10539,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12294,33 +12271,40 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Alat  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Penyediaan atau bump satu pin ke versi tertentu (default: terbaru stabil)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr ""
 "# Penyediaan setiap ikatan saat ini tidak terikat pada stabil terakhirnya"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Offline gate (CI): pin hadir, lock-stepped, peti ada. Keluar 1 pada setiap"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Saran: tambahan pin bendera yang di hulu sungai memiliki pelepasan stabil "
 "yang lebih baru"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr "# Mematerialkan repo hulu di ref diikat ke gitignored hulu/<name>"
 
 #: src/native-libraries/upstream-pins.md:71
@@ -12554,15 +12538,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "Untuk CI yang tidak boleh menggantikan bungkus parsial, atur:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12717,7 +12701,7 @@ msgstr "Kenyataan"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12734,7 +12718,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14713,19 +14697,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Dibandingkan dengan worker_threads Node.js"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~ 15 baris, file terpisah diperlukan ────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14745,12 +14729,11 @@ msgid "/* handle */"
 msgstr "/* tangani */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// ── Perry: 1 baris ──────────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const hasil = menunggu spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14964,13 +14947,14 @@ msgid "Mental Model"
 msgstr "Model Mental"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "UI Perry mengikuti model yang sama dengan SwiftUI dan Flutter: Anda menyusun "
 "widget native menggunakan container layout berbasis stack (`VStack`, "
@@ -15057,7 +15041,7 @@ msgstr "`App({})` menerima objek konfigurasi dengan properti berikut:"
 msgid "Property"
 msgstr "Properti"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15503,7 +15487,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15526,7 +15510,7 @@ msgid ""
 msgstr ""
 "Perilaku spesifik platform dicatat pada halaman dokumentasi setiap widget."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17150,7 +17134,8 @@ msgid "Double-click handler"
 msgstr "Handler klik ganda"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17212,12 +17197,13 @@ msgstr ""
 "mengompilasi dan menjalankannya pada setiap PR."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Pembantu tata letak adalah fungsi gratis: `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17694,7 +17680,7 @@ msgstr "Efek"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17707,7 +17693,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "Anak-anak diratakan ke tepi leading (kiri)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17720,7 +17706,7 @@ msgid "Children centered horizontally"
 msgstr "Anak-anak dipusatkan secara horizontal"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17741,7 +17727,7 @@ msgstr "**Penjajaran HStack** (cross-axis = vertikal):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17768,8 +17754,8 @@ msgstr "Anak-anak dipusatkan secara vertikal"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17823,9 +17809,9 @@ msgstr "Perilaku"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17848,11 +17834,11 @@ msgstr "Semua anak mendapatkan ukuran yang sama"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18050,9 +18036,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stack dengan Padding Bawaan"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Buat sebuah stack dengan padding dalam satu pemanggilan. Urutannya adalah "
 "**top, left, bottom, right** (gaya shorthand CSS), bukan top/right/bottom/"
@@ -18077,11 +18064,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` adalah padanan "
 "horizontalnya. Setara dengan membuat sebuah stack lalu memanggil "
@@ -18371,8 +18359,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18758,6 +18747,7 @@ msgstr ""
 "selalu merupakan API yang diterima compiler."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18769,7 +18759,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18797,11 +18786,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Warna"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18817,11 +18806,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Font"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18837,15 +18826,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Gunakan `\"monospaced\"` untuk font monospaced sistem."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Corner Radius"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18857,21 +18846,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Border"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding dan Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18881,11 +18870,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Pengaturan Ukuran"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18901,11 +18898,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Opacity"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18917,11 +18914,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Background Gradient"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18943,11 +18940,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Ukuran Kontrol"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18959,7 +18956,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -18967,11 +18964,11 @@ msgstr ""
 "**macOS**: Dipetakan ke `NSControl.ControlSize`. Platform lain mungkin "
 "menginterpretasikannya secara berbeda."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltip"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18983,7 +18980,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18991,11 +18988,11 @@ msgstr ""
 "**macOS/Windows/Linux**: Tooltip native. **iOS/Android**: Tidak ada dukungan "
 "tooltip. **Web**: Atribut HTML `title`."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Aktif/Nonaktif"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -19007,11 +19004,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Contoh Imperatif Lengkap"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -19031,7 +19029,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19059,10 +19057,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19135,15 +19133,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Menyusun Style (fungsi helper imperatif)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Kurangi pengulangan dengan membuat fungsi helper:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19153,11 +19151,11 @@ msgstr ""
 "mendefinisikan design token dalam JSON dan menghasilkan file tema yang "
 "bertipe. Lihat [Theming](theming.md) untuk alur kerja lengkap."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Dukungan platform"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19168,7 +19166,7 @@ msgstr ""
 "styling_matrix.rs` dan diperiksa CI terhadap export `lib.rs` setiap backend "
 "pada setiap PR."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19188,15 +19186,15 @@ msgstr ""
 "dikelola secara manual; periksa matriks sehingga dokumentasi tidak dapat "
 "menyimpang dari inventaris backend."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — Container layout"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — Animasikan perubahan style"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — Design token melalui paket `perry-styling`"
 
@@ -20533,8 +20531,8 @@ msgstr "Implementasi"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Status"
 
@@ -24065,7 +24063,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opsi"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25659,7 +25657,7 @@ msgstr "Kesetaraan dengan ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26381,15 +26379,18 @@ msgid "Cross-Compilation"
 msgstr "Kompilasi Lintas Platform"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# Default: mengkompilasi untuk platform saat ini"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# Mengkompilasi untuk target tertentu"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  Android pada jam"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26605,7 +26606,8 @@ msgid "Building"
 msgstr "Membangun"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS adalah target default"
 
 #: src/platforms/macos.md:18
@@ -26709,7 +26711,8 @@ msgid "App Store Distribution"
 msgstr "Distribusi App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Mendaftar dengan sertifikat App Store"
 
 #: src/platforms/macos.md:60
@@ -26717,7 +26720,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -26848,15 +26852,18 @@ msgstr ""
 "Cara termudah untuk membangun dan menjalankan di iOS adalah `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# Mengidentifikasi otomatis device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# Streaming langsung stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Gunakan Perry Hub build server"
 
 #: src/platforms/ios.md:40
@@ -27505,7 +27512,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Ini menghasilkan biner ARM64 untuk perangkat keras Apple TV fisik."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Simulator Apple TV yang di-boot secara otomatis"
 
 #: src/platforms/tvos.md:39
@@ -27992,11 +28000,13 @@ msgstr ""
 "(#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# simulator (tingkat 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28106,20 +28116,14 @@ msgstr ""
 "kemudian arahkan `PERRY_RUNTIME_DIR` ke mereka:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (Seri 9+ / watchOS 26+)  target perangkat default"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (Seri 4-8 / SE)  memilih dengan PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28136,7 +28140,7 @@ msgid "Build environment variables"
 msgstr "Membangun variabel lingkungan"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Variabel"
@@ -28257,7 +28261,8 @@ msgstr ""
 "penutupan sebagai objek."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Simulator jam tangan yang di boot secara otomatis"
 
 #: src/platforms/watchos.md:126
@@ -28855,36 +28860,13 @@ msgstr ""
 "cap adalah kosmetik), kemudian `lipo` mereka bersama:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 irisan pada target penyebaran bersama (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 slice (target perangkat default)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. selaraskan minos + sekering"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -29005,19 +28987,8 @@ msgstr ""
 "membutuhkan **Rekam aplikasi baru sendiri** di App Store Connect."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Distribusi Apple: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -29030,6 +29001,10 @@ msgid ""
 msgstr ""
 "`altool` tidak dapat mengunggah aplikasi menonton (\"tidak dapat menentukan "
 "platform\"). Gunakan Transporter:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29381,19 +29356,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Pengaturan satu kali (contoh macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` mungkin 9.x  pin 8.x jika "
 "demikian)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# atau Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 "# 2. Arahkan env ke SDK / NDK / JDK 17 (tambahkan ke profil shell Anda)"
 
@@ -29402,7 +29380,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g. 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -29414,32 +29393,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. Paket SDK + gambar arm64 Wear OS"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"Platform-tools\" \"emulator\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"platform;android-35\" \"build-tools;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"Sistem-gambar;android-34;android-pakai;arm64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Target silang Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Membuat + boot emulator Wear OS (round watch)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29464,7 +29424,8 @@ msgstr ""
 "ke dalam jam tangan APK terjadi pada waktu berjalan (di bawah)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# Otomatis mendeteksi jam tangan yang terhubung / boot Wear emulator"
 
 #: src/platforms/wearos.md:82
@@ -31456,7 +31417,8 @@ msgstr ""
 "`WidgetPaintable` + `GskRenderer` untuk pengambilan yang akurat per piksel."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# Di terminal lain:"
 
 #: src/platforms/linux.md:82
@@ -31475,7 +31437,8 @@ msgstr ""
 "jembatan JavaScript untuk widget DOM."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# output yang sama dengan --target wasm"
 
 #: src/platforms/web.md:10
@@ -31554,15 +31517,18 @@ msgstr ""
 "threading Web Worker \"secara gratis\"."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML mandiri (default)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# Hal yang sama"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm binary (tidak ada HTML wrapper)"
 
 #: src/platforms/wasm.md:21
@@ -31882,11 +31848,13 @@ msgid "Provide them when instantiating:"
 msgstr "Sediakan saat menginstansiasi:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Melalui __ffiImports global (ditempatkan sebelum boot)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// Atau melalui bootPerryWasm argumen kedua"
 
 #: src/platforms/wasm.md:95
@@ -32435,7 +32403,7 @@ msgstr "Stdlib lengkap"
 msgid "The compiler links only the required runtime components."
 msgstr "Kompiler hanya menautkan komponen runtime yang diperlukan."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Binding native eksternal"
 
@@ -32554,7 +32522,7 @@ msgstr "[Sistem Berkas](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Jaringan](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Database](database.md)"
 
@@ -32778,8 +32746,8 @@ msgstr ""
 "Teruskan path file melewati batas thread dan buka kembali file di dalam "
 "worker."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Ikhtisar](overview.md) — Semua modul stdlib"
 
@@ -32879,10 +32847,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Didukung pada `IncomingMessage`: `.method`, `.url`, `.headers`, "
@@ -32891,10 +32860,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33492,10 +33462,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / Penyimpanan Objek yang Kompatibel dengan S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33511,11 +33507,11 @@ msgstr ""
 "diperlukan — diverifikasi byte-per-byte cocok dengan presigned-URL SigV4 "
 "dari `bun` (issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33589,78 +33585,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "Kode yang sama bekerja terhadap layanan apa pun yang kompatibel dengan S3 — "
 "hanya `endPoint` yang berubah:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Layanan"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (pengujian)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33676,7 +33672,7 @@ msgstr ""
 "byte-identik dengan `bun` terhadap vektor pengujian yang disematkan dan akan "
 "terautentikasi terhadap S3 nyata."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33689,7 +33685,7 @@ msgstr ""
 "tetapi tidak diverifikasi secara independen terhadap vektor yang disematkan "
 "di sini."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34332,9 +34328,10 @@ msgstr ""
 "`sumBy`, `meanBy`, `max`, `min`, `maxBy`, `minBy`, dan `inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Gunakan impor bernama: bentuk penerima impor default (`import _ from "
@@ -34545,20 +34542,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Paket npm tambahan dan API Node.js yang didukung oleh Perry. Semua yang "
-"terdaftar di sini terhubung melalui registry binding native well-known Perry "
-"(#466) dan dikompilasi menjadi kode native tanpa keterlibatan runtime "
-"JavaScript."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Pemrosesan Gambar)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34566,7 +34558,7 @@ msgstr ""
 "Binding native melalui `perry-ext-sharp` (v0.5.551). Resize, konversi "
 "format, dan output buffer/berkas semuanya bekerja."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34616,15 +34608,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (Parsing HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Binding native melalui `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34642,11 +34634,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (Email)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34686,15 +34678,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Kompresi)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Binding native melalui `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34712,11 +34704,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Penjadwalan Tugas)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34724,7 +34716,7 @@ msgstr ""
 "Binding native melalui `perry-ext-cron` (v0.5.564). Baik nama paket `cron` "
 "maupun `node-cron` dirutekan ke backend yang sama."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34744,11 +34736,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34758,7 +34750,7 @@ msgstr ""
 "plumbing ABI bergaya [`ethers-rs`](https://github.com/gakonst/ethers-rs)\\ "
 "melalui antarmuka BigInt + Buffer dari `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34776,11 +34768,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -34788,7 +34780,7 @@ msgstr ""
 "Binding native melalui `perry-ext-events` (v0.5.546). Bentuk `EventEmitter` "
 "cocok dengan Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -34806,15 +34798,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Logika Retry)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Binding native melalui `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -34836,11 +34828,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Presisi Arbitrer)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -34848,7 +34840,7 @@ msgstr ""
 "Binding native melalui `perry-ext-decimal` (v0.5.547). Kedua nama paket "
 "diarahkan ke backend yang sama — `Decimal` dan `BigNumber` keduanya tersedia."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -34884,11 +34876,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Manipulasi Tanggal)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -34896,7 +34888,7 @@ msgstr ""
 "Binding native melalui `perry-ext-dayjs` (v0.5.548). Kedua nama paket "
 "diarahkan ke backend Rust yang sama — antarmuka parse/format/diff yang sama."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -34914,11 +34906,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Tanggal Legacy)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -34928,7 +34920,7 @@ msgstr ""
 "mode pemeliharaan di upstream — disarankan menggunakan `dayjs` untuk kode "
 "baru, tetapi Perry mendukung keduanya untuk basis kode yang sudah ada."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -34944,11 +34936,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -34956,7 +34948,7 @@ msgstr ""
 "Binding native melalui `perry-ext-ratelimit` (v0.5.552). Limiter in-memory "
 "sudah terpasang; backing store Redis / cluster akan menyusul."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -34980,11 +34972,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -35002,7 +34994,7 @@ msgstr ""
 "`parallelMap` / `parallelFilter` / `spawn` dari `perry/thread` tetap menjadi "
 "antarmuka yang lebih sederhana (lihat [Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -35040,12 +35032,12 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr "URL modul Web Worker ditemukan relatif terhadap file sumber impor:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -35078,10 +35070,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (Parsing CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35123,11 +35288,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35150,7 +35315,7 @@ msgstr ""
 "`sizeCalculation`, `dispose`, `fetch`, `allowStale` dan permukaan iterator "
 "belum diimplementasikan."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35180,11 +35345,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35234,11 +35399,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35253,7 +35418,7 @@ msgstr ""
 "lain `spawn` melemparkan, yang memicu jalur cadangan konsumen yang tidak "
 "kosong."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35266,7 +35431,7 @@ msgstr ""
 "`kill()` default ke `SIGHUP` seperti node-pty. `TERM` pada anak berasal dari "
 "`name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35312,11 +35477,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35332,7 +35497,7 @@ msgstr ""
 "fasad asli pada saat kompilasi. Perilaku diperiksa terhadap `@parcel/"
 "watcher` 2.5.1."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35353,7 +35518,7 @@ msgstr ""
 "Pemberitahuan overflow/rescan backend memicu snapshot pohon baru dan "
 "memancarkan perbedaannya."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35372,7 +35537,7 @@ msgstr ""
 "`writeSnapshot` dan `getEventsSince` menggunakan semantik diferensi snapshot "
 "yang sama dengan pemulihan overflow."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35382,7 +35547,7 @@ msgstr ""
 "sendiri — keduanya diimpor melalui `bun add` seperti paket npm lainnya, "
 "tetapi didukung oleh Rust dan dikompilasi secara native melalui `perry-ffi`:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35390,7 +35555,7 @@ msgstr ""
 "**`@perryts/tursodb`** — klien basis data Turso (fork libSQL). Lihat "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35398,11 +35563,11 @@ msgstr ""
 "**`@perryts/iroh`** — jaringan peer-to-peer Iroh. Lihat [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "Driver TypeScript murni yang dikompilasi melalui `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35412,7 +35577,7 @@ msgstr ""
 "**`@perryts/redis`** — klien protokol wire yang juga berjalan di Node.js dan "
 "Bun tanpa perubahan."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35420,11 +35585,11 @@ msgstr ""
 "Lihat [Native Bindings — Overview](../native-libraries/overview.md) untuk "
 "kontrak yang diikuti paket-paket eksternal ini."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[File System](fs.md) — API fs dan path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr ""
 "[Native Bindings](../native-libraries/overview.md) — Membuat milik Anda "
@@ -35450,7 +35615,8 @@ msgstr ""
 "di target yang dipilih."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Total: 3019 entri di 138 modul."
 
 #: src/api/reference.md:9
@@ -35547,4831 +35713,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Metode"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — modul"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Properti"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount`  modul"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince`  modul"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — modul"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — modul"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot`  modul"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — modul"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — modul"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — modul"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — modul"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — modul"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — instance"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — instance"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — instance"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — instance"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — instance"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — instance"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — instance"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — modul"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — modul"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — modul"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — modul"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — modul"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — modul"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — modul"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — modul"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — modul"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — modul"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — modul"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — modul"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — modul"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — modul"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — modul"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — modul"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — modul"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — modul"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — modul"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — modul"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — modul"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — modul"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — modul _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — modul _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — modul"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — instance"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — instance _(class: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — instance"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — modul"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — modul"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — instance"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — instance"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — instance"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — instans _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — modul _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — modul"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — instans _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — modul"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — modul"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — modul"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — modul"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — modul"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — modul"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — modul"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — modul"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — modul"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — modul"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — modul"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — instance"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — instance"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — instans"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — instance"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — instance"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — instans"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — instans"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — instans"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — instance"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — instans"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — instans"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — modul"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — modul"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — modul"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — modul"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — modul"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — modul"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Transfer"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob`  modul"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — modul"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — modul"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — modul"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — modul"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — modul"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — modul"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file`  modul"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — modul"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — modul"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — modul"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — modul"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — modul"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — instansi _(class: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instans _(kelas: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — modul"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth`  modul"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — modul"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instans _(kelas: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction`  contoh _ ((kelas: `Database`) _"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported`  modul"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — modul"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — modul"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — modul"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — modul"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — modul"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction`  modul"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString`  modul"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback`  modul"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — modul"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols`  modul"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr`  modul"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer`  modul"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer`  modul"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource`  modul"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — modul"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database`  modul"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction`  contoh _ ((kelas: `Database`) _"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values`  contoh _ ((kelas: `Statement`) _"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — instance"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — instance"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — instance"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — instance"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — instance"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — instance"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — instance"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — instance"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — instance"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — modul"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — instance"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — instance"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — instance"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — modul"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — modul"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — modul"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — modul"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — modul"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — modul"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — modul"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — modul"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — modul"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — modul"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — instance"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  contoh"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  contoh"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — instance"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — instance"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — instance"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — instance"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — instance"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — instance"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — instance"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — instance"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — modul"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — modul"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — modul"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — modul"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — modul"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — modul"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — modul"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — modul"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — modul"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — modul"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — modul"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — modul"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — modul"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — modul"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — modul"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — modul"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — modul"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — modul"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — modul"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — modul"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — modul"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — modul"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — modul"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — modul"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — modul"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — instance"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — instance"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — modul"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — instance"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — instance"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — modul"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash`  modul"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac`  modul"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign`  modul"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify`  modul"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2`  modul"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync`  modul"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime`  modul"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync`  modul"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv`  modul"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv`  modul"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman`  modul"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup`  modul"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH`  modul"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — modul"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — modul"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey`  modul"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey`  modul"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey`  modul"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign`  modul"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify`  modul"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate`  modul"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman`  modul"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — modul"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — modul"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — modul"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — modul"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — modul"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — modul"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — modul"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — modul"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — modul"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — modul"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — modul"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — modul"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — modul"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — modul"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — modul"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — modul"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — modul"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — modul"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — modul"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — modul"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — modul"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — modul"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — modul"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — modul"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — modul"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — modul"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — modul"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — modul"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — modul"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — modul"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — modul"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — modul"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — modul"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — modul"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — modul"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — modul"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — modul"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — modul"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — modul"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — modul"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — modul"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — modul"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — modul"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — modul"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — modul"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — instance"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — instance"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — instance"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — instance"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — modul"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — instance"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — instance"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — instance"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — instance"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — instance"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — instance"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — instance"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — instance"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — instance"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — instance"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — instance"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — instance"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — instance"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — instance"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — instance"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — instance"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — instance"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — instance"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — instance"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — instance"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — instance"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — instance"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — instance"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — instance"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — instance"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — instance"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — instance"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — instance"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — instance"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — instance"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — instance"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — instance"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — instance"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — instance"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — instance"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — instance"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — instance"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — instance"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — instance"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — instance"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — instance"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — modul"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — modul"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — instansi _(class: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — modul"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — modul"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — modul"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — modul"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — modul"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — modul"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — modul"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — modul"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — modul"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — modul"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — modul"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — modul"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — modul"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — modul"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — modul"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — modul"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — modul"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — modul"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — modul"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — modul"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — modul"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — modul"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — modul"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — modul"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — modul"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — modul"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — instansi _(class: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — modul"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — instansi"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — instansi"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — modul"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — instance"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — instansi"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — instansi"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — instance"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — instansi"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — modul"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — modul"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — modul _(kelas: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — modul"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — modul"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — modul"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — modul"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — modul"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — modul"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — modul"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — modul"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — instansi _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — instansi _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — instansi"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — instansi _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — instansi"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — modul"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — instansi"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — modul"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — modul"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — instansi"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — modul"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — instansi"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — instansi"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — modul"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — instansi"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — modul"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — instansi"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — instansi"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — instansi"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — instance"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — instance"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — instansi"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — modul"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — instansi _(kelas: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — modul"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — instance"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — instance"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — instance"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — instance"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — instance"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — instance"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — instance"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — instance"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — instance"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — instance"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — instance"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — instance"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — instance"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — instance"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — instance"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — instance"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — instance"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — instance"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — instance"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — instance"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — instance"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — instance"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — instansi"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — instance"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — instance"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — instansi"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — instance"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — instance"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer`  modul"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString`  modul"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — modul"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — modul"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — modul"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — modul"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — modul"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — modul"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — modul"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — modul"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — modul"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — modul"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — modul"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — modul"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — modul"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — modul"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — modul"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — modul"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — modul"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — modul"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — modul"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — modul"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — modul"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — modul"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — modul"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — modul"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — modul"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — modul"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — modul"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — modul"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — modul"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — modul"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — modul"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — modul"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — modul"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — modul"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — modul"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — modul"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — modul"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — modul"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — modul"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — modul"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — modul"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — modul"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — modul"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — modul"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — modul"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — modul"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — modul"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — modul"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — modul"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — modul"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — modul"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — modul"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — modul"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — modul"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — modul"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — modul"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — modul"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — modul"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — modul"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — modul"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — modul"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — modul"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — modul"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — modul"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — modul"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — modul"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — modul"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — modul"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — modul"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — modul"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — modul"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — modul"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — modul"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — modul"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — modul"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — modul"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — modul"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — modul"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — modul"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — modul"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — modul"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — modul"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — modul"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — modul"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — modul"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — modul"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — modul"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — modul"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — modul"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — modul"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — modul"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — modul"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — modul"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — modul"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — instansi _(kelas: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — instansi _(kelas: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — instansi _(kelas: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — modul"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — modul"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — instansi _(kelas: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening`  contoh _ ((kelas: `HttpServer`) _"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — instansi _(kelas: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — instansi _(kelas: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — instansi _(kelas: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — instansi _(kelas: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — instansi _(kelas: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — instansi _(kelas: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instansi _(kelas: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — modul"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — modul"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40379,103 +40692,103 @@ msgstr ""
 "`keepSocketAlive`  contoh _ ((kelas: `Agent`) _ **Bentuk** reqwest memiliki "
 "kolam hidup; per soket kait adalah no-ops, memperingatkan sekali (# 4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening`  contoh _ ((kelas: `HttpServer`) _"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once`  contoh _ ((kelas: `ClientRequest`) _"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref`  contoh _ ((kelas: `HttpServer`) _"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40483,375 +40796,369 @@ msgstr ""
 "`reuseSocket`  contoh _ ((kelas: `Agent`) _ **Bentuk** reqwest memiliki "
 "kolam hidup; per soket kait adalah no-ops, memperingatkan sekali (# 4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — modul"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — modul"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket`  contoh _ ((kelas: `IncomingMessage`) _"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — instans _(class: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — instans _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — instans _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref`  contoh _ ((kelas: `HttpServer`) _"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — instans _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — modul"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — modul"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — instans _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — modul"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — modul"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — modul"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — modul"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — modul"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — modul"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening`  contoh _ ((kelas: `HttpsServer`) _"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening`  contoh _ ((kelas: `HttpsServer`) _"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref`  contoh _ ((kelas: `HttpsServer`) _"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — instans _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref`  contoh _ ((kelas: `HttpsServer`) _"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — modul"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — instans _(class: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — instans _(class: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  modul _ ((kelas: `console`)"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — instans _(class: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  modul _ ((kelas: `console`)"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  modul _ ((kelas: `console`)"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  modul _ ((kelas: `console`)"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — instance _(kelas: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — instance _(kelas: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -40860,7 +41167,7 @@ msgstr ""
 "akhir inspektur WebSocket yang sebenarnya; sesi adalah pemalsuan dalam "
 "proses (# 4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -40870,7 +41177,7 @@ msgstr ""
 "subset Runtime.evaluate kaleng menanggapi; setiap metode protokol lainnya "
 "melemparkan Inspektur error -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -40878,7 +41185,7 @@ msgstr ""
 "`url`  modul **Bentuk** selalu tidak didefinisikan: Perry tidak pernah "
 "mengekspos titik akhir inspektur nyata (# 4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -40886,3285 +41193,3276 @@ msgstr ""
 "`waitForDebugger`  modul **Bentuk** kembali segera setelah open ((); tidak "
 "ada debugger untuk menunggu (# 4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  modul _ ((kelas: `console`)"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — instance _(kelas: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — instance"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — modul"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — instance"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — instance"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — instance"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — instance"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — instance"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — instance"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — instance"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — instance"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — instance"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — instance"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — modul"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — instance"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — instance"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — instance"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — instance"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — instance"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — instance"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — modul"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — modul"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — modul"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — modul"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — modul"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — modul"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — modul"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — modul"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — modul"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — modul"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — modul"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — modul"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — modul"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — modul"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — modul"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — modul"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — modul"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — modul"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — modul"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — modul"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — modul"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — modul"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — modul"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — modul"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — modul"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — modul"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — modul"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — instance"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — instance"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  contoh"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — instance"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — modul"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — modul"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — modul"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — modul"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — modul"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — modul"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — modul"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — modul"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — modul"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — modul"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — modul"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — modul"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — modul"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — modul"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — modul"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — modul"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — modul"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — modul"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — modul"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — modul"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — modul"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — modul"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — modul"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  contoh"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  contoh"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — modul"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  contoh"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — instance"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — instance"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — instance"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — instance"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — instance"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — instance"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — instance"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — instance"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — instance"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — instance"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — instance"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — instance"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — modul"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — modul"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — instance _(kelas: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — instance"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — instance _(kelas: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — instance _(kelas: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — instance"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — instance"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — instance _(kelas: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — instance _(kelas: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — instance"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — instance"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — modul"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — modul"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — modul"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — modul"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — modul"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — modul"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — instance _(kelas: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — instance _(kelas: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — instance _(kelas: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — modul"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — modul"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — modul _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — modul"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — modul"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — modul"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — modul _(kelas: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — instance _(kelas: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — instance _(kelas: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — modul"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — modul"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert`  contoh _ ((kelas: `Socket`) _"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — instance _(kelas: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — instance _(kelas: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem`  modul"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem`  modul"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate`  modul"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem`  modul"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem`  modul"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem`  modul"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions`  contoh _ ((kelas: `Certificate`) _"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer`  contoh _ ((kelas: `Certificate`) _"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject`  contoh _ ((kelas: `Certificate`) _"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign`  contoh _ ((kelas: `Certificate`) _"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — modul"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — instance"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — instance"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — modul"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — modul"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — modul"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — modul"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — modul"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — modul"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — modul"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — modul"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — modul"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — modul"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — modul"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — modul"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — modul"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — modul"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — modul"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — modul"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — modul"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — modul"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — modul"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — modul"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — modul"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — modul"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — modul"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — modul"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — modul"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — modul"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — modul"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — modul"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — modul"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — modul"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — modul"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — instans _(kelas: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization`  modul"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — modul"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — instans _(kelas: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — instans _(kelas: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — modul"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles`  modul"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded`  modul"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — modul"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — modul"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — modul"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — modul"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent`  modul"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — modul"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — modul"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — modul"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — modul"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — modul"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — modul"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — modul"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — modul"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — modul"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — modul"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — modul"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — modul"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — modul"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — modul"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — modul"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — modul"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — modul"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — modul"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — modul"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — modul"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — modul"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — modul"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — modul"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — modul"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — modul"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — modul"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — modul"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — modul"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — modul"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — modul"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — modul"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — modul"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — modul"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — modul"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — modul"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — modul"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — modul"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — modul"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — modul"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — modul"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — modul"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — modul"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — modul"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — modul"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — modul"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — modul"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — modul"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — modul"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — modul"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — modul"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — modul"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — modul"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect`  modul"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint`  modul"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor`  modul"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — modul"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — modul"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — modul"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — modul"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — modul"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — modul"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — modul"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — modul"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession`  modul"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession`  modul"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability`  modul"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment`  modul"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange`  modul"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange`  modul"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond`  modul"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — modul"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — modul"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — modul"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — modul"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — modul"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — modul"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — modul"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — modul"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  modul _ ((intrinsik) _"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32`  modul"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64`  modul"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16`  modul"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32`  modul"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64`  modul"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8`  modul"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize`  modul"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  modul _ ((intrinsik) _"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  modul _ ((intrinsik) _"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16`  modul"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32`  modul"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64`  modul"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8`  modul"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize`  modul"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — modul"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — modul"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — modul"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — modul"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — modul"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — modul"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — modul"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — modul"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — modul"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — modul"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — modul"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — modul"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — modul"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — modul"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — modul"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — modul"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — modul"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — modul"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — modul"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — modul"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — modul"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — modul"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — modul"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — modul"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — modul"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — modul"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — modul"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — modul"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — modul"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — modul"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — modul"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — modul"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — modul"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — modul"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — modul"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — modul"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — modul"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — modul"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — modul"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — modul"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay`  modul"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — modul"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — modul"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — modul"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — modul"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — modul"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — modul"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — modul"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — modul"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — modul"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — modul"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — modul"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — modul"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — modul"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — modul"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — modul"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — modul"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — modul"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — modul"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — modul"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — modul"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — modul"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — modul"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — modul"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — modul"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — modul"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — modul"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — modul"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — modul"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — modul"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — modul"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — modul"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — modul"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — modul"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — modul"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — modul"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — modul"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — modul"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — modul"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — modul"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — modul"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — modul"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — modul"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — modul"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — modul"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — modul"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — modul"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — modul"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — modul"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — modul"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — modul"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — instans _(kelas: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — modul"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — modul"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — instans _(kelas: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — modul"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — instans _(kelas: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — modul"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — instans _(kelas: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — modul"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — instans _(kelas: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — instance _(kelas: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — instans _(kelas: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — modul"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — instans _(kelas: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — instance _(kelas: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — instans _(kelas: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — modul"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — modul"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — modul"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — modul"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — modul"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — modul"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — modul"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — modul"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — modul"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — modul"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — modul"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — modul"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — modul"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — instans _(kelas: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — instans _(kelas: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — modul"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — modul"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView`  modul"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — modul"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — modul"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — modul"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — modul"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — modul"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — modul"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — modul"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — modul"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — modul"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — modul"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — modul"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — modul"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — modul"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — modul"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — modul"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — modul"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — modul"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — modul"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — modul"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — modul"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — modul"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — modul"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — modul"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — modul"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — modul"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — modul"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — modul"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — modul"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker`  modul"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — modul"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — modul"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — modul"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — modul"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — modul"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy`  modul"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — modul"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — modul"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — modul"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — modul"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — modul"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd`  modul"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle`  modul"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — modul"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — modul"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — modul"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — modul"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — modul"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — modul"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — modul"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — modul"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — modul"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — modul"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — modul"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — modul"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — modul"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — modul"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — modul"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — modul"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — modul"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — modul"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — modul"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — modul"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — modul"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — modul"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — modul"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — modul"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — modul"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — modul"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — modul"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — modul"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — modul"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — modul"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — modul"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — modul"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — modul"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — modul"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — modul"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — modul"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — modul"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — modul"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — modul"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — modul"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — modul"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — modul"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — modul"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — modul"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — modul"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — modul"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — modul"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — modul"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — modul"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — modul"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — modul"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — modul"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — modul"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — modul"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — modul"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — modul"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — modul"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — modul"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — modul"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — modul"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — modul"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — modul"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — modul"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — modul"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — modul"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — modul"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — modul"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — modul"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — modul"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — modul"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — modul"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem`  modul"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected`  modul"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected`  modul"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — modul"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — modul"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — modul"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders`  modul"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl`  modul"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue`  modul"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — modul"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig`  modul"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — modul"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — modul"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — modul"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — modul"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — modul"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse`  modul"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — modul"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — modul"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — modul"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — modul"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — modul"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — modul"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — modul"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — modul"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — modul"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — modul"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout`  modul"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount`  modul"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed`  modul"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge`  modul"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild`  modul"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree`  modul"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew`  modul"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild`  modul"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge`  modul"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum`  modul"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap`  modul"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc`  modul"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber`  modul"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc`  modul"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — modul"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — instance _(kelas: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — modul"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — modul"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — modul"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — modul"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — modul"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — modul"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — modul"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — modul"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — modul"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — modul"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — modul"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — modul"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — modul"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — modul"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — modul"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — modul"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — modul"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — modul"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — modul"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — modul"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — modul"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — modul"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — modul"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — modul"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — modul"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — modul"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — modul"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — modul"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — modul"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — modul"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — modul"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — modul"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — modul"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — modul"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — modul"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — modul"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — modul"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — modul"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — modul"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — modul"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — modul"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — modul"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — modul"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — modul"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — modul"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — modul"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — modul"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — modul"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — modul"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — modul"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — modul"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — modul"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — modul"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — modul"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — modul"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — modul"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — modul"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  contoh"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  contoh"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  contoh"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  contoh"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — modul"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — modul"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — modul"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — modul"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — modul"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — instans"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — instans"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — instans"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — instans"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — modul"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — instans"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — instans"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — instance"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — instans"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — instans"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — instans"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — instans"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44174,43 +44472,43 @@ msgstr ""
 "aliran input, dan .write() hanya mengevaluasi literal numerik, pencarian "
 "konteks, dan satu '+'; tidak ada loop eval JS nyata (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — modul"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44220,1459 +44518,1459 @@ msgstr ""
 "aliran input, dan .write() hanya mengevaluasi literal numerik, pencarian "
 "konteks, dan satu '+'; tidak ada loop eval JS nyata (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — instans _(kelas: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — modul"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — modul"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — modul"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — modul"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — modul"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  contoh"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  contoh"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — instance"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  contoh"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  contoh"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  contoh"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — instance"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — instance"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — instance"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — instance"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — instance"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — instance"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — instance"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — instance"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — instance"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — modul"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  contoh"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — instance"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — instance"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  contoh"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — instance"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — instance"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — instans"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — modul"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — modul"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — instans"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — instans _(kelas: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — instans"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — modul"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — instans"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — instans"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — instans _(kelas: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  contoh"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — instans _(kelas: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — instans"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — instans"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — instans _(kelas: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — instans"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — instans"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — instans"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — instans"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — instans"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — instans"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — instans"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  contoh"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — instans"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — instans"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — instans _(kelas: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — instans"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — instans"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — instans _(kelas: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — instans"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — modul"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — modul"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — modul"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — modul"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — instans"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — instans"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — modul"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — instans"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — instans"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — instans"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — modul"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — instans"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — modul"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — modul"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — modul"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — modul"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — modul"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — instans"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — modul"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — modul"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — instans"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — modul"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — instans"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — instans"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — instans"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — instans"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — instans"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — instans"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — instans"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — instans"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — instans"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — instans"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — instans"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — modul"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — instans"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — instans"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — instans"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — instans"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — instans"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — instans"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — instans"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — instans"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — instans"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — instans"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — instans"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — instans"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — modul"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — modul"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — modul"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — modul"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — modul"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — modul"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — instans _(kelas: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — instans _(kelas: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — modul"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — modul"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — modul"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — modul"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — modul"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — modul"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — modul"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — modul"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — modul"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — modul"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — modul"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — modul"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — modul"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — modul"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — modul"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — modul"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — modul"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — modul"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — modul"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — modul"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — modul"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — modul"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — modul"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — modul"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — modul"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — modul"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — modul"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — modul"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — modul"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — modul"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — modul"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — modul"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — modul _(kelas: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — modul"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — modul"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — modul"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — modul _(kelas: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — modul _(kelas: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — modul _(kelas: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — modul _(kelas: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — modul _(kelas: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — modul"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — modul"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — modul"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — modul _(kelas: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — modul"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — modul"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — modul"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — modul"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — modul"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — modul"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — modul"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — modul"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — modul"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — modul"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — modul"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — modul"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — modul"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — modul"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — modul"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols`  modul"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — modul"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — modul"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms`  modul"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — instans _(kelas: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — instans _(kelas: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — modul"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — instans _(kelas: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — instans _(kelas: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — modul"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — modul"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — modul"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — instans _(kelas: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — instans _(kelas: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — instance"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — instance"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — instance"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — instance"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — instance"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText`  modul"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule`  modul"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent`  modul"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close`  contoh _ ((kelas: `ProxyAgent`) _"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy`  contoh _ ((kelas: `ProxyAgent`) _"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch`  modul"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher`  modul"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher`  modul"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — modul"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — modul"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — modul"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — instans _(kelas: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — modul"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — modul"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — instans _(kelas: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — modul"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — modul"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — modul"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — modul"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — modul"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — modul"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — modul"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — modul"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — modul"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — modul"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — modul"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — modul"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — modul"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — modul"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — modul"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — modul"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — modul"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — modul"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — modul"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — modul"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — modul"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — modul"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — modul"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — modul"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — modul"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — modul"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — modul"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — modul"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — modul"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — modul"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — modul"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — modul"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — modul"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — modul"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — modul"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — modul"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — modul"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — modul"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — modul"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — modul"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — modul"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — modul"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — modul"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — modul"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — modul"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3`  modul"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — modul"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5`  modul"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — modul"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — instans _(kelas: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — instans _(kelas: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — modul"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — instans _(kelas: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — modul"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — modul"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45680,11 +45978,11 @@ msgstr ""
 "`getHeapCodeStatistics`  modul **Bentuk** semua bidang 0; Perry "
 "mengkompilasi AOT, tidak ada heap kode JIT (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — modul"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45694,7 +45992,7 @@ msgstr ""
 "penggunaan langsung yang dikaitkan dengan old_space dari arena Perry; ruang "
 "lain melaporkan 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45708,87 +46006,87 @@ msgstr ""
 "diberlakukan); \\*\\_eksekusi, external_memory, global-handles dan bidang "
 "zap adalah 0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — instans _(kelas: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — modul"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — instans _(kelas: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — instans _(kelas: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — instans _(kelas: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — instans _(kelas: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — modul"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — instans _(kelas: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — modul"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — instans _(kelas: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — modul"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — modul"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — instans _(kelas: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — modul"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -45796,459 +46094,469 @@ msgstr ""
 "`stop`  contoh _ ((kelas: `GCProfiler`) _ **Bentuk** laporan memiliki bentuk "
 "Node tetapi array statistik selalu kosong (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — modul"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — modul"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — modul"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — instans _(kelas: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — modul"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — modul"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — modul"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — modul"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — modul"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — modul"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — instans"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — modul"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — modul"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — instans"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — instans"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — instans"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — instans"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — instans"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — instans"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — instans"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — modul"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — instans"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — instans"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — modul"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — instans"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — instans"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — modul"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — modul"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — modul"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — instance"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — modul"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — instance _(kelas: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — instance _(kelas: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — instance _(kelas: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — instance _(kelas: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — modul"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — modul"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  contoh"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — modul"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — modul"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — modul"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — modul"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — modul"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — modul"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — modul"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload`  contoh _ ((kelas: `Worker`) _"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  contoh"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — modul"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — instance _(kelas: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — modul"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — instance _(kelas: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — instance"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — instans"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — instance _(kelas: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — modul"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — instance"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — instance _(kelas: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  contoh"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — instance _(kelas: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — modul"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — modul"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — modul"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — modul"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — modul"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — modul"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46256,7 +46564,7 @@ msgstr ""
 "`createBrotliCompress`  modul **Bentuk** params/quality pilihan diterima "
 "tetapi diabaikan, memperingatkan sekali (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46264,7 +46572,7 @@ msgstr ""
 "`createBrotliDecompress`  modul **Bentuk** params/quality pilihan diterima "
 "tetapi diabaikan, memperingatkan sekali (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46272,7 +46580,7 @@ msgstr ""
 "`createDeflate`  modul **Bentuk** tingkat dihormati; strategy/memLevel "
 "divalidasi tetapi tidak diterapkan (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46280,11 +46588,11 @@ msgstr ""
 "`createDeflateRaw`  modul **Bentuk** tingkat dihormati; strategy/memLevel "
 "divalidasi tetapi tidak diterapkan (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — modul"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46292,19 +46600,19 @@ msgstr ""
 "`createGzip`  modul **Bentuk** tingkat dihormati; strategy/memLevel "
 "divalidasi tetapi tidak diterapkan (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — modul"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — modul"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — modul"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46312,7 +46620,7 @@ msgstr ""
 "`createZstdCompress`  modul **Bentuk** params/quality pilihan diterima "
 "tetapi diabaikan, memperingatkan sekali (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46320,79 +46628,71 @@ msgstr ""
 "`createZstdDecompress`  modul **Bentuk** params/quality pilihan diterima "
 "tetapi diabaikan, memperingatkan sekali (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — modul"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — modul"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — modul"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — modul"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — modul"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — modul"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — modul"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — modul"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — modul"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — modul"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — modul"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — modul"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — modul"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — modul"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — modul"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — modul"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — modul"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — modul"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -46927,9 +47227,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "Anda biasanya akan menggunakan file `docker-compose.yaml`."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "Kedua modul berbagi runtime; Anda dapat mencampurnya dalam program yang sama "
@@ -47465,12 +47766,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` setara dengan `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Catatan pada bentuk pengembalian `logs` dan `exec`:** hari ini FFI "
 "mengembalikan penanganan registry-id ke dalam `Vec<ContainerLogs>` bukan "
@@ -47600,9 +47902,10 @@ msgstr ""
 "`OnceLock` yang telah di-cache dan langsung mengembalikan hasil."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` adalah async dan mengembalikan array JSON dari _every_ "
@@ -48363,9 +48666,10 @@ msgstr ""
 "siap melayani:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Gunakan blok `healthcheck` pada layanan** (di bangun, runtime menangani "
@@ -48743,8 +49047,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "Contoh Forgejo menggunakan pola portabel ini (`container_name:  'forgejo-"
@@ -48815,8 +49120,9 @@ msgid "Single-network shorthand"
 msgstr "Singkatan jaringan tunggal"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49226,9 +49532,10 @@ msgid "External volumes"
 msgstr "Volume eksternal"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Tandai volume `external: true` untuk membaginya di seluruh tumpukan atau "
@@ -49250,8 +49557,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49322,15 +49630,18 @@ msgstr ""
 "mendasarinya:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# daftar volume yang dipromosikan oleh aplikasi"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# titik pemasangan, driver, label"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# mount + memeriksa isi"
 
 #: src/container/volumes.md:160
@@ -49495,9 +49806,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49684,8 +49996,9 @@ msgstr ""
 "terhadap digest yang sama tidak memerlukan biaya tambahan."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -49953,8 +50266,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**Jalankan sebagai non-root** (`user: \"nobody\"` atau UID numerik)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Jatuhkan semua kemampuan, tambahkan yang spesifik kembali** (`cap_drop:  "
@@ -50104,7 +50418,8 @@ msgstr ""
 "Cetak banner yang menghadap operator dengan URL + \"cara untuk teardown\"."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr "Keluar 0. Kontainer terus berjalan berkat `restart:  unless-stopped`."
 
 #: src/container/production-patterns.md:42
@@ -50325,11 +50640,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Startup dependensi yang dijaga oleh healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres membutuhkan ~510 detik untuk memulai pada saat pertama kali "
 "dijalankan (initdb + pendengar mengikat). Tanpa gerbang, Forgejo mulai "
@@ -50501,7 +50817,8 @@ msgstr ""
 "secrets manager:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# . env"
 
 #: src/container/production-patterns.md:225
@@ -50514,7 +50831,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50574,11 +50892,13 @@ msgstr ""
 "memerlukan recreate), lakukan `--down` eksplisit terlebih dahulu:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# volume konservasi"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# redistribusikan dengan versi baru"
 
 #: src/container/production-patterns.md:268
@@ -50596,35 +50916,42 @@ msgid "Running it"
 msgstr "Menjalankannya"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Bangun Perry sekali"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Membangun contoh"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Backend: Docker"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Kunjungi http://localhost:3000/ di browser."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Hentikan (mempertahankan volume untuk penerapan ulang):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Tear down + drop volume (DESTROYS DATA):"
 
 #: src/container/production-patterns.md:300
@@ -50937,19 +51264,23 @@ msgstr ""
 "nilai divergen."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// diuji + dikeluarkan seperti-ada"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// mesin meniru host-side"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// diturunkan + peringatan"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// terbatas subset; alasan didokumentasikan"
 
 #: src/container/determinism.md:156
@@ -51073,7 +51404,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "Setiap protokol mengembalikan konstanta dari metode `capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... pembangun arg"
 
 #: src/container/determinism.md:192
@@ -51101,7 +51433,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"spec field dropped/translated untuk backend\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- bersih spek"
 
 #: src/container/determinism.md:212
@@ -51114,15 +51447,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// Lapangan dihapus"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// dipetakan ke setara"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// mesin meniru sebaliknya"
 
 #: src/container/determinism.md:231
@@ -51130,15 +51466,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. Mode penegakan  memilih bagaimana peringatan muncul"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// default  silent tracing:: peringatan!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// permukaan ke TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// bidang tidak didukung → hard up() kegagalan"
 
 #: src/container/determinism.md:241
@@ -51201,7 +51540,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "Normalisasi output  bentuk yang sama terlepas dari backend"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// bentuk Docker (baris NDJSON)"
 
 #: src/container/determinism.md:292
@@ -51209,7 +51549,8 @@ msgid "/* docker JSON */"
 msgstr "/* Docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Bentuk Apple (Array JSON dari objek `configuration`-wrapped)"
 
 #: src/container/determinism.md:294
@@ -51217,7 +51558,8 @@ msgid "/* apple JSON */"
 msgstr "/* apel JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr ""
 "// Keduanya menghasilkan ContainerInfo dengan semantik bidang yang sama:"
 
@@ -51556,7 +51898,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51569,7 +51912,8 @@ msgid "\"Back\""
 msgstr "\"Kembali\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (nilai kosong = kebutuhan terjemahan)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -51799,7 +52143,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -51916,7 +52261,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (bahasa Polandia: satu, beberapa, banyak)"
 
 #: src/i18n/interpolation.md:65
@@ -52695,19 +53041,23 @@ msgid "Typical translation workflow:"
 msgstr "Alur kerja penerjemahan tipikal:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Tulis kode dengan string bahasa Inggris"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Ekstrak string ke file lokal"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr "# 3. Kirim locales/de.json ke penerjemah (nilai kosong perlu diisi)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Build  Perry memvalidasi semuanya"
 
 #: src/i18n/cli.md:49
@@ -53389,53 +53739,22 @@ msgstr ""
 "dikonsumsi oleh `perry update`."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) Generasi keypair satu kali. Simpan kp.json dengan mode 0600 dan"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) Penandatanganan per rilis. Lembar output JSON berisi setiap"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 3) Periksa tanda tangan secara lokal sebelum mengunggah manifest"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    di sini memprediksi melewati verifikasi pada klien."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) Rilis CI tanda tangan CLI manifesto, mengikat arsip URL, platform,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Menulis manifesto akhir dengan menyalurkan output `sign` melalui `jq` untuk "
@@ -55076,9 +55395,10 @@ msgstr ""
 "tumpang tindih (misalnya: beberapa tembakan, beberapa langkah kaki)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** sebuah kelompok pencampuran. Suara rute melalui Bus, Bus rute "
@@ -56087,6 +56407,7 @@ msgstr ""
 "wall-clock."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -56096,7 +56417,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57289,23 +57610,28 @@ msgstr ""
 "tidak diperlukan pengetahuan bahasa khusus platform."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# Ekstensi iOS WidgetKit"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android Widget Aplikasi"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS Komplikasi"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOS Simulator"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS Tile"
 
 #: src/widgets/overview.md:60
@@ -58220,10 +58546,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -58820,11 +59142,13 @@ msgid "Build Commands"
 msgstr "Perintah Build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -59714,19 +60038,23 @@ msgid "Build Instructions"
 msgstr "Instruksi Build"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# Salin file .kt ke app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# Gabungkan AndroidManifest_snippet.xml ke AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Salin file .kt ke modul Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# Gabungkan AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -59917,11 +60245,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "Refresh latar belakang menggunakan framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Untuk perangkat Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Untuk Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -61532,11 +61862,13 @@ msgstr ""
 "fungsi yang dideklarasikan menggunakan `#[no_mangle] pub extern \"C\"`:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry runtime FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... panggilan platform API, menyelesaikan janji ketika selesai ..."
 
 #: src/plugins/native-extensions.md:200
@@ -61667,25 +61999,17 @@ msgstr ""
 "`swiftc`, dengan menargetkan SDK platform yang tepat:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (disederhanakan)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// mendeteksi target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// Kompilasi: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// Link: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -61712,7 +62036,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Selesaikan promise Perry dengan hasilnya"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Dapatkan Aktivitas dari PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -61728,7 +62053,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "// Panggilan API platform melalui JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -62355,15 +62681,18 @@ msgstr ""
 "ada bangun."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# Gerbang"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# apa yang dalam lingkup, dan apa yang tidak"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# Buktikan gerbang masih bisa gagal"
 
 #: src/testing/test-registration.md:18
@@ -62720,33 +63049,40 @@ msgstr ""
 "otomatis ketika Anda mengompilasi dengan `--enable-geisterhand`."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Mengkompilasi dengan geisterhand diaktifkan (libs auto-build pada "
 "penggunaan pertama)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Jalankan aplikasi"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. Di terminal lain  berinteraksi dengan aplikasi"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Daftar semua widget"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Klik tombol dengan pegangan 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Mengambil screenshot jendela"
 
 #: src/testing/geisterhand.md:25
@@ -62763,7 +63099,8 @@ msgstr ""
 "kedua flag tersebut):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# atau dengan perry run:"
 
 #: src/testing/geisterhand.md:35
@@ -62909,8 +63246,8 @@ msgid "Menu item"
 msgstr "Item menu"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -62922,8 +63259,8 @@ msgstr "Pintasan keyboard"
 msgid "Data table"
 msgstr "Tabel data"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -63038,17 +63375,6 @@ msgstr ""
 "Mengatur konten text field dan memicu callback `onChange`-nya dengan teks "
 "baru sebagai string yang di-NaN-box."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"Tipe konten: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "'{\"teks\":\"halo dunia\"}'"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Menggeser Slider"
@@ -63072,10 +63398,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "Mengatur posisi slider dan memicu `onChange` dengan nilai numerik."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"nilai\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -63126,10 +63448,6 @@ msgstr ""
 "Mengatur nilai sel `State` secara langsung, melewati callback widget. Ini "
 "memicu setiap binding reaktif yang melekat pada state tersebut (label teks "
 "ter-bind, visibilitas, loop forEach, dll.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "'{\"nilai\":42}'"
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -63207,10 +63525,6 @@ msgstr ""
 "dikirim ke `menuAddItem` (misalnya, `\"s\"` untuk Cmd+S, `\"S\"` untuk "
 "Cmd+Shift+S, `\"n\"` untuk Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "'{\"jalur pintas\":\"s\"}'"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63245,10 +63559,6 @@ msgid ""
 msgstr ""
 "Mengatur offset scroll dari widget ScrollView. Baik `x` maupun `y` dalam "
 "satuan poin."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -63350,12 +63660,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Menembak input acak setiap 200ms"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -63496,12 +63803,16 @@ msgstr ""
 "(jaringan Wi-Fi yang sama) atau gunakan `iproxy` dari `libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Menginstal dan meluncurkan melalui Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IPnya:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -63528,7 +63839,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Paket ke APK dan instal"
 
 #: src/testing/geisterhand.md:381
@@ -63536,7 +63848,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Instal pustaka pengembangan GTK4 terlebih dahulu:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -63560,15 +63873,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Pengujian end-to-end sederhana menggunakan bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Bangun dengan tangan hantu"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Mulai aplikasi di latar belakang"
 
 #: src/testing/geisterhand.md:419
@@ -63580,33 +63896,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"membunuh $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Tunggu sampai aplikasi siap"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Dapatkan widget"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Cari tombol berlabel \"Submit\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Klik itu"
 
 #: src/testing/geisterhand.md:436
@@ -63614,7 +63934,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Ambil screenshot setelah interaksi"
 
 #: src/testing/geisterhand.md:441
@@ -63626,7 +63947,8 @@ msgid "Python Test Example"
 msgstr "Contoh Pengujian Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# Mulai aplikasi"
 
 #: src/testing/geisterhand.md:450
@@ -63634,11 +63956,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Tunggu untuk memulai"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Widget Daftar"
 
 #: src/testing/geisterhand.md:455
@@ -63646,11 +63970,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Cari widget berdasarkan label"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# Ketik ke bidang teks pertama"
 
 #: src/testing/geisterhand.md:464
@@ -63670,7 +63996,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Klik tombol pertama"
 
 #: src/testing/geisterhand.md:470
@@ -63678,7 +64005,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Mengambil tangkapan layar untuk regresi visual"
 
 #: src/testing/geisterhand.md:473
@@ -63694,7 +64022,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Pastikan aplikasi masih sehat"
 
 #: src/testing/geisterhand.md:478
@@ -63726,40 +64055,14 @@ msgstr ""
 "atau state tak terduga:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Membangun dan meluncurkan"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Mulai kekacauan agresif (setiap 50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Biarkan berjalan selama 30 detik"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Periksa statistik"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"berjalan\": benar, \"events_fired\": 600, \"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Ambil tangkapan layar untuk melihat keadaan akhir"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Hentikan kekacauan"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Periksa aplikasi masih hidup"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -63772,11 +64075,13 @@ msgstr ""
 "Tangkap screenshot pada titik interaksi kunci dan bandingkan dengan baseline:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# Keadaan awal"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -63784,24 +64089,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Penangkapan setelah interaksi"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# Bandingkan (menggunakan ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "Integrasi Pipeline CI"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# Contoh tindakan GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# Contoh GitHub Actions\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -63850,7 +64157,8 @@ msgid "Run UI tests"
 msgstr "Jalankan pengujian UI"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Jalankan skrip tes Anda"
 
 #: src/testing/geisterhand.md:568
@@ -64028,20 +64336,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Setelah dikompilasi dengan `--enable-geisterhand` dan dijalankan:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Lihat semua widget interaktif"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"pengendali\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
 "\"Reset\"},"
@@ -64051,8 +64362,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
 
@@ -64061,19 +64373,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Klik Increment 3 kali"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# Label konter sekarang menunjukkan \"Hitung: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Ketik nama"
 
 #: src/testing/geisterhand.md:669
@@ -64081,7 +64396,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Atur slider ke 80%"
 
 #: src/testing/geisterhand.md:672
@@ -64089,11 +64405,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Aktifkan mode gelap"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64402,16 +64720,13 @@ msgstr ""
 "Jika auto-build gagal atau Anda ingin melakukan cross-compile secara manual:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Bangun libs geisterhand untuk macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Build untuk iOS (cross-compile)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -64604,15 +64919,18 @@ msgstr ""
 "run. Semakin sempit:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# beberapa modul"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# hanya ekspor ini"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# bentuk gabungan mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -64632,15 +64950,18 @@ msgid "Full sweep and the CI gate"
 msgstr "Sapu penuh dan gerbang CI"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# seluruh matriks + tabel ringkasan"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# Keluar 1 pada regresi vs garis dasar"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# Menulis ulang garis dasar yang telah diikat"
 
 #: src/testing/node-compat-matrix.md:43
@@ -64925,7 +65246,7 @@ msgstr ""
 "`needs: plan` dan dipasangi dengan `fromJSON(needs.plan.outputs.plan).jobs."
 "<name>`."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -65021,11 +65342,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -65050,95 +65371,108 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6x lebih cepat"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3x cepat"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x penuh"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "hanya deps"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr ""
 "Dalam **Pr** tier daftar file yang diubah mempersempit rencana lebih lanjut:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -65147,7 +65481,7 @@ msgstr ""
 "`packaging/`, `.claude/`, ...  lihat `NON_CORE_GLOBS` di `ci_plan.py`) → "
 "hanya `lint` berjalan."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -65155,7 +65489,7 @@ msgstr ""
 "**inti** (apa pun yang dapat mengubah compiler, runtime, atau hasil tes) → "
 "seluruh tingkat PR."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -65164,7 +65498,7 @@ msgstr ""
 "`skills/`, ...) → tambahan alur kerja `security-audit` yang dapat digunakan "
 "kembali."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -65179,7 +65513,7 @@ msgstr ""
 "yang dibuat dalam HIR, transform, atau ketergantungan lain tanpa menambahkan "
 "Rust setup untuk docs-only PRs."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -65189,11 +65523,11 @@ msgstr ""
 "`plan` gagal gagal gerbang langsung  perencana yang rusak tidak boleh "
 "berubah menjadi \"semua dilewatkan, oleh karena itu hijau\"."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "Mengapa terlihat seperti ini (diukur 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -65206,13 +65540,13 @@ msgstr ""
 "pekerjaan / ~ 650 menit berjalan**, dan `main` melihat ~ 66 PR mendorong dan "
 "~ 58 merges sehari. Itu adalah 1.52 × total kapasitas, jadi:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "Waktu tunggu antrian pekerjaan adalah 37 h (`conformance-smoke` shards: "
 "median 4 h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -65220,7 +65554,7 @@ msgstr ""
 "**0 dari 66** PR menjalankan alur kerja `Tests` mencapai kesimpulan di "
 "jendela sampel  8 gagal, 56 dibatalkan oleh dorongan berikutnya;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -65233,7 +65567,7 @@ msgstr ""
 "penggabungan terakhir adalah bypass admin** dengan `lint` dan `cargo-test` "
 "masih menunggu."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -65248,11 +65582,11 @@ msgstr ""
 "konteks yang diperlukan yang terfragmentasi dengan fan-in `pr-gate` tunggal "
 "yang dijelaskan di atas."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Dua biaya khusus mendominasi:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -65273,7 +65607,7 @@ msgstr ""
 "otomatis 8-shard disimpan di tingkat penuh karena itu adalah satu-satunya "
 "lengan yang melihat bug tautan pengoptimalan otomatis saja."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -65288,7 +65622,19 @@ msgstr ""
 "runs; PRs mengembalikan blob main-line terbaru. `cache-warm.yml` hilang: "
 "sweep adalah build yang menghasilkan cache pada `main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -65311,75 +65657,75 @@ msgstr ""
 "`test.yml`. PR yang tidak diberi label masih mendapatkan setiap  dengan "
 "setiap pekerjaan yang dilewatkan, yang tidak membutuhkan slot pelari."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "pekerjaan khas"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "menit-menit pelari khas"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "jam dinding target"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (inti)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 pecahan celah)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 menit setelah antrian"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (hanya untuk dokumen)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 menit"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "bukan target  itu bersatu"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "Bukan sasaran"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -65409,11 +65755,20 @@ msgstr ""
 "jendela (`previous sweep SHA .. this sweep SHA`), persis seperti untuk "
 "gerbang enam jam."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Memilih PR menjadi lebih"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -65427,7 +65782,7 @@ msgstr ""
 "dan untuk apa pun yang menyentuh suite tingkat penuh saja. Menerapkan label "
 "kembali menyalakan (`labeled` pemicu)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -65435,7 +65790,7 @@ msgstr ""
 "**`skip-changelog` label** melewatkan langkah perubahan dalam `lint` "
 "(perubahan `crates/` harus menambahkan fragmen `changelog.d/<PR>-<slug>.md`)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -65443,11 +65798,11 @@ msgstr ""
 "**`workflow_dispatch`** pada cabang manapun: `tier` (`pr` / `sweep` / "
 "`full`) dan `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Membuat kembali basis snapshot kesenjangan"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -65460,15 +65815,17 @@ msgstr ""
 "regenerasi itu **dari CI**, bukan dari laptop (baseline yang diperlukan "
 "adalah mode Linux, `fast`):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# Tunggu untuk lari, maka:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# isi `issue` / `reason` untuk setiap entri baru, lalu commit"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -65478,11 +65835,11 @@ msgstr ""
 "dan alasan sebelum bergabung. Sebuah tabrakan mungkin tidak pernah diparkir "
 "di snapshot (`run_gap_tests.sh` menolak)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Perlindungan cabang"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -65499,11 +65856,11 @@ msgstr ""
 "dalam anggarannya; jalan gerbang sendiri membawa apakah hasil itu lulus atau "
 "gagal."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -65516,7 +65873,7 @@ msgstr ""
 "pada SHA yang sama tidak dihitung. Lihat [Releasing](../contributing/"
 "releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -65532,6 +65889,173 @@ msgstr ""
 "tren berjalan sekali di `parity-aggregate` atas laporan yang digabungkan "
 "(`scripts/parity_report_merge.py`, yang menolak shard yang hilang daripada "
 "mengecilkan suite)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Apa yang dikirim cek"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Jalankan secara lokal dengan:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"perintah\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -65654,36 +66178,13 @@ msgid "Reproduce the core of it with:"
 msgstr "Reproduksi intinya dengan:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# Apa yang sebenarnya berjalan, repo-wide, pada tingkat pekerjaan:"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "Pekerjaan | select(.status==\"in_progress\") | (label)|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Seberapa dalam antrean, dan di kolam mana:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "Pekerjaan | select(.status==\"queued\") | (label)|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -65874,24 +66375,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# tidak berubah  setiap PR masih diukur"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # terhambat; lihat tabel di bawah ini"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -65902,12 +66401,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# Pembebasan tetap terjaga secara individual"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -66188,11 +66686,13 @@ msgstr ""
 "tidak."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# membuktikan itu masih bisa gagal"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# API nyata, tidak ada masalah menulis"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -66226,10 +66726,49 @@ msgstr ""
 "berarti detektor bekerja, bukan berarti tidak ada yang dicoba."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "Antrian di depan jadwal (# 7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -66237,57 +66776,57 @@ msgstr ""
 "Penggeledahan setiap enam jam hanya membantu jika antrian menguras lebih "
 "cepat dari enam jam. Pada 2026-08-12 tidak, dan alasannya bukan gerbang:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "berturut-turut"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "Perjalanan bersamaan diamati"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "antrian berdasarkan peristiwa"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "cabang kepala yang berbeda di antara PR yang berturut-turut"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**cabang yang masih ada**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -66304,11 +66843,12 @@ msgstr ""
 "sepuluh gerbang `main` yang belum selesai dalam 32+ jam. Tidak ada jumlah "
 "jadwal yang pulih dari itu; sampah harus dihilangkan."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -66325,7 +66865,7 @@ msgstr ""
 "keberadaan cabang, yang merupakan apa yang menjaga fork PR aman  cabang "
 "kepala garpu tidak pernah muncul dalam ref repo ini."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -66337,7 +66877,7 @@ msgstr ""
 "adalah `python3 scripts/reap_stale_ci_runs.py --apply` manual (dry run "
 "adalah default); jadwalnya tetap jelas setelahnya."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
@@ -66345,7 +66885,7 @@ msgstr ""
 "Mengapa \"pintu gerbang gelap\" tidak sama dengan \"pintu gerbang akan "
 "menangkapnya\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -66357,7 +66897,7 @@ msgstr ""
 "membiarkannya melewati  tidak bertahan dari pemeriksaan, dan mencatat "
 "mengapa lebih penting daripada insiden:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -66369,7 +66909,7 @@ msgstr ""
 "benar menemukan \\#7965 (`collection_kind: \"full\"` pergi 0 → 2) bukan "
 "salah satunya. Tidak ada gerbang di repo ratchets koleksi-_kind_ hitungan."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -66381,7 +66921,7 @@ msgstr ""
 "dalam `tolerances.json`. Mereka hanya menggunakan `pinned_host`, yang CI "
 "tidak pernah gunakan."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -66389,7 +66929,7 @@ msgstr ""
 "Beban kerja yang menunjukkannya (`retain`, `deeplist`, ...) adalah corpus gc-"
 "handoff, bukan 14 probe tetap `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -66615,14 +67155,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Kompilasi TypeScript menjadi executable native."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# Atau singkatan (detector otomatis mengkompilasi):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Flag"
 
@@ -66651,7 +67192,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (default) atau `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -66659,7 +67200,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "Cetak representasi intermediate HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -66671,7 +67212,7 @@ msgstr ""
 "Menghasilkan objek file ((s) saja, melewatkan linking; ditulis ke `-o` "
 "(lihat [Bendera Kompilator](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -66679,7 +67220,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "Pertahankan file `.o` dan `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -66687,7 +67228,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "Aktifkan fallback runtime JavaScript V8"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -66699,8 +67240,8 @@ msgstr ""
 "Paksa-link runtime host WebAssembly wasmi (terdeteksi otomatis saat "
 "`WebAssembly.*` digunakan)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -66708,15 +67249,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Aktifkan pemeriksaan tipe melalui tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "Minify dan obfuscate output (otomatis aktif untuk `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -66724,7 +67265,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (diperlukan untuk target widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -66733,23 +67274,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "Bundle ekstensi TypeScript dari direktori"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Kompilasi dasar"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Cross-compile untuk iOS Simulator"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Buat plugin"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: melihat representasi perantara"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Buat widget iOS"
 
 #: src/cli/commands.md:82
@@ -66757,23 +67303,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Kompilasi dan luncurkan aplikasi Anda dalam satu langkah."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# File entri deteksi otomatis"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Jalankan pada iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Jalankan pada Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Jalankan pada perangkat Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Arahkan args ke program Anda"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -66907,19 +67458,23 @@ msgstr ""
 "untuk memaksa salah satu jalur."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Jalankan program CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Jalankan pada simulator tertentu"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Kekuatan remote build"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Jalankan target web"
 
 #: src/cli/commands.md:131
@@ -66935,19 +67490,23 @@ msgstr ""
 "setiap kali save."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# menonton + membangun kembali + peluncuran kembali pada menyimpan"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# Args ke depan untuk anak"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# menonton direktori tambahan"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# jalan keluar override"
 
 #: src/cli/commands.md:144
@@ -67082,7 +67641,7 @@ msgstr ""
 "Pelestarian state di antara rebuild / HMR — \"fast restart\" adalah target "
 "yang jujur."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -67147,19 +67706,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Sertakan perbaikan dengan tingkat keyakinan sedang"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Periksa satu file"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Periksa dengan analisis ketergantungan"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Masalah perbaikan otomatis"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Perbaikan pratinjau tanpa menerapkan"
 
 #: src/cli/commands.md:207
@@ -67454,27 +68017,33 @@ msgstr ""
 "toolchain untuk Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Tampilkan menu platform"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# macOS setup (penandatanganan kredensial)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# iOS setup (penandatanganan kredensial)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# visionOS setup (penandatanganan kredensial)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Android setup (penandatanganan kredensial)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows toolchain (mengunduh MS CRT + Windows SDK melalui xwin)"
 
 #: src/cli/commands.md:318
@@ -67503,19 +68072,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Perbarui ke terbaru"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Periksa tanpa menginstal"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Abaikan jawaban yang disimpan di cache"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Simpan bagaimana pembaruan harus berperilaku, lalu keluar"
 
 #: src/cli/commands.md:333
@@ -67533,7 +68106,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` menulis `[update] mode` ke `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -67646,14 +68219,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Buat kerangka paket native-bindings baru:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"Native binding untuk libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\"'"
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -68193,10 +68758,21 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr "Output executable, bundle, shared library, archive, atau path objek."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -68204,16 +68780,16 @@ msgstr ""
 "Pilih Linux libc/linkage; `musl` meningkatkan target Linux yang sesuai ke "
 "build tanpa kepala yang sepenuhnya statis."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "ID bundel yang dibutuhkan oleh target widget layar utama."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "Temukan dan statis bundel paket ekstensi asli dari direktori."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -68221,21 +68797,21 @@ msgstr ""
 "Jalankan penguji TypeScript asli (`@typescript/native-preview`) sebelum "
 "codegen."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Atur tingkat kompatibilitas Windows PE; diabaikan untuk target non-Windows."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -68243,11 +68819,11 @@ msgstr ""
 "Pilih subsistem Windows PE alih-alih mengandalkan deteksi otomatis berbasis "
 "impor."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -68255,11 +68831,11 @@ msgstr ""
 "Untuk target widget Apple, keluarkan sumber dan metadata SwiftUI tanpa "
 "memanggil `swiftc`."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -68267,35 +68843,68 @@ msgstr ""
 "Pilih HarmonyOS bahan penandatanganan HAP. Memilih sumber environment/config "
 "yang sesuai untuk rahasia."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "Rantai sertifikat aplikasi HarmonyOS."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS menandatangani profil penyediaan."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS alias keystore; default untuk `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — modul"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Mengintegrasikan Aset"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -68303,11 +68912,11 @@ msgstr ""
 "Panggang file statis (SPA `dist/`, gambar, JSON, font, ...) ke dalam file "
 "eksekusi mandiri sehingga berjalan tanpa file eksternal pada disk (# 5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -68317,11 +68926,23 @@ msgstr ""
 "Repeatable. Digabungkan dengan `perry.embed` (package.json) dan `[compile] "
 "embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -68330,19 +68951,20 @@ msgstr ""
 "`dir` ke pegangan `$perryfs` yang stabil. Dapat diulang; peta sumber tidak "
 "termasuk."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# melayani dist/ dari memori  tidak perlu dist/ folder"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "File tertanam dapat diakses pada saat runtime dengan tiga cara:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -68374,7 +68996,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -68386,7 +69008,7 @@ msgstr ""
 "`readEmbedded(path)` dan `node:fs` menerima baik jalur virtual `$perryfs/"
 "<path>` atau kunci relatif embed."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -68394,7 +69016,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -68404,7 +69026,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -68418,7 +69068,7 @@ msgstr ""
 "`{ type: \"file\" }`, dan menyimpan sumber yang dihasilkan di cache daripada "
 "memodifikasi checkout."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -68426,11 +69076,7 @@ msgstr ""
 "Untuk grafik sumber OpenCode yang disematkan, bangun UI web hulu terlebih "
 "dahulu, lalu kompilasi dari root paket `packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -68444,7 +69090,7 @@ msgstr ""
 "impor yang tidak terpecahkan. Jalankan perintah persiapan untuk setiap "
 "revisi sumber sehingga input yang dihasilkan tidak bisa usang."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -68456,7 +69102,7 @@ msgstr ""
 "eksplisit. Ini mencatat pegangan yang dikemas, asal sumber proyek-relatif, "
 "ukuran byte, SHA-256 digest, dan modul aset penghasil jika berlaku."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -68471,7 +69117,7 @@ msgstr ""
 "nyata dengan jalur mutlak, dan menggunakan bentuk eksplisit `$perryfs/"
 "<path>` ketika Anda secara khusus berarti salinan tertanam."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -68483,19 +69129,19 @@ msgstr ""
 "`PERRY_LLVM_CLANG` ketika clang yang cocok tidak pertama pada `PATH`. Cross-"
 "target embedding saat ini tidak didukung."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Flag Debug"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "Cetak HIR (intermediate representation) ke stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -68504,11 +69150,11 @@ msgstr ""
 "pasca-transform), `llvm` (per-modul `.ll` ke dalam `.perry-trace/llvm/`), "
 "atau `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -68518,7 +69164,7 @@ msgstr ""
 "`NAME`, menyembunyikan noise import/export/init. Mengimplikasikan `--trace "
 "hir` jika tidak ada tahap yang diberikan"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -68532,11 +69178,11 @@ msgstr ""
 "beberapa file. Tanpa `-o` mereka mendarat di direktori saat ini. Setiap "
 "jalur dicetak sebagai `Wrote object file: <path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -68546,15 +69192,15 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`). Lihat [Konfigurasi Proyek](../getting-started/"
 "project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "Simpan berkas perantara `.o` dan `.asm`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
@@ -68562,30 +69208,30 @@ msgstr ""
 "Simpan symbols/DWARF (dan keluarkan PDB Windows) alih-alih menghapus "
 "hasilnya."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Matikan cache objek per-modul untuk build ini; juga `PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr "Tolak root cache lokal mesin; lihat [Direktori cache](cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -68593,32 +69239,32 @@ msgstr ""
 "Jalankan representasi asli menurunkan invarians dan paksa codegen alih-alih "
 "cache penggunaan kembali."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 "Menonaktifkan Buffer/Uint8Array load/store menurunkan asli untuk diagnosis A/"
 "B."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 "Mengeluarkan laporan bukti penurunan tipe; menyiratkan verifikasi wilayah "
 "asli."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -68629,11 +69275,11 @@ msgstr ""
 "mengeluarkan skema yang stabil untuk alat. Juga diatur melalui "
 "`PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -68646,7 +69292,7 @@ msgstr ""
 "`PERRY_RS4GC=1`, satu native-root backend (pelan stack-map dan eksplisit-"
 "bridge mode yang juga disebut hilang)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -68663,11 +69309,11 @@ msgstr ""
 "biasanya melewati codegen untuk modul yang tidak berubah, sehingga direktori "
 "trace kosong)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  mengapa nilai tetap kotak"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -68685,11 +69331,11 @@ msgstr ""
 "komentar: itu mencetak apa yang terbukti, apa yang tidak, dan aturan yang "
 "membuat panggilan."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Setiap nilai ditolak membawa:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -68698,7 +69344,7 @@ msgstr ""
 "**Posisi** `local`, `param`, `return`, `field`, atau `alloc-site` (objek "
 "literal yang tidak pernah terikat dengan lokal, idiom `.map(x => ({...}))`)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -68706,7 +69352,7 @@ msgstr ""
 "**Aturan yang menyangkalnya**, dalam penomoran kolektor sendiri, sehingga "
 "Anda dapat memeriksanya dengan file sumber yang diberi nama."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -68718,7 +69364,7 @@ msgstr ""
 "no action), or _Perry limitation_ (not your code; names the tracking issue "
 "where one exists)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -68733,7 +69379,7 @@ msgstr ""
 "elemen, sehingga kedalaman loop saja peringkat terakhir. Juga bukan profil  "
 "mereka adalah proxy statis."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -68741,7 +69387,7 @@ msgstr ""
 "Kemenangan dilaporkan di samping kegagalan, sehingga rasio terlihat bukan "
 "hanya keluhan."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -68756,7 +69402,7 @@ msgstr ""
 "Laporan ini berbunyi: **Sederet**, sehingga tidak pernah bercampur dengan "
 "muatan `--format json` atau output pipa program Anda."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -68770,15 +69416,15 @@ msgstr ""
 "bawah `schema_version: 1`; JSON yang berbeda dari dua build adalah cek CI "
 "murah terhadap representasi yang diam-diam regresi ke nol."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Optimasi Keluaran"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -68799,11 +69445,11 @@ msgstr ""
 "dari `generic`. Berlaku pada kode aplikasi dan rebuild runtime/stdlib "
 "otomatis dioptimalkan."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -68811,11 +69457,11 @@ msgstr ""
 "Mendefinisikan konstan `__feature_NAME__` waktu kompilasi yang dipisahkan "
 "dengan koma untuk menghilangkan kode mati."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -68823,25 +69469,25 @@ msgstr ""
 "Gunakan runtime/stdlib lengkap yang sudah dibangun sebelumnya alih-alih "
 "membangun kembali set fitur terkecil yang dapat dicapai."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "Izinkan pencocokan ulang tanda layang; lihat [Fast-math](fast-math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "Kontrol bergabung multiply-add kontraksi terpisah dari reasosiasi."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -68849,11 +69495,11 @@ msgstr ""
 "Minifikasi menghapus komentar, memadatkan whitespace, dan mengacak nama "
 "variabel lokal/parameter/fungsi non-ekspor untuk keluaran yang lebih kecil."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Bangunan yang dioptimalkan ukurannya"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -68865,11 +69511,11 @@ msgstr ""
 "disetel untuk ukuran alih-alih kecepatan (mereka membutuhkan checkout ruang "
 "kerja Perry, seperti yang lain dioptimalkan secara otomatis):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -68881,11 +69527,11 @@ msgstr ""
 "(komputer-berat internal loop dapat berjalan ~ 2-3× lebih lambat). Arsip "
 "ukuran yang dioptimalkan dan arsip normal disimpan secara independen."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -68894,11 +69540,11 @@ msgstr ""
 "kembali (membangun kembali yang lebih lambat, biner yang lebih kecil). Hanya "
 "berarti bersama dengan `PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -68917,7 +69563,7 @@ msgstr ""
 "`catch`, `finally`, kesalahan tumpukan dan `uncaughtException` tidak "
 "terpengaruh."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -68929,15 +69575,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. Program yang menggunakan lebih banyak "
 "runtime menyusut kurang, secara proporsional."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Flag Pengujian"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -68945,26 +69591,26 @@ msgstr ""
 "Sematkan server HTTP [Geisterhand](../testing/geisterhand.md) untuk "
 "pengujian UI secara programatik (port default 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Atur port khusus untuk server Geisterhand (mengimplikasikan `--enable-"
 "geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Flag Runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "Aktifkan runtime JavaScript V8 untuk paket npm yang tidak didukung"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -68974,15 +69620,15 @@ msgstr ""
 "`WebAssembly.*` direferensikan; hanya diperlukan saat memuat via dlopen / "
 "FFI tanpa referensi statis)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Aktifkan pemeriksaan tipe via IPC tsgo"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -68999,11 +69645,11 @@ msgstr ""
 "perry.toml). `PERRY_ALLOW_EVAL=1` memaksanya mati. Lihat [Limitations](../"
 "language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -69026,11 +69672,11 @@ msgstr ""
 "finite union-type params, glob) tidak terpengaruh. Lihat [Limitations](../"
 "language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -69038,23 +69684,23 @@ msgstr ""
 "Gagal pada waktu kompilasi ketika API Node/stdlib yang diakui tetapi tidak "
 "diimplementasikan dirujuk alih-alih mengeluarkan kesalahan runtime tertunda."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Mengirim `<binary>.attest.json`; lihat [Sertifikat biner](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Mengeluarkan sidecar sandbox platform; lihat [Profil kotak pasir](emit-"
 "sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -69062,31 +69708,31 @@ msgstr ""
 "Menolak permukaan pengeksekusi kode sewenang-wenang yang dapat dicapai; "
 "lihat [Lockdown](lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Variabel Lingkungan"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Kunci lisensi Perry Hub untuk `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Kata sandi untuk sertifikat .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -69094,63 +69740,63 @@ msgstr ""
 "Basis CPU untuk kode mesin yang dihasilkan (nilai yang sama dengan `--"
 "march`; bendera dan perry.toml `[build] march` menang atas lingkungan)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Nonaktifkan pemeriksaan pembaruan otomatis"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "Sama, menggunakan ejaan seluruh ekosistem"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` untuk satu putaran  lihat [Updates]"
 "(updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL server pembaruan khusus"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Lewati pemeriksaan pembaruan secara otomatis (diatur oleh sebagian besar "
 "sistem CI)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Level logging debug (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -69158,7 +69804,7 @@ msgstr ""
 "`1`/`text` atau `json`  sama dengan `--opt-report[=json]`, untuk menjalankan "
 "laporan dari lingkungan di mana menambahkan flag tidak nyaman"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -69173,15 +69819,15 @@ msgstr ""
 "GC env kelima tanpa lengan CI, dan dihapus di bawah kebijakan membunuh "
 "tombol GC CLAUDE.md."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "Berkas Konfigurasi"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (proyek)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -69261,11 +69907,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (global)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -69287,57 +69933,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Program CLI sederhana"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# Aplikasi iOS untuk simulator"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# Aplikasi visionOS untuk simulator"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Aplikasi web (WASM dengan DOM bridge  alias: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Perpustakaan bersama plugin"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# iOS widget dengan ID bundel"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Pengumpulan debug"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Kompilasi kata-kata"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Kompilasi yang diperiksa tipe"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# Raw WASM biner (tidak ada HTML wrapper)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Output web minified (mengompres JS embedded bridge)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Perintah](commands.md) — Semua perintah CLI"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[Ikhtisar Platform](../platforms/overview.md) — Target platform"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"module\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Identitas cache"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"module\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "Sumber"
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"Lodash\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"target\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"fungsi\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"subtitle\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -69579,15 +70421,18 @@ msgstr ""
 "Flag CLI menang atas variabel env, variabel env menang atas package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. Per-build CLI flag"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Lingkungan per shell"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. package.json per proyek (yang paling umum)"
 
 #: src/cli/fast-math.md:35
@@ -69603,18 +70448,21 @@ msgid "Contraction is separate from reassociation:"
 msgstr "Kontraksi terpisah dari reassociation:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Izinkan kontraksi FMA saja."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Memungkinkan modus kontraksi paling agresif frontend tanpa re-asosiasi."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# Jaga hubungan kembali dari --fast-math tapi blok kontraksi FMA."
 
 #: src/cli/fast-math.md:55
@@ -70615,7 +71463,8 @@ msgid "Emit"
 msgstr "Emit"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -70703,7 +71552,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"ukuran\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -71931,10 +72780,6 @@ msgstr ""
 msgid "produces:"
 msgstr "menghasilkan:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"module\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -72019,9 +72864,10 @@ msgstr ""
 "sumber host dilaporkan di bawah `<host source>`."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Mengembalikan kesalahan yang jelas jika manifest belum ada  `perry  compile` "
 "atau `perry run` menuliskannya pada setiap build yang berhasil."
@@ -74181,7 +75027,7 @@ msgstr "Perry membaca konfigurasi dari kedua file. Berikut pembagiannya:"
 msgid "Setting"
 msgstr "Pengaturan"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "File"
 
@@ -74266,16 +75112,19 @@ msgstr ""
 "`~/.perry/config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr ""
 "# Mengkonfigurasi penandatanganan iOS (sertifikat, profil provisioning)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Mengkonfigurasi penandatanganan Android (keystore, kunci Play Store)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Mengkonfigurasi distribusi macOS (App Store, notarisasi)"
 
 #: src/cli/perry-toml.md:605
@@ -74315,8 +75164,11 @@ msgstr ""
 "kredensial di `perry.toml`:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# Contoh tindakan GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -75571,20 +76423,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Kapal Perry **dua saluran opt-in independen** untuk mengirim data pulang  "
-"tidak ada yang meninggalkan mesin Anda tanpa `enabled = true` atau `on` "
-"eksplisit di `~/.perry/config.toml`. Keduanya menghormati "
-"`PERRY_NO_TELEMETRY=1` dan `CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Analisis penggunaan umum  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Analisis penggunaan umum  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -75594,14 +76446,16 @@ msgstr ""
 "latar belakang HTTP POST. Mengirim: nama perintah, platform (`darwin`/"
 "`linux`/...), versi Perry, status success/error, dan UUID klien anonim."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. Laporan kompatibilitas  `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -75612,17 +76466,17 @@ msgstr ""
 "`UnsupportedExpression`, `UnsupportedStatement`, `DynamicPropertyAccess`, "
 "`ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Tiga mode:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 "`off`  tidak pernah mengirim. Kolam renang bahkan tidak dipasang, nol "
 "overhead."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -75631,99 +76485,99 @@ msgstr ""
 "sekali per sesi: `[y] just this once / [a] always / [n] not this time / [N] "
 "never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  selalu mengirim (setelah dedup + redaction). Tidak ada perintah."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**Apa yang dikirim (seluruh skema muatan):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"kode\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"kategori\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"gap-kategori\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"tahap\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"hir-bawah\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"dekorator\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"Node:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"Darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -75740,7 +76594,7 @@ msgstr ""
 "`<id1>`, `<id2>`, dibatasi pada 200 karakter, dengan penolakan keras jika "
 "ada invarian yang gagal."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -75748,32 +76602,36 @@ msgstr ""
 "Cache dedup lokal 30 hari di `~/.perry/.report-cache` mencegah mengirim "
 "kembali `snippet_hash` yang sama pada setiap pengisian ulang."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Memeriksa & mengelola"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# menunjukkan mode saat ini, sent/queued menghitung"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# cetak dihapus muatan berturut-turut ini menjalankan"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# Hapus 30 hari dedup cache"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "Untuk memilih keluar di tingkat file, mengedit `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -75782,7 +76640,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -76034,15 +76892,18 @@ msgstr ""
 "(`crates/perry-runtime/src/gc/types.rs`):"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "/ Tanda | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// total ukuran alokasi, digunakan untuk arena blok berjalan"
 
 #: src/internals/memory-model.md:69
@@ -76385,7 +77246,7 @@ msgstr ""
 "barrier helper eksak runtime saat runtime, untuk benchmark/debug bisection. "
 "Jika tidak diatur, `=1`, `=on`, dan `=true` tetap mengaktifkan barrier."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -76574,10 +77435,11 @@ msgstr ""
 "retired_set=#N` di bawah `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -76806,10 +77668,24 @@ msgstr ""
 "melebih-lebihkan apa yang sebenarnya akan proses bertahan di bawah tekanan."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Peta sumber"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -76818,183 +77694,183 @@ msgstr ""
 "kembali, dan setiap baris tabel ini pernah menunjuk ke `gc.rs` yang tidak "
 "ada lagi."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Topik"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Simbol yang harus dicari"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaN-boxing tag"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, konstanta tipe/flag"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Bingkai bayangan (menurunkan akar mundur)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Scanner root terdaftar"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Menyalin minor"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Promosi di seluruh blok"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Kebijakan Promosi"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Batas masa jabatan yang dapat disesuaikan"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Menulis hambatan"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Penetapan eksplisit"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Predikat pin konservatif"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Pemicu pengumpulan dan pacing"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Halaman operasi saat ini"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Rencana desain (sejarah)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -77434,12 +78310,18 @@ msgstr ""
 "heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "pada proses desktop/server yang tidak terbatas, skala hingga seperdelapan "
 "dari anggaran device/container dengan lantai 1 MiB. Overflow dikembalikan ke "
@@ -77448,7 +78330,7 @@ msgstr ""
 "deferred dan mengosongkan kolam ketika koleksi penuh yang harus selesai "
 "dengan pemulihan arena."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -77458,102 +78340,216 @@ msgstr ""
 "`process.memoryUsage().heapUsed`) adalah post-collection yang tepat **sensus "
 "hidup** ditambah delta tambahan, bukan jumlah blok offset air tinggi."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Kontrol yang didukung"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 "Ini adalah kontrol operasional yang paling berguna di luar pengembangan "
 "kolektor:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "Bisection fallback ke penuh mark-sweep"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime penghalang bisection; juga kekuatan penuh tanda-sweep"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "menonaktifkan pemurnian langsung untuk perbandingan kecepatan"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "Kembali promosi seluruh blok untuk evakuasi objek per objek"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "Tekan tutup dasar tempat bayi"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "Mengganti anggaran heap proses di MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "pilih akar bayangan pada target yang mampu root asli"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "Scan tumpukan asli penuh diagnostik; menonaktifkan penyalinan"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "Membuat catatan jejak yang terstruktur per siklus"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "memancarkan diagnostik kolektor yang dapat dibaca manusia"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -77562,10 +78558,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "Tekanan rooting menggunakan `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -77580,7 +78577,7 @@ msgstr ""
 "`PERRY_STACKMAP_WALKER` diterima tetapi bukan mode kolektor tambahan yang "
 "didukung."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -77609,11 +78606,11 @@ msgstr ""
 "`cargo-test`; tidak bisa diam sementara halaman ini terus mengklaim hal yang "
 "lama."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Otoritas Validasi dan CI"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -77625,36 +78622,36 @@ msgstr ""
 "tiers.md`; kebijakan tingkat adalah `scripts/ci_plan.py`). Cakupan khusus GC "
 "secara sengaja dibagi:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "di mana ia berjalan"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "status yang diperlukan"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr "root-holder custody, GC-knob drift, dan klaim path/number halaman ini"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "Ya (melalui `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "runtime unit suite dan `run_memory_stability_tests.sh` empat-mode matriks"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -77662,7 +78659,7 @@ msgstr ""
 "ya (melalui `pr-gate`; tingkat PR dif-scoped, tingkat sweep/full menjalankan "
 "ruang kerja)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -77670,25 +78667,25 @@ msgstr ""
 "GC × matriks representasi-seleksi, instrumen rooting-bug, tekanan pembatas "
 "penulisan"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "ya (melalui `pr-gate`; subset PR pada PR, matriks penuh dalam menyapu)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "Dominasi akar yang dipancarkan, termasuk IR titik keadaan asli"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -77696,27 +78693,27 @@ msgstr ""
 "tidak diperlukan cabang; Opt-in lengan PR melalui `run-extended-tests`, "
 "setiap enam jam pada `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "kolektor pin counters/RSS/wall matriks"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "anggaran thread-local mechanism/policy"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Perintah lokal yang berguna sebelum penerbangan:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -77726,11 +78723,11 @@ msgstr ""
 "dan host yang lebih luas; file alur kerja mereka adalah otoritas untuk "
 "perintah yang tepat dan filter relevansi."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Bukti sejarah"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -77738,7 +78735,7 @@ msgstr ""
 "[Rencana GC Generasi](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): desain asli dan log pendaratan fase demi fase."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -77748,7 +78745,7 @@ msgstr ""
 "statepoint-gc-experiment.md): pengukuran prototipe kronologis dan koreksi "
 "yang mengarah ke default root asli."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -77756,7 +78753,7 @@ msgstr ""
 "[Invarian akar GC](gc-rooting-invariant.md): aturan ketenaran codegen saat "
 "ini, mode checker, titik buta yang diketahui, dan alat debugging."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -78084,7 +79081,8 @@ msgstr ""
 "adalah biaya setiap kali."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "Lima cara yang sebenarnya telah rusak"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -78242,14 +79240,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` di `gc/mod.rs` dalam commit yang sama."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Cara memeriksa pekerjaan Anda"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. Static checker  jalankan ini"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -78260,7 +79299,7 @@ msgstr ""
 "lingkup itu, itu adalah satu-satunya instrumen yang melihat cacat sebelum "
 "menabrak, itulah sebabnya ia berjalan terlebih dahulu."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -78268,7 +79307,7 @@ msgstr ""
 "**Itu buta untuk tiga kelas, semua ditemukan dengan cara yang sulit. Laporan "
 "bersih bukan bukti untuk salah satu dari mereka:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -78277,7 +79316,7 @@ msgstr ""
 "dan tidak dapat melihat sel runtime. Katakan: gagal 10/10 daripada secara "
 "intermiten."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -78287,7 +79326,7 @@ msgstr ""
 "membaca `0 violations` di kedua sisi bug nyata yang perbaikan adalah satu "
 "baris `GcSuppressScope` dalam bootstrap `globalThis`."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -78306,7 +79345,7 @@ msgstr ""
 "ini terhadap apa codegen benar-benar memancarkan, cara # 7227 audit "
 "`ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -78316,7 +79355,7 @@ msgstr ""
 "quarantine di bawah dan beban kerja _dependency-scale_  # 7280 mencatat 25 "
 "file corpus yang dikuratori yang melewati sementara 20 baris stok zod gagal."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -78334,29 +79373,14 @@ msgstr ""
 "belum default pada setiap target walk-frame sejak # 7370. **Jalankan "
 "keduanya**, dan tahu yang mana yang Anda lari:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr ""
 "# SHADOW (PERRY_RS4GC=0): masih menurunkan pada arm64_32 watchOS dan ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# NATIVE (PERRY_RS4GC=1): default di tempat lain. Anchor di atas"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` alokasi root dan LLVM menyisipkan safepoints kemudian, "
-"sehingga"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -78367,11 +79391,11 @@ msgstr ""
 "dan korpus bayangan memiliki nol safepoints, sehingga `--min-statepoints` "
 "gagal di sana."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Apa yang diperiksa `--statepoints`, dan bagaimana ia berbeda"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -78383,7 +79407,7 @@ msgstr ""
 "adalah hasil `gc.relocate`. Jadi \"rumput akar harus mendominasi setiap "
 "titik pengumpulan selanjutnya\" menjadi:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -78391,7 +79415,7 @@ msgstr ""
 "Tidak ada register yang menamai objek GC dapat digunakan di bawah safepoint "
 "kecuali nilai yang dipindahkan."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -78406,23 +79430,23 @@ msgstr ""
 "sebagai `double`. Dua kelas putusan, karena mereka memiliki dua perbaikan "
 "yang berbeda:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -78430,15 +79454,15 @@ msgstr ""
 "Tidak ada nilai `ptr addrspace(1)` dalam rantai cast register yang ada di "
 "bundel live safepoint. Tidak ada yang menandai atau menulis ulang objek."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "akarnya"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -78446,13 +79470,13 @@ msgstr ""
 "obyek TIDAK dalam bundel dan dipindahkan, tetapi salinan mentah dari alamat "
 "pra-pindah digunakan di bawah ini"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr ""
 "Menghasilkan kembali dari nilai yang dipindahkan "
 "(`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -78469,7 +79493,7 @@ msgstr ""
 "dibungkus callee**, sehingga `--moving-only` mengklasifikasikan terhadap "
 "simbol nyata daripada `llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -78493,15 +79517,15 @@ msgstr ""
 "Hal ini sepihak: panggilan yang tidak dikenali dihitung sebagai pengumpulan, "
 "sehingga celah dalam modelnya biaya positif palsu, tidak pernah bug hilang."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Untuk satu file yang sedang Anda iterasi:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "Kedua tombol lingkungan penting, karena alasan yang berbeda."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -78517,7 +79541,7 @@ msgstr ""
 "dan hanya dengan ini pada. Jadi bug yang membutuhkan koleksi antara dua "
 "titik dari tubuh loop inert tidak bisa muncul dalam corpus tanpa itu."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -78539,7 +79563,7 @@ msgstr ""
 "`js_object_set_field_by_name`, `js_object_get_field_ic_miss` dan "
 "`js_closure_call1`. Mereka bergerak tanpa polling di dekat mereka."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -78547,14 +79571,14 @@ msgstr ""
 "Jadi: menyalakan tombol, karena memperluas apa yang dapat dinyatakan korpus, "
 "tetapi tidak membaca fungsi bebas poll sebagai aman."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` adalah oleh EXACT dipancarkan simbol, dan yang telah "
 "menggigit dua kali"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -78566,7 +79590,8 @@ msgstr ""
 "dan terlihat persis seperti cakupan saat melakukannya. Dua putaran ini "
 "sekarang telah diukur:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -78577,7 +79602,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -78594,7 +79619,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` pada `clone` zod. Pelindung dan "
 "pemeriksa tidak setuju; pemeriksa salah."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -78616,7 +79641,7 @@ msgstr ""
 "nol kali; titik masuk yang sebenarnya adalah `js_closure_callN`, yang "
 "`RECEIVER_SINKS` dalam file yang sama sudah dieja dengan benar."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -78637,60 +79662,60 @@ msgstr ""
 "di bawah mode CI berjalan. Menanam kembali kode yang tepat dan menjalankan "
 "setiap mode (# 7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (dominansi)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (pengurangan yang kapal)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (tidak disaring)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (tidak disaring)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -78702,7 +79727,7 @@ msgstr ""
 "pengiriman menurunkan. Menambahkan satu nama membawa senjata yang disabotasi "
 "menjadi 13 dan 8 dan meninggalkan senjata yang bersih pada 2 dan 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -78732,7 +79757,7 @@ msgstr ""
 "tambahkan ke `POLL_CAPABLE_RUNTIME` dalam commit yang sama.** Tidak ada yang "
 "akan memintamu."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -78742,7 +79767,7 @@ msgstr ""
 "reach` adalah gerbang untuk ronde 3; ronde 4 tidak memiliki gerbang. `gc-"
 "root-dominance.yml` berjalan bersama `--audit-alloc-re` sebelum build."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -78769,7 +79794,7 @@ msgstr ""
 "merah, **menggantikan** hantu dengan simbol codegen sebenarnya memancarkan "
 "daripada menghapus  menghapus mengubah audit hijau dan meninggalkan lubang."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -78799,21 +79824,17 @@ msgstr ""
 "10 lagi), dan komentar dan string literals dihilangkan terlebih dahulu "
 "sehingga nama yang disebutkan dalam prosa tidak bisa menjadi premis."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "Memeriksa nama yang masuk akal tidak cukup. Konfirmasi terhadap IR yang "
 "dipancarkan:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -78821,7 +79842,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` membuat setiap root store `js_shadow_slot_bind` "
 "panggilan bentuk checker jangkar pada."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -78837,7 +79858,7 @@ msgstr ""
 "lengan yang dibaseline oleh allowlist, jadi kasus 3 dan 4 hanya permukaan "
 "ketika Anda menjalankan mode ini dengan tangan."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -78853,7 +79874,7 @@ msgstr ""
 "pemblokiran memanggil fungsi bersih. Ini menemukan `lower_call/new.rs` "
 "inline-tor `this_slot` independen dari setiap probe runtime."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -78871,15 +79892,15 @@ msgstr ""
 "`Symbol` lokal tidak mendapatkan slot bayangan sama sekali. Jalankan secara "
 "manual ketika Anda menyentuh situs `alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. Instrumen runtime  detik, dan hati-hati kedalaman"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Dari #7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -78894,7 +79915,7 @@ msgstr ""
 "jajak pendapat ketika jendela yang Anda kejar hanya dijalankan sekali  jauh "
 "lebih lambat."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -78903,11 +79924,12 @@ msgstr ""
 "evakuasi sehingga kesalahan membaca basi segera alih-alih membaca sampah "
 "masuk akal."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT`  sekarang benar-benar berjalan."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -78915,7 +79937,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -78931,7 +79953,7 @@ msgstr ""
 "pisahkan. `scripts/gc_schedule_fuzz.sh <binary> [seed-count]` menyapu benih "
 "dan mencetak perintah reproduksi per kegagalan."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -78946,7 +79968,7 @@ msgstr ""
 "Mengubah api adalah satu-satunya cara murah untuk menjelajahi ruang tempat "
 "bug hidup."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -78959,7 +79981,7 @@ msgstr ""
 "dereferenced. **Gunakan 800.** Perjalanan bersih pada kedalaman default "
 "tidak berarti apa-apa."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -78987,7 +80009,7 @@ msgstr ""
 "setuju dengan static checker, lihat checker pertama. Itulah bagaimana "
 "perbedaan pendapat zod `clone` diselesaikan."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -78999,7 +80021,7 @@ msgstr ""
 "memiliki register  nilai biasanya tiba sebagai argumen dari penelepon yang "
 "membiarkannya menjadi basi."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -79011,11 +80033,11 @@ msgstr ""
 "setiap probe runtime untuk melihat. Instrumen ini menangkap _konsekuensi_, "
 "kemudian. Pengontrol statis menangkap penyebabnya, sekarang."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "Gambar cermin: penghalang menulis yang hilang (# 8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -79027,43 +80049,43 @@ msgstr ""
 "mengatakan tentang**. Keduanya adalah dualis, dan ini adalah bagian yang "
 "terus menangkap orang **Detektor mereka diganti**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "serangga berakar"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted penghalang menulis"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "apa yang salah"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "nilai hidup tidak terlihat untuk pemindaian akar"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "sebuah tepi old→young tidak ada di dalam set yang diingat"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "ketika terjadi kesalahan"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "di pengumpulan, diam-diam"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "tidak di toko sama sekali; di beberapa _later_ minor"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "detektor"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -79072,30 +80094,30 @@ msgstr ""
 "instrumen runtime (`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_PROTECT_FROMSPACE`), "
 "ditambah penguji statis untuk IR-visible half"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **pernyataan IR statis**, dan tidak ada yang lain"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "titik buta"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "Pemeriksa statis tidak dapat melihat cache sisi runtime dari penunjuk heap "
 "(lihat §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**setiap probe runtime yang kita miliki**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "Mengapa tidak ada probe runtime bisa melihatnya"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -79109,17 +80131,17 @@ msgstr ""
 "lengkap_. Mengubahnya menjadi kegagalan yang dapat diamati membutuhkan "
 "konjungsi yang harus disediakan oleh program itu sendiri:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "orang tua harus bertahan sampai tua-gen (atau tetap) **Sebelumnya** toko;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "anak harus masih berada di kamar bayi **pada minor berikutnya**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -79127,7 +80149,7 @@ msgstr ""
 "a **kecil** koleksi  tidak penuh tanda-sweep, yang menyusul segala sesuatu "
 "dan kertas di seluruh kelas  harus mendarat di jendela itu; dan"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -79135,7 +80157,7 @@ msgstr ""
 "bahwa tepi harus menjadi _only_ jalur ke anak, atau beberapa akar lain "
 "menemukannya pula dan koleksi bersih."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -79144,7 +80166,7 @@ msgstr ""
 "mencetak jawaban yang benar, dan probe melaporkan keberhasilan. Tidak ada "
 "yang dicoba."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -79154,7 +80176,7 @@ msgstr ""
 "ditujukan untuk properti yang sama sekali berbeda, dan mudah untuk membaca "
 "hijau mereka sebagai bukti:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -79168,7 +80190,7 @@ msgstr ""
 "slot yang gagal ditulis ulang. Mengingat dan menulis ulang adalah sifat yang "
 "berbeda, dan verifier hanya bertanya tentang yang kedua."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -79180,7 +80202,7 @@ msgstr ""
 "bug tidak dapat dicapai. Jalan hijau di sini adalah bukti yang paling kuat "
 "dan paling kosong dari ketiga."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -79192,7 +80214,7 @@ msgstr ""
 "sisi rooting dualitas. Mereka salah pada penunjuk yang tergantung dari ruang "
 "angkasa, bukan pada benda hidup yang tidak pernah dilacak."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -79207,7 +80229,7 @@ msgstr ""
 "Setiap nama dalam dokumen ini adalah salah satu gerbang telah dikonfirmasi "
 "parser hidup memiliki."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -79219,7 +80241,7 @@ msgstr ""
 "tidak dapat diamati dengan menjalankan program.** Tidak ada eksekusi di mana "
 "\"penghalang tidak berjalan\" adalah peristiwa yang berbeda."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -79239,11 +80261,11 @@ msgstr ""
 "baik pada perlengkapan celah dan yang lebih besar kontradiksi. Tes IR statis "
 "adalah satu-satunya hal yang mengatakan tidak."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "Apa PR yang menambahkan atau memindahkan toko di slot GC berhutang"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -79253,7 +80275,7 @@ msgstr ""
 "hal yang harus ditempel, masing-masing karena sabotase yang melewatinya "
 "tidak tertangkap:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -79263,7 +80285,7 @@ msgstr ""
 "catatan tata letak, dan string addref. Jika salah satu dari tiga yang hilang "
 "adalah # 5094 / # 7511 keluarga diam terdampar."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -79277,7 +80299,7 @@ msgstr ""
 "**IR mati** bahwa setiap pernyataan konten dengan senang hati diperiksa, dan "
 "awalnya lulus. Kehadiran kode bukanlah bukti bahwa itu berjalan."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -79287,7 +80309,7 @@ msgstr ""
 "pembukuan. Penghalang yang bocor ke dalamnya berarti diskriminator berhenti "
 "mendiskriminasi, dan \"optimasi\" tidak mengukur apa pun."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -79297,9 +80319,10 @@ msgstr ""
 "dan catat bahwa tes menjadi merah. Sebuah tes yang tidak pernah gagal adalah "
 "tes yang mode kegagalan tidak diketahui."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -79316,35 +80339,26 @@ msgstr ""
 "class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` dan "
 "`write_pic_barrier_tests.rs` adalah bentuk."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr ""
 "Penanda `GC_STORE_AUDIT`, dan apa yang ia lakukan dan tidak membuktikan"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Setiap situs toko yang relevan dengan GC mentah membawa tanda di dekatnya "
 "yang menyebut putusan:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "// GC_STORE_AUDIT(BARRIERED): slot menulis tidak bersyarat; penghalang"
-
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// di bawah ini hanya dijaga oleh tes hidup bahwa bit yang disimpan tidak "
-"membawa tumpukan"
 
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// pointer, yang merupakan tes pertama dari penghalang itu sendiri."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -79357,7 +80371,7 @@ msgstr ""
 "sehingga **baru** situs toko tidak bisa mendarat dengan pertanyaan tidak "
 "terjawab."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -79365,7 +80379,7 @@ msgstr ""
 "Karena #8185 mendarat di paruh kedua, naskah verifikasi **klaim**, bukan "
 "hanya komentar, untuk dua kelas di mana klaim palsu untaian objek:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -79406,7 +80420,7 @@ msgstr ""
 "memindahkan panggilan keluar bloknya, melewati gerbang) berjalan di suite "
 "terhadap setiap batang."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -79433,7 +80447,7 @@ msgstr ""
 "satu panggilan penghalang dalam fungsi yang sama masih melewati), dan skrip "
 "mencetak batas itu."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -79456,11 +80470,11 @@ msgstr ""
 "`gc_rekeyed_key_tables.py`), dan `--self-test` tanaman lima belas bentuk, "
 "yang masing-masing harus dinilai."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "Masalah corpus, dan dua corpora (# 7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -79469,7 +80483,7 @@ msgstr ""
 "skala ketergantungan, dan untuk sementara waktu tidak ada yang bisa "
 "mengatakan, karena itu hijau.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -79484,7 +80498,7 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. # 7280 menempatkan dalam satu "
 "kalimat: _25 kurasi file melewati sementara 20 baris stok zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -79492,39 +80506,39 @@ msgstr ""
 "Itu bukan masalah ukuran. Kedua corpora diukur pada compiler yang sama "
 "dengan `--stale-registers --moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "penggunaan usang"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "apa yang mendominasi"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "dikuratori, 124 sumber / 144 modul"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "jendela property-GET helper, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "skala ketergantungan, 81 modul / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -79532,7 +80546,7 @@ msgstr ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -79549,7 +80563,7 @@ msgstr ""
 "berakar hidup dalam bentuk**, jadi corpus tanpa bentuk tidak bisa "
 "mengekspresikannya berapa banyak file yang ada."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -79557,11 +80571,12 @@ msgstr ""
 "Jadi ada corpus kedua, yang dihasilkan dari ketergantungan npm nyata "
 "daripada dari apa pun yang ditulis untuk kesempatan:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod adalah package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -79575,7 +80590,7 @@ msgstr ""
 "adalah cek ukuran lantai tidak bisa, karena ~ 90 modul `zod` rawa apapun "
 "menghitung sumber 40 baris yang hilang akan melintasi."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -79587,11 +80602,11 @@ msgstr ""
 "dalam jumlah instruksi. Anggaran `--stale-registers` adalah yang mahal (~ 5 "
 "menit): pemindainya superlinear, dan 62 MB adalah 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "Gerbang CI"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -79603,19 +80618,19 @@ msgstr ""
 "compiler build; dua pemeriksaan gerbang adalah sekitar tiga detik masing-"
 "masing lebih dari ~ 2000 dan ~ 12900 fungsi."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "Hal ini dibangun untuk dapat gagal, terhadap semua empat bahaya di CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "status keluar penguji adalah pekerjaan  tidak ada `continue-on-error`, tidak "
 "ada pipa;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -79623,7 +80638,7 @@ msgstr ""
 "`concurrency` hanya membatalkan pull-request run, jadi `main` run tidak "
 "pernah kelaparan;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -79633,7 +80648,7 @@ msgstr ""
 "corpus terlalu tipis untuk melakukan apa pun, dan berjalan mencetak `checked "
 "N functions / M modules` sehingga berjalan diam-kosong terlihat;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -79645,7 +80660,7 @@ msgstr ""
 "IR dan membutuhkan semua 40 untuk dilaporkan  yaitu lengan yang menangkap "
 "checker diam-diam kehilangan kemampuan untuk membaca output Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -79661,11 +80676,11 @@ msgstr ""
 "instan dan keduanya telah mengirim entri mati: sembilan di `ALLOC_RE` di dua "
 "putaran, sepuluh di `POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "Daftar izin, dan mengapa itu bukan nomor"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -79675,7 +80690,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, satu entri masing-masing dengan sidik "
 "jari, masalah, dan pembenaran tertulis."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -79688,11 +80703,11 @@ msgstr ""
 "untuk green a build merah adalah untuk meningkatkan jumlah dengan satu, dan "
 "tidak ada dalam perbedaan mengatakan apa yang kebobolan."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Jadi checker memberlakukan tiga properti:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -79703,7 +80718,7 @@ msgstr ""
 "mengapa bug tetap tidak bisa meninggalkan batu nisan yang diam-diam "
 "memperluas cakupan nanti."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -79711,13 +80726,13 @@ msgstr ""
 "**suatu entri paling banyak menghapus `count`.** Pelanggaran kedua dari "
 "bentuk yang sama dalam fungsi yang sama adalah baru, dan gagal."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**pelanggaran tanpa masuk gagal**, tidak peduli berapa banyak entri yang ada."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -79725,11 +80740,11 @@ msgstr ""
 "Menambahkan entri adalah acara review kode. Menggemparkan `count` untuk "
 "membuat build hijau adalah hal yang tepat file ini ada untuk mencegah."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Mempromosikan gerbang ini"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -79738,11 +80753,11 @@ msgstr ""
 "pemeriksaan wajib perlindungan branch**, yang berarti job itu tidak dapat "
 "membuat merge gagal — bahaya 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Kedua kondisi # 7198 yang disebutkan sekarang terpenuhi:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -79752,7 +80767,7 @@ msgstr ""
 "**kosong** allowlist (posisi #7211 dihapus ketika predikat itu ditetapkan "
 "dalam \\#7226);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -79763,7 +80778,7 @@ msgstr ""
 "setelah, dan 0 setelah `Type::Symbol` berhenti diklasifikasikan sebagai "
 "segera."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -79771,7 +80786,7 @@ msgstr ""
 "Jadi langkah yang tersisa adalah untuk **Admin repo** untuk menambahkan `gc-"
 "root-dominance` ke konteks yang diperlukan untuk perlindungan cabang:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -79785,7 +80800,7 @@ msgstr ""
 "dengan langkah `--unrooted-allocas` termasuk  gerbang yang tidak pernah "
 "hijau dalam bentuk saat ini blok setiap PR terbuka pada hari yang dibutuhkan."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -79808,11 +80823,11 @@ msgstr ""
 "promosi yang membekukan anggaran di mana itu telah membeli angka, bukan "
 "invarian."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Aturan praktis"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -79827,7 +80842,7 @@ msgstr ""
 "yang disediakan penulis, tidak pernah tentang panggilan "
 "`js_object_set_field_by_name` yang dikeluarkan sendiri."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -79835,7 +80850,7 @@ msgstr ""
 "**Baca kembali akar setelah setiap titik pengumpulan.** Jangan pernah cache "
 "beban dari root slot selama panggilan. `rooted_handle_get` ada untuk ini."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -79845,7 +80860,7 @@ msgstr ""
 "lebih operand di mana satu termaterialisasi sebelum yang lain diturunkan "
 "membutuhkan yang pertama berakar."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -79853,7 +80868,7 @@ msgstr ""
 "**`--trace llvm` dan membacanya.** Tiga detik dari checker mengalahkan hari "
 "membagi dua `not a function` lima siklus hilir."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -80110,6 +81125,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Jalankan secara lokal dengan:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Validasi Waktu-Kompilasi"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "Pengguna memilih backend per beban kerja"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -80567,7 +81751,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: String -- nama register, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -80606,38 +81791,36 @@ msgid "Three types and one rule."
 msgstr "Tiga jenis dan satu aturan."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 "/// Sebuah register yang memegang nilai yang dikelola GC yang TIDAK berakar."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// Meminjam pemancar tidak berubah. Tidak klon, tidak Copy."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Akar lubang bayangan. Mengungguli titik pengumpulan; tidak bisa dibaca "
 "secara langsung."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// hanya dapat diperoleh dari ShadowFrame:: alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 "/// Sebuah register menyimpan sesuatu yang tidak dikelola GC: i32, ganda, "
 "bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// indeks slot. Bebas dikloning, tidak ada umur, tidak ada pinjaman dari "
-"emitter."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -80648,28 +81831,33 @@ msgstr ""
 "mereka dapat mengumpulkan**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "/// Tidak bisa mengambil. Mengambil &self, sehingga luar biasa `Raw` "
 "pegangan tetap berlaku."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// Dapat mengumpulkan. Mengambil & mut diri, yang mengakhiri setiap "
 "pinjaman `Raw` yang belum dibayarkan."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// Baca ulang slot. Raw yang dikembalikan berlaku sampai & mut berikutnya "
 "dipancarkan."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 "/// Mengkonsumsi daftar ini ke dalam akar. Satu-satunya cara untuk membuat "
 "Rooted."
@@ -80689,24 +81877,22 @@ msgstr ""
 "digunakan di seluruh titik pengumpulan** compiler menolaknya."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_>, meminjam e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// kebutuhan & mut e"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERROR: obj meminjam e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// yang mudah berubah"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// dipinjam di atas"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -80716,7 +81902,8 @@ msgstr ""
 "kesalahan:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// Baca ulang, benar"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -81357,8 +82544,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**Lukis pelarian**, selama setiap penelepon menggunakannya."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -82988,18 +84176,36 @@ msgstr ""
 "`node_modules` mesin build."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Model sidecar ini tidak memiliki penulisan pertama kali, sehingga direktori "
 "instalasi baca saja didukung. Memindahkan executable membutuhkan memindahkan "
 "`.perry-native` saudaranya. File yang hilang atau hash-mismatched gagal "
 "sebelum `dlopen` dengan kesalahan pengemasan."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -83016,7 +84222,7 @@ msgstr ""
 "tidak menghapus atribut karantina dari biner yang tidak dapat diandalkan "
 "saat berjalan."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -83033,11 +84239,11 @@ msgstr ""
 "menyimpan kredensial registri dan resolusi ketergantungan di manajer paket "
 "sementara mencegah host `.node` file dari memasuki artefak target."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Identitas cache"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -83045,31 +84251,31 @@ msgstr ""
 "Kompilasi waktu addon manifesto disortir secara deterministik dan "
 "berkontribusi sebagai berikut untuk membangun dan link cache identitas:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "versi skema kebijakan dan versi Node-API yang diiklankan;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "target tuple dan alollist normal;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "paket name/version yang dipilih dan jalur masuk relatif;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 dan ukuran setiap file muatan sidecar;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "inventaris simbol yang diekspor;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "model pengiriman (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -83083,11 +84289,11 @@ msgstr ""
 "dihasilkan. Perubahan hash sidecar harus melewatkan cache build tingkat atas "
 "bahkan ketika semua file TypeScript dan objek tidak berubah."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -83106,22 +84312,15 @@ msgstr ""
 "resolusi biner, tetapi secara deterministik melaporkan fasilitas yang tidak "
 "didukung yang dinyatakan."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: inti sampai versi 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Titik masuk"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -83129,49 +84328,56 @@ msgstr "Titik masuk"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Penyimpanan yang stabil di lingkungan"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "Nilai singleton menerima pegangan berskala biasa"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Alokator Perry object/array"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -83179,11 +84385,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry Konversi kotak NaN"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -83191,37 +84397,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Berbatas panjang; `NAPI_AUTO_LENGTH` didukung"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "Native callback menggunakan rekaman host"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` diinstal ketika disediakan"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "Termasuk perbedaan fungsi, eksternal, simbol, dan bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -83229,11 +84435,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Periksa perilaku type/status"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -83241,11 +84447,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "Semantik panjang kueri dan NUL termasuk"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -83253,19 +84459,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "Kode pengguna terjebak pengecualian"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Semantik objek umum"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -83273,11 +84479,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "String, simbol, dan kunci numerik"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -83285,11 +84491,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "Nama UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -83297,43 +84503,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Array dan objek terindeks eksotis"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Deskriptor data, metode, dan aksesor"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Tidak ada pintasan identitas pointer"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "Umum Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "Callback-info seumur hidup adalah panggilan asli"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -83341,11 +84547,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Tabel metadata objek asli"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -83353,11 +84559,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Desain referensi kuat dan lemah di atas"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -83367,11 +84573,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Validasi nesting dan generasi yang ketat"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -83379,19 +84585,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Model slot menunggu"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Tersedia sementara menunggu"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -83399,37 +84605,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Pointer pendukung yang stabil"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Semua sebelas jenis array diklasifikasikan"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Identitas pendukung dan offset dipertahankan"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Kembali 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -83437,19 +84643,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "Catatan yang ditangguhkan adalah akar yang dimiliki lingkungan"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -83457,40 +84663,40 @@ msgstr ""
 "Mengembalikan `napi_generic_failure`; eksekusi sumber runtime sewenang-"
 "wenang akan melanggar model mesin no-runtime"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Akuntansi tekanan kolektor"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: versi 5 sampai 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "Antrian setelah finalisasi GC"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -83498,11 +84704,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Keakuratan sewenang-wenang"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -83510,23 +84716,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "`lossless` yang tepat dan perilaku penghitungan kata"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "Mode pengumpulan, filter, dan konversi kunci dihormati"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -83534,46 +84740,46 @@ msgstr ""
 "Satu catatan per lingkungan; penggantian ditimpa tanpa memanggil finalis "
 "sebelumnya"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Penyebaran lepas yang ada"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "Tag 128 bit dalam metadata objek"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Mesin deskriptor Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: versi 9, versi 10, dan eksperimen"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -83581,16 +84787,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "Iklan hanya dengan permukaan versi-9 lengkap"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -83598,11 +84804,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Membutuhkan kerja string eksternal lifetime/accounting"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -83610,29 +84816,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "Versi-10 alias jalur cepat"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "Bukan bagian dari ABI stabil yang diiklankan"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -83640,33 +84846,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Pendaftaran Legacy dan jalur abort"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Integrasi async-hook yang ada"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -83674,11 +84880,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Identitas Perry `Buffer` dan byte stabil"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -83686,15 +84892,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Mesin keadaan eksplisit di atas"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -83702,16 +84908,16 @@ msgstr ""
 "Mengembalikan komponen semver Perry dengan rantai rilis `perry`; tidak "
 "mengklaim rilis Node"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "Mengembalikan `napi_generic_failure` dan loop nol; Perry tidak memiliki libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -83719,19 +84925,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Siklus hidup thread utama"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Konteks asinkron dan nesting ketat"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -83739,11 +84945,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN yang didukung oleh event pump"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -83751,35 +84957,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Jumlah benang dan event-loop keepalive"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "Penutupan menunggu untuk selesai"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "Lingkungan sudah mencatat nilai masa depan"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Iklan dengan versi 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -83788,18 +84994,18 @@ msgstr ""
 "Initializer sisi addon mengekspor `node_api_module_get_api_version_v1` dan "
 "`napi_register_module_v1`; ini dicari di addon dan bukan ekspor host."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Gerbang yang diperlukan"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "Implementasi tidak selesai sampai gerbang di bawah ini dapat secara "
 "independen gagal:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -83811,7 +85017,7 @@ msgstr ""
 "collections; handles yang usang gagal validasi generasi; root-holder dan "
 "rekey-table audit script bersih."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -83821,7 +85027,7 @@ msgstr ""
 "misuse, dan callback TSFN semua kembali melalui C sebelum Perry mengangkat; "
 "addon berinstrumen menegaskan bahwa tidak ada unwind memasuki bingkinya."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -83831,7 +85037,7 @@ msgstr ""
 "yang disebut `napi_*` dan tes membuktikan bahwa alamat milik Perry eksekusi. "
 "Jumlah panggilan asap harus lebih besar dari nol."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -83843,7 +85049,7 @@ msgstr ""
 "finalizers, dan buffer. Versi NAPI yang tidak didukung, perlengkapan NAN/V8, "
 "dan `uv_*` menegaskan diagnostik yang tepat."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -83854,7 +85060,7 @@ msgstr ""
 "aliran gabungan yang identik; kedua belah pihak menegaskan bahwa "
 "implementasi asli mereka benar-benar berjalan."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -83864,7 +85070,7 @@ msgstr ""
 "bisa dibaca dan muat dengan sukses; penghapusan atau mutasi sidecar gagal "
 "dalam pemeriksaan hash manifest."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -83872,7 +85078,7 @@ msgstr ""
 "**Gerbang cache:** mengubah hanya byte addon atau kebijakan melewatkan build "
 "cache; membangun kembali input yang tidak berubah memukulnya."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -83881,7 +85087,7 @@ msgstr ""
 "kosong; melaporkan delta host-only untuk addon build dan menegakkan anggaran "
 "0.6 MB."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -84443,28 +85649,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "Gunakan perintah eksplisit untuk ruang lingkup yang lebih luas:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Produk feedback loop"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Setiap anggota ruang kerja yang kompatibel dengan host (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$ paket\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Memeriksa atau memvalidasi arsitektur ruang kerja"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -84618,7 +85810,8 @@ msgstr ""
 "teks."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# Membangun produk default dan penutupan ketergantungan"
 
 #: src/contributing/building.md:37
@@ -84741,7 +85934,8 @@ msgstr ""
 "lingkungan pengguna Anda, kemudian menjalankan Cargo melalui bungkus:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# CLI pengembang yang ramping dan dioptimalkan"
 
 #: src/contributing/building.md:80
@@ -84775,25 +85969,30 @@ msgid "Build Specific Crates"
 msgstr "Bangun Crate Tertentu"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# Runtime saja (harus membangun kembali stdlib juga!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Arsip statis dipancarkan oleh kotak bungkus terpisah (# 5422), sehingga"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# secara eksplisit ketika Anda perlu libperry_runtime.a / libperry_stdlib.a "
 "(e.g. untuk link"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Hanya Codegen"
 
 #: src/contributing/building.md:106
@@ -84839,17 +86038,21 @@ msgid "Run Tests"
 msgstr "Jalankan Tes"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Target unit produk"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Periksa ruang lingkup tes CI setiap malam (semua peti tes yang kompatibel "
 "dengan Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Kotak khusus"
 
 #: src/contributing/building.md:137
@@ -84857,11 +86060,13 @@ msgid "Compile and Run TypeScript"
 msgstr "Kompilasi dan Jalankan TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Membuat file TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Debug: cetak HIR"
 
 #: src/contributing/building.md:148
@@ -84929,19 +86134,23 @@ msgstr ""
 "shasum registri publik berbeda."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Mengkonfirmasi checkout adalah saat ini dan bersih."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# harus mencetak 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# Jangan cetak apa-apa"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Kebijakan cepat dan pemeriksaan naskah."
 
 #: src/contributing/releasing.md:23
@@ -84949,7 +86158,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Pemeriksaan perilaku yang dapat dijalankan oleh host. Ini meningkatkan "
 "turnaround, tetapi tidak"
@@ -84974,7 +86185,8 @@ msgstr ""
 "mendaratkan versi baru ke dalam proses penggabungan normal terlebih dahulu."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Ganti versi yang sudah ada di Cargo.toml."
 
 #: src/contributing/releasing.md:48
@@ -84994,7 +86206,8 @@ msgid "'[0-9]*.md'"
 msgstr "[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # harus mencetak apa-apa"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -85101,9 +86314,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "tindakan yang diizinkan: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -85135,22 +86349,15 @@ msgstr ""
 "Saluran pelepasan sengaja menolak set parsial."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# satu Release Packages run: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # menerbitkan + memverifikasi semua 9 melalui "
-"OIDC, kemudian membuat"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub Rilis terakhir"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# Periksa tanda terima commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -85367,11 +86574,13 @@ msgstr ""
 "dengan `xcrun simctl` untuk memverifikasi contoh doc berjalan tanpa manusia:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# Mengkompilasi untuk simulator"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# Boot perangkat (satu kali; gunakan kembali UDID di seluruh jalan)"
 
 #: src/contributing/releasing.md:178
@@ -85379,22 +86588,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Menginstal + meluncurkan dengan mode uji"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# Aplikasi keluar 0 setelah rendering; tangkapan layar mendarat di counter-"
-"ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -85666,6 +86862,10 @@ msgid "patch distance"
 msgstr "Jarak patch"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -85700,15 +86900,18 @@ msgstr ""
 "sendiri setelah registri telah mengejar."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# membuktikan itu bisa gagal"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# Daftar nyata, tidak ada masalah menulis"
 
 #: src/contributing/releasing.md:289
@@ -85765,6 +86968,371 @@ msgstr ""
 "Untuk mencoba lagi bagian distribusi paket rilis lama, kirimkan dengan "
 "`existing_tag=vX.Y.Z`; tambahkan `publish_npm=true` hanya ketika bagian npm "
 "yang idempotent itu sendiri juga perlu dicoba lagi."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# Mengedit src/lib.rs  menambahkan fungsi `js_*` Anda, semua menggunakan "
+#~ "hanya"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# Edit src/index.ts  menyatakan kode pengguna permukaan TS impor"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# Edit package.json  daftar setiap js_* ekspor di"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ manifest cocok dengan staticlib"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# Scaffolded release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # Membangun prebuilds untuk semua "
+#~ "target"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr ""
+#~ "                                    # dan mengikat mereka dengan pelepasan"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Pengikat asli untuk <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  ekstrak teks dari buffer PDF."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # Keamanan"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` harus null atau valid untuk `buf_len` byte. Perry lulus"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// pasangan ini dari `buffer+len` manifest parameter."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const hasil = menunggu spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding dan Insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 slice (target perangkat default)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. selaraskan minos + sekering"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"platform;android-35\" \"build-tools;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"Sistem-gambar;android-34;android-pakai;arm64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Target silang Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Membuat + boot emulator Wear OS (round watch)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Paket npm tambahan dan API Node.js yang didukung oleh Perry. Semua yang "
+#~ "terdaftar di sini terhubung melalui registry binding native well-known "
+#~ "Perry (#466) dan dikompilasi menjadi kode native tanpa keterlibatan "
+#~ "runtime JavaScript."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr "# 3) Periksa tanda tangan secara lokal sebelum mengunggah manifest"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    di sini memprediksi melewati verifikasi pada klien."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Rilis CI tanda tangan CLI manifesto, mengikat arsip URL, platform,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// mendeteksi target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos "
+#~ "SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// Kompilasi: swiftc -emit-library -static -target ... -sdk ... "
+#~ "-framework StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// Link: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"Tipe konten: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "'{\"teks\":\"halo dunia\"}'"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"nilai\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "'{\"nilai\":42}'"
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "'{\"jalur pintas\":\"s\"}'"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IPnya:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Biarkan berjalan selama 30 detik"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Periksa statistik"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"berjalan\": benar, \"events_fired\": 600, \"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Ambil tangkapan layar untuk melihat keadaan akhir"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Hentikan kekacauan"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Periksa aplikasi masih hidup"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Build untuk iOS (cross-compile)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "Pekerjaan | select(.status==\"in_progress\") | (label)|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# Seberapa dalam antrean, dan di kolam mana:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "Pekerjaan | select(.status==\"queued\") | (label)|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"Native binding untuk libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\"'"
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Kapal Perry **dua saluran opt-in independen** untuk mengirim data pulang  "
+#~ "tidak ada yang meninggalkan mesin Anda tanpa `enabled = true` atau `on` "
+#~ "eksplisit di `~/.perry/config.toml`. Keduanya menghormati "
+#~ "`PERRY_NO_TELEMETRY=1` dan `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "memancarkan diagnostik kolektor yang dapat dibaca manusia"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# NATIVE (PERRY_RS4GC=1): default di tempat lain. Anchor di atas"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` alokasi root dan LLVM menyisipkan safepoints "
+#~ "kemudian, sehingga"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): slot menulis tidak bersyarat; penghalang"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// di bawah ini hanya dijaga oleh tes hidup bahwa bit yang disimpan tidak "
+#~ "membawa tumpukan"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// pointer, yang merupakan tes pertama dari penghalang itu sendiri."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// Meminjam pemancar tidak berubah. Tidak klon, tidak Copy."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// indeks slot. Bebas dikloning, tidak ada umur, tidak ada pinjaman dari "
+#~ "emitter."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERROR: obj meminjam e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// yang mudah berubah"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// dipinjam di atas"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$ paket\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Memeriksa atau memvalidasi arsitektur ruang kerja"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# satu Release Packages run: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # menerbitkan + memverifikasi semua 9 melalui "
+#~ "OIDC, kemudian membuat"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub Rilis terakhir"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# Aplikasi keluar 0 setelah rendering; tangkapan layar mendarat di "
+#~ "counter-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -86816,9 +88384,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "Variabel env `LANG` / `LC_ALL` / `LC_MESSAGES`"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Validasi Waktu-Kompilasi"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr "Perry memvalidasi parameter di seluruh locale selama kompilasi:"
 
@@ -86920,13 +88485,6 @@ msgstr ""
 
 #~ msgid "`SKStoreReviewController.requestReview()`"
 #~ msgstr "`SKStoreReviewController.requestReview()`"
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# Contoh GitHub Actions\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "Hanya hasilkan file object, lewati linking"

--- a/docs/po/it.po
+++ b/docs/po/it.po
@@ -214,7 +214,7 @@ msgstr "Hook"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Esempi"
 
@@ -571,139 +571,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "Livelli CI (controllo PR / sweep / suite completa)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Pianificazione dei controlli CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "Riferimento CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Comandi"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Flag del compilatore"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Directory della cache"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dispatch Dinamico della Stdlib"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "Abilitazione del Runtime JS"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar di attestazione binaria)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Allowlist di Uscita (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Capabilities per Pacchetto (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Allowlist Host (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "Riferimento perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Controlli degli aggiornamenti nelle tue app"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Privacy e telemetria"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Internals"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Modello di Memoria"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Garbage collector"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Gestione esplicita della memoria"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "L’invariante di rooting del GC (generazione del codice)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Evidenze di tipo per i binding locali"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Limiti dei passi del GC incrementale"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: rooting per costruzione"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Contribuire"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Architettura"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Criteri per i crate"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Compilazione dai sorgenti"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Pubblicare una versione di Perry"
 
@@ -935,7 +943,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Apre una finestra macOS/Windows/Linux nativa"
 
 #: src/introduction.md:79
@@ -969,11 +978,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -982,9 +991,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -994,7 +1003,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Prossimi passi"
@@ -1067,27 +1076,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux linker toolchain per distribuzione:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Stream Fedora / RHEL / CentOS"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# Alpino / musl-based"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Void Linux"
 
 #: src/getting-started/installation.md:41
@@ -1129,15 +1144,18 @@ msgstr ""
 "unico comando:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Project-local (la versione di Perry insieme ai tuoi deps)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Zero-installa, un colpo solo"
 
 #: src/getting-started/installation.md:66
@@ -1335,7 +1353,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "Il binario si trova in `target/release/perry`. Aggiungilo al tuo PATH:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Aggiungi a ~/.zshrc o ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1474,16 +1493,14 @@ msgstr ""
 "richiedono.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2170,24 +2187,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "Lo stesso codice viene eseguito su tutte e 6 le piattaforme:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (default)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# Simulatore iOS"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# Web (compila WebAssembly + bridge DOM in un file HTML autonomo)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# alias: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Altre piattaforme"
 
 #: src/getting-started/first-app.md:138
@@ -2430,7 +2452,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2448,7 +2470,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2674,7 +2696,8 @@ msgstr ""
 "emette lo stesso validatore come sorgente semplice. Lo script generatore:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2706,7 +2729,8 @@ msgid "\"port\""
 msgstr "\"porto\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// fonte autonoma"
 
 #: src/getting-started/project-config.md:122
@@ -2953,19 +2977,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Campo"
 
@@ -2980,9 +3005,9 @@ msgstr "Campo"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3104,11 +3129,13 @@ msgstr ""
 "configurazione:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3163,7 +3190,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3172,7 +3199,7 @@ msgstr ""
 "integrate di Perry. Vedi [Libreria Standard](../stdlib/overview.md) per "
 "l'elenco completo."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3181,46 +3208,49 @@ msgstr ""
 "pacchetti TS/JS puri, oppure il fallback al runtime JavaScript per pacchetti "
 "complessi."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Struttura del progetto"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr ""
 "Perry è flessibile riguardo alla struttura del progetto. Pattern comuni:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Per le app UI:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Compilazione"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Compila un file"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# Compila con un obiettivo specifico"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Debug: rappresentazione intermedia di stampa"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "Vedi [Comandi CLI](../cli/commands.md) per tutte le opzioni."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 "[Comandi CLI](../cli/commands.md) — Tutti i comandi e i flag del compilatore"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3228,7 +3258,7 @@ msgstr ""
 "[Funzionalità supportate](../language/supported-features.md) — Quali "
 "funzionalità TypeScript funzionano"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Libreria Standard](../stdlib/overview.md) — Pacchetti npm supportati"
 
@@ -3368,32 +3398,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Classi"
 
@@ -5436,6 +5467,7 @@ msgstr ""
 "supporta due percorsi:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5445,7 +5477,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Decorator di classe legacy, decorator di metodo, decorator di proprietà, "
 "decorator di parametri del costruttore e decorator di parametri di metodo** "
@@ -5457,7 +5493,7 @@ msgstr ""
 "`@Reflect.metadata(...)` sono disponibili. Perry emette `design:paramtypes` "
 "per classi/metodi decorati e `design:type` per le proprietà decorate."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5470,15 +5506,15 @@ msgstr ""
 "decorator a runtime. Vedi `crates/perry-hir/src/decorator_log.rs` per "
 "l'implementazione."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Cosa non funziona"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Decorator di accessor e sostituzione del descriptor"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5494,17 +5530,17 @@ msgstr ""
 "che restituiscono classi avvolte necessitano di un port Perry-aware — la "
 "classe abbassata è fissa nell'IR e non può essere sostituita a runtime."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Chiamate helper generiche `Reflect.metadata(...)` al di fuori della sintassi "
 "dei decorator"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` come chiave di metadati"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5512,7 +5548,7 @@ msgstr ""
 "`emitDecoratorMetadata` oltre a `design:paramtypes` per classi/metodi e "
 "`design:type` per le proprietà"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5522,12 +5558,12 @@ msgstr ""
 "canary del costruttore di classe ridotto (`tsyringe`, comportamento completo "
 "dell'iniettore NestJS, iniettore root di Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "Flussi di metadati a runtime di `class-validator`, `type-graphql`, `TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5537,11 +5573,11 @@ msgstr ""
 "ancora il cablaggio esplicito o una trasformazione AOT dedicata, non fare "
 "affidamento sull'intero runtime legacy dei decorator TypeScript."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Pattern raccomandato: costruzione esplicita"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5553,7 +5589,7 @@ msgstr ""
 "programma Go o Rust comporrebbe i servizi, ed è così che i framework TS "
 "senza decoratori (Hono, server tRPC, app Drizzle) funzionano già."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5569,7 +5605,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5579,11 +5615,11 @@ msgstr ""
 "l'ordine di costruzione _è_ il grafo delle dipendenze, ed è verificato dal "
 "compilatore TypeScript."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Ricetta di migrazione: un servizio Angular"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5593,19 +5629,19 @@ msgstr ""
 "rating.service.ts`, ~80 righe), mostrato nella sua forma Angular originale e "
 "portato a Perry."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Prima — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Dopo — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Tre modifiche meccaniche:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5613,7 +5649,7 @@ msgstr ""
 "**Rimuovi `@Injectable`.** Non portava alcuna informazione che la forma "
 "della classe non porti già."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5623,7 +5659,7 @@ msgstr ""
 "maggior parte degli Observable Angular derivati da HTTP è a valore singolo e "
 "si comporta come un Promise. (Per stream a più valori, usa `AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5635,11 +5671,11 @@ msgstr ""
 "parameter properties, ma i campi espliciti risultano più chiari quando la "
 "classe viene istanziata a mano anziché da un container."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Wiring"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5659,7 +5695,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5677,7 +5713,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5687,11 +5723,11 @@ msgstr ""
 "`providedIn: 'root'`, la lookup implicita del container — tutto collassa in "
 "un'unica riga `new RatingService(api)` in `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "E i componenti Angular, i controller NestJS, le entità TypeORM?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5714,11 +5750,11 @@ msgstr ""
 "esplicita equivalente, registrare percorsi o schema come semplici funzioni "
 "chiamate / modulo-livello costanti."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Direzione futura"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6434,12 +6470,13 @@ msgstr ""
 "al momento del link."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Chiamate letterali statiche** (`WebAssembly.instantiate(bytes)` scritto "
@@ -8029,58 +8066,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Creare un binding — il tour in 60 secondi"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"Binding per il rendering PDF\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"\""
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# Modificare src/lib.rs &gt; aggiungi le tue funzioni `js_*`, tutte usando "
-"solo"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr ""
-"# Modifica src/index.ts ® Dichiara le importazioni del codice utente di "
-"superficie TS"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# Modifica l'elenco package.json di JS_* ogni esportazione di js_*"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# Il manifesto combacia con il lib statico"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# il ponteggio release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # costruisce precostruiti per tutti gli "
-"obiettivi"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # e li lega al rilascio"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8477,7 +8469,7 @@ msgstr "Situazione attuale"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8497,7 +8489,7 @@ msgstr "Bundled; rimozione in attesa"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8549,7 +8541,7 @@ msgstr "Bundled; migrazione in attesa"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8609,7 +8601,7 @@ msgstr "Compila il sorgente del pacchetto upstream"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8617,7 +8609,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8625,7 +8617,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8633,7 +8625,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8665,7 +8657,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8673,7 +8665,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8681,7 +8673,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8713,7 +8705,7 @@ msgstr "Bundled; mantenuto"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8721,7 +8713,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8753,7 +8745,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8761,7 +8753,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8769,7 +8761,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8777,7 +8769,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8793,7 +8785,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8801,7 +8793,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8809,7 +8801,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8817,7 +8809,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8841,7 +8833,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8849,7 +8841,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8857,7 +8849,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8865,7 +8857,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8873,7 +8865,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8881,7 +8873,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8889,7 +8881,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8897,7 +8889,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8905,7 +8897,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8913,7 +8905,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8921,7 +8913,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8929,7 +8921,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8984,14 +8976,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr "1. Scaffold"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Collanamenti nativi per <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Questo crea:"
@@ -9023,27 +9007,14 @@ msgstr ""
 "ogni chiamata visibile a TypeScript, usando **solo** i tipi di `perry_ffi`:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string` Testo estratto da un buffer PDF."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # Sicurezza"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr` deve essere nullo o valido per `buf_len` byte. Perry passa"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// questa coppia da un parametro `buffer+len`."
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9180,7 +9151,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"genere\""
 
@@ -9421,7 +9392,8 @@ msgid "In a separate directory:"
 msgstr "In una directory separata:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# o qualsiasi percorso il vostro strumento supporta"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9814,7 +9786,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Event listener (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// puntatori di chiusura, tenuti in vita dallo scanner GC qui sotto"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10259,7 +10232,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... leggere il file, impostare le var, restituire 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10566,8 +10540,8 @@ msgstr "Obbligatorio"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Note"
 
@@ -10625,14 +10599,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -11167,7 +11141,9 @@ msgstr "`\"usize\"`"
 
 #: src/native-libraries/manifest-v1.md:236
 msgid "checked pointer-sized unsigned safe-integer `number`"
-msgstr "`number` intero sicuro senza segno, verificato e delle dimensioni di un puntatore"
+msgstr ""
+"`number` intero sicuro senza segno, verificato e delle dimensioni di un "
+"puntatore"
 
 #: src/native-libraries/manifest-v1.md:237
 #: src/native-libraries/manifest-v1.md:265
@@ -12369,34 +12345,41 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Strumentazione `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Fornitura o urto di un pin a una versione specifica (default: ultima "
 "stabile)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr ""
 "# Fornitura di ogni legame attualmente non applicato al più tardi stabile"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Cancello offline (CI): perni presenti, con scalino, casse esistono. Uscita "
 "1 su qualsiasi"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Advisory: inoltre flag pins il cui upstream ha un nuovo rilascio stabile"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# Materializzare il repo upstream al ref pinned in gitignored upstream/<name>"
 
@@ -12634,15 +12617,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "Per CI che non deve mai sostituire un involucro parziale, impostare:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12799,7 +12782,7 @@ msgstr "Realtà"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12816,7 +12799,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14815,19 +14798,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Confronto con worker_threads di Node.js"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~15 righe, file separato necessario ──────────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14847,14 +14830,12 @@ msgid "/* handle */"
 msgstr "/* maniglia */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr ""
 "// ── Perry: 1 linea ───────────────────────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr ""
-"// risultato di coste = attendere spawn((() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -15068,13 +15049,14 @@ msgid "Mental Model"
 msgstr "Modello Concettuale"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "L'UI di Perry segue lo stesso modello di SwiftUI e Flutter: si compongono "
 "widget nativi tramite contenitori di layout basati su stack (`VStack`, "
@@ -15163,7 +15145,7 @@ msgstr ""
 msgid "Property"
 msgstr "Proprietà"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15611,7 +15593,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15635,7 +15617,7 @@ msgstr ""
 "Il comportamento specifico per piattaforma è indicato nella pagina di "
 "documentazione di ciascun widget."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17263,7 +17245,8 @@ msgid "Double-click handler"
 msgstr "Handler del doppio click"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17325,12 +17308,13 @@ msgstr ""
 "ui/layout/snippets.ts) — la CI lo compila ed esegue su ogni PR."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Gli helper di layout sono funzioni gratuite: `widgetAddChild(parent, "
 "child)`, `stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, "
@@ -17814,7 +17798,7 @@ msgstr "Effetto"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17827,7 +17811,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "I figli si allineano al bordo iniziale (sinistro)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17840,7 +17824,7 @@ msgid "Children centered horizontally"
 msgstr "I figli sono centrati orizzontalmente"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17861,7 +17845,7 @@ msgstr "**Allineamento HStack** (asse trasversale = verticale):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17888,8 +17872,8 @@ msgstr "I figli sono centrati verticalmente"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17943,9 +17927,9 @@ msgstr "Comportamento"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17969,11 +17953,11 @@ msgstr "Tutti i figli ottengono la stessa dimensione"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18176,9 +18160,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stack con padding integrato"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Crea uno stack con padding in una singola chiamata. L'ordine è **top, left, "
 "bottom, right** (stile shorthand CSS), non top/right/bottom/left:"
@@ -18202,11 +18187,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` è la versione "
 "orizzontale equivalente. Equivale a creare uno stack e poi chiamare "
@@ -18496,8 +18482,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18883,6 +18870,7 @@ msgstr ""
 "compiler."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18894,7 +18882,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18922,11 +18909,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Colori"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18942,11 +18929,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Font"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18962,15 +18949,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Usa `\"monospaced\"` per il font monospazio di sistema."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Raggio degli angoli"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18982,21 +18969,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Bordi"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding e inset"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -19006,11 +18993,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Dimensioni"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -19026,11 +19021,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Opacità"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -19042,11 +19037,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Gradiente di sfondo"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -19068,11 +19063,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Dimensione del controllo"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -19084,7 +19079,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -19092,11 +19087,11 @@ msgstr ""
 "**macOS**: Mappa a `NSControl.ControlSize`. Le altre piattaforme potrebbero "
 "interpretarlo diversamente."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltip"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -19108,7 +19103,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -19116,11 +19111,11 @@ msgstr ""
 "**macOS/Windows/Linux**: Tooltip nativi. **iOS/Android**: Tooltip non "
 "supportati. **Web**: Attributo HTML `title`."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Abilitato/Disabilitato"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -19132,11 +19127,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Esempio imperativo completo"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -19156,7 +19152,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19184,10 +19180,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19260,15 +19256,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Composizione degli stili (funzioni helper imperative)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Riduci la ripetizione creando funzioni helper:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19278,11 +19274,11 @@ msgstr ""
 "token in JSON e generare un file di tema tipizzato. Vedi [Theming]"
 "(theming.md) per il flusso di lavoro completo."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Supporto per piattaforma"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19293,7 +19289,7 @@ msgstr ""
 "`crates/perry-ui/src/styling_matrix.rs` e verificata in CI rispetto agli "
 "export di `lib.rs` di ciascun backend ad ogni PR."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19313,15 +19309,15 @@ msgstr ""
 "consultare la matrice in modo che la documentazione non possa defluire "
 "dall'inventario del backend."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — Contenitori di layout"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — Animare le modifiche agli stili"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr ""
 "[Theming](theming.md) — Design token tramite il pacchetto `perry-styling`"
@@ -20666,8 +20662,8 @@ msgstr "Implementazione"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Stato"
 
@@ -24223,7 +24219,7 @@ msgstr ""
 msgid "Options"
 msgstr "Opzioni"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25828,7 +25824,7 @@ msgstr "Equivalenza con ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26552,15 +26548,18 @@ msgid "Cross-Compilation"
 msgstr "Compilazione incrociata"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# Predefinito: compila per la piattaforma corrente"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# Compilare per un obiettivo specifico"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS Android su un orologio"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26776,7 +26775,8 @@ msgid "Building"
 msgstr "Build"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS è l'obiettivo predefinito"
 
 #: src/platforms/macos.md:18
@@ -26881,7 +26881,8 @@ msgid "App Store Distribution"
 msgstr "Distribuzione sull'App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Firma con il certificato App Store"
 
 #: src/platforms/macos.md:60
@@ -26889,7 +26890,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -27020,15 +27022,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "Il modo più semplice per compilare ed eseguire su iOS è `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# Rilevamento automatico device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# Stream live stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Utilizzare il server di generazione Hub Perry"
 
 #: src/platforms/ios.md:40
@@ -27685,7 +27690,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Questo produce un binario ARM64 per hardware Apple TV fisico."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Rilevamento automatico del simulatore Apple TV"
 
 #: src/platforms/tvos.md:39
@@ -28176,11 +28182,13 @@ msgstr ""
 "std` (vedi [Edificio per dispositivo](#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# simulatore (livello 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28291,20 +28299,14 @@ msgstr ""
 "punta `PERRY_RUNTIME_DIR` a loro:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (Serie 9+ / watchOS 26+)"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (serie 4-8 / SE) Opt in con PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28321,7 +28323,7 @@ msgid "Build environment variables"
 msgstr "Genera variabili d'ambiente"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Variabile"
@@ -28443,7 +28445,8 @@ msgstr ""
 "`TypeError` valore-coercizione dereferenced la chiusura come un oggetto."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Rilevamento automatico del simulatore di orologio avviato"
 
 #: src/platforms/watchos.md:126
@@ -29045,36 +29048,13 @@ msgstr ""
 "watchOS 26+, quindi il timbro è cosmetico), poi `lipo` insieme:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 fetta al target di distribuzione condivisa (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 fetta (obiettivo predefinito del dispositivo)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. allineare i minos + fusibile"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -29195,19 +29175,8 @@ msgstr ""
 "ha bisogno della sua **proprio nuovo record di app** in App Store Connect."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Apple Distribution: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -29220,6 +29189,10 @@ msgid ""
 msgstr ""
 "`altool` non può caricare app di orologio (\"non può determinare la "
 "piattaforma\"). Usa trasportatore:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29573,19 +29546,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Configurazione unica (esempio macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (`gradle` di Homebrew può essere 9.x pin 8.x pin "
 "8.x in caso affermativo)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# o qualsiasi Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 "# 2. Puntare l'env al SDK / NDK / JDK 17 (aggiungere il profilo della shell)"
 
@@ -29594,7 +29570,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g. 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -29606,32 +29583,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. Pacchetti SDK + un'immagine Wear OS arm64"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"piattaforma-tools\" \"emulatore\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"piattaforme;android-35\" \"strumenti di costruzione;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"immagini di sistema;android-34;android-wear;arm64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Il target Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Crea + avvia un emulatore Wear OS (orologio rotondo)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29657,7 +29615,8 @@ msgstr ""
 "orologio APK avviene al tempo di esecuzione (sotto)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# Rilevamento automatico di un orologio/emulatore di usura collegato"
 
 #: src/platforms/wearos.md:82
@@ -31665,7 +31624,8 @@ msgstr ""
 "pixel."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# In un altro terminale:"
 
 #: src/platforms/linux.md:82
@@ -31685,7 +31645,8 @@ msgstr ""
 "JavaScript per i widget DOM."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# stesso output di --target wasm"
 
 #: src/platforms/web.md:10
@@ -31764,15 +31725,18 @@ msgstr ""
 "Worker \"gratuitamente\"."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML autonomo (default)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# Stessa cosa"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm binario (nessun wrapper HTML)"
 
 #: src/platforms/wasm.md:21
@@ -32093,11 +32057,13 @@ msgid "Provide them when instantiating:"
 msgstr "Fornirle durante l'istanziazione:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Via __ffiImporta globale (impostato prima dell'avvio)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// O tramite bootPerryWasm secondo argomento"
 
 #: src/platforms/wasm.md:95
@@ -32651,7 +32617,7 @@ msgstr "Stdlib completa"
 msgid "The compiler links only the required runtime components."
 msgstr "Il compiler collega solo i componenti runtime richiesti."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Binding nativi esterni"
 
@@ -32766,7 +32732,7 @@ msgstr "[File System](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Networking](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Database](database.md)"
 
@@ -32991,8 +32957,8 @@ msgstr ""
 "Passa i path dei file attraverso i confini dei thread e riapri i file "
 "all'interno del worker."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Overview](overview.md) — Tutti i moduli della stdlib"
 
@@ -33090,10 +33056,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Supportato su `IncomingMessage`: `.method`, `.url`, `.headers`, "
@@ -33102,10 +33069,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33704,10 +33672,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / Object Storage compatibile S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33723,11 +33717,11 @@ msgstr ""
 "necessarie — verificato contro un presigned URL SigV4 byte per byte con "
 "`bun` (issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33801,78 +33795,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "Lo stesso codice funziona con qualsiasi servizio compatibile S3 — cambia "
 "solo `endPoint`:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Servizio"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (testing)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33889,7 +33883,7 @@ msgstr ""
 "identici a `bun` rispetto a vettori di test fissati e si autenticheranno "
 "correttamente contro S3 reale."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33902,7 +33896,7 @@ msgstr ""
 "#562 — quel percorso si compila ma non è verificato indipendentemente "
 "rispetto a vettori fissati qui."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34547,9 +34541,10 @@ msgstr ""
 "`minBy`, `inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Usa le importazioni con nome: il modulo ricevitore di importazione "
@@ -34764,20 +34759,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Ulteriori pacchetti npm e API Node.js supportati da Perry. Tutti quelli "
-"elencati qui sono collegati tramite il registro dei binding nativi noti di "
-"Perry (#466) e compilano in codice nativo senza alcun coinvolgimento di un "
-"runtime JavaScript."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Elaborazione immagini)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34786,7 +34776,7 @@ msgstr ""
 "conversione di formato e output su buffer/file funzionano tutti "
 "correttamente."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34836,15 +34826,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (Parsing HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Binding nativi tramite `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34862,11 +34852,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (Email)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34906,15 +34896,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Compressione)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Binding nativi tramite `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34932,11 +34922,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Pianificazione di job)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34944,7 +34934,7 @@ msgstr ""
 "Binding nativi tramite `perry-ext-cron` (v0.5.564). Sia il nome del "
 "pacchetto `cron` che `node-cron` vengono instradati allo stesso backend."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34964,11 +34954,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34978,7 +34968,7 @@ msgstr ""
 "dall'infrastruttura ABI in stile [`ethers-rs`](https://github.com/gakonst/"
 "ethers-rs) attraverso le superfici BigInt + Buffer di `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34996,11 +34986,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -35009,7 +34999,7 @@ msgstr ""
 "`EventEmitter` corrisponde a quella di Node.js — `on`, `off`, `once`, "
 "`emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -35027,15 +35017,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Logica di retry)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Binding nativi tramite `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -35057,11 +35047,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Precisione arbitraria)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -35070,7 +35060,7 @@ msgstr ""
 "pacchetto vengono instradati allo stesso backend — sia `Decimal` che "
 "`BigNumber` sono esposti."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -35106,11 +35096,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Manipolazione delle date)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -35119,7 +35109,7 @@ msgstr ""
 "pacchetto vengono instradati allo stesso backend Rust — stessa superficie di "
 "parse/format/diff."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -35137,11 +35127,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Date legacy)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -35151,7 +35141,7 @@ msgstr ""
 "di manutenzione upstream — preferisci `dayjs` per il nuovo codice, ma Perry "
 "supporta entrambi per le codebase esistenti."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -35167,11 +35157,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -35179,7 +35169,7 @@ msgstr ""
 "Binding nativi tramite `perry-ext-ratelimit` (v0.5.552). Il limiter in-"
 "memory è collegato; i backing store Redis / cluster sono sviluppi futuri."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -35203,11 +35193,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -35226,7 +35216,7 @@ msgstr ""
 "`perry/thread` rimangono l'interfaccia più semplice (vedere [Threading](../"
 "threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -35264,14 +35254,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Gli URL del modulo Web Worker vengono scoperti rispetto al file sorgente di "
 "importazione:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -35304,10 +35294,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (parsing della CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35349,11 +35512,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35375,7 +35538,7 @@ msgstr ""
 "`updateAgeOnGet` e `peek`; `maxSize`/`sizeCalculation`, `dispose`, `fetch`, "
 "`allowStale` e la superficie dell'iteratore non sono ancora implementate."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35405,11 +35568,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35459,11 +35622,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35478,7 +35641,7 @@ msgstr ""
 "Linux); su altri host `spawn` lancia, che innesca i percorsi di ripiego non-"
 "pty dei consumatori."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35490,7 +35653,7 @@ msgstr ""
 "numerico per una morte del segnale e `undefined` altrimenti; `kill()` di "
 "default a `SIGHUP` come nodo-pty. `TERM` nel bambino proviene da `name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35536,11 +35699,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35557,7 +35720,7 @@ msgstr ""
 "compilazione. Il comportamento è stato controllato con `@parcel/watcher` "
 "2.5.1."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35578,7 +35741,7 @@ msgstr ""
 "il nuovo percorso. Backend Le notifiche overflow/rescan attivano una nuova "
 "istantanea ad albero ed emettono il suo diff."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35598,7 +35761,7 @@ msgstr ""
 "`getEventsSince` utilizzano la stessa semantica di snapshot come recupero di "
 "overflow."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35608,7 +35771,7 @@ msgstr ""
 "vengono importati tramite `bun add` come qualsiasi pacchetto npm, ma "
 "supportati da Rust e compilati nativamente tramite `perry-ffi`:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35616,7 +35779,7 @@ msgstr ""
 "**`@perryts/tursodb`** — client di database Turso (fork libSQL). Vedi "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35624,11 +35787,11 @@ msgstr ""
 "**`@perryts/iroh`** — networking peer-to-peer Iroh. Vedi [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "Driver Pure-TypeScript compilati tramite `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35638,7 +35801,7 @@ msgstr ""
 "**`@perryts/redis`** — client a protocollo wire che funzionano anche su "
 "Node.js e Bun senza modifiche."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35646,11 +35809,11 @@ msgstr ""
 "Vedi [Binding Nativi — Panoramica](../native-libraries/overview.md) per il "
 "contratto che questi pacchetti esterni seguono."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[File System](fs.md) — API fs e path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[Binding Nativi](../native-libraries/overview.md) — Crearne di propri"
 
@@ -35674,7 +35837,8 @@ msgstr ""
 "runtime sul target scelto."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Totale: 3019 voci su 138 moduli."
 
 #: src/api/reference.md:9
@@ -35771,4833 +35935,4980 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Metodi"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — modulo"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Proprietà"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "Modulo `__nativeEventCount`"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "Modulo `getEventsSince`"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — modulo"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — modulo"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "Modulo `writeSnapshot`"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — modulo"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — modulo"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — modulo"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — modulo"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — modulo"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — istanza"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — istanza"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — istanza"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — istanza"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — istanza"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — istanza"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — istanza"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — modulo"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — modulo"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — modulo"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — modulo"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — modulo"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — modulo"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — modulo"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — modulo"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — modulo"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — modulo"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — modulo"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — modulo"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — modulo"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — modulo"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — modulo"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — modulo"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — modulo"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — modulo"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — modulo"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — modulo"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — modulo"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "Modulo `throws`"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — istanza _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — modulo _(classe: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — modulo _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — istanza _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — modulo"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — istanza"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — istanza _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — istanza _(classe: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — istanza"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — modulo"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — modulo"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — istanza"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — istanza"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — istanza"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — istanza _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — modulo _(classe: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — modulo"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — istanza _(classe: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — modulo"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — modulo"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — modulo"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — modulo"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — modulo"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — modulo"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — modulo"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — modulo"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — modulo"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — modulo"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — modulo"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — istanza"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — istanza"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — istanza"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — istanza"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — istanza"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — istanza"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — istanza"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — istanza"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — istanza"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — istanza"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — istanza"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — modulo"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — modulo"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — modulo"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — modulo"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — modulo"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — modulo"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Trasferimento"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "Modulo `Glob`"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — modulo"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — modulo"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — modulo"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — modulo"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — modulo"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — modulo"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "Modulo `file`"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — modulo"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — modulo"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — modulo"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — modulo"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — modulo"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — istanza _(classe: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — istanza _(classe: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — modulo"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "Modulo `stringWidth`"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — modulo"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — istanza _(classe: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction` istanza di zecca _(classe: `Database`)_"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "Modulo `unsupported`"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — modulo"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — modulo"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — modulo"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — modulo"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — modulo"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "Modulo `CFunction`"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "Modulo `CString`"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "Modulo `JSCallback`"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — modulo"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "Modulo `linkSymbols`"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "Modulo `ptr`"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "Modulo `toArrayBuffer`"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "Modulo `toBuffer`"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "Modulo `viewSource`"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — modulo"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "Modulo `Database`"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction` istanza di zecca _(classe: `Database`)_"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values` istanza di zecca _(classe: `Statement`)_"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — istanza"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — istanza"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — istanza"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — istanza"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — istanza"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — istanza"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — istanza"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — istanza"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — istanza"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — modulo"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — istanza"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — istanza"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — istanza"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — modulo"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — modulo"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — modulo"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — modulo"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — modulo"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — modulo"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — modulo"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — modulo"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — modulo"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — modulo"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — istanza"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "istanza di `args`"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "istanza di `argument`"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — istanza"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — istanza"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — istanza"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — istanza"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — istanza"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — istanza"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — istanza"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — istanza"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — modulo"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — modulo"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — modulo"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — modulo"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — modulo"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — modulo"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — modulo"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — modulo"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — modulo"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — modulo"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — modulo"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — modulo"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — modulo"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — modulo"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — modulo"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — modulo"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — modulo"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — modulo"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — modulo"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — modulo"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — modulo"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — modulo"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — modulo"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — modulo"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — modulo"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — istanza"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — istanza"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — modulo"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — istanza"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — istanza"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — modulo"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — modulo"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — modulo"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — modulo"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — modulo"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — modulo"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — modulo"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — modulo"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — modulo"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — modulo"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — modulo"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — modulo"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — modulo"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — modulo"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — modulo"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — modulo"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — modulo"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — modulo"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — modulo"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — modulo"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — modulo"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — modulo"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — modulo"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — modulo"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — modulo"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — modulo"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — modulo"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — modulo"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — modulo"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — modulo"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — modulo"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — modulo"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — modulo"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — modulo"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — modulo"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — modulo"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — modulo"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — modulo"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — modulo"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — modulo"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — modulo"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — modulo"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — modulo"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — modulo"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — modulo"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — modulo"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — modulo"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — modulo"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — modulo"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — modulo"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — modulo"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — modulo"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — modulo"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — modulo"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — modulo"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — modulo"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — modulo"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — modulo"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — modulo"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — modulo"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — modulo"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — modulo"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — modulo"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — modulo"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — modulo"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — modulo"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — modulo"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — modulo"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — istanza"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — istanza"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — istanza"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — istanza"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — modulo"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — istanza"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — istanza"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — istanza"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — istanza"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — istanza"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — istanza"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — istanza"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — istanza"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — istanza"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — istanza"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — istanza"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — istanza"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — istanza"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — istanza"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — istanza"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — istanza"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — istanza"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — istanza"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — istanza"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — istanza"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — istanza"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — istanza"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — istanza"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — istanza"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — istanza"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — istanza"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — istanza"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — istanza"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — istanza"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — istanza"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — istanza"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — istanza"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — istanza"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — istanza"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — istanza"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — istanza"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — istanza"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — istanza"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — istanza"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — istanza"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — istanza"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — modulo"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — modulo"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — modulo"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — modulo"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — modulo"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — modulo"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — modulo"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — modulo"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — modulo"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — modulo"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — modulo"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — modulo"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — modulo"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — modulo"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — modulo"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — modulo"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — modulo"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — modulo"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — modulo"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — modulo"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — modulo"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — modulo"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — modulo"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — modulo"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — modulo"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — modulo"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — modulo"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — modulo"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — istanza _(classe: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — modulo"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — istanza"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — istanza"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — modulo"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — istanza"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — istanza"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — istanza"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — istanza"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — istanza"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — modulo"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — modulo"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — modulo _(classe: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — modulo"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — modulo"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — modulo"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — modulo"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — modulo"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — modulo"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — modulo"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — modulo"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — istanza _(classe: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — istanza _(classe: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — istanza"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — istanza _(classe: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — istanza"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — modulo"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — istanza"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — modulo"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — modulo"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — istanza"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — modulo"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — istanza"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — istanza"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — modulo"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — istanza"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — modulo"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — istanza"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — istanza"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — istanza"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — istanza"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — istanza"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — istanza"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — modulo"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — istanza _(classe: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — modulo"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — istanza"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — istanza"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — istanza"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — istanza"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — istanza"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — istanza"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — istanza"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — istanza"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — istanza"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — istanza"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — istanza"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — istanza"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — istanza"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — istanza"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — istanza"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — istanza"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — istanza"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — istanza"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — istanza"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — istanza"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — istanza"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — istanza"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — istanza"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — istanza"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — istanza"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — istanza"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — istanza"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — istanza"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "Modulo `getRawPointer`"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "Modulo `toString`"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — modulo"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — modulo"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — modulo"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — modulo"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — modulo"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — modulo"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — modulo"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — modulo"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — modulo"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — modulo"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — modulo"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — modulo"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — modulo"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — modulo"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — modulo"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — modulo"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — modulo"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — modulo"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — modulo"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — modulo"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — modulo"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — modulo"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — modulo"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — modulo"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — modulo"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — modulo"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — modulo"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — modulo"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — modulo"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — modulo"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — modulo"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — modulo"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — modulo"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — modulo"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — modulo"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — modulo"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — modulo"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — modulo"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — modulo"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — modulo"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — modulo"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — modulo"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — modulo"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — modulo"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — modulo"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — modulo"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — modulo"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — modulo"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — modulo"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — modulo"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — modulo"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — modulo"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — modulo"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — modulo"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — modulo"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — modulo"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — modulo"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — modulo"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — modulo"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — modulo"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — modulo"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — modulo"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — modulo"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — modulo"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — modulo"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — modulo"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — modulo"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — modulo"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — modulo"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — modulo"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — modulo"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — modulo"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — modulo"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — modulo"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — modulo"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — modulo"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — modulo"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — modulo"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — modulo"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — modulo"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — modulo"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — modulo"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — modulo"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — modulo"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — modulo"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — modulo"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — modulo"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — modulo"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — modulo"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — modulo"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — modulo"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — modulo"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — modulo"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — modulo"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — istanza _(classe: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — istanza _(classe: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — istanza _(classe: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — modulo"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — modulo"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMajor` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMinor` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening` istanza di zecca _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — modulo"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — modulo"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40607,103 +40918,103 @@ msgstr ""
 "piscina di tenuta è di proprietà di Reqwest; gli ami per socket sono no-op, "
 "avverte una volta (#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening` istanza di zecca _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once` istanza di zecca _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref` istanza di zecca _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40713,375 +41024,369 @@ msgstr ""
 "piscina di tenuta è di proprietà di Reqwest; gli ami per socket sono no-op, "
 "avverte una volta (#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — modulo"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — modulo"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket` istanza di zecca _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — istanza _(classe: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — istanza _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — istanza _(classe: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref` istanza di zecca _(classe: `HttpServer`)_"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — istanza _(classe: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — modulo"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — modulo"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — istanza _(classe: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — modulo"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — modulo"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — modulo"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — modulo"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — modulo"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — modulo"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening` istanza di zecca _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening` istanza di zecca _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref` istanza di zecca _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — istanza _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref` istanza di zecca _(classe: `HttpsServer`)_"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — modulo"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "Modulo `debug` _(classe: `console`)_"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "Modulo `error` _(classe: `console`)_"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "Modulo `info` _(classe: `console`)_"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "Modulo `log` _(classe: `console`)_"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -41090,7 +41395,7 @@ msgstr ""
 "endpoint dell'ispettore WebSocket; le sessioni sono in-processing fakes "
 "(#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -41101,7 +41406,7 @@ msgstr ""
 "Runtime.enable e un sottoinsieme Runtime.evaluate in scatola rispondono; "
 "ogni altro metodo di protocollo lancia l'errore dell'ispettore -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -41109,7 +41414,7 @@ msgstr ""
 "Modulo `url` **stub** Perry non espone mai un vero e proprio endpoint di "
 "ispettore (#4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -41117,3285 +41422,3276 @@ msgstr ""
 "Modulo `waitForDebugger` **stub** Il debugger ritorna immediatamente dopo "
 "open(); non c'è nessun debugger da aspettare (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "Modulo `warn` _(classe: `console`)_"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — istanza _(classe: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — istanza"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — modulo"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — istanza"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — istanza"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — istanza"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — istanza"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — istanza"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — istanza"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — istanza"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — istanza"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — istanza"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — istanza"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — modulo"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — istanza"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — istanza"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — istanza"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — istanza"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — istanza"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — istanza"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — modulo"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — modulo"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — modulo"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — modulo"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — modulo"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — modulo"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — modulo"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — modulo"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — modulo"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — modulo"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — modulo"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — modulo"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — modulo"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — modulo"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — modulo"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — modulo"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — modulo"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — modulo"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — modulo"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — modulo"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — modulo"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — modulo"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — modulo"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — modulo"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — modulo"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — modulo"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — modulo"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — istanza"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — istanza"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "istanza di `peek`"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — istanza"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — modulo"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — modulo"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — modulo"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — modulo"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — modulo"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — modulo"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — modulo"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — modulo"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — modulo"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — modulo"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — modulo"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — modulo"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — modulo"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — modulo"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — modulo"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — modulo"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — modulo"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — modulo"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — modulo"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — modulo"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — modulo"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — modulo"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — modulo"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "istanza di `fromNow`"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "istanza di `isBetween`"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — modulo"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "istanza di `toDate`"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — istanza"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — istanza"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — istanza"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — istanza"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — istanza"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — istanza"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — istanza"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — istanza"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — istanza"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — istanza"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — istanza"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — istanza"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — modulo"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — modulo"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — istanza _(classe: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — istanza"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — istanza _(classe: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — istanza _(classe: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — istanza"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — istanza"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — istanza _(classe: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — istanza _(classe: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — istanza"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — istanza"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — modulo"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — modulo"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — modulo"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — modulo"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — modulo"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — modulo"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — istanza _(classe: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — istanza _(classe: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — istanza _(classe: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — modulo"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — modulo"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — modulo _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — modulo"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — modulo"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — modulo"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — modulo _(classe: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — istanza _(classe: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — modulo"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — modulo"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert` istanza di zecca _(classe: `Socket`)_"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — istanza _(classe: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — istanza _(classe: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "Modulo `certificateFromPem`"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "Modulo `certificateToPem`"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "Modulo `createCertificate`"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "Modulo `privateKeyFromPem`"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "Modulo `privateKeyToPem`"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "Modulo `publicKeyToPem`"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions` istanza di zecca _(classe: `Certificate`)_"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer` istanza di zecca _(classe: `Certificate`)_"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject` istanza di zecca _(classe: `Certificate`)_"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign` istanza di zecca _(classe: `Certificate`)_"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — modulo"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — istanza"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — istanza"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — modulo"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — modulo"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — modulo"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — modulo"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — modulo"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — modulo"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — modulo"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — modulo"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — modulo"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — modulo"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — modulo"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — modulo"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — modulo"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — modulo"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — modulo"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — modulo"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — modulo"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — modulo"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — modulo"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — modulo"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — modulo"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — modulo"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — modulo"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — modulo"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — modulo"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — modulo"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — modulo"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — modulo"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — modulo"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — modulo"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — modulo"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — istanza _(classe: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "Modulo `eventLoopUtilization`"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — modulo"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — istanza _(classe: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — istanza _(classe: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — modulo"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "Modulo `embeddedFiles`"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "Modulo `readEmbedded`"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — modulo"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — modulo"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — modulo"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — modulo"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "Modulo `js_ads_request_consent`"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — modulo"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — modulo"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — modulo"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — modulo"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — modulo"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — modulo"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — modulo"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — modulo"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — modulo"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — modulo"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — modulo"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — modulo"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — modulo"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — modulo"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — modulo"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — modulo"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — modulo"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — modulo"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — modulo"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — modulo"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — modulo"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — modulo"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — modulo"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — modulo"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — modulo"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — modulo"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — modulo"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — modulo"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — modulo"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — modulo"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — modulo"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — modulo"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — modulo"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — modulo"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — modulo"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — modulo"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — modulo"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — modulo"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — modulo"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — modulo"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — modulo"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — modulo"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — modulo"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — modulo"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — modulo"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — modulo"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — modulo"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — modulo"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — modulo"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — modulo"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — modulo"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — modulo"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "Modulo `collect`"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "Modulo `idleHint`"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "Modulo `minor`"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — modulo"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — modulo"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — modulo"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — modulo"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — modulo"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — modulo"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — modulo"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — modulo"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "Modulo `createLanguageModelSession`"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "Modulo `destroyLanguageModelSession`"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "Modulo `foundationModelAvailability`"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "Modulo `getLayoutEnvironment`"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "Modulo `offLayoutChange`"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "Modulo `onLayoutChange`"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "Modulo `respond`"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — modulo"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — modulo"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — modulo"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — modulo"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — modulo"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — modulo"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — modulo"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — modulo"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof` Modulo _(intrinseco)_"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "Modulo `f32`"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "Modulo `f64`"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "Modulo `i16`"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "Modulo `i32`"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "Modulo `i64`"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "Modulo `i8`"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "Modulo `isize`"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof` Modulo _(intrinseco)_"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof` Modulo _(intrinseco)_"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "Modulo `u16`"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "Modulo `u32`"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "Modulo `u64`"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "Modulo `u8`"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "Modulo `usize`"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — modulo"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — modulo"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — modulo"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — modulo"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — modulo"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — modulo"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — modulo"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — modulo"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — modulo"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — modulo"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — modulo"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — modulo"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — modulo"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — modulo"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — modulo"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — modulo"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — modulo"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — modulo"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — modulo"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — modulo"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — modulo"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — modulo"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — modulo"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — modulo"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — modulo"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — modulo"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — modulo"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — modulo"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — modulo"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — modulo"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — modulo"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — modulo"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — modulo"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — modulo"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — modulo"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — modulo"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — modulo"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — modulo"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — modulo"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — modulo"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "Modulo `hapticPlay`"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — modulo"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — modulo"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — modulo"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — modulo"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — modulo"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — modulo"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — modulo"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — modulo"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — modulo"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — modulo"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — modulo"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — modulo"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — modulo"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — modulo"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — modulo"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — modulo"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — modulo"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — modulo"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — modulo"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — modulo"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — modulo"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — modulo"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — modulo"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — modulo"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — modulo"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — modulo"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — modulo"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — modulo"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — modulo"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — modulo"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — modulo"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — modulo"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — modulo"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — modulo"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — modulo"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — modulo"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — modulo"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — modulo"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — modulo"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — modulo"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — modulo"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — modulo"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — modulo"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — modulo"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — modulo"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — modulo"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — modulo"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — modulo"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — modulo"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — modulo"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — istanza _(classe: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — modulo"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — modulo"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — istanza _(classe: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — modulo"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — istanza _(classe: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — modulo"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — istanza _(classe: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — modulo"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — istanza _(classe: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — istanza _(classe: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — istanza _(classe: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — modulo"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — istanza _(classe: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — istanza _(classe: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — istanza _(classe: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — modulo"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — modulo"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — modulo"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — modulo"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — modulo"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — modulo"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — modulo"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — modulo"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — modulo"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — modulo"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — modulo"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — modulo"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — modulo"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — istanza _(classe: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — istanza _(classe: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — modulo"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — modulo"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "Modulo `BloomView`"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — modulo"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — modulo"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — modulo"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — modulo"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — modulo"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — modulo"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — modulo"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — modulo"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — modulo"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — modulo"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — modulo"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — modulo"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — modulo"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — modulo"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — modulo"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — modulo"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — modulo"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — modulo"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — modulo"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — modulo"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — modulo"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — modulo"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — modulo"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — modulo"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — modulo"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — modulo"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — modulo"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — modulo"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "Modulo `WheelPicker`"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — modulo"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — modulo"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — modulo"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — modulo"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — modulo"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "Modulo `appSetActivationPolicy`"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — modulo"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — modulo"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — modulo"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — modulo"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — modulo"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "Modulo `bloomViewGetHwnd`"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "Modulo `bloomViewGetNativeHandle`"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — modulo"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — modulo"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — modulo"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — modulo"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — modulo"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — modulo"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — modulo"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — modulo"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — modulo"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — modulo"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — modulo"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — modulo"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — modulo"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — modulo"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — modulo"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — modulo"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — modulo"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — modulo"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — modulo"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — modulo"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — modulo"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — modulo"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — modulo"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — modulo"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — modulo"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — modulo"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — modulo"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — modulo"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — modulo"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — modulo"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — modulo"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — modulo"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — modulo"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — modulo"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — modulo"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — modulo"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — modulo"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — modulo"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — modulo"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — modulo"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — modulo"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — modulo"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — modulo"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — modulo"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — modulo"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — modulo"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — modulo"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — modulo"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — modulo"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — modulo"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — modulo"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — modulo"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — modulo"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — modulo"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — modulo"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — modulo"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — modulo"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — modulo"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — modulo"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — modulo"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — modulo"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — modulo"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — modulo"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — modulo"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — modulo"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — modulo"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — modulo"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — modulo"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — modulo"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — modulo"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — modulo"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "Modulo `wheelPickerAddItem`"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "Modulo `wheelPickerGetSelected`"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "Modulo `wheelPickerSetSelected`"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — modulo"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — modulo"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — modulo"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "Modulo `embeddedCheckHeaders`"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "Modulo `embeddedCheckUrl`"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "Modulo `embeddedRefreshDue`"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — modulo"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "Modulo `getEmbeddedConfig`"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — modulo"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — modulo"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — modulo"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — modulo"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — modulo"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "Modulo `recordEmbeddedResponse`"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — modulo"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — modulo"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — modulo"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — modulo"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — modulo"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — modulo"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — modulo"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — modulo"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — modulo"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — modulo"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "Modulo `calculateLayout`"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "Modulo `childCount`"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "Modulo `getComputed`"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "Modulo `getComputedEdge`"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "Modulo `insertChild`"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "Modulo `nodeFree`"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "Modulo `nodeNew`"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "Modulo `removeChild`"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "Modulo `setEdge`"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "Modulo `setEnum`"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "Modulo `setGap`"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "Modulo `setMeasureFunc`"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "Modulo `setNumber`"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "Modulo `unsetMeasureFunc`"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — modulo"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — istanza _(classe: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — modulo"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — modulo"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — modulo"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — modulo"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — modulo"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — modulo"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — modulo"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — modulo"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — modulo"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — modulo"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — modulo"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — modulo"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — modulo"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — modulo"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — modulo"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — modulo"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — modulo"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — modulo"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — modulo"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — modulo"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — modulo"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — modulo"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — modulo"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — modulo"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — modulo"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — modulo"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — modulo"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — modulo"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — modulo"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — modulo"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — modulo"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — modulo"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — modulo"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — modulo"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — modulo"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — modulo"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — modulo"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — modulo"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — modulo"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — modulo"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — modulo"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — modulo"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — modulo"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — modulo"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — modulo"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — modulo"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — modulo"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — modulo"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — modulo"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — modulo"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — modulo"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — modulo"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — modulo"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — modulo"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — modulo"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — modulo"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — modulo"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "istanza di `block`"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "istanza di `consume`"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "istanza di `penalty`"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "istanza di `reward`"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — modulo"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — modulo"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — modulo"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — modulo"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — modulo"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — istanza"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — istanza"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — istanza"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — istanza"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — modulo"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — istanza"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — istanza"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — istanza"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — istanza"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — istanza"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — istanza"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — istanza"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44405,43 +44701,43 @@ msgstr ""
 "di input, e .write() valuta solo le lettere numeriche, le ricerche di "
 "contesto e un singolo '+'; nessun loop reale JS (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — modulo"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44451,1459 +44747,1459 @@ msgstr ""
 "input, e .write() valuta solo le lettere numeriche, le ricerche di contesto "
 "e un singolo '+'; nessun loop reale JS (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — istanza _(classe: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — modulo"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — modulo"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — modulo"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — modulo"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — modulo"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "istanza di `autoOrient`"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "istanza di `avif`"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — istanza"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "istanza di `composite`"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "istanza di `extend`"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "istanza di `extract`"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — istanza"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — istanza"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — istanza"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — istanza"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — istanza"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — istanza"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — istanza"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — istanza"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — istanza"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — modulo"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "istanza di `sharpen`"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — istanza"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — istanza"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "istanza di `trim`"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — istanza"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — istanza"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — istanza"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — modulo"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — modulo"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — istanza"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — istanza _(classe: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — istanza"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — modulo"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — istanza"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — istanza"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — istanza _(classe: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "istanza di `deserialize`"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — istanza _(classe: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — istanza"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — istanza"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — istanza _(classe: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — istanza"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — istanza"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — istanza"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — istanza"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — istanza"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — istanza"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — istanza"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "istanza di `serialize`"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — istanza"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — istanza"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — istanza _(classe: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — istanza"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — istanza"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — istanza _(classe: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — istanza"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — modulo"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — modulo"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — modulo"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — modulo"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — istanza"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — istanza"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — modulo"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — istanza"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — istanza"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — istanza"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — modulo"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — istanza"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — modulo"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — modulo"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — modulo"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — modulo"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — modulo"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — istanza"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — modulo"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — modulo"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — istanza"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — modulo"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — istanza"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — istanza"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — istanza"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — istanza"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — istanza"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — istanza"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — istanza"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — istanza"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — istanza"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — istanza"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — istanza"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — modulo"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — istanza"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — istanza"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — istanza"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — istanza"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — istanza"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — istanza"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — istanza"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — istanza"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — istanza"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — istanza"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — istanza"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — istanza"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — modulo"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — modulo"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — modulo"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — modulo"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — modulo"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — modulo"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — istanza _(classe: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — istanza _(classe: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — modulo"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — modulo"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — modulo"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — modulo"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — modulo"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — modulo"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — modulo"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — modulo"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — modulo"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — modulo"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — modulo"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — modulo"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — modulo"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — modulo"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — modulo"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — modulo"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — modulo"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — modulo"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — modulo"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — modulo"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — modulo"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — modulo"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — modulo"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — modulo"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — modulo"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — modulo"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — modulo"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — modulo"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — modulo"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — modulo"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — modulo"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — modulo"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — modulo _(classe: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — modulo"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — modulo"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — modulo"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — modulo _(classe: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — modulo _(classe: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — modulo _(classe: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — modulo _(classe: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — modulo _(classe: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — modulo"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — modulo"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — modulo"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — modulo _(classe: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — modulo"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — modulo"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — modulo"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — modulo"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — modulo"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — modulo"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — modulo"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — modulo"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — modulo"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — modulo"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — modulo"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — modulo"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — modulo"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — modulo"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — modulo"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "Modulo `convertALPNProtocols`"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — modulo"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — modulo"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "Modulo `getCertificateCompressionAlgorithms`"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — modulo"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — istanza _(classe: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — modulo"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — modulo"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — modulo"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — istanza _(classe: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — istanza _(classe: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — istanza"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — istanza"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — istanza"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — istanza"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — istanza"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "Modulo `flattenDiagnosticMessageText`"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "Modulo `transpileModule`"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "Modulo `ProxyAgent`"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close` istanza di zecca _(classe: `ProxyAgent`)_"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy` istanza di zecca _(classe: `ProxyAgent`)_"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "Modulo `fetch`"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "Modulo `getGlobalDispatcher`"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "Modulo `setGlobalDispatcher`"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — modulo"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — modulo"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — modulo"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — istanza _(classe: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — modulo"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — modulo"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — istanza _(classe: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — modulo"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — modulo"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — modulo"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — modulo"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — modulo"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — modulo"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — modulo"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — modulo"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — modulo"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — modulo"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — modulo"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — modulo"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — modulo"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — modulo"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — modulo"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — modulo"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — modulo"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — modulo"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — modulo"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — modulo"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — modulo"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — modulo"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — modulo"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — modulo"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — modulo"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — modulo"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — modulo"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — modulo"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — modulo"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — modulo"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — modulo"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — modulo"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — modulo"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — modulo"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — modulo"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — modulo"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — modulo"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — modulo"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — modulo"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — modulo"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — modulo"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — modulo"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — modulo"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — modulo"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — modulo"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "Modulo `v3`"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — modulo"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "Modulo `v5`"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — modulo"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — istanza _(classe: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — istanza _(classe: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — modulo"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — istanza _(classe: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — modulo"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — modulo"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45911,11 +46207,11 @@ msgstr ""
 "Modulo `getHeapCodeStatistics` **stub** Tutti i campi 0; Perry compila AOT, "
 "non c'è un mucchio di codice JIT (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — modulo"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45924,7 +46220,7 @@ msgstr ""
 "Modulo `getHeapSpaceStatistics` **stub** Nodo con tutti gli usi live "
 "attribuiti a old_space da arene Perry; altri spazi segnalano 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45938,87 +46234,87 @@ msgstr ""
 "applicato); \\*\\_eseguibile, external_memory, globale-maniglie e campi di "
 "zap sono 0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — istanza _(classe: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — modulo"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — istanza _(classe: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — istanza _(classe: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — istanza _(classe: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — istanza _(classe: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — modulo"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — istanza _(classe: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — modulo"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — istanza _(classe: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — modulo"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — modulo"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — istanza _(classe: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — modulo"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -46028,459 +46324,469 @@ msgstr ""
 "rapporto Hoppenstedt ha la forma del nodo ma l'array statistico è sempre "
 "vuoto (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — modulo"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — modulo"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — modulo"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — istanza _(classe: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — modulo"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — modulo"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — modulo"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — modulo"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — modulo"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — modulo"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — istanza"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — modulo"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — modulo"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — istanza"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — istanza"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — istanza"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — istanza"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — istanza"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — istanza"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — istanza"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — modulo"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — istanza"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — istanza"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — modulo"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — istanza"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — istanza"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — modulo"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — modulo"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — modulo"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — istanza"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — modulo"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — istanza _(classe: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — istanza _(classe: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — istanza _(classe: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — istanza _(classe: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — modulo"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — modulo"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "istanza di `addEventListener`"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — modulo"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — modulo"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — modulo"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — modulo"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — modulo"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — modulo"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — modulo"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload` istanza di zecca _(classe: `Worker`)_"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "istanza di `removeEventListener`"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — modulo"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — istanza _(classe: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — modulo"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — istanza _(classe: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — istanza"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — istanza"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — istanza _(classe: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — modulo"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — istanza"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — istanza _(classe: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "istanza di `readyState`"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — istanza _(classe: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — modulo"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — modulo"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — modulo"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — modulo"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — modulo"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — modulo"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46488,7 +46794,7 @@ msgstr ""
 "Modulo `createBrotliCompress` **stub** Opzioni params/quality accettate ma "
 "ignorate, avverte una volta (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46496,7 +46802,7 @@ msgstr ""
 "Modulo `createBrotliDecompress` **stub** Opzioni params/quality accettate ma "
 "ignorate, avverte una volta (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46504,7 +46810,7 @@ msgstr ""
 "Modulo `createDeflate` **stub** Livello di NPH onorato; strategy/memLevel "
 "convalidato ma non applicato (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46512,11 +46818,11 @@ msgstr ""
 "Modulo `createDeflateRaw` **stub** Livello di NPH onorato; strategy/memLevel "
 "convalidato ma non applicato (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — modulo"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46524,19 +46830,19 @@ msgstr ""
 "Modulo `createGzip` **stub** Livello di NPH onorato; strategy/memLevel "
 "convalidato ma non applicato (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — modulo"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — modulo"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — modulo"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46544,7 +46850,7 @@ msgstr ""
 "Modulo `createZstdCompress` **stub** Opzioni params/quality accettate ma "
 "ignorate, avverte una volta (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46552,79 +46858,71 @@ msgstr ""
 "Modulo `createZstdDecompress` **stub** Opzioni params/quality accettate ma "
 "ignorate, avverte una volta (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — modulo"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — modulo"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — modulo"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — modulo"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — modulo"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — modulo"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — modulo"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — modulo"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — modulo"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — modulo"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — modulo"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — modulo"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — modulo"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — modulo"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — modulo"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — modulo"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — modulo"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — modulo"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -47164,9 +47462,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "Altrimenti si ricorrerebbe a un file `docker-compose.yaml`."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "I due moduli condividono un runtime; è possibile mescolarli nello stesso "
@@ -47703,12 +48002,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` equivale a `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Nota sulla forma di ritorno `logs` e `exec`:** oggi l'FFI restituisce un "
 "handle Registry-id in un `Vec<ContainerLogs>` piuttosto che un oggetto JS. "
@@ -47837,9 +48137,10 @@ msgstr ""
 "restituiscono immediatamente."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` è async e restituisce un array JSON di _every_ candidato "
@@ -48599,9 +48900,10 @@ msgstr ""
 "operativo:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Utilizzare il blocco `healthcheck` sul servizio** (integrato, runtime lo "
@@ -48986,8 +49288,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "L'esempio Forgejo utilizza questo modello portatile (`container_name:  "
@@ -49059,8 +49362,9 @@ msgid "Single-network shorthand"
 msgstr "Forma abbreviata per rete singola"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49476,9 +49780,10 @@ msgid "External volumes"
 msgstr "Volumi esterni"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Contrassegna un volume `external: true` per condividerlo tra stack o per "
@@ -49500,8 +49805,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49571,15 +49877,18 @@ msgstr ""
 "sottostante:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# elencare i volumi delle app predefinite"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# mountpoint, driver, etichette"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# montaggio + controllo contenuto"
 
 #: src/container/volumes.md:160
@@ -49747,9 +50056,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49939,8 +50249,9 @@ msgstr ""
 "successive sullo stesso digest sono gratuite."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -50210,8 +50521,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**Esegui come non-root** (`user: \"nobody\"` o UID numerico)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Rilascia tutte le funzionalità, aggiungi quelle specifiche indietro** "
@@ -50362,7 +50674,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "Stampa un banner per l'operatore con URL + \"come smontare lo stack\"."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 "Uscita 0. I contenitori continuano a funzionare grazie a `restart:  unless-"
 "stopped`."
@@ -50584,11 +50897,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Avvio delle dipendenze con controllo di healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres impiega ~5 0,0310 secondi per inizializzare il primo run (initdb + "
 "listener bind). Senza gating, fungejo inizia immediatamente, non può "
@@ -50762,7 +51076,8 @@ msgstr ""
 "un gestore di secret:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -50775,7 +51090,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50836,11 +51152,13 @@ msgstr ""
 "di env che richiedono un recreate), eseguire prima un `--down` esplicito:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# conservare i volumi"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# ridistribuisci con la nuova versione"
 
 #: src/container/production-patterns.md:268
@@ -50858,35 +51176,42 @@ msgid "Running it"
 msgstr "Come eseguirlo"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Costruisci perry una volta"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Costruisci l'esempio"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Backend: mobile"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Visita http://localhost:3000/ in un browser."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Arresta (mantiene i volumi per la nuova distribuzione):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Diminuisce + volumi a goccia (DETTI DISTROY):"
 
 #: src/container/production-patterns.md:300
@@ -51202,19 +51527,23 @@ msgstr ""
 "suo reale supporto per asse. I nomi dei campi sono stabili tra i valori di"
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// provata + emessa nell'i-è"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// motore emula lato-host"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// caduto + avviso"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// sottoinsieme limitato; motivo documentato"
 
 #: src/container/determinism.md:156
@@ -51339,7 +51668,8 @@ msgstr ""
 "Ogni protocollo restituisce la sua costante da un metodo `capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... costruttori"
 
 #: src/container/determinism.md:192
@@ -51367,7 +51697,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"campo specifico dropped/translated per il backend\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- clean spec"
 
 #: src/container/determinism.md:212
@@ -51380,15 +51711,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// campo rimosso"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// mappato in equivalente"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// motore emula invece"
 
 #: src/container/determinism.md:231
@@ -51396,15 +51730,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. Modalità di applicazione"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// predefinitamente silent tracciamento::warn!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// superficie a TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// campo non supportato → hard up() guasto"
 
 #: src/container/determinism.md:241
@@ -51467,7 +51804,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "Normalizzazione dell'uscita indipendentemente dal backend"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Forma Docker (linea NDJSON)"
 
 #: src/container/determinism.md:292
@@ -51475,7 +51813,8 @@ msgid "/* docker JSON */"
 msgstr "/* docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Forma Apple (array JSON di oggetti `configuration`-wrapped)"
 
 #: src/container/determinism.md:294
@@ -51483,7 +51822,8 @@ msgid "/* apple JSON */"
 msgstr "JSON di mele"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// Entrambi producono ContainerInfo con lo stesso campo semantica:"
 
 #: src/container/determinism.md:301
@@ -51822,7 +52162,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51835,7 +52176,8 @@ msgid "\"Back\""
 msgstr "\"Indietro\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (valori vuoti = bisogno di traduzione)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -52066,7 +52408,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -52190,7 +52533,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (Polish: uno, pochi, molti)"
 
 #: src/i18n/interpolation.md:65
@@ -52973,21 +53317,25 @@ msgid "Typical translation workflow:"
 msgstr "Flusso di lavoro tipico per la traduzione:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Scrivi codice con stringhe in inglese"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Estrai le stringhe sui file locali"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 "# 3. Invia locales/de.json a traduttori (i valori vuoti devono essere "
 "riempiti)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Costruisci Perry convalida tutto"
 
 #: src/i18n/cli.md:49
@@ -53674,56 +54022,24 @@ msgstr ""
 "autenticato consumato da `perry update`."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr ""
 "# 1) Generazione di una coppia di chiavi. Salva kp.json con la modalità 0600 "
 "e"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) Firma per rilascio. La busta di output JSON contiene ogni"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 3) Controllare la firma localmente prima di caricare il manifesto"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    Qui prevede una verifica di passaggio sul cliente."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) Release CI firma il manifesto CLI, legando il suo URL archivio, "
-"piattaforma,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Componete un manifesto finale con l'uscita `sign` tramite `jq` per ogni "
@@ -55375,9 +55691,10 @@ msgstr ""
 "sovrapporsi a se stesso (ad esempio: più colpi di pistola, più passi)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** Un gruppo di mixer. Suona percorso attraverso un autobus, autobus "
@@ -56394,6 +56711,7 @@ msgstr ""
 "parete."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -56403,7 +56721,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57610,23 +57928,28 @@ msgstr ""
 "— senza necessità di conoscenze specifiche del linguaggio della piattaforma."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# Estensione iOS WidgetKit"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Widget app Android"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS Complication"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# Simulatore watchOS"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Piastrelle Wear OS"
 
 #: src/widgets/overview.md:60
@@ -58549,10 +58872,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -59155,11 +59474,13 @@ msgid "Build Commands"
 msgstr "Comandi di Build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -60054,19 +60375,23 @@ msgid "Build Instructions"
 msgstr "Istruzioni di Build"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# Copia file .kt in app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# Unisce AndroidManifest_snippet.xml in AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Copia file .kt nel modulo Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# Unisce AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -60258,11 +60583,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "L'aggiornamento in background usa il framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Per il dispositivo Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Per il simulatore di orologio Apple"
 
 #: src/widgets/watchos.md:70
@@ -61890,11 +62217,13 @@ msgstr ""
 "dichiarate usando `#[no_mangle] pub extern \"C\"`:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry runtime FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... call platform API, risolvere promessa quando fatto ..."
 
 #: src/plugins/native-extensions.md:200
@@ -62025,26 +62354,17 @@ msgstr ""
 "`swiftc`, specificando il target per il corretto SDK di piattaforma:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (semplificato)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// Rilevamento obiettivo: aarch64-apple-ios → arm64-apple-ios16.0, iphonos "
-"SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// Compile: switchc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// Link: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -62072,7 +62392,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Risolvi la promise Perry con il risultato"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Ottieni attività da PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -62088,7 +62409,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "// API della piattaforma di chiamata tramite JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -62721,15 +63043,18 @@ msgstr ""
 "non ha bisogno di compilatore, nessun nodo e nessuna generazione."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# il cancello"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# che cosa è in campo, e che cosa non è"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# dimostrare che il cancello può ancora fallire"
 
 #: src/testing/test-registration.md:18
@@ -63088,32 +63413,39 @@ msgstr ""
 "quando compili con `--enable-geisterhand`."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Compila con geisterhand abilitato (libs auto-build al primo utilizzo)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Esegui l'app"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. In un altro terminale la FME interagisce con l'app"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Elenca tutti i widget"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Pulsante Click con maniglia 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Cattura schermata finestra"
 
 #: src/testing/geisterhand.md:25
@@ -63130,7 +63462,8 @@ msgstr ""
 "flag):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# o con corsa perry:"
 
 #: src/testing/geisterhand.md:35
@@ -63275,8 +63608,8 @@ msgid "Menu item"
 msgstr "Voce di menu"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -63288,8 +63621,8 @@ msgstr "Scorciatoia da tastiera"
 msgid "Data table"
 msgstr "Tabella dati"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -63403,17 +63736,6 @@ msgstr ""
 "Imposta il contenuto del campo di testo e attiva il suo callback `onChange` "
 "con il nuovo testo come stringa NaN-boxed."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"Tipo di contenuto: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "\"{\"testo\": \"ciao mondo\"}\""
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Sposta uno Slider"
@@ -63438,10 +63760,6 @@ msgstr ""
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr ""
 "Imposta la posizione dello slider e attiva `onChange` con il valore numerico."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"valore\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -63493,10 +63811,6 @@ msgstr ""
 "Imposta direttamente il valore di una cella `State`, bypassando i callback "
 "dei widget. Questo attiva tutti i binding reattivi associati allo stato "
 "(etichette di testo collegate, visibilità, cicli forEach, ecc.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "\"{\"valore\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -63574,10 +63888,6 @@ msgstr ""
 "e minuscole e corrispondono alla stringa del tasto passata a `menuAddItem` "
 "(es. `\"s\"` per Cmd+S, `\"S\"` per Cmd+Shift+S, `\"n\"` per Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "\"{\"s\"}\""
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63612,10 +63922,6 @@ msgid ""
 msgstr ""
 "Imposta l'offset di scorrimento di un widget ScrollView. Sia `x` che `y` "
 "sono espressi in punti."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -63717,12 +64023,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Fuoco ingressi casuali ogni 200m"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -63864,12 +64167,16 @@ msgstr ""
 "`libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Installare e lanciare tramite Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -63896,7 +64203,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Pacchetto in APK e installare"
 
 #: src/testing/geisterhand.md:381
@@ -63904,7 +64212,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Installare prima le librerie di sviluppo GTK4:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -63928,15 +64237,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Un semplice test end-to-end usando bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Costruire con geisterhand"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Avvia l'app in background"
 
 #: src/testing/geisterhand.md:419
@@ -63948,33 +64260,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"kill $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Aspetta che l'app sia pronta"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Ottieni widget"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Widget registrati: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Trova il pulsante etichettato \"Invia\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Fai clic su di esso"
 
 #: src/testing/geisterhand.md:436
@@ -63982,7 +64298,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Fai una schermata dopo l'interazione"
 
 #: src/testing/geisterhand.md:441
@@ -63994,7 +64311,8 @@ msgid "Python Test Example"
 msgstr "Esempio di Test Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# Avvia l'app"
 
 #: src/testing/geisterhand.md:450
@@ -64002,11 +64320,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Aspetta l'avvio"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Elenco widget"
 
 #: src/testing/geisterhand.md:455
@@ -64014,11 +64334,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Trova i widget per etichetta"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# Digitare nel primo campo di testo"
 
 #: src/testing/geisterhand.md:464
@@ -64038,7 +64360,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Fare clic sul primo pulsante"
 
 #: src/testing/geisterhand.md:470
@@ -64046,7 +64369,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Cattura schermata per regressione visiva"
 
 #: src/testing/geisterhand.md:473
@@ -64062,7 +64386,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Assert l'app è ancora sana"
 
 #: src/testing/geisterhand.md:478
@@ -64094,40 +64419,14 @@ msgstr ""
 "stati imprevisti:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Costruire e lanciare"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Iniziare il caos aggressivo (ogni 50m)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Lascialo correre per 30 secondi"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Controlla le statistiche"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Fai una schermata per vedere lo stato finale"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Ferma il caos"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Controllare che l'app sia ancora viva"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -64141,11 +64440,13 @@ msgstr ""
 "baseline:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# Stato iniziale"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -64153,24 +64454,25 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "\"{\"testo\":\"Ciao\"}\""
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Catturare dopo l'interazione"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# Confronta (usando ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "Integrazione nella Pipeline CI"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# Esempio di azioni GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr "# Esempio di azioni GitHub"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -64219,7 +64521,8 @@ msgid "Run UI tests"
 msgstr "Esegui i test UI"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Esegui il tuo script di test"
 
 #: src/testing/geisterhand.md:568
@@ -64397,20 +64700,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Dopo aver compilato con `--enable-geisterhand` e avviato l'app:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Visualizza tutti i widget interattivi"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Incremento\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
 
@@ -64419,8 +64725,9 @@ msgid "\"Enter your name\""
 msgstr "\"Inserisci il tuo nome\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"},"
 
 #: src/testing/geisterhand.md:661
@@ -64428,19 +64735,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Modalità oscura\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Fare clic su Increment 3 volte"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# L'etichetta del contatore ora mostra \"Conteggio: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Digita un nome"
 
 #: src/testing/geisterhand.md:669
@@ -64448,7 +64758,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "\"{\"testo\":\"Perry\"}\""
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Imposta il cursore all'80%"
 
 #: src/testing/geisterhand.md:672
@@ -64456,11 +64767,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "\"{\"valore\":0.8}\""
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Commuta la modalità scura"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64775,16 +65088,13 @@ msgstr ""
 "manualmente:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Costruisci librerie geisterhand per macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Generazione per iOS (cross-compile)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -64978,15 +65288,18 @@ msgstr ""
 "compilare + eseguire. Vicino oltre:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# alcuni moduli"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# Solo queste esportazioni"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# modulo mod.export combinato"
 
 #: src/testing/node-compat-matrix.md:30
@@ -65007,15 +65320,18 @@ msgid "Full sweep and the CI gate"
 msgstr "Spazzatura completa e il cancello IC"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# intera matrice + tabella riassuntiva"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# uscita 1 sulle regressioni rispetto al basale"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# riscrivere la base di riferimento impegnata"
 
 #: src/testing/node-compat-matrix.md:43
@@ -65303,7 +65619,7 @@ msgstr ""
 "lavoro del workflow (`plan`). Ogni altro lavoro è `needs: plan` e relegato "
 "su `fromJSON(needs.plan.outputs.plan).jobs.<name>`."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -65399,11 +65715,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -65428,96 +65744,109 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6x veloce"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3x veloce"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x completo"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "Solo dep"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr ""
 "All'interno della **tor** livello l'elenco dei file modificati restringe "
 "ulteriormente il piano:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -65526,7 +65855,7 @@ msgstr ""
 "`, `.claude/`, ... και vedere `NON_CORE_GLOBS` in `ci_plan.py`) → solo "
 "`lint` esegue."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -65534,7 +65863,7 @@ msgstr ""
 "**nucleo** (qualsiasi cosa che possa cambiare il compilatore, il runtime o "
 "un risultato di test) → l'intero livello PR."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -65543,7 +65872,7 @@ msgstr ""
 "`.claude/`, `skills/`, ...) → inoltre il flusso di lavoro riutilizzabile "
 "`security-audit`."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -65558,7 +65887,7 @@ msgstr ""
 "trasformare, o un'altra dipendenza senza aggiungere Rust setup per i PR solo "
 "docs."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -65568,11 +65897,11 @@ msgstr ""
 "lavoro `plan` fallisce il cancello ... ..un pianificatore rotto non deve mai "
 "trasformarsi in \"tutto saltato, quindi verde.\""
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "Perché sembra così (misurato 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -65586,13 +65915,13 @@ msgstr ""
 "push PR e ~58 si unisce al giorno. Questa è la capacità totale di 1.5 "
 "0,012×, quindi:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "le attese della coda di lavoro sono state 3 04017 h (`conformance-smoke` "
 "shards: mediana 4 h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -65601,7 +65930,7 @@ msgstr ""
 "conclusione nella finestra di campionamento 8 non riuscita, 56 sono state "
 "cancellate dalla successiva spinta;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -65613,7 +65942,7 @@ msgstr ""
 "che erano stati rossi su `main` per giorni, quindi **ognuna delle ultime 12 "
 "unioni era un bypass admin** con `lint` e `cargo-test` ancora in coda."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -65628,11 +65957,11 @@ msgstr ""
 "passare su Linux, e #8187 sostituito la lista frammentata richiesto-contesto "
 "con il singolo `pr-gate` fan-in descritto sopra."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Due costi specifici dominati:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -65654,7 +65983,7 @@ msgstr ""
 "shard viene mantenuta in tutto il livello perché è l'unico braccio che vede "
 "i bug di collegamento auto-ottimizza-solo."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -65669,7 +65998,19 @@ msgstr ""
 "più recente blob main-line. `cache-warm.yml` non c'è più: lo spazzatura è la "
 "generazione della cache su `main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -65691,75 +66032,75 @@ msgstr ""
 "l'etichetta `run-extended-tests` ad un PR e lo eseguono, insieme al livello "
 "`full` di `test.yml`. Un PR non marcato ottiene ancora una corsa di ogni"
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "lavori tipici"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "tipico corridore-minuti"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "Orologio da parete bersaglio"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (core)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 frammenti di spazio)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 min una volta in coda"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (solo per uso medico)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 min"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "non è un obiettivo che coalizza"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "non è un obiettivo"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -65790,11 +66131,20 @@ msgstr ""
 "per finestra (`previous sweep SHA .. this sweep SHA`), esattamente come per "
 "i cancelli di sei ore."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Ottimizzare una PR in più"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -65808,7 +66158,7 @@ msgstr ""
 "unire, e per qualsiasi cosa toccando una suite completa. Applicando "
 "l'etichetta si riaccende il run (`labeled` trigger)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -65817,7 +66167,7 @@ msgstr ""
 "`lint` (una modifica `crates/` deve altrimenti aggiungere un frammento "
 "`changelog.d/<PR>-<slug>.md`)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -65825,11 +66175,11 @@ msgstr ""
 "**`workflow_dispatch`** su qualsiasi ramo: `tier` (`pr` / `sweep` / `full`) "
 "e `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Ri-baselining l'istantanea di spaziatura"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -65843,15 +66193,17 @@ msgstr ""
 "computer portatile (la base di riferimento richiesta è Linux, modalità "
 "`fast`):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# Aspetta la corsa, poi:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# compilare `issue` / `reason` per ogni nuova voce, quindi commit"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -65861,11 +66213,11 @@ msgstr ""
 "numero e una ragione prima di fondersi. Un crash non può mai essere "
 "parcheggiato nell'istantanea (`run_gap_tests.sh` rifiuta)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Protezione dei rami"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -65881,11 +66233,11 @@ msgstr ""
 "spazza produce un risultato _completato_ entro il suo budget; la corsa del "
 "cancello porta se il risultato è passato o fallito."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -65897,7 +66249,7 @@ msgstr ""
 "suite-gate`** job succeeded è un'esecuzione green spazzatura o PR-tier sulla "
 "stessa SHA non conta. Vedere [Releasing](../contributing/releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -65913,6 +66265,173 @@ msgstr ""
 "girano una volta in `parity-aggregate` rispetto al rapporto fuso (`scripts/"
 "parity_report_merge.py`, che rifiuta un frammento mancante piuttosto che "
 "restringere la suite)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Che cosa invia un assegno"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Eseguirlo localmente con:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"comando\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -66034,7 +66553,8 @@ msgid "Reproduce the core of it with:"
 msgstr "Riprodurre il nucleo di esso con:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr ""
 "# Che cosa è effettivamente in esecuzione, a livello di repo, a livello di "
 "lavoro:"
@@ -66042,31 +66562,6 @@ msgstr ""
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr ""
-"'.jobs[] | select(.status==\"in_progress\") | (.etichetta|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Quanto è profonda la coda, e su quali piscine:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "'.jobs[] | select(.status==\"queued\") | (.etichetta|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -66258,24 +66753,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# N.B.:"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # sfalsato; vedi la tabella sottostante"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -66286,12 +66779,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# rilascia rimanere individualmente recintato"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -66570,11 +67062,13 @@ msgstr ""
 "della sicurezza; un chiamante che salta anche uno dei cinque non lo è."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# prova che può ancora fallire"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# reale API, nessun problema scrive"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -66609,10 +67103,49 @@ msgstr ""
 "non che nulla è stato provato."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "La coda davanti al programma (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -66620,57 +67153,57 @@ msgstr ""
 "Una perlustrazione di sei ore aiuta solo se la coda drena più velocemente di "
 "sei ore. Il 2026-08-12 non lo fece, e la ragione non era le porte"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "esecuzione in coda"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "si osservano corse concomitanti"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "in coda per evento"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "rami di testa distinti tra le uscite PR in coda"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**rami che ancora esistevano**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -66688,11 +67221,12 @@ msgstr ""
 "cadenza di programmazione recupera da questo; la spazzatura deve essere "
 "rimosso."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -66708,7 +67242,7 @@ msgstr ""
 "predicate su PR aperti piuttosto che sull'esistenza di ramo, che è che cosa "
 "mantiene la forchetta PR sicuri"
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -66720,7 +67254,7 @@ msgstr ""
 "un manuale `python3 scripts/reap_stale_ci_runs.py --apply` (la prova a secco "
 "è l'impostazione predefinita); il programma lo mantiene chiaro in seguito."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
@@ -66728,7 +67262,7 @@ msgstr ""
 "Perché \"il cancello era buio\" non è lo stesso che \"il cancello l'avrebbe "
 "preso\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -66740,7 +67274,7 @@ msgstr ""
 "che il cancello oscuro ha lasciato attraverso il controllo non sopravvive, e "
 "la registrazione perché conta più dell'incidente:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -66753,7 +67287,7 @@ msgstr ""
 "(`collection_kind: \"full\"` andando 0 → 2) non è uno di loro. Nessun "
 "cancello nel repo cricchettos una collezione-_kind_ conteggio."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -66765,7 +67299,7 @@ msgstr ""
 "`shared_ci`, con la logica registrata in `tolerances.json`. Portano solo "
 "sotto `pinned_host`, che CI non usa mai."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -66773,7 +67307,7 @@ msgstr ""
 "I carichi di lavoro che lo hanno mostrato (`retain`, `deeplist`, ...) sono "
 "il corpus gc-handoff, non le 14 sonde fisse di `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -67000,14 +67534,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Compila TypeScript in un eseguibile nativo."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# O shorthand (auto-detects compile):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Flag"
 
@@ -67036,7 +67571,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (predefinito) o `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -67044,7 +67579,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "Stampa la rappresentazione intermedia HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -67056,7 +67591,7 @@ msgstr ""
 "Produrre solo oggetto file(s), saltare il collegamento; scritto a `-o` "
 "(vedere [Flag del compilatore](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -67064,7 +67599,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "Conserva i file `.o` e `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -67072,7 +67607,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "Abilita il fallback al runtime JavaScript V8"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -67084,8 +67619,8 @@ msgstr ""
 "Forza il collegamento del runtime host WebAssembly wasmi (rilevato "
 "automaticamente all'uso di `WebAssembly.*`)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -67093,16 +67628,16 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Abilita il type checking tramite tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr ""
 "Minimizza e offusca l'output (abilitato automaticamente per `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -67110,7 +67645,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (obbligatorio per i target widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -67119,23 +67654,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "Raggruppa le estensioni TypeScript dalla directory"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Raccolta di base"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Cross-compile per iOS Simulatore"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Costruisci un plugin"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: visualizza la rappresentazione intermedia"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Genera un widget iOS"
 
 #: src/cli/commands.md:82
@@ -67143,23 +67683,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Compila e avvia l'app in un unico passaggio."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# Rilevamento automatico del file di inserimento"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Esegui su iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Esegui su Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Esegui sul dispositivo Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Inoltra gli arg al tuo programma"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -67293,19 +67838,23 @@ msgstr ""
 "`--remote` per forzare uno dei due percorsi."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Eseguire un programma CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Eseguire su un simulatore specifico"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Forza la generazione remota"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Esegui obiettivo web"
 
 #: src/cli/commands.md:131
@@ -67321,19 +67870,23 @@ msgstr ""
 "ad ogni salvataggio."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# orologio + ricostruzione + rilancio al salvataggio"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# Inviare args al bambino"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# guarda una directory extra"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# sovrascrive il percorso di output"
 
 #: src/cli/commands.md:144
@@ -67475,7 +68028,7 @@ msgstr ""
 "Preservazione dello stato tra le ricompilazioni / HMR — \"fast restart\" è "
 "l'obiettivo dichiarato."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -67540,19 +68093,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Includi correzioni a media confidenza"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Seleziona un singolo file"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Controllare con l'analisi della dipendenza"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Risolvere automaticamente i problemi"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Anteprima correzioni senza applicare"
 
 #: src/cli/commands.md:207
@@ -67848,27 +68405,33 @@ msgstr ""
 "oltre alla configurazione della toolchain per Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Mostra menu piattaforma"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# Configurazione macOS (firma credenziali)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# Configurazione iOS (firma credenziali)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# Configurazione visionOS (firma credenziali)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Configurazione Android (firma credenziali)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows toolchain (scarica MS CRT + Windows SDK via xwin)"
 
 #: src/cli/commands.md:318
@@ -67899,19 +68462,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Aggiorna all'ultima"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Controllo senza installazione"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Ignora la risposta in cache"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Salva come dovrebbero comportarsi gli aggiornamenti, poi esci"
 
 #: src/cli/commands.md:333
@@ -67929,7 +68496,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` scrive `[update] mode` a `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -68046,14 +68613,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Crea lo scaffold di un nuovo pacchetto di binding nativi:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "Legare i nativi per libfoo"
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\"\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -68592,10 +69151,21 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr "Eseguibile, bundle, libreria condivisa, archivio o percorso oggetto."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -68603,20 +69173,20 @@ msgstr ""
 "Seleziona Linux libc/linkage; `musl` aggiorna il target Linux corrispondente "
 "ad una costruzione completamente statica senza testa."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr ""
 "Identifier del pacchetto richiesto dai bersagli del widget a schermo "
 "domestico."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr ""
 "Scoprire e integrare staticamente i pacchetti di estensione nativi da una "
 "directory."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -68624,22 +69194,22 @@ msgstr ""
 "Eseguire il controllore TypeScript nativo (`@typescript/native-preview`) "
 "prima del codegen."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Imposta il pavimento di compatibilità Windows PE; ignorato per obiettivi non "
 "Windows."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -68647,11 +69217,11 @@ msgstr ""
 "Selezionare il sottosistema Windows PE invece di affidarsi al rilevamento "
 "automatico basato sull'importazione."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -68659,11 +69229,11 @@ msgstr ""
 "Per gli obiettivi del widget Apple, emettono sorgente SwiftUI e metadati "
 "senza invocare `swiftc`."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -68671,35 +69241,68 @@ msgstr ""
 "Selezionare HarmonyOS HAP materiale di firma. Preferisci le sorgenti "
 "environment/config corrispondenti per i segreti."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "Catena dei certificati di applicazione HarmonyOS."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "Profilo di provisioning HarmonyOS firmato."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "alias del keystore HarmonyOS; default su `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — modulo"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Incorporazione delle attività"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -68708,11 +69311,11 @@ msgstr ""
 "nell'eseguibile standalone in modo che funzioni senza file esterni sul disco "
 "(#5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -68722,11 +69325,23 @@ msgstr ""
 "del progetto). Repeatable. Unito con `perry.embed` (package.json) e "
 "`[compile] embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -68735,19 +69350,20 @@ msgstr ""
 "sotto `dir` in una maniglia `$perryfs` stabile. Ripetibile; sono escluse le "
 "mappe sorgente."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# serve dist/ da memoria • nessuna cartella dist/ necessaria"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "I file incorporati sono raggiungibili al runtime in tre modi:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -68779,7 +69395,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -68791,7 +69407,7 @@ msgstr ""
 "`readEmbedded(path)` e `node:fs` accettano il percorso virtuale `$perryfs/"
 "<path>` o la chiave embed-relative."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -68799,7 +69415,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -68809,7 +69425,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -68823,7 +69467,7 @@ msgstr ""
 "`{ type: \"file\" }` e mantiene la sorgente generata nella sua cache "
 "piuttosto che modificare la cassa."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -68831,11 +69475,7 @@ msgstr ""
 "Per il grafico sorgente OpenCode, compilare prima l'interfaccia utente web "
 "upstream, quindi compilare dalla radice del pacchetto `packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -68850,7 +69490,7 @@ msgstr ""
 "il comando di preparazione per ogni revisione sorgente in modo che gli input "
 "generati non possano essere stantii."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -68863,7 +69503,7 @@ msgstr ""
 "relativa al progetto, le dimensioni del byte, il digestivo SHA-256 e, se del "
 "caso, il modulo di asset generatore."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -68878,7 +69518,7 @@ msgstr ""
 "assoluto, e utilizzare il modulo `$perryfs/<path>` esplicito quando si "
 "intende specificamente la copia incorporata."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -68890,19 +69530,19 @@ msgstr ""
 "`PERRY_LLVM_CLANG` quando il clang corrispondente non è il primo su `PATH`. "
 "Attualmente l'integrazione tra obiettivi non è supportata."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Flag di debug"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "Stampa la HIR (rappresentazione intermedia) sullo stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -68911,11 +69551,11 @@ msgstr ""
 "(HIR post-trasformazione), `llvm` (`.ll` per modulo in `.perry-trace/llvm/"
 "`), oppure `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -68925,7 +69565,7 @@ msgstr ""
 "`NAME`, sopprimendo il rumore da import/export/init. Implica `--trace hir` "
 "se non viene specificato alcuno stage"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -68939,11 +69579,11 @@ msgstr ""
 "non può nominare diversi file. Senza `-o` atterrano nella directory "
 "corrente. Ogni percorso è stampato come `Wrote object file: <path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -68953,15 +69593,15 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`). Vedi [Configurazione del progetto](../getting-"
 "started/project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "Mantiene i file intermedi `.o` e `.asm`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
@@ -68969,33 +69609,33 @@ msgstr ""
 "Mantieni symbols/DWARF (ed emetti un PDB Windows) invece di spogliare il "
 "risultato."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Disabilita la cache dell'oggetto per modulo per questa generazione; anche "
 "`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "Sovrascrivere la cache root machine-local; vedere [Directory della cache]"
 "(cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -69003,32 +69643,32 @@ msgstr ""
 "Eseguire nativo-rappresentazione abbassando invarianti e codecgen forza "
 "invece di riuso cache."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 "Disabilita l'abbassamento nativo di Buffer/Uint8Array load/store per la "
 "diagnosi di A/B."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 "Emit un rapporto di prova di riduzione del tipo; implica la verifica nativo-"
 "regione."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -69039,11 +69679,11 @@ msgstr ""
 "report=json` emette uno schema stabile per gli strumenti. Settabile anche "
 "tramite `PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -69056,7 +69696,7 @@ msgstr ""
 "ricerca; richiede `PERRY_RS4GC=1`, l'unico backend nativo-root (le modalità "
 "stack-map e bridge esplicito che ha anche nominato sono andati)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -69073,11 +69713,11 @@ msgstr ""
 "(altrimenti la cache degli oggetti salta la codegen per i moduli invariati, "
 "lasciando la directory di trace vuota)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report` (perché un valore è rimasto inscatolato)"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -69096,11 +69736,11 @@ msgstr ""
 "stampa ciò che è stato dimostrato, ciò che non è stato, e quale regola ha "
 "fatto la chiamata."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Ogni valore negato porta:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -69109,7 +69749,7 @@ msgstr ""
 "**Posizione** `local`, `param`, `return`, `field` o `alloc-site` (un oggetto "
 "letterale che non è mai legato a un idioma locale, `.map(x => ({...}))`)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -69117,7 +69757,7 @@ msgstr ""
 "**La regola che lo ha negato**, nella numerazione del collezionista, in modo "
 "da poter controllare il file sorgente chiamato."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -69129,7 +69769,7 @@ msgstr ""
 "boxed "
 "κανινινινινινινινινινινινινινινινινινινινινινινινονινονινινινινινινινινισισισισησησισισισισησισηνισησησησησησησηση"
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -69143,7 +69783,7 @@ msgstr ""
 "un loop a sé stante ma funziona una volta per elemento, quindi la profondità "
 "del loop da solo è di rango. Né è un profilo sono proxy statici."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -69151,7 +69791,7 @@ msgstr ""
 "Le vincite sono segnalate insieme alle mancate, quindi il rapporto è "
 "visibile piuttosto che solo le lamentele."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -69167,7 +69807,7 @@ msgstr ""
 "si mescola mai in un carico utile `--format json` o l'uscita pipe del vostro "
 "programma."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -69182,15 +69822,15 @@ msgstr ""
 "controllo CI a buon mercato contro una rappresentazione che regredisce "
 "silenziosamente a zero."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Ottimizzazione dell'output"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -69212,11 +69852,11 @@ msgstr ""
 "stenografia per `generic`. Riguarda solo il codice app e la ricostruzione "
 "automatica di runtime/stdlib ottimizzata."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -69224,11 +69864,11 @@ msgstr ""
 "Definisci le costanti di compilazione `__feature_NAME__` separate da virgola "
 "per l'eliminazione del codice morto."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -69236,28 +69876,28 @@ msgstr ""
 "Utilizzare il set completo runtime/stdlib precostruito invece di ricostruire "
 "il più piccolo set di funzionalità raggiungibili."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "Permesso di riassociazione in virgola mobile; vedere [Fast-math](fast-"
 "math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr ""
 "Controllo fuso moltiplicare-aggiungere la contrazione separatamente dalla "
 "riassociazione."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -69266,11 +69906,11 @@ msgstr ""
 "nomi di variabili locali, parametri e funzioni non esportate per ridurre la "
 "dimensione dell'output."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Generazioni ottimizzate per le dimensioni"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -69282,11 +69922,11 @@ msgstr ""
 "sintonizzati per le dimensioni invece della velocità (che richiedono un "
 "checkout Perry spazio di lavoro, come il resto di auto-ottimizzare):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -69298,11 +69938,11 @@ msgstr ""
 "interni pesanti compute possono funzionare ~2-3× più lentamente). Gli "
 "archivi size-ottimizzata e normale sono cached indipendente."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -69311,11 +69951,11 @@ msgstr ""
 "(ricostruzione più lenta, binario più piccolo). Solo significativo insieme a "
 "`PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -69334,7 +69974,7 @@ msgstr ""
 "simboleggiata JS `throw`/`catch`, `finally`, stack di errori e "
 "`uncaughtException` non sono inalterati."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -69346,15 +69986,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. I programmi che usano più del runtime si "
 "riducono, proporzionalmente."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Flag di testing"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -69362,26 +70002,26 @@ msgstr ""
 "Incorpora il server HTTP [Geisterhand](../testing/geisterhand.md) per il "
 "testing UI programmatico (porta predefinita 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Imposta una porta personalizzata per il server Geisterhand (implica `--"
 "enable-geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Flag di runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "Abilita il runtime JavaScript V8 per i pacchetti npm non supportati"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -69391,15 +70031,15 @@ msgstr ""
 "si fa riferimento a `WebAssembly.*`; necessario solo quando si carica "
 "tramite dlopen / FFI senza un riferimento statico)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Abilita il type checking tramite IPC di tsgo"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -69417,11 +70057,11 @@ msgstr ""
 "forza. Vedere [Limitations](../language/limitations.md#no-eval-or-dynamic-"
 "code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -69444,11 +70084,11 @@ msgstr ""
 "finiti di tipo union, glob) non sono inalterati. Vedere [Limitations](../"
 "language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -69457,23 +70097,23 @@ msgstr ""
 "ma non implementata viene riferimento invece di emettere un errore di "
 "runtime differito."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Emit `<binary>.attest.json`; vedere [Certificato binario](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Emit il sidecar sandbox della piattaforma; vedere [Profili a sandbox](emit-"
 "sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -69481,31 +70121,31 @@ msgstr ""
 "Rifiutare le superfici di esecuzione arbitraria del codice raggiungibili; "
 "vedere [Lockdown](lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Variabili d'ambiente"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Chiave di licenza Perry Hub per `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Password per il certificato .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -69513,63 +70153,63 @@ msgstr ""
 "CPU baseline per codice macchina generato (stessi valori come `--march`; il "
 "flag e perry.toml `[build] march` vincono sulla v env)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Disabilita i controlli automatici degli aggiornamenti"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "Lo stesso, usando l'ortografia dell'ecosistema"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` per un'unica esecuzione vedere [Updates]"
 "(updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL del server di aggiornamento personalizzato"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Salta automaticamente i controlli degli aggiornamenti (impostato dalla "
 "maggior parte dei sistemi CI)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Livello di log di debug (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -69577,7 +70217,7 @@ msgstr ""
 "`1`/`text` o `json` è uguale a `--opt-report[=json]`, per guidare il report "
 "da un ambiente in cui aggiungere una bandiera è scomodo"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -69592,15 +70232,15 @@ msgstr ""
 "quinta manopola GC env senza braccio CI, ed è stato eliminato sotto "
 "CLAUDE.mdLa politica di uccisione della manopola GC."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "File di configurazione"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (progetto)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -69680,11 +70320,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (globale)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -69706,59 +70346,255 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Semplice programma CLI"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# App iOS per simulatore"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# App visionOS per simulatore"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# App web (WASM con il bridge DOM alias: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Libreria condivisa plugin"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# Widget iOS con ID bundle"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Compilazione debug"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Compilazione verbosa"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Compilazione controllata dal tipo"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# Raw WASM binario (nessun wrapper HTML)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Uscita web ridotta (comprende il ponte JS incorporato)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Comandi](commands.md) — Tutti i comandi della CLI"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr ""
 "[Panoramica delle piattaforme](../platforms/overview.md) — Target di "
 "piattaforma"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"moduli\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Identità cache"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"moduli\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"fonte\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"Lodash\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"obiettivi\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"funzionamenti\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Incremento\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"didascalia\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -70006,15 +70842,18 @@ msgstr ""
 "ha priorità su package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. Flag CLI per-build"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Ambiente per guscio"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. Per progetto package.json (più comune)"
 
 #: src/cli/fast-math.md:35
@@ -70030,19 +70869,22 @@ msgid "Contraction is separate from reassociation:"
 msgstr "La contrazione è separata dalla riassociazione:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Permesso solo contrazione FMA."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Permetti la modalità di contrazione più aggressiva del frontend senza "
 "riassociarsi."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr ""
 "# Mantenere la riassociazione da --fast-math ma bloccare la contrazione FMA."
 
@@ -71060,7 +71902,8 @@ msgid "Emit"
 msgstr "Generazione"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → miapp"
 
 #: src/cli/emit-attest.md:27
@@ -71148,7 +71991,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"dimensione\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -72388,10 +73231,6 @@ msgstr ""
 msgid "produces:"
 msgstr "produce:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"moduli\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -72473,9 +73312,10 @@ msgstr ""
 "sorgente host viene riportato sotto `<host source>`."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Restituisce un errore chiaro se il manifesto non esiste ancora `perry  "
 "compile` o `perry run` lo scrive su ogni build riuscito."
@@ -74649,7 +75489,7 @@ msgstr "Perry legge la configurazione da entrambi i file. Ecco cosa va dove:"
 msgid "Setting"
 msgstr "Impostazione"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "File"
 
@@ -74734,15 +75574,18 @@ msgstr ""
 "config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# Configura la firma iOS (certificato, profilo di provisioning)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Configura la firma Android (keystore, chiave Play Store)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Configura la distribuzione macOS (App Store, notarizzazione)"
 
 #: src/cli/perry-toml.md:605
@@ -74783,8 +75626,11 @@ msgstr ""
 "le credenziali in `perry.toml`:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# Esempio di azioni GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -76042,20 +76888,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Navi Perry **due canali indipendenti di opt-in** per l'invio di dati a "
-"casa ... non lascia la vostra macchina senza un `enabled = true` esplicito o "
-"`on` in `~/.perry/config.toml`. Entrambi onorano `PERRY_NO_TELEMETRY=1` e "
-"`CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Analisi d'uso generico `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Analisi d'uso generico `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -76065,15 +76911,17 @@ msgstr ""
 "sfondo HTTP POST. Invia: nome di comando, piattaforma (`darwin`/"
 "`linux`/...), versione Perry, stato success/error e un UUID client anonimo."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr ""
 "2. Segnalazioni di compatibilità `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -76084,16 +76932,16 @@ msgstr ""
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Tre modalità:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 "`off` non inviare mai. Il lavello non è nemmeno installato; zero in testa."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -76102,99 +76950,99 @@ msgstr ""
 "spara, prompt una volta per sessione: `[y] just this once / [a] always / [n] "
 "not this time / [N] never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on` ® invia sempre (dopo il dedup + redazione). Non c'e' fretta."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**Che cosa viene inviato (l'intero schema di carico):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"codice\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"categoria\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"gap-categorycal\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"Stage\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"Ascensore\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:...\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"decoratore\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"nodo:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -76211,7 +77059,7 @@ msgstr ""
 "built-in come `console`, `Math`, `Promise`) → `<id1>`, `<id2>`, limitato a "
 "200 caratteri, con un rifiuto duro se qualsiasi invariante fallisce."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -76219,32 +77067,36 @@ msgstr ""
 "Una cache di 30 giorni locale a `~/.perry/.report-cache` impedisce di "
 "reinviare lo stesso `snippet_hash` ad ogni ricarica."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Ispezionare e gestire"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# mostra la modalità corrente, i conteggi sent/queued"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# stampa i payload cancellati in coda a questa esecuzione"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# pulire la cache di 30 giorni"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "Per disattivare il file, modificare `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -76253,7 +77105,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -76504,15 +77356,18 @@ msgstr ""
 "byte (`crates/perry-runtime/src/gc/types.rs`):"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// dimensione totale alloc, usata per camminare blocco arena"
 
 #: src/internals/memory-model.md:69
@@ -76858,7 +77713,7 @@ msgstr ""
 "barrier helper precise del runtime per benchmark/debug per bisection. Se non "
 "impostata, `=1`, `=on` e `=true` mantengono le barrier abilitate."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -77050,10 +77905,11 @@ msgstr ""
 "retired_set=#N` sotto `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -77286,10 +78142,24 @@ msgstr ""
 "che il processo avrebbe effettivamente tenuto sotto pressione."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Mappa dei sorgenti"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -77298,183 +78168,183 @@ msgstr ""
 "derives, e ogni riga di questa tabella una volta puntato in un `gc.rs` che "
 "non esiste più."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Argomento"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Simbolo da cercare"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "Etichette NaN-boxing"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, costanti di tipo/flag"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Cornici ombre (abbassamento della radice del fallback)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Scanner di radici registrati"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Copia minore"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Promozione a blocchi interi in loco"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Politica di promozione"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Soglia di permanenza adattabile"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Scrivi barriere"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Pinning esplicito"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Predicato del pignone conservatore"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Inneschi di raccolta e pacing"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Pagina delle operazioni correnti"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Piano di progettazione (storico)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -77919,12 +78789,18 @@ msgstr ""
 "heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "su un processo desktop/server non limitato, scalato a un ottavo di un budget "
 "device/container con un piano MiB. L'overflow viene restituito "
@@ -77933,7 +78809,7 @@ msgstr ""
 "periodi unsafe/deferred e svuota la piscina quando la collezione completa "
 "dovuta termina la sua bonifica dell'arena."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -77944,105 +78820,219 @@ msgstr ""
 "vivo** più delta elementari, non una somma di blocchi di compensazione ad "
 "alta acqua."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Controlli supportati"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 "Questi sono i controlli operativi più utili all'esterno dello sviluppo del "
 "collettore:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "ripiegamento della bisezione al punto completo"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime barriera bisection; anche forza il marchio-sweep"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr ""
 "disabilitare la scavenging diretto del vivaio per il confronto del ritmo"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr ""
 "ripristinare la promozione di un blocco intero all'evacuazione oggetto per "
 "oggetto"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "impostare il tappo base del vivaio"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "sovrascrivere il budget del mucchio di processo in MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "seleziona le radici ombre su un target nativo-radice-capable"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "scansione diagnostica completa dello stack nativo; disabilita la copia"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "emettono tracce strutturate per ciclo"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "emettono diagnostica del collettore leggibile dall'uomo"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -78051,10 +79041,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "Lo stress da radicazione utilizza `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -78069,7 +79060,7 @@ msgstr ""
 "`PERRY_STACKMAP_WALKER` sono accettati ma non sono modalità aggiuntive "
 "supportate da collezionisti."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -78098,11 +79089,11 @@ msgstr ""
 "comportamento fallisce `cargo-test`; né può andare in silenzio mentre questa "
 "pagina continua a rivendicare la vecchia cosa."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Convalida e autorità CI"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -78114,38 +79105,38 @@ msgstr ""
 "src/testing/ci-tiers.md`; la politica di livello è `scripts/ci_plan.py`). La "
 "copertura specifica del GC è divisa deliberatamente:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "dove funziona"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "stato richiesto"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 "custodia root-holder, deriva GC-knob, e questa pagina path/number crediti"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "sì (tramite `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "suite unità runtime e matrice `run_memory_stability_tests.sh` a quattro "
 "modalità"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -78153,7 +79144,7 @@ msgstr ""
 "sì (tramite `pr-gate`; il livello PR è diff-scoped, i livelli sweep/full "
 "eseguono lo spazio di lavoro)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -78161,26 +79152,26 @@ msgstr ""
 "GC × matrice di rappresentazione-selezione, strumenti di radicamento-"
 "insetto, stress da barriera di scrittura"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr ""
 "sì (tramite `pr-gate`; sottoinsieme PR su PR, matrice completa nello sweep)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "dominanza della radice emessa, compreso lo stato nativo IR"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -78188,27 +79179,27 @@ msgstr ""
 "non è richiesto il ramo; braccio PR opt-in tramite `run-extended-tests`, sei "
 "ore su `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "Collettore pinned matrice counters/RSS/wall"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "budget thread-local mechanism/policy"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Comandi locali di pre-volo utili:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -78218,11 +79209,11 @@ msgstr ""
 "compilazione e host più ampi; i loro file di flusso di lavoro sono "
 "l'autorità per i comandi esatti e filtri di rilevanza."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Prove storiche"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -78231,7 +79222,7 @@ msgstr ""
 "generational-gc-plan.md): disegno originale e log di atterraggio fase per "
 "fase."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -78241,7 +79232,7 @@ msgstr ""
 "statepoint-gc-experiment.md): misurazioni cronologiche del prototipo e "
 "correzioni che portano al default nativo-root."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -78250,7 +79241,7 @@ msgstr ""
 "codice corrente, modalità di controllo, punti ciechi noti e strumenti di "
 "debug."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -78581,7 +79572,8 @@ msgstr ""
 "correzione, era il costo ogni volta."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "I cinque modi in cui si è rotto"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -78740,14 +79732,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` in `gc/mod.rs` nello stesso commit."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Come controllare il tuo lavoro"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. Il controllo statico"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -78758,7 +79791,7 @@ msgstr ""
 "tale ambito è l'unico strumento che vede un difetto prima che si schianti, "
 "ed è per questo che funziona per primo."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -78766,7 +79799,7 @@ msgstr ""
 "**E' cieco a tre classi, tutti trovarono la strada difficile. Una relazione "
 "pulita non è una prova per nessuno di loro:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -78775,7 +79808,7 @@ msgstr ""
 "vedere una cella runtime. Dillo: non riesce 10/10 piuttosto che in modo "
 "intermittente."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -78785,7 +79818,7 @@ msgstr ""
 "`0 violations` su entrambi i lati di un bug reale la cui correzione era una "
 "`GcSuppressScope` una linea nella trappola di avvio `globalThis`."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -78804,7 +79837,7 @@ msgstr ""
 "contro ciò che il codegen effettivamente emette, il modo #7227 audit "
 "`ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -78815,7 +79848,7 @@ msgstr ""
 "registra 25 file corpus curati passando mentre 20 linee di stock zod "
 "falliscono."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -78833,30 +79866,14 @@ msgstr ""
 "abbassamento che non è stato il default su qualsiasi walkable-frame "
 "obiettivo dal #7370. **Esegui entrambi**, e sai quale hai corso:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr ""
 "# SHADOW (PERRY_RS4GC=0): ancora l'abbassamento di arm64_32 watchOS e ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr ""
-"# NATIVE (PERRY_RS4GC=1): il valore predefinito ovunque. Ancoraggi in corso"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` alloca radice e LLVM inserisce i punti di sicurezza in "
-"seguito, quindi il"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -78867,11 +79884,11 @@ msgstr ""
 "lì, e il corpus ombra ha zero safepoint, quindi `--min-statepoints` fallisce "
 "lì."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Che cosa `--statepoints` controlla, e come differisce"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -78883,7 +79900,7 @@ msgstr ""
 "il punto sicuro è il risultato `gc.relocate`. Così \"il root store deve "
 "dominare ogni successivo punto di raccolta\" diventa:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -78891,7 +79908,7 @@ msgstr ""
 "Nessun registro che nomini un oggetto GC può essere utilizzato sotto un "
 "punto sicuro a meno che non sia il valore trasferito."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -78905,23 +79922,23 @@ msgstr ""
 "quindi un JSValue trascorre la maggior parte della sua vita come `double`. "
 "Due classi di verdetto, perché hanno due diverse correzioni:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -78929,15 +79946,15 @@ msgstr ""
 "nessun valore `ptr addrspace(1)` nella catena di cast del registro è nel "
 "pacchetto live del punto sicuro. Niente segna o riscrive l'oggetto."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "radicelo"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -78945,11 +79962,11 @@ msgstr ""
 "l'oggetto IS nel pacchetto e viene trasferito, ma una copia raw del suo "
 "indirizzo pre-muovi è usata di seguito"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "ri-derive dal valore trasferito (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -78966,7 +79983,7 @@ msgstr ""
 "classifica contro il simbolo reale piuttosto che "
 "`llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -78990,15 +80007,15 @@ msgstr ""
 "percorso. E' unilaterale: una chiamata non riconosciuta conta come raccolta, "
 "quindi un buco nel suo modello costa un falso positivo, mai un bug mancato."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Per un singolo file si sta iterando su:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "Entrambe le manopole env contano, per ragioni diverse."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -79014,7 +80031,7 @@ msgstr ""
 "una raccolta tra due punti di un altro corpo di ciclo inerte non può "
 "apparire nel corpus senza di esso."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -79036,7 +80053,7 @@ msgstr ""
 "`js_object_set_field_by_name`, `js_object_get_field_ic_miss` e "
 "`js_closure_call1`. Quelli si stanno muovendo senza sondaggi."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -79044,13 +80061,13 @@ msgstr ""
 "Quindi: accendere la manopola, perché allarga ciò che il corpus può "
 "esprimere, ma non leggere una funzione senza polls come sicura."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` è da EXACT emesso simbolo, e che ha morso due volte"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -79061,7 +80078,8 @@ msgstr ""
 "nomina un codice simbolo non emette nulla, per sempre, e sembra esattamente "
 "come la copertura mentre lo fa. Sono stati misurati due cicli:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -79072,7 +80090,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -79089,7 +80107,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` a zod `clone`. Il protettore e il "
 "pedinatore non erano d'accordo; il pedinatore era sbagliato."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -79111,7 +80129,7 @@ msgstr ""
 "volte; i punti di entrata reali sono `js_closure_callN`, che "
 "`RECEIVER_SINKS` nello stesso file già scritto correttamente."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -79131,60 +80149,60 @@ msgstr ""
 "κανονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονονον "
 "Ripiantare il codice esatto ed eseguire ogni modalità (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (dominanza)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (l'abbassamento delle navi)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (non filtrato)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (non filtrato)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -79196,7 +80214,7 @@ msgstr ""
 "all'abbassamento della spedizione. L'aggiunta di un nome porta le armi "
 "sabotate a 13 e 8 e lascia le braccia pulite a 2 e 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -79226,7 +80244,7 @@ msgstr ""
 "che può, aggiungerlo a `POLL_CAPABLE_RUNTIME` nello stesso commit.** Niente "
 "ti chiedera' di farlo."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -79237,7 +80255,7 @@ msgstr ""
 "root-dominance.yml` corre entrambi insieme a `--audit-alloc-re` prima della "
 "generazione."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -79264,7 +80282,7 @@ msgstr ""
 "fantasma con il codice simbolo emette in realtà piuttosto che cancellarlo "
 "και cancellando gira il verde audit e lascia il buco."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -79295,21 +80313,17 @@ msgstr ""
 "prima in modo che un nome menzionato in prosa non possa diventare una "
 "premessa."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "Controllare un nome _plausibile_ non è sufficiente. Conferma contro IR "
 "emessa:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -79317,7 +80331,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` rende ogni root store la chiamata "
 "`js_shadow_slot_bind` forma le ancore del pedinatore acceso."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -79332,7 +80346,7 @@ msgstr ""
 "ancorato è il braccio che è alla base della permitlist, quindi i casi 3 e 4 "
 "sono in superficie solo quando si esegue questa modalità a mano."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -79348,7 +80362,7 @@ msgstr ""
 "chiama la funzione pulita. Ha trovato `lower_call/new.rs` in linea-ctor "
 "`this_slot` indipendentemente da qualsiasi sonda runtime."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -79366,15 +80380,15 @@ msgstr ""
 "locale `Symbol` non ha avuto slot ombra affatto. Eseguire a mano quando si "
 "tocca un sito `alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. Gli strumenti runtime secondo, e la mente la profondità"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Dal numero 7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -79389,7 +80403,7 @@ msgstr ""
 "modalità letterale every-poll quando la finestra che stai cacciando esegue "
 "solo una volta che è molto più lento."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -79398,11 +80412,12 @@ msgstr ""
 "quindi un errore di lettura stantio immediatamente invece di leggere "
 "spazzatura plausibile."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT` ora è effettivamente eseguito."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -79410,7 +80425,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -79427,7 +80442,7 @@ msgstr ""
 "gc_schedule_fuzz.sh <binary> [seed-count]` spazza i semi e stampa un comando "
 "di riproduzione per guasto."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -79442,7 +80457,7 @@ msgstr ""
 "collections fire è l'unico modo economico per esplorare lo spazio in cui il "
 "bug vive."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -79455,7 +80470,7 @@ msgstr ""
 "dentro quando viene dereferenced. **Usa 800.** Un'esecuzione pulita alla "
 "profondità predefinita non significa nulla."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -79484,7 +80499,7 @@ msgstr ""
 "statico, guarda prima il controllore. Questo è il modo in cui lo zod `clone` "
 "disaccordo è stato risolto."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -79496,7 +80511,7 @@ msgstr ""
 "frame che possiede il registro di registrazione di solito arriva come un "
 "argomento da un chiamante che lo lascia andare stantio."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -79508,11 +80523,11 @@ msgstr ""
 "sonda runtime da notare. Questi strumenti catturano il _consequence_, più "
 "tardi. La pedina statica cattura la _cause_, ora."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "L'immagine dello specchio: una barriera di scrittura mancante (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -79524,43 +80539,43 @@ msgstr ""
 "**raccontato di**. I due sono doppie, e questa è la parte che continua a "
 "catturare la gente **i loro rivelatori sono scambiati**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "rooting bug"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "Barriera di scrittura missing/deleted"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "ciò che va storto"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "un valore live è invisibile alla scansione radice"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "un vecchio→giovane bordo è assente dal set ricordato"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "quando va storto"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "alla collezione, silenziosamente"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "non al negozio per niente; in qualche _più tardi_ minore"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "il rivelatore"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -79570,30 +80585,30 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE`), più il controllo statico per la metà IR-"
 "visibile"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **asserzione IR statica**, e nient'altro"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "il punto cieco"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "il checker statico non può vedere una cache di un puntatore di massa sul "
 "lato runtime (vedere §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**ogni sonda runtime che abbiamo**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "Perché nessuna sonda di runtime può vederlo"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -79608,18 +80623,18 @@ msgstr ""
 "in un guasto osservabile ha bisogno di una congiunzione il programma deve "
 "fornire da solo:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "il genitore deve sopravvivere nel vecchio-gene (o essere tenuto) **prima** "
 "il deposito;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "il bambino deve essere ancora nel vivaio **al prossimo minore**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -79627,7 +80642,7 @@ msgstr ""
 "a **minore** la raccolta non è un'intera striscia, che ripercorre tutto e le "
 "carte su tutta la classe che deve atterrare in quella finestra; e"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -79635,7 +80650,7 @@ msgstr ""
 "quel bordo deve essere il percorso _only_ al bambino, o qualche altra radice "
 "lo trova comunque e la collezione è pulita."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -79643,7 +80658,7 @@ msgstr ""
 "Miss uno e il minore raccoglie correttamente, il programma stampa la "
 "risposta giusta, e la sonda segnala il successo. Non e' stato provato niente."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -79653,7 +80668,7 @@ msgstr ""
 "loro sono rivolte ad una proprietà completamente diversa, ed è facile da "
 "leggere il loro verde come prova:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -79667,7 +80682,7 @@ msgstr ""
 "non è riuscito a riscrivere. Ricordare e riscrivere sono proprietà diverse, "
 "e il verificatore chiede solo della seconda."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -79678,7 +80693,7 @@ msgstr ""
 "il set ricordato**. Non rende visibile il bug; rende il bug irraggiungibile. "
 "Una corsa verde qui è la prova più forte e vuota dei tre."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -79690,7 +80705,7 @@ msgstr ""
 "lato radicante della dualità. Colpa di un puntatore penzolante dallo spazio, "
 "non di un oggetto vivo che non è mai stato rintracciato."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -79705,7 +80720,7 @@ msgstr ""
 "Ogni nome in questo documento è uno che il cancello ha confermato un parser "
 "dal vivo possiede."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -79718,7 +80733,7 @@ msgstr ""
 "esecuzione in cui \"la barriera non è stata eseguita\" è un evento "
 "distinguibile."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -79738,11 +80753,11 @@ msgstr ""
 "0**, sia su un dispositivo di gap che su uno più ampio avversario. Il test "
 "statico IR è stato l'unica cosa che ha detto di no."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "Che un PR che aggiunge o muove un negozio su un GC slot deve"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -79752,7 +80767,7 @@ msgstr ""
 "comportamentale. Quattro cose che deve pin, ciascuno perché un sabotaggio "
 "che saltato è stato _not_ catturato:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -79762,7 +80777,7 @@ msgstr ""
 "scrittura, la nota di layout e la stringa addref. Uno dei tre che mancano è "
 "la famiglia #5094 / #7511 di ciocche silenziose."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -79775,7 +80790,7 @@ msgstr ""
 "che ogni affermazione di contenuto felicemente ispezionato, e inizialmente "
 "passato. La presenza di codice non è una prova che funziona."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -79786,7 +80801,7 @@ msgstr ""
 "significa che il discriminatore ha smesso di discriminare, e "
 "l'\"ottimizzazione\" non sta misurando nulla."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -79796,9 +80811,10 @@ msgstr ""
 "registrare che il test diventa rosso. Un test che non ha mai fallito è un "
 "test la cui modalità di guasto è sconosciuta."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -79815,36 +80831,25 @@ msgstr ""
 "class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` e "
 "`write_pic_barrier_tests.rs` sono la forma."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "Il marcatore `GC_STORE_AUDIT`, e ciò che fa e non prova"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Ogni negozio GC grezzo ha un marcatore nelle vicinanze che indica il "
 "verdetto:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// GC_STORE_AUDIT(BARRIERED): la scrittura dello slot è incondizionata; la "
-"barriera"
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr ""
-"// qui sotto è sorvegliato solo da un test dal vivo che i bit memorizzati "
-"non trasportano cumuli"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// puntatore, che è il primo test della barriera."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -79857,7 +80862,7 @@ msgstr ""
 "non si dispone di marcatore **nuovo** sito di negozio non può atterrare con "
 "la domanda senza risposta."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -79866,7 +80871,7 @@ msgstr ""
 "**Indicazione**, non solo il commento, per le due classi in cui un falso "
 "claim si oppone:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -79908,7 +80913,7 @@ msgstr ""
 "cancello, spostare la chiamata dal suo blocco, bypassare il cancello) "
 "correre nella suite contro ogni stelo."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -79935,7 +80940,7 @@ msgstr ""
 "sbarrati e una chiamata di barriera nella stessa funzione passano ancora), e "
 "lo script stampe che limitano."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -79959,11 +80964,11 @@ msgstr ""
 "piante `--self-test` quindici forme, ciascuna delle quali deve essere "
 "giudicata."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "Il problema del corpus e i due corpora (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -79971,7 +80976,7 @@ msgstr ""
 "**Un corpus scritto a mano non può esprimere questa classe di bug a scala di "
 "dipendenza, e per un po 'nessuno ha potuto dire, perché era verde.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -79986,7 +80991,7 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. #7280 lo mette in una frase: _25 "
 "file curati passano mentre 20 linee di stock zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -79994,39 +80999,39 @@ msgstr ""
 "Non è un problema di dimensioni. Entrambi i corpi sono stati misurati sullo "
 "stesso compilatore con `--stale-registers --moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "Utilizzi stantii"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "ciò che domina"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "curato, 124 fonti / 144 moduli"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "windows helper property-GET, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "scala di dipendenza, 81 moduli / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -80034,7 +81039,7 @@ msgstr ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -80050,7 +81055,7 @@ msgstr ""
 "per campo fuori dai dati. **I pericoli di radicamento vivono nelle forme**, "
 "quindi un corpus senza le forme non può esprimerle per quanti file ha."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -80058,11 +81063,12 @@ msgstr ""
 "Quindi c'è un secondo corpus, generato da una reale dipendenza npm piuttosto "
 "che da qualsiasi cosa scritta per l'occasione:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod è un package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -80077,7 +81083,7 @@ msgstr ""
 "dal momento che ~90 moduli di `zod` palude qualsiasi conteggio una fonte "
 "mancante 40-linea attraverserebbe."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -80089,11 +81095,11 @@ msgstr ""
 "sono lineari nel conteggio delle istruzioni. Il budget `--stale-registers` è "
 "quello costoso (~5 min): la sua scansione è superlineare, e 62 MB è 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "Il cancello IC"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -80105,20 +81111,20 @@ msgstr ""
 "build; i due controlli gated sono circa tre secondi ciascuno oltre ~2000 e "
 "~12900 funzioni."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "È costruito per essere in grado di fallire, contro tutti e quattro i "
 "pericoli in CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "lo stato di uscita del pedinatore è il valore di `continue-on-error` del "
 "lavoro, senza pipe;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -80126,7 +81132,7 @@ msgstr ""
 "`concurrency` annulla solo le uscite di pull-request, quindi le uscite "
 "`main` non hanno mai fame;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -80137,7 +81143,7 @@ msgstr ""
 "l'esecuzione stampe `checked N functions / M modules` in modo che una corsa "
 "silenziosamente vuoto è visibile;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -80149,7 +81155,7 @@ msgstr ""
 "richiede che tutti i 40 siano segnalati  sul braccio che cattura la pedina "
 "perdendo silenziosamente la capacità di leggere l'output di Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -80165,11 +81171,11 @@ msgstr ""
 "sono statici ed istantanei ed entrambi hanno spedito voci morte: nove in "
 "`ALLOC_RE` su due round, dieci in `POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "La lista delle autorizzazioni, e perché non è un numero"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -80179,7 +81185,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, una voce ciascuno con un'impronta "
 "digitale, un problema, e una giustificazione scritta."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -80192,11 +81198,11 @@ msgstr ""
 "per verde una costruzione rossa è quello di aumentare il numero di uno, e "
 "nulla nel diff dice ciò che è stato concesso."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Quindi il controllore applica tre proprietà:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -80207,7 +81213,7 @@ msgstr ""
 "questo che un bug fisso non può lasciare una lapide che allarga "
 "tranquillamente la copertura in seguito."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -80215,14 +81221,14 @@ msgstr ""
 "**una voce sopprime al massimo il suo `count`.** Una seconda violazione "
 "della stessa forma nella stessa funzione è nuova, e fallisce."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**una violazione senza ingressi non riesce**, indipendentemente da quante "
 "voci esistono."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -80231,11 +81237,11 @@ msgstr ""
 "`count` a verde una build è la cosa esatta che questo file esiste per "
 "prevenire."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Promuovere questa porta"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -80244,11 +81250,11 @@ msgstr ""
 "della protezione dei branch**, quindi non può far fallire un merge — rischio "
 "2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Entrambe le condizioni #7198 sono ora soddisfatte:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -80258,7 +81264,7 @@ msgstr ""
 "voci #7211 sono state eliminate quando il predicato è stato fissato in "
 "\\#7226);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -80268,7 +81274,7 @@ msgstr ""
 "(#7236). Questo era quello eccezionale: era 98 prima #7235, 2 dopo, e 0 una "
 "volta `Type::Symbol` smesso di essere classificato come immediato."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -80276,7 +81282,7 @@ msgstr ""
 "Quindi il passo rimanente è per un **repo admin** per aggiungere `gc-root-"
 "dominance` ai contesti richiesti per la protezione dei rami:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -80291,7 +81297,7 @@ msgstr ""
 "stato verde nei suoi blocchi di forma attuali ogni PR aperto il giorno che "
 "diventa necessario."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -80314,11 +81320,11 @@ msgstr ""
 "fissato; una promozione che congela il bilancio dove è comprato un numero, "
 "non un invariante."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Regole del pollice"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -80333,7 +81339,7 @@ msgstr ""
 "circa gli inizializzatori forniti dall'autore, mai circa le chiamate "
 "`js_object_set_field_by_name` emesse dall'abbassamento."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -80342,7 +81348,7 @@ msgstr ""
 "carico da un root slot attraverso una chiamata. `rooted_handle_get` esiste "
 "per questo."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -80352,7 +81358,7 @@ msgstr ""
 "più operandi dove uno è materializzato prima che un altro sia abbassato ha "
 "bisogno del primo radicato."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -80360,7 +81366,7 @@ msgstr ""
 "**`--trace llvm` e leggilo.** Tre secondi della pedina batte al giorno di "
 "bisettare un `not a function` cinque cicli a valle."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -80624,6 +81630,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Eseguirlo localmente con:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Validazione in Fase di Compilazione"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "L'utente sceglie il backend per ogni carico di lavoro"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -81083,7 +82258,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: String -- il nome del registro, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -81121,38 +82297,35 @@ msgid "Three types and one rule."
 msgstr "Tre tipi e una regola."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr "/// Un registro contenente un valore gestito da GC NON radicato."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr ""
-"/// Prende in prestito l'emittente immutabilmente. Non clone, non copia."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Una radice ombra-slot. Outlives punti di raccolta; non può essere letto "
 "direttamente."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// ottenibili solo da ShadowFrame::alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 "/// Un registro contenente qualcosa che il GC non gestisce: i32, doppio, "
 "bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// un indice delle bande orarie. Liberamente clonabile, senza vita, senza "
-"prendere in prestito l'emittente."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -81163,28 +82336,33 @@ msgstr ""
 "loro capacità di raccogliere**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "/// Impossibile raccogliere. Prende & self, quindi le maniglie `Raw` "
 "eccezionali rimangono valide."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// PUÒ raccogliere. Prende &mut self, che termina ogni prestito `Raw` "
 "eccezionale."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// Rileggere lo slot. Il Raw restituito è valido fino alla prossima "
 "emissione di &mut."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 "/// Consumare questo registro in una radice. L'unico modo per fare un Rooted."
 
@@ -81203,24 +82381,22 @@ msgstr ""
 "utilizzato in un punto di raccolta** Il compilatore lo rifiuta."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_>, prese in prestito e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// needs &mut e"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERRORE:"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// che è mutevole"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// preso in prestito"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -81230,7 +82406,8 @@ msgstr ""
 "dall'errore:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// riletto, corretto"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -81875,8 +83052,9 @@ msgstr ""
 "**Il portellone di fuga**, per tutto il tempo che ogni chiamante lo usa."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -83524,11 +84702,15 @@ msgstr ""
 "macchina di compilazione."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Questo modello di sidecar non ha una scrittura di prima esecuzione, quindi "
 "sono supportate le directory di installazione in sola lettura. Spostare "
@@ -83536,7 +84718,21 @@ msgstr ""
 "mancanti o non corrispondenti a hash falliscono prima di `dlopen` con un "
 "errore di imballaggio."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -83553,7 +84749,7 @@ msgstr ""
 "archivio. Perry non rimuove gli attributi di quarantena da binari scaricati "
 "non attendibili al runtime."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -83572,11 +84768,11 @@ msgstr ""
 "gestore dei pacchetti, impedendo al file host `.node` di inserire un "
 "artefatto di destinazione."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Identità cache"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -83584,31 +84780,31 @@ msgstr ""
 "L'addon manifest del tempo di compilazione è ordinato deterministicamente e "
 "contribuisce alle identità della cache di compilazione e collegamento:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "la versione schema policy e la versione Node-API pubblicizzata;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "tuple bersaglio e liste di permessi normalizzati;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "pacchetto selezionato name/version e relativo percorso di ingresso;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 e dimensioni di ogni file di carico del sidecar;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "l'inventario ordinato dei simboli esportati;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "modello di spedizione (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -83623,11 +84819,11 @@ msgstr ""
 "di build di livello superiore anche quando tutti i file TypeScript e gli "
 "oggetti sono immutati."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -83646,22 +84842,15 @@ msgstr ""
 "versione-8 quando necessario per la risoluzione binaria, ma segnala "
 "deterministicamente la funzione dichiarata non supportata."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: core attraverso la versione 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Punti di entrata"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -83669,49 +84858,56 @@ msgstr "Punti di entrata"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Stabile archiviazione per ambiente"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "I valori di Singleton ricevono normali maniglie con scopo"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Allocatori Perry object/array"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -83719,11 +84915,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Conversioni Perry NaN-box"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -83731,37 +84927,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Bounded di lunghezza; supportato da `NAPI_AUTO_LENGTH`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "I callback nativi usano i record degli host"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` viene installato quando viene fornito"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "Include funzione, esterna, simbolo e distinzioni bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -83769,11 +84965,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Comportamento type/status controllato"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -83781,11 +84977,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "Semantica della lunghezza della query e NUL-termination incluso"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -83793,19 +84989,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "Il codice utente è un'eccezione"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Semantica generale dell'oggetto"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -83813,11 +85009,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "Stringa, simbolo e tasti numerici"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -83825,11 +85021,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "Nome UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -83837,43 +85033,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Array e oggetti esotici indicizzati"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Descrittori di dati, metodi e accessori"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Nessuna scorciatoia di identità del puntatore"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "Generale Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "Callback-info vita è la chiamata nativa"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -83881,11 +85077,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Tabella dei metadati degli oggetti nativi"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -83893,11 +85089,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Design di riferimento forte e debole sopra"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -83907,11 +85103,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Strict nidificazione e validazione della generazione"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -83919,19 +85115,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Modello in attesa di fessura"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Disponibile durante l'attesa"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -83939,37 +85135,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Puntatori di supporto stabili"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Tutti e undici i tipi dichiarati di \"arrotondamento\""
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Protezione dell'identità e degli offset"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Restituisce 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -83977,19 +85173,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "I record differiti sono radici di proprietà ambientale"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -83997,40 +85193,40 @@ msgstr ""
 "Restituisce `napi_generic_failure`; l'esecuzione arbitraria della sorgente "
 "runtime violerebbe il modello no-runtime-engine"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Contabilità della pressione dei collettori"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: versioni da 5 a 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "Post-definizione del GC in questione"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -84038,11 +85234,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Precisione arbitraria"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -84050,23 +85246,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "Esatto comportamento `lossless` e word-count"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "Modalità raccolta, filtro e conversione chiavi onorate"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -84074,46 +85270,46 @@ msgstr ""
 "Un record per ambiente; la sostituzione sovrascrive senza chiamare il "
 "finalizzatore precedente"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Propagazione del distacco esistente"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "Tag a 128 bit nei metadati oggetto"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Macchine per descrittore Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: versione 9, versione 10, e sperimentale"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -84121,16 +85317,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "Pubblicità solo con una superficie completa della versione-9"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -84138,11 +85334,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Richiede stringa esterna lifetime/accounting lavoro"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -84150,29 +85346,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "alias per il percorso veloce della versione-10"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "Non fa parte dell'ABI stabile pubblicizzato"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -84180,33 +85376,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Registrazione del legacy e percorso di interruzione"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Integrazione degli asincroni esistenti"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -84214,11 +85410,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` identità e byte stabili"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -84226,15 +85422,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Macchina di stato esplicita sopra"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -84242,15 +85438,15 @@ msgstr ""
 "Restituisce i componenti di semver di Perry con la stringa di rilascio "
 "`perry`; non rivendica una release Node"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr "Restituisce `napi_generic_failure` e un loop null; Perry non ha libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -84258,19 +85454,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Ciclo di vita del filo principale"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Contesto async e nidificazione rigorosa"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -84278,11 +85474,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN supportato da pompa di eventi"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -84290,35 +85486,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Conteggio filetta e conservazione loop eventi"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "Spegnimento attende il completamento"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "L'ambiente registra già il valore futuro"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Pubblicità con la versione 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -84328,18 +85524,18 @@ msgstr ""
 "`napi_register_module_v1`; questi sono esaminati nell'addon e non sono "
 "esportazioni host."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Portoni richiesti"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "L'implementazione non è completa fino a quando i cancelli sottostanti non "
 "possono fallire in modo indipendente:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -84351,7 +85547,7 @@ msgstr ""
 "forzati e alle collezioni complete; la convalida della generazione di "
 "stantia; gli script di revisione root-holder e rekey-table sono puliti."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -84362,7 +85558,7 @@ msgstr ""
 "prima che Perry rilanci; un addon strumentale afferma che nessun "
 "rilassamento è entrato nei suoi frame."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -84373,7 +85569,7 @@ msgstr ""
 "all'eseguibile Perry. Il numero di chiamate al fumo deve essere maggiore di "
 "zero."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -84385,7 +85581,7 @@ msgstr ""
 "buffer. La versione NAPI non supportata, NAN/V8, e `uv_*` dispositivi "
 "affermano la loro diagnostica esatta."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -84396,7 +85592,7 @@ msgstr ""
 "emettono flussi di coalescenza identici; entrambi i lati affermano che la "
 "loro implementazione nativa effettivamente è stata eseguita."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -84406,7 +85602,7 @@ msgstr ""
 "in una posizione di sola lettura e caricare con successo; la cancellazione o "
 "la mutazione di una sidecar non riesce il controllo hash manifesto."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -84414,7 +85610,7 @@ msgstr ""
 "**Cancello della cache:** cambiando solo addon byte o policy manca la cache "
 "di compilazione; la ricostruzione degli input immutati lo colpisce."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -84423,7 +85619,7 @@ msgstr ""
 "addon vuoto; segnala il delta host-only per una generazione addon e applica "
 "il budget 0.6 MB."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -84992,28 +86188,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "Utilizzare comandi espliciti per scopi più ampi:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Prodotto feedback ciclo"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Ogni membro dello spazio di lavoro compatibile con l'host (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$package\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Ispezionare o convalidare l'architettura dello spazio di lavoro"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -85165,7 +86347,8 @@ msgstr ""
 "costruisce con `--no-default-features` per separare il backend testual-IR."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr ""
 "# Costruisci il prodotto predefinito e la sua chiusura della dipendenza"
 
@@ -85291,7 +86474,8 @@ msgstr ""
 "l'involucro:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# Sottile, sviluppatore ottimizzato CLI"
 
 #: src/contributing/building.md:80
@@ -85325,26 +86509,31 @@ msgid "Build Specific Crates"
 msgstr "Build di crate specifici"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# Solo runtime (devono ricostruire anche stdlib!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Gli archivi statici .a sono emessi da casse separate di involucro (#5422), "
 "quindi un"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# esplicitamente quando avete bisogno di libperry_runtime.a / "
 "libperry_stdlib.a (e.g. per collegare"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Solo codice"
 
 #: src/contributing/building.md:106
@@ -85391,17 +86580,21 @@ msgid "Run Tests"
 msgstr "Esecuzione dei test"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Obiettivi delle unità di prodotto"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Ispezionare il campo di prova IC notturno (tutte le casse di prova "
 "compatibili con Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Cassetta specifica"
 
 #: src/contributing/building.md:137
@@ -85409,11 +86602,13 @@ msgid "Compile and Run TypeScript"
 msgstr "Compilare ed eseguire TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Compila un file TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Debug: stampa HIR"
 
 #: src/contributing/building.md:148
@@ -85482,19 +86677,23 @@ msgstr ""
 "registro pubblico differisce."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Confermare che il checkout è corrente e pulito."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# deve stampare 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# deve stampare nulla"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Politica veloce e controllo script."
 
 #: src/contributing/releasing.md:23
@@ -85502,7 +86701,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Controlli comportamentali da host-runnable. Questi migliorano la svolta, "
 "ma non"
@@ -85529,7 +86730,8 @@ msgstr ""
 "attraverso il normale processo di fusione prima."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Sostituire la versione già presente in Cargo.toml."
 
 #: src/contributing/releasing.md:48
@@ -85549,7 +86751,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # must print nothing"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -85657,9 +86860,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "azione consentita: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -85691,22 +86895,15 @@ msgstr ""
 "sopra. Il condotto di rilascio rifiuta intenzionalmente un set parziale."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# esecuzione di un pacchetto di rilascio: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # pubblica + verifica tutti i 9 tramite OIDC, "
-"quindi crea"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + la versione GitHub ultima"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# controllare la ricevuta commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -85924,11 +87121,13 @@ msgstr ""
 "simctl` per verificare che un esempio di doc sia eseguito senza un umano:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# Compila per il simulatore"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr ""
 "# Avviare un dispositivo (una volta; riutilizzare l'UDID attraverso le corse)"
 
@@ -85937,21 +87136,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Installare + lanciare con la modalità test"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# App esce 0 dopo il rendering; screenshot atterra al contatore-ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -86223,6 +87410,10 @@ msgid "patch distance"
 msgstr "distanza del cerotto"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -86258,15 +87449,18 @@ msgstr ""
 "che il registro ha raggiunto."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# dimostra che può fallire"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# registro reale, nessun problema scrive"
 
 #: src/contributing/releasing.md:289
@@ -86323,6 +87517,378 @@ msgstr ""
 "di lavoro fallito. Per riprovare le gambe di distribuzione legacy release-"
 "packages, spedirlo con `existing_tag=vX.Y.Z`; aggiungere `publish_npm=true` "
 "solo quando la gamba idempotent npm stessa ha bisogno di riprovare."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"\""
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# Modificare src/lib.rs &gt; aggiungi le tue funzioni `js_*`, tutte "
+#~ "usando solo"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr ""
+#~ "# Modifica src/index.ts ® Dichiara le importazioni del codice utente di "
+#~ "superficie TS"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# Modifica l'elenco package.json di JS_* ogni esportazione di js_*"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# Il manifesto combacia con il lib statico"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# il ponteggio release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # costruisce precostruiti per tutti "
+#~ "gli obiettivi"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # e li lega al rilascio"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Collanamenti nativi per <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string` Testo estratto da un buffer PDF."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # Sicurezza"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` deve essere nullo o valido per `buf_len` byte. Perry passa"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// questa coppia da un parametro `buffer+len`."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr ""
+#~ "// risultato di coste = attendere spawn((() => "
+#~ "heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding e inset"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 fetta (obiettivo predefinito del dispositivo)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. allineare i minos + fusibile"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"piattaforme;android-35\" \"strumenti di costruzione;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"immagini di sistema;android-34;android-wear;arm64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Il target Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Crea + avvia un emulatore Wear OS (orologio rotondo)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Ulteriori pacchetti npm e API Node.js supportati da Perry. Tutti quelli "
+#~ "elencati qui sono collegati tramite il registro dei binding nativi noti "
+#~ "di Perry (#466) e compilano in codice nativo senza alcun coinvolgimento "
+#~ "di un runtime JavaScript."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr "# 3) Controllare la firma localmente prima di caricare il manifesto"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    Qui prevede una verifica di passaggio sul cliente."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Release CI firma il manifesto CLI, legando il suo URL archivio, "
+#~ "piattaforma,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// Rilevamento obiettivo: aarch64-apple-ios → arm64-apple-ios16.0, "
+#~ "iphonos SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// Compile: switchc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// Link: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"Tipo di contenuto: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "\"{\"testo\": \"ciao mondo\"}\""
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"valore\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "\"{\"valore\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "\"{\"s\"}\""
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Lascialo correre per 30 secondi"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Controlla le statistiche"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Fai una schermata per vedere lo stato finale"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Ferma il caos"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Controllare che l'app sia ancora viva"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Generazione per iOS (cross-compile)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "'.jobs[] | select(.status==\"in_progress\") | (.etichetta|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# Quanto è profonda la coda, e su quali piscine:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "'.jobs[] | select(.status==\"queued\") | (.etichetta|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "Legare i nativi per libfoo"
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\"\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Navi Perry **due canali indipendenti di opt-in** per l'invio di dati a "
+#~ "casa ... non lascia la vostra macchina senza un `enabled = true` "
+#~ "esplicito o `on` in `~/.perry/config.toml`. Entrambi onorano "
+#~ "`PERRY_NO_TELEMETRY=1` e `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "emettono diagnostica del collettore leggibile dall'uomo"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr ""
+#~ "# NATIVE (PERRY_RS4GC=1): il valore predefinito ovunque. Ancoraggi in "
+#~ "corso"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` alloca radice e LLVM inserisce i punti di sicurezza "
+#~ "in seguito, quindi il"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): la scrittura dello slot è incondizionata; "
+#~ "la barriera"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// qui sotto è sorvegliato solo da un test dal vivo che i bit memorizzati "
+#~ "non trasportano cumuli"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// puntatore, che è il primo test della barriera."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr ""
+#~ "/// Prende in prestito l'emittente immutabilmente. Non clone, non copia."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// un indice delle bande orarie. Liberamente clonabile, senza vita, "
+#~ "senza prendere in prestito l'emittente."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERRORE:"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// che è mutevole"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// preso in prestito"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$package\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Ispezionare o convalidare l'architettura dello spazio di lavoro"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# esecuzione di un pacchetto di rilascio: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # pubblica + verifica tutti i 9 tramite OIDC, "
+#~ "quindi crea"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + la versione GitHub ultima"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# App esce 0 dopo il rendering; screenshot atterra al contatore-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -87388,9 +88954,6 @@ msgstr ""
 
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "Variabili d'ambiente `LANG` / `LC_ALL` / `LC_MESSAGES`"
-
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Validazione in Fase di Compilazione"
 
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""

--- a/docs/po/ja.po
+++ b/docs/po/ja.po
@@ -214,7 +214,7 @@ msgstr "フック"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "例"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "CI レベル（PR チェック / スイープ / 完全スイート）"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "CI チェックのスケジューリング"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "CLI リファレンス"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "コマンド"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "コンパイラフラグ"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "キャッシュディレクトリ"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "動的 Stdlib ディスパッチ"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS ランタイム オプトイン"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest`（バイナリ証明サイドカー）"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "出力先許可リスト（`allowedHosts`）"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "パッケージ別ケイパビリティ（`perry.permissions`）"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "ホスト許可リスト（nativeLibrary、compilePackages）"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "perry.toml リファレンス"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "アプリ内のアップデート確認"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "プライバシーとテレメトリ"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "内部実装"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "メモリモデル"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "ガベージコレクター"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "明示的なメモリ管理"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "GC ルート保持の不変条件（コード生成）"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "ローカルバインディングの型根拠"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "インクリメンタル GC ステップの上限"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC：構造による GC ルート保持"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "コントリビューション"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "アーキテクチャ"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "クレートポリシー"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "ソースからビルド"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Perry のリリース"
 
@@ -932,7 +940,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# オリジナル macOS/Windows/Linux ウィンドウを開きます"
 
 #: src/introduction.md:79
@@ -965,11 +974,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -978,9 +987,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -990,7 +999,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "次のステップ"
@@ -1063,27 +1072,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux リンクヤー ツールチェーンの分布:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint について"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# アーチ / マンジャロ / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS ストリーム"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# アルプス/モスルベース"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# 無効 Linux"
 
 #: src/getting-started/installation.md:41
@@ -1125,15 +1140,18 @@ msgstr ""
 "す"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Project-local (depsの隣に Perry のバージョンをピン)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# ゼロインストール ワンショット"
 
 #: src/getting-started/installation.md:66
@@ -1327,7 +1345,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "バイナリは`target/release/perry`にあります。PATHに追加してください:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# ~/.zshrc または ~/.bashrc に追加する"
 
 #: src/getting-started/installation.md:129
@@ -1463,16 +1482,14 @@ msgstr ""
 "用途や他のプラットフォームへのクロスコンパイルでは不要です。）"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / デビアン"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2152,24 +2169,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "同じコードが6つのプラットフォームすべてで動作します:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (デフォルト)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOSシミュレーター"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# Web (自立 HTML ファイルで WebAssembly + DOM ブリッジにコンパイル)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# アリエス:--target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# 他のプラットフォーム"
 
 #: src/getting-started/first-app.md:138
@@ -2413,7 +2435,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2431,7 +2453,7 @@ msgstr "\"ペリー\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2648,7 +2670,8 @@ msgstr ""
 "プレーンなソースとして出力します。生成スクリプトの例："
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2680,7 +2703,8 @@ msgid "\"port\""
 msgstr "\"港\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// 独立したソース"
 
 #: src/getting-started/project-config.md:122
@@ -2926,19 +2950,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "フィールド"
 
@@ -2953,9 +2978,9 @@ msgstr "フィールド"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3073,11 +3098,13 @@ msgid ""
 msgstr "Perryは設定なしで多くの人気npmパッケージをネイティブにサポートします:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3132,7 +3159,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3140,7 +3167,7 @@ msgstr ""
 "これらはPerryの組み込み実装を使用してネイティブコードにコンパイルされます。完"
 "全なリストは[標準ライブラリ](../stdlib/overview.md)を参照。"
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3149,46 +3176,49 @@ msgstr ""
 "`compilePackages`を、複雑なパッケージにはJavaScriptランタイムフォールバックを"
 "使用します。"
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "プロジェクト構造"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perryはプロジェクト構造について柔軟です。一般的なパターン:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "UIアプリの場合:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "コンパイル"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# ファイルをコンパイルする"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# 特定のターゲットでコンパイルする"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# デバッグ: プリント中間表示"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr ""
 "すべてのオプションについては[CLIコマンド](../cli/commands.md)を参照してくださ"
 "い。"
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr "[CLIコマンド](../cli/commands.md) — すべてのコンパイラコマンドとフラグ"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3196,7 +3226,7 @@ msgstr ""
 "[サポートされている機能](../language/supported-features.md) — どのTypeScript"
 "機能が動作するか"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr ""
 "[標準ライブラリ](../stdlib/overview.md) — サポートされているnpmパッケージ"
@@ -3336,32 +3366,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "クラス"
 
@@ -5374,6 +5405,7 @@ msgstr ""
 "ポートします:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5383,7 +5415,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**レガシークラスデコレーター、メソッドデコレーター、プロパティデコレーター、"
 "コンストラクターパラメーターデコレーター、メソッドパラメーターデコレーター**"
@@ -5395,7 +5431,7 @@ msgstr ""
 "はデコレートされたクラス／メソッドに対して`design:paramtypes`を、デコレートさ"
 "れたプロパティに対して`design:type`を出力します。"
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5407,15 +5443,15 @@ msgstr ""
 "ンタイムのデコレーター機構は一切使用しません。実装は`crates/perry-hir/src/"
 "decorator_log.rs`を参照してください。"
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "動作しないもの"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "アクセサーデコレーターとディスクリプターの置き換え"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5430,16 +5466,16 @@ msgstr ""
 "ど、実際のデコレーターをPerryで使用するにはPortingが必要です。変換後のクラス"
 "はIR上で固定されており、ランタイムで置き換えることはできません。"
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "デコレーター構文の外での一般的な`Reflect.metadata(...)`ヘルパー呼び出し"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "メタデータキーとしての`Symbol(...)`"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5447,7 +5483,7 @@ msgstr ""
 "クラス/メソッドの`design:paramtypes`およびプロパティの`design:type`を超えた"
 "`emitDecoratorMetadata`"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5457,12 +5493,12 @@ msgstr ""
 "ターのcanaryを超えるもの: `tsyringe`、フルNestJSインジェクターの動作、Angular"
 "のrootインジェクター）"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "`class-validator`、`type-graphql`、`TypeORM`のランタイムメタデータフロー"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5472,11 +5508,11 @@ msgstr ""
 "用のAOT変換であり、レガシーTypeScriptデコレーターランタイムへの依存ではありま"
 "せん。"
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "推奨パターン: 明示的な構築"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5488,7 +5524,7 @@ msgstr ""
 "構成する方法であり、デコレータフリーのTSフレームワーク(Hono、tRPCサーバ、"
 "Drizzleアプリ)がすでに動作している方法です。"
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5504,7 +5540,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5514,11 +5550,11 @@ msgstr ""
 "順序が依存関係グラフ_そのもの_であり、TypeScriptコンパイラによってチェックさ"
 "れます。"
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "移行レシピ: Angularサービス"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5527,19 +5563,19 @@ msgstr ""
 "以下の例はsharity-appの実際のサービス(`src/app/services/rating.service.ts`、"
 "~80行)で、元のAngularフォームで示し、Perryに移植したものです。"
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "変更前 — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "変更後 — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "3つの機械的な変更:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5547,7 +5583,7 @@ msgstr ""
 "**`@Injectable`を削除します。** クラスの形状がすでに持っていない情報は含まれ"
 "ていませんでした。"
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5557,7 +5593,7 @@ msgstr ""
 "Angular Observable-from-HTTPは単一値でPromiseのように動作します。(マルチ値ス"
 "トリームには`AsyncIterable`を使用。)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5569,11 +5605,11 @@ msgstr ""
 "クラスがコンテナではなく手動でインスタンス化されるときには、明示的なフィール"
 "ドの方が読みやすくなります。"
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "配線"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5593,7 +5629,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5611,7 +5647,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5621,13 +5657,13 @@ msgstr ""
 "のコンテナルックアップ — すべてが`services.ts`の1つの`new RatingService(api)`"
 "行に折りたたまれます。"
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr ""
 "Angularコンポーネント、NestJSコントローラ、TypeORMエンティティについてはどう"
 "ですか?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5648,11 +5684,11 @@ msgstr ""
 "りデコラタを削除し,同等の明示的なコンストラクションを書き,ルートやスキーマを"
 "単純な関数呼び出し/モジュールレベルの常数として登録します."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "今後の方向性"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6344,12 +6380,13 @@ msgstr ""
 "面を使用し,リンク時に何も必要ありません."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**文字どおりの静的呼び出し** (`WebAssembly.instantiate(bytes)` はグローバルに"
@@ -7899,55 +7936,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "バインディング作成 — 60秒ツアー"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF rendering bindings\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr "# src/lib.rsを編集する  `js_*`関数を追加する"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# src/index.ts を編集する  TS 表面ユーザコードの輸入を宣言する"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# package.json を編集する"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ マニフェストがスタティックリブと一致する"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# スキャフォルド release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # すべてのターゲットにプリビルドを建設し"
-"ます"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr ""
-"                                    # そして,それらを解放に結びつけます"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8329,7 +8324,7 @@ msgstr "現状"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8349,7 +8344,7 @@ msgstr "包装済み 引越し未定"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8401,7 +8396,7 @@ msgstr "バンドで 移行が待っています"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8461,7 +8456,7 @@ msgstr "上流パッケージソースをコンパイルする"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8469,7 +8464,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8477,7 +8472,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8485,7 +8480,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8517,7 +8512,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8525,7 +8520,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8533,7 +8528,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8565,7 +8560,7 @@ msgstr "包装されたもの"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8573,7 +8568,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8605,7 +8600,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8613,7 +8608,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8621,7 +8616,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8629,7 +8624,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8645,7 +8640,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8653,7 +8648,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8661,7 +8656,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8669,7 +8664,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8693,7 +8688,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8701,7 +8696,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8709,7 +8704,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8717,7 +8712,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8725,7 +8720,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8733,7 +8728,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8741,7 +8736,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8749,7 +8744,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8757,7 +8752,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8765,7 +8760,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8773,7 +8768,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8781,7 +8776,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8834,14 +8829,6 @@ msgstr "事前ビルドリリースCIの足場をすぐに動作させたい場�
 msgid "1. Scaffold"
 msgstr "1. 足場の作成"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"<upstream crate>のネイティブバインド\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "これにより以下が作成されます:"
@@ -8873,28 +8860,14 @@ msgstr ""
 "`#[no_mangle] pub extern \"C\" fn`、`perry_ffi`の型**のみ**を使用:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  PDFバッファからテキストを抽出します"
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # セキュリティ"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr` は NULL または `buf_len` バイトで有効である必要があります. "
-"Perryが通過する"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// このペアは `buffer+len` マニフェストパラメータから"
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9029,7 +9002,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"優しい\""
 
@@ -9268,7 +9241,8 @@ msgid "In a separate directory:"
 msgstr "別のディレクトリで:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# またはあなたのツールがサポートする任意のパス"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9661,7 +9635,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "イベントリスナー(`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// 閉じるポインタは,下にあるGCスキャナーによって保持されています"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10092,7 +10067,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ...ファイルを読み,設定環境,返信 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10394,8 +10370,8 @@ msgstr "必須"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "備考"
 
@@ -10453,14 +10429,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12177,30 +12153,37 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "ツール  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# 特定のバージョンに1ピンを設定またはブンプする (デフォルト: 最新の安定)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# 最新の安定した時点で現在,非固定されたすべての結合の提供"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# オフラインゲート (CI):ピンは存在し,ロック・ステープ,箱は存在します. 出口1"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr "# 推奨:さらに,上流がより新しい安定解脱を持つフラグピン"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# アップストリームリポをピニングされたリフで gitignored アップストリーム/"
 "<name>にマテリアル化します"
@@ -12432,15 +12415,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "部分包装を決して置き換えてはならないCIについては,以下をセットします"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12593,7 +12576,7 @@ msgstr "現実"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12610,7 +12593,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14573,19 +14556,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Node.js worker_threadsとの比較"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~15行,別ファイルが必要です ──────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14605,14 +14588,13 @@ msgid "/* handle */"
 msgstr "/* ハンドル */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr ""
 "// ── Perry: 1行 "
 "───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const の結果 = spawn を待つ (x) => heavyComputation (x) inputData)"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14826,13 +14808,14 @@ msgid "Mental Model"
 msgstr "メンタルモデル"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "PerryのUIはSwiftUIやFlutterと同じモデルに従います: スタックベースのレイアウト"
 "コンテナ(`VStack`、`HStack`、`ZStack`)を使ってネイティブウィジェットを構成"
@@ -14918,7 +14901,7 @@ msgstr "`App({})`は以下のプロパティを持つ設定オブジェクトを
 msgid "Property"
 msgstr "プロパティ"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15363,7 +15346,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15387,7 +15370,7 @@ msgstr ""
 "プラットフォーム固有の動作は各ウィジェットのドキュメントページに記載されてい"
 "ます。"
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17003,7 +16986,8 @@ msgid "Double-click handler"
 msgstr "ダブルクリックハンドラ"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17064,12 +17048,13 @@ msgstr ""
 "抜粋です — CIはすべてのPRでコンパイルして実行します。"
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "レイアウトヘルパーは無料の機能である. `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17543,7 +17528,7 @@ msgstr "効果"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17556,7 +17541,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "子が先頭(左)の端に整列します"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17569,7 +17554,7 @@ msgid "Children centered horizontally"
 msgstr "子が水平方向に中央揃え"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17590,7 +17575,7 @@ msgstr "**HStackの整列**(交差軸=垂直):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17617,8 +17602,8 @@ msgstr "子が垂直方向に中央揃え"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17672,9 +17657,9 @@ msgstr "動作"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17697,11 +17682,11 @@ msgstr "すべての子が同じサイズになります"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -17896,9 +17881,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "組み込みパディング付きのスタック"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "1回の呼び出しでパディング付きのスタックを作成します。順序は**上、左、下、右"
 "**(CSSショートハンドスタイル)であり、上/右/下/左ではありません:"
@@ -17922,11 +17908,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)`は水平の対応物です。ス"
 "タックを作成してから`widgetSetEdgeInsets`を呼び出すのと同等ですが、より簡潔で"
@@ -18214,8 +18201,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18598,6 +18586,7 @@ msgstr ""
 "です。"
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18609,7 +18598,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18637,11 +18625,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "色"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18657,11 +18645,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "フォント"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18677,15 +18665,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "システム等幅フォントには`\"monospaced\"`を使用します。"
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "角の丸み"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18697,21 +18685,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "ボーダー"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "パディングとインセット"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "パディング"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18721,11 +18709,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "サイジング"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18741,11 +18737,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "不透明度"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18757,11 +18753,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "背景グラデーション"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18783,11 +18779,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "コントロールサイズ"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18799,7 +18795,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -18807,11 +18803,11 @@ msgstr ""
 "**macOS**: `NSControl.ControlSize`にマップ。他のプラットフォームは異なる解釈"
 "をする可能性があります。"
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "ツールチップ"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18823,7 +18819,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18831,11 +18827,11 @@ msgstr ""
 "**macOS/Windows/Linux**: ネイティブツールチップ。**iOS/Android**: ツールチッ"
 "プサポートなし。**Web**: HTML `title`属性。"
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "有効/無効"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -18847,11 +18843,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "完全な命令的例"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -18871,7 +18868,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -18899,10 +18896,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -18975,15 +18972,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "スタイルの構成(命令的ヘルパー関数)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "ヘルパー関数を作成して反復を削減します:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -18993,11 +18990,11 @@ msgstr ""
 "クンを定義し、型付きテーマファイルを生成します。完全なワークフローについては"
 "[テーミング](theming.md)を参照。"
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "プラットフォームサポート"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19008,7 +19005,7 @@ msgstr ""
 "ら自動生成され、すべてのPRで各バックエンドの`lib.rs`エクスポートに対してCI"
 "チェックされます。"
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19027,15 +19024,15 @@ msgstr ""
 "210)に記録されます. 数値を別の手作業のテーブルにコピーしないでください.マト"
 "リックスを参照してください."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — レイアウトコンテナ"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — スタイル変更のアニメーション"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr ""
 "[テーミング](theming.md) — `perry-styling`パッケージ経由のデザイントークン"
@@ -20374,8 +20371,8 @@ msgstr "実装"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "ステータス"
 
@@ -23889,7 +23886,7 @@ msgstr ""
 msgid "Options"
 msgstr "オプション"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25476,7 +25473,7 @@ msgstr "inkとの等価性"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26197,15 +26194,18 @@ msgid "Cross-Compilation"
 msgstr "クロスコンパイル"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# デフォルト: 現在のプラットフォームのコンパイル"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# 特定のターゲットのためにコンパイルする"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  Android 時計で"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26420,7 +26420,8 @@ msgid "Building"
 msgstr "ビルド"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS はデフォルトのターゲットです"
 
 #: src/platforms/macos.md:18
@@ -26524,7 +26525,8 @@ msgid "App Store Distribution"
 msgstr "App Store配布"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# App Store 証明書でサイン"
 
 #: src/platforms/macos.md:60
@@ -26532,7 +26534,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -26662,15 +26665,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "iOSでビルドして実行する最も簡単な方法は`perry run`です:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# device/simulator を自動検出する"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# stdout/stderrをライブ配信する"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Perry ハブビルドサーバを使用"
 
 #: src/platforms/ios.md:40
@@ -27310,7 +27316,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "これは物理的なApple TVハードウェア向けのARM64バイナリを生成します。"
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# オート検出 起動した Apple TV シミュレーター"
 
 #: src/platforms/tvos.md:39
@@ -27795,11 +27802,13 @@ msgstr ""
 "(#building-for-device)を参照) を用いてソースから構築する必要があります"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# シミュレーター (レベル2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -27908,20 +27917,14 @@ msgstr ""
 "を指します"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (シリーズ9+ / watchOS 26+)  デフォルトデバイスターゲット"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (4-8 / SEシリーズ)  PERRY_WATCHOS_ARM64_32で選択する"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -27938,7 +27941,7 @@ msgid "Build environment variables"
 msgstr "環境変数を構築する"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "変数"
@@ -28054,7 +28057,8 @@ msgstr ""
 "`TypeError` 値強制は 閉ざしをオブジェクトとして定義した."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# 自動検出起動時計シミュレーター"
 
 #: src/platforms/watchos.md:126
@@ -28644,36 +28648,13 @@ msgstr ""
 "ら`lipo`を一緒に:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# arm64_32 は共有展開目標 (e.g) に切断する. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64スライス (デフォルトデバイスのターゲット)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. ミノス + フューズを調整する"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -28790,19 +28771,8 @@ msgstr ""
 "ます **独自の新しいアプリの記録** アップストア・コネクトで"
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Apple ディストリビューション:<Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -28815,6 +28785,10 @@ msgid ""
 msgstr ""
 "`altool` はウォッチ アプリをアップロードできません (\"プラットフォームを決定"
 "できません\"). トランスポーターを使用:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29164,18 +29138,21 @@ msgid "One-time setup (macOS example)"
 msgstr "一回設定 (macOS例)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (Homebrew の `gradle` は 9.x  pin 8.x かもしれない)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# または任意のGradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr "# 2. SDK / NDK / JDK 17 に env を指す (シェル プロフィールに追加する)"
 
 #: src/platforms/wearos.md:40
@@ -29183,7 +29160,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -29195,32 +29173,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. SDK パッケージ + Wear OS arm64 イメージ"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"プラットフォームツール\" \"エミュレーター\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"プラットフォーム\" \"Android-35\" \"ビルドツール\" \"35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"システム画像 アンドロイド34 アンドロイドウェア アーム64V8A\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Rustクロスターゲット"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Wear OS エミュレーターを作成 + 起動 (ラウンドウォッチ)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29245,7 +29204,8 @@ msgstr ""
 "に (下) 起こります."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# 接続された時計 / 起動された Wear エミュレーターの自動検出"
 
 #: src/platforms/wearos.md:82
@@ -31224,7 +31184,8 @@ msgstr ""
 "います。"
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# 別のターミナルでは"
 
 #: src/platforms/linux.md:82
@@ -31243,7 +31204,8 @@ msgstr ""
 "完結型 HTML ファイルを生成します。"
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# --target wasm と同じ出力"
 
 #: src/platforms/web.md:10
@@ -31320,15 +31282,18 @@ msgstr ""
 "になりました。"
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# 固有 HTML (デフォルト)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# 同じこと"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasmバイナリ (HTMLラッパーなし)"
 
 #: src/platforms/wasm.md:21
@@ -31647,11 +31612,13 @@ msgid "Provide them when instantiating:"
 msgstr "インスタンス化時に提供してください:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// __ffiImports global (起動前に設定) を通して"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// またはbootPerryWasmの第2引数で"
 
 #: src/platforms/wasm.md:95
@@ -32195,7 +32162,7 @@ msgstr "完全なstdlib"
 msgid "The compiler links only the required runtime components."
 msgstr "コンパイラは必要なランタイムコンポーネントのみをリンクします。"
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "外部ネイティブバインディング"
 
@@ -32309,7 +32276,7 @@ msgstr "[ファイルシステム](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & ネットワーク](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[データベース](database.md)"
 
@@ -32532,8 +32499,8 @@ msgstr ""
 "スレッド境界を越える場合はファイルパスを渡し、ワーカー内でファイルを再オープ"
 "ンしてください。"
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[概要](overview.md) — すべてのstdlibモジュール"
 
@@ -32632,10 +32599,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "`IncomingMessage`でサポートされている: `.method`, `.url`, `.headers`, "
@@ -32644,10 +32612,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33243,10 +33212,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / S3互換オブジェクトストレージ"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33262,11 +33257,11 @@ msgstr ""
 "できます — `bun` との SigV4 事前署名 URL のバイト単位での一致に対して検証済み"
 "（issue #551）。"
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33340,78 +33335,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "同じコードがあらゆるS3互換サービスに対して動作します — `endPoint`だけが変わり"
 "ます:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "サービス"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack(テスト)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33427,7 +33422,7 @@ msgstr ""
 "は固定テストベクトルに対して `bun` とバイト単位で一致することが検証済みで、実"
 "際の S3 に対して認証されます。"
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33439,7 +33434,7 @@ msgstr ""
 "`TransformStream` のサブクラス化 — を行使します。そのパスはコンパイルされます"
 "が、ここでは固定ベクトルに対して独立して検証されていません。"
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34081,9 +34076,10 @@ msgstr ""
 "および`inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "名前付き輸入を使用:デフォルトの輸入受信機形式 (`import _ from \"lodash\";  "
@@ -34294,20 +34290,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Perry がサポートする追加の npm パッケージと Node.js API です。ここに掲載する"
-"すべては Perry の well-known native bindings レジストリ（#466）を介して配線さ"
-"れており、JavaScript ランタイムを介在させずにネイティブコードにコンパイルされ"
-"ます。"
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp(画像処理)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34315,7 +34306,7 @@ msgstr ""
 "`perry-ext-sharp` 経由のネイティブバインディング（v0.5.551）。リサイズ、"
 "フォーマット変換、バッファ/ファイル出力がすべて動作します。"
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34365,15 +34356,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio(HTMLパース)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "`perry-ext-cheerio`(v0.5.550)経由のネイティブバインディング。"
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34391,11 +34382,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer(メール)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34435,15 +34426,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib(圧縮)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "`perry-ext-zlib`(v0.5.541)経由のネイティブバインディング。"
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34461,11 +34452,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron(ジョブスケジューリング)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34473,7 +34464,7 @@ msgstr ""
 "`perry-ext-cron` 経由のネイティブバインディング（v0.5.564）。`cron` と `node-"
 "cron` のパッケージ名は両方とも同じバックエンドにルーティングされます。"
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34493,11 +34484,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers(Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34507,7 +34498,7 @@ msgstr ""
 "の BigInt + Buffer 表面を介して [`ethers-rs`](https://github.com/gakonst/"
 "ethers-rs) スタイルの ABI 配線によって支えられています。"
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34525,11 +34516,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events(EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -34538,7 +34529,7 @@ msgstr ""
 "`EventEmitter` の形は Node.js と一致します — `on`、`off`、`once`、`emit`、"
 "`removeAllListeners`。"
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -34556,16 +34547,16 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff(リトライロジック)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr ""
 "`perry-ext-exponential-backoff`(v0.5.542)経由のネイティブバインディング。"
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -34587,11 +34578,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js(任意精度)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -34600,7 +34591,7 @@ msgstr ""
 "ケージ名が同じバックエンドにルーティングされます — `Decimal` と `BigNumber` "
 "の両方が公開されます。"
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -34636,11 +34627,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns(日付操作)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -34649,7 +34640,7 @@ msgstr ""
 "ジ名が同じ Rust バックエンドにルーティングされます — 同じ parse/format/diff "
 "表面です。"
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -34667,11 +34658,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment(レガシーDate)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -34681,7 +34672,7 @@ msgstr ""
 "流ではメンテナンスモードです — 新しいコードでは `dayjs` を推奨しますが、"
 "Perry は既存のコードベースのために両方をサポートします。"
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -34697,11 +34688,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -34710,7 +34701,7 @@ msgstr ""
 "リミッターは配線済みです。Redis / クラスタバッキングストアはフォローアップで"
 "す。"
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -34734,11 +34725,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -34755,7 +34746,7 @@ msgstr ""
 "作業では,`perry/thread`から`parallelMap` / `parallelFilter` / `spawn`がよりシ"
 "ンプルなインターフェースである ([Threading](../threading/overview.md)を参照)."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -34793,14 +34784,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Web Worker モジュールの URL は,インポートするソースファイルに関連して発見され"
 "ます:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -34833,10 +34824,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander(CLIパース)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -34878,11 +35042,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -34903,7 +35067,7 @@ msgstr ""
 "`sizeCalculation`,`dispose`,`fetch`,`allowStale`およびイテレーター表面はまだ"
 "実装されていません."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -34933,11 +35097,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -34987,11 +35151,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35005,7 +35169,7 @@ msgstr ""
 "(macOS + Linux);他のホストでは`spawn`が投下され,消費者の非空きバックパスを引"
 "き起こす."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35017,7 +35181,7 @@ msgstr ""
 "signal }` を発射し,他の場合は `undefined` を発射する; `kill()` はノード-pty "
 "のような `SIGHUP` にデフォルトで設定される. `TERM`は`name`から生まれています"
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35063,11 +35227,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35083,7 +35247,7 @@ msgstr ""
 "時にネイティブファサードに折りたたまれます. 動作は`@parcel/watcher` 2.5.1と対"
 "照的にチェックされました"
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35102,7 +35266,7 @@ msgstr ""
 "`delete`と新しいパスには`create`と変更されます. バックエンドの overflow/"
 "rescan 通知は,新しいツリースナップショットを起動し,そのdiffを発信します."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35120,7 +35284,7 @@ msgstr ""
 "ベントループをアクティブにします `writeSnapshot`と`getEventsSince`は,オーバー"
 "フロー復元と同じスナップショットディフセマンティクスを使用します."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35130,7 +35294,7 @@ msgstr ""
 "の npm パッケージとも同じように `bun add` でインポートされますが、Rust で支え"
 "られ、`perry-ffi` を介してネイティブにコンパイルされます:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35139,7 +35303,7 @@ msgstr ""
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings) を参"
 "照してください。"
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35147,11 +35311,11 @@ msgstr ""
 "**`@perryts/iroh`** — Iroh のピアツーピアネットワーキング。[PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings) を参照してください。"
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "`compilePackages`経由でコンパイルされた純粋なTypeScriptドライバ:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35161,7 +35325,7 @@ msgstr ""
 "**`@perryts/redis`** — Node.js および Bun でもそのまま動作するワイヤープロト"
 "コルクライアント。"
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35169,11 +35333,11 @@ msgstr ""
 "これらの外部パッケージが従う契約については [Native Bindings — Overview](../"
 "native-libraries/overview.md) を参照してください。"
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[ファイルシステム](fs.md) — fsとpath API"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr ""
 "[ネイティブバインディング](../native-libraries/overview.md) — 独自のものを作"
@@ -35199,7 +35363,8 @@ msgstr ""
 "no-op になります。"
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "138つのモジュールで合計3019のエントリ"
 
 #: src/api/reference.md:9
@@ -35296,4835 +35461,4982 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "メソッド"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — モジュール"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "プロパティ"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount`  モジュール"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince`  モジュール"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — モジュール"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — モジュール"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot`  モジュール"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — モジュール"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — モジュール"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — モジュール"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — モジュール"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — モジュール"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — インスタンス"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — インスタンス"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — インスタンス"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — インスタンス"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — インスタンス"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — インスタンス"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — インスタンス"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — モジュール"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — モジュール"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — モジュール"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — モジュール"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — モジュール"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — モジュール"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — モジュール"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — モジュール"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — モジュール"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — モジュール"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — モジュール"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — モジュール"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — モジュール"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — モジュール"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — モジュール"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — モジュール"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — モジュール"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — モジュール"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — モジュール"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — モジュール"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — モジュール"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — モジュール"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — インスタンス _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — モジュール _(クラス: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — モジュール _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — インスタンス _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — モジュール"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — インスタンス"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — インスタンス _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — インスタンス _(クラス: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — インスタンス"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — モジュール"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — モジュール"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — インスタンス"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — インスタンス"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — インスタンス"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — インスタンス _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — モジュール _(クラス: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — モジュール"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — インスタンス _(クラス: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — モジュール"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — モジュール"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — モジュール"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — モジュール"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — モジュール"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — モジュール"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — モジュール"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — モジュール"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — モジュール"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — モジュール"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — モジュール"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — インスタンス"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — インスタンス"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — インスタンス"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — インスタンス"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — インスタンス"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — インスタンス"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — インスタンス"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — インスタンス"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — インスタンス"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — インスタンス"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — インスタンス"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — モジュール"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — モジュール"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — モジュール"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — モジュール"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — モジュール"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — モジュール"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "転送"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob`  モジュール"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — モジュール"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — モジュール"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — モジュール"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — モジュール"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — モジュール"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — モジュール"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file`  モジュール"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — モジュール"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — モジュール"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — モジュール"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — モジュール"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — モジュール"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — インスタンス _(クラス: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — インスタンス _(クラス: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — モジュール"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth`  モジュール"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — モジュール"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — インスタンス _(クラス: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction` インスタンスの _ ((クラス: `Database`) _"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported`  モジュール"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — モジュール"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — モジュール"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — モジュール"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — モジュール"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — モジュール"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction`  モジュール"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString`  モジュール"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback`  モジュール"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — モジュール"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols`  モジュール"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr`  モジュール"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer`  モジュール"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer`  モジュール"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource`  モジュール"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — モジュール"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database`  モジュール"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction` インスタンスの _ ((クラス: `Database`) _"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values` インスタンスの _ ((クラス: `Statement`) _"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — インスタンス"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — インスタンス"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — インスタンス"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — インスタンス"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — インスタンス"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — インスタンス"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — インスタンス"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — インスタンス"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — インスタンス"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — モジュール"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — インスタンス"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — インスタンス"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — インスタンス"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — モジュール"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — モジュール"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — モジュール"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — モジュール"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — モジュール"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — モジュール"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — モジュール"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — モジュール"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — モジュール"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — モジュール"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — インスタンス"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  インスタンスは"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  インスタンスは"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — インスタンス"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — インスタンス"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — インスタンス"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — インスタンス"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — インスタンス"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — インスタンス"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — インスタンス"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — インスタンス"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — モジュール"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — モジュール"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — モジュール"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — モジュール"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — モジュール"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — モジュール"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — モジュール"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — モジュール"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — モジュール"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — モジュール"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — モジュール"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — モジュール"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — モジュール"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — モジュール"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — モジュール"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — モジュール"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — モジュール"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — モジュール"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — モジュール"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — モジュール"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — モジュール"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — モジュール"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — モジュール"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — モジュール"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — モジュール"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — インスタンス"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — インスタンス"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — モジュール"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — インスタンス"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — インスタンス"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — モジュール"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash`  モジュール"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac`  モジュール"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign`  モジュール"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify`  モジュール"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2`  モジュール"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync`  モジュール"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime`  モジュール"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync`  モジュール"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv`  モジュール"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv`  モジュール"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman`  モジュール"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup`  モジュール"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH`  モジュール"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — モジュール"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — モジュール"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey`  モジュール"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey`  モジュール"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey`  モジュール"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign`  モジュール"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify`  モジュール"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate`  モジュール"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — モジュール"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — モジュール"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — モジュール"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — モジュール"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — モジュール"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — モジュール"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — モジュール"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — モジュール"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — モジュール"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — モジュール"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — モジュール"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — モジュール"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — モジュール"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — モジュール"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — モジュール"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — モジュール"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — モジュール"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — モジュール"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — モジュール"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — モジュール"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — モジュール"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — モジュール"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — モジュール"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — モジュール"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — モジュール"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — モジュール"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — モジュール"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — モジュール"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — モジュール"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — モジュール"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — モジュール"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — モジュール"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — モジュール"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — モジュール"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — モジュール"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — モジュール"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — モジュール"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — モジュール"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — モジュール"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — モジュール"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — モジュール"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — モジュール"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — モジュール"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — モジュール"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — モジュール"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — モジュール"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — インスタンス"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — インスタンス"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — インスタンス"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — インスタンス"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — モジュール"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — インスタンス"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — インスタンス"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — インスタンス"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — インスタンス"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — インスタンス"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — インスタンス"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — インスタンス"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — インスタンス"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — インスタンス"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — インスタンス"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — インスタンス"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — インスタンス"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — インスタンス"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — インスタンス"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — インスタンス"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — インスタンス"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — インスタンス"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — インスタンス"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — インスタンス"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — インスタンス"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — インスタンス"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — インスタンス"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — インスタンス"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — インスタンス"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — インスタンス"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — インスタンス"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — インスタンス"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — インスタンス"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — インスタンス"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — インスタンス"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — インスタンス"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — インスタンス"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — インスタンス"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — インスタンス"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — インスタンス"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — インスタンス"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — インスタンス"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — インスタンス"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — インスタンス"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — インスタンス"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — インスタンス"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — モジュール"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — モジュール"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — モジュール"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — モジュール"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — モジュール"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — モジュール"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — モジュール"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — モジュール"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — モジュール"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — モジュール"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — モジュール"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — モジュール"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — モジュール"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — モジュール"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — モジュール"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — モジュール"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — モジュール"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — モジュール"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — モジュール"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — モジュール"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — モジュール"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — モジュール"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — モジュール"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — モジュール"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — モジュール"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — モジュール"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — モジュール"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — モジュール"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — インスタンス _(クラス: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — モジュール"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — インスタンス"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — インスタンス"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — モジュール"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — インスタンス"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — インスタンス"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — インスタンス"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — インスタンス"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — インスタンス"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — モジュール"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — モジュール"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — モジュール _(class: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — モジュール"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — モジュール"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — モジュール"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — モジュール"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — モジュール"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — モジュール"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — モジュール"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — モジュール"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — インスタンス _(クラス: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — インスタンス _(クラス: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — インスタンス"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — インスタンス _(クラス: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — インスタンス"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — モジュール"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — インスタンス"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — モジュール"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — モジュール"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — インスタンス"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — モジュール"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — インスタンス"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — インスタンス"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — モジュール"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — インスタンス"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — モジュール"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — インスタンス"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — インスタンス"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — インスタンス"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — インスタンス"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — インスタンス"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — インスタンス"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — モジュール"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr ""
 "`triggerAsyncId` — インスタンス _(クラス: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — モジュール"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — インスタンス"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — インスタンス"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — インスタンス"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — インスタンス"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — インスタンス"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — インスタンス"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — インスタンス"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — インスタンス"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — インスタンス"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — インスタンス"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — インスタンス"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — インスタンス"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — インスタンス"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — インスタンス"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — インスタンス"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — インスタンス"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — インスタンス"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — インスタンス"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — インスタンス"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — インスタンス"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — インスタンス"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — インスタンス"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — インスタンス"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — インスタンス"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — インスタンス"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — インスタンス"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — インスタンス"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — インスタンス"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer`  モジュール"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString`  モジュール"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — モジュール"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — モジュール"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — モジュール"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — モジュール"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — モジュール"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — モジュール"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — モジュール"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — モジュール"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — モジュール"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — モジュール"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — モジュール"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — モジュール"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — モジュール"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — モジュール"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — モジュール"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — モジュール"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — モジュール"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — モジュール"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — モジュール"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — モジュール"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — モジュール"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — モジュール"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — モジュール"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — モジュール"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — モジュール"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — モジュール"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — モジュール"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — モジュール"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — モジュール"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — モジュール"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — モジュール"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — モジュール"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — モジュール"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — モジュール"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — モジュール"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — モジュール"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — モジュール"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — モジュール"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — モジュール"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — モジュール"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — モジュール"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — モジュール"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — モジュール"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — モジュール"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — モジュール"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — モジュール"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — モジュール"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — モジュール"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — モジュール"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — モジュール"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — モジュール"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — モジュール"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — モジュール"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — モジュール"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — モジュール"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — モジュール"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — モジュール"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — モジュール"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — モジュール"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — モジュール"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — モジュール"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — モジュール"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — モジュール"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — モジュール"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — モジュール"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — モジュール"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — モジュール"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — モジュール"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — モジュール"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — モジュール"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — モジュール"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — モジュール"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — モジュール"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — モジュール"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — モジュール"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — モジュール"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — モジュール"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — モジュール"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — モジュール"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — モジュール"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — モジュール"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — モジュール"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — モジュール"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — モジュール"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — モジュール"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — モジュール"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — モジュール"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — モジュール"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — モジュール"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — モジュール"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — モジュール"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — モジュール"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — モジュール"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — モジュール"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — インスタンス _(クラス: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — インスタンス _(クラス: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — インスタンス _(クラス: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — モジュール"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — モジュール"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMajor` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMinor` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening` インスタンスの _ ((クラス: `HttpServer`) _"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr ""
 "`__set_strictContentLength` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — モジュール"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — モジュール"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40132,103 +40444,103 @@ msgstr ""
 "`keepSocketAlive`  インスタンスの _ ((クラス: `Agent`) _ **スタブ** reqwestは"
 "保持プールを所有している; ソーケットのフックはNo-ops,一度警告 (#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening` インスタンスの _ ((クラス: `HttpServer`) _"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once` インスタンスの _ ((クラス: `ClientRequest`) _"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref` インスタンスの _ ((クラス: `HttpServer`) _"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40236,377 +40548,371 @@ msgstr ""
 "`reuseSocket`  インスタンスの _ ((クラス: `Agent`) _ **スタブ** reqwestは保持"
 "プールを所有している; ソーケットのフックはNo-ops,一度警告 (#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — モジュール"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — モジュール"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket` インスタンスの _ ((クラス: `IncomingMessage`) _"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — インスタンス _(クラス: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — インスタンス _(クラス: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — インスタンス _(クラス: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref` インスタンスの _ ((クラス: `HttpServer`) _"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — インスタンス _(クラス: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — モジュール"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — モジュール"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — インスタンス _(クラス: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — モジュール"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — モジュール"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — モジュール"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — モジュール"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — モジュール"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — モジュール"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr ""
 "`__get_keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening` インスタンスの _ ((クラス: `HttpsServer`) _"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr ""
 "`__set_keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening` インスタンスの _ ((クラス: `HttpsServer`) _"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref` インスタンスの _ ((クラス: `HttpsServer`) _"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — インスタンス _(クラス: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref` インスタンスの _ ((クラス: `HttpsServer`) _"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — モジュール"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  モジュール _ (クラス:`console`)"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  モジュール _ (クラス:`console`)"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  モジュール _ (クラス:`console`)"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  モジュール _ (クラス:`console`)"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -40614,7 +40920,7 @@ msgstr ""
 "`open`  モジュール **スタブ** port/host を受容するが,実際の WebSocket 検査者"
 "のエンドポイントを拘束しない.セッションはプロセス中の偽物である (#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -40624,7 +40930,7 @@ msgstr ""
 "Runtime.evaluate のサブセットのみが応答します.他のすべてのプロトコルメソッド"
 "はインスペクターエラー -32601 (#4916) を投げます"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -40632,7 +40938,7 @@ msgstr ""
 "`url`  モジュール **スタブ** 常に定義されていない: Perry は,実際のインスペク"
 "ターエンドポイント (#4916) を決して暴露しない"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -40640,3286 +40946,3277 @@ msgstr ""
 "`waitForDebugger`  モジュール **スタブ** openのすぐ後に返します ();待たなけれ"
 "ばならないデバガーはありません (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  モジュール _ (クラス:`console`)"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — インスタンス _(クラス: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — インスタンス"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — モジュール"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — インスタンス"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — インスタンス"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — インスタンス"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — インスタンス"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — インスタンス"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — インスタンス"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — インスタンス"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — インスタンス"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — インスタンス"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — インスタンス"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — モジュール"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — インスタンス"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — インスタンス"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — インスタンス"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — インスタンス"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — インスタンス"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — インスタンス"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — モジュール"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — モジュール"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — モジュール"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — モジュール"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — モジュール"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — モジュール"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — モジュール"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — モジュール"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — モジュール"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — モジュール"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — モジュール"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — モジュール"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — モジュール"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — モジュール"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — モジュール"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — モジュール"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — モジュール"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — モジュール"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — モジュール"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — モジュール"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — モジュール"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — モジュール"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — モジュール"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — モジュール"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — モジュール"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — モジュール"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — モジュール"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — インスタンス"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — インスタンス"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  インスタンスは"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — インスタンス"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — モジュール"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — モジュール"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — モジュール"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — モジュール"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — モジュール"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — モジュール"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — モジュール"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — モジュール"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — モジュール"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — モジュール"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — モジュール"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — モジュール"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — モジュール"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — モジュール"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — モジュール"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — モジュール"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — モジュール"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — モジュール"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — モジュール"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — モジュール"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — モジュール"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — モジュール"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — モジュール"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  インスタンスは"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  インスタンスは"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — モジュール"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  インスタンスは"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — インスタンス"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — インスタンス"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — インスタンス"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — インスタンス"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — インスタンス"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — インスタンス"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — インスタンス"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — インスタンス"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — インスタンス"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — インスタンス"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — インスタンス"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — インスタンス"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — モジュール"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — モジュール"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — インスタンス _(class: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — インスタンス"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — インスタンス _(class: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — インスタンス _(class: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — インスタンス"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — インスタンス"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — インスタンス _(class: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — インスタンス _(class: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — インスタンス"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — インスタンス"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — モジュール"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — モジュール"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — モジュール"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — モジュール"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — モジュール"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — モジュール"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — インスタンス _(クラス: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr ""
 "`autoSelectFamilyAttemptedAddresses` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — インスタンス _(クラス: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — インスタンス _(クラス: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — モジュール"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — モジュール"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — モジュール _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — モジュール"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — モジュール"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — モジュール"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — モジュール _(クラス: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — インスタンス _(クラス: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — モジュール"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — モジュール"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert` インスタンスの _ ((クラス: `Socket`) _"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — インスタンス _(クラス: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — インスタンス _(クラス: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — インスタンス _(class: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem`  モジュール"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem`  モジュール"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate`  モジュール"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem`  モジュール"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem`  モジュール"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem`  モジュール"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions` インスタンスの _ ((クラス: `Certificate`) _"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer` インスタンスの _ ((クラス: `Certificate`) _"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject` インスタンスの _ ((クラス: `Certificate`) _"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign` インスタンスの _ ((クラス: `Certificate`) _"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — モジュール"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — インスタンス"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — インスタンス"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — モジュール"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — モジュール"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — モジュール"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — モジュール"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — モジュール"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — モジュール"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — モジュール"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — モジュール"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — モジュール"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — モジュール"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — モジュール"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — モジュール"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — モジュール"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — モジュール"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — モジュール"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — モジュール"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — モジュール"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — モジュール"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — モジュール"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — モジュール"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — モジュール"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — モジュール"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — モジュール"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — モジュール"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — モジュール"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — モジュール"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — モジュール"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — モジュール"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — モジュール"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — モジュール"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — モジュール"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — インスタンス _(クラス: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization`  モジュール"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — モジュール"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — インスタンス _(クラス: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — インスタンス _(クラス: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — モジュール"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles`  モジュール"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded`  モジュール"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — モジュール"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — モジュール"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — モジュール"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — モジュール"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent`  モジュール"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — モジュール"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — モジュール"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — モジュール"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — モジュール"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — モジュール"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — モジュール"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — モジュール"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — モジュール"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — モジュール"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — モジュール"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — モジュール"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — モジュール"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — モジュール"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — モジュール"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — モジュール"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — モジュール"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — モジュール"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — モジュール"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — モジュール"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — モジュール"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — モジュール"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — モジュール"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — モジュール"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — モジュール"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — モジュール"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — モジュール"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — モジュール"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — モジュール"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — モジュール"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — モジュール"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — モジュール"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — モジュール"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — モジュール"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — モジュール"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — モジュール"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — モジュール"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — モジュール"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — モジュール"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — モジュール"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — モジュール"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — モジュール"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — モジュール"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — モジュール"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — モジュール"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — モジュール"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — モジュール"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — モジュール"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — モジュール"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — モジュール"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — モジュール"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — モジュール"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — モジュール"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect`  モジュール"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint`  モジュール"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor`  モジュール"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — モジュール"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — モジュール"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — モジュール"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — モジュール"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — モジュール"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — モジュール"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — モジュール"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — モジュール"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession`  モジュール"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession`  モジュール"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability`  モジュール"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment`  モジュール"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange`  モジュール"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange`  モジュール"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond`  モジュール"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — モジュール"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — モジュール"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — モジュール"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — モジュール"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — モジュール"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — モジュール"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — モジュール"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — モジュール"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  モジュール _ (内在)"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32`  モジュール"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64`  モジュール"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16`  モジュール"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32`  モジュール"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64`  モジュール"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8`  モジュール"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize`  モジュール"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  モジュール _ (内在)"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  モジュール _ (内在)"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16`  モジュール"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32`  モジュール"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64`  モジュール"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8`  モジュール"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize`  モジュール"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — モジュール"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — モジュール"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — モジュール"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — モジュール"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — モジュール"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — モジュール"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — モジュール"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — モジュール"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — モジュール"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — モジュール"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — モジュール"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — モジュール"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — モジュール"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — モジュール"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — モジュール"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — モジュール"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — モジュール"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — モジュール"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — モジュール"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — モジュール"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — モジュール"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — モジュール"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — モジュール"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — モジュール"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — モジュール"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — モジュール"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — モジュール"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — モジュール"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — モジュール"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — モジュール"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — モジュール"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — モジュール"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — モジュール"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — モジュール"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — モジュール"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — モジュール"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — モジュール"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — モジュール"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — モジュール"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — モジュール"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay`  モジュール"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — モジュール"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — モジュール"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — モジュール"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — モジュール"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — モジュール"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — モジュール"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — モジュール"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — モジュール"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — モジュール"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — モジュール"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — モジュール"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — モジュール"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — モジュール"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — モジュール"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — モジュール"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — モジュール"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — モジュール"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — モジュール"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — モジュール"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — モジュール"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — モジュール"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — モジュール"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — モジュール"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — モジュール"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — モジュール"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — モジュール"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — モジュール"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — モジュール"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — モジュール"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — モジュール"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — モジュール"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — モジュール"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — モジュール"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — モジュール"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — モジュール"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — モジュール"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — モジュール"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — モジュール"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — モジュール"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — モジュール"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — モジュール"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — モジュール"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — モジュール"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — モジュール"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — モジュール"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — モジュール"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — モジュール"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — モジュール"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — モジュール"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — モジュール"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — インスタンス _(クラス: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — モジュール"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — モジュール"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — インスタンス _(クラス: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — モジュール"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — インスタンス _(クラス: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — モジュール"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — インスタンス _(クラス: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — モジュール"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — インスタンス _(クラス: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — インスタンス _(class: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — インスタンス _(クラス: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — モジュール"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — インスタンス _(クラス: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — インスタンス _(class: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — インスタンス _(クラス: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — モジュール"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — モジュール"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — モジュール"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — モジュール"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — モジュール"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — モジュール"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — モジュール"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — モジュール"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — モジュール"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — モジュール"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — モジュール"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — モジュール"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — モジュール"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — インスタンス _(クラス: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — インスタンス _(クラス: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — モジュール"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — モジュール"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView`  モジュール"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — モジュール"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — モジュール"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — モジュール"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — モジュール"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — モジュール"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — モジュール"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — モジュール"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — モジュール"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — モジュール"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — モジュール"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — モジュール"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — モジュール"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — モジュール"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — モジュール"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — モジュール"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — モジュール"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — モジュール"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — モジュール"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — モジュール"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — モジュール"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — モジュール"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — モジュール"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — モジュール"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — モジュール"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — モジュール"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — モジュール"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — モジュール"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — モジュール"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker`  モジュール"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — モジュール"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — モジュール"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — モジュール"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — モジュール"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — モジュール"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy`  モジュール"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — モジュール"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — モジュール"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — モジュール"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — モジュール"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — モジュール"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd`  モジュール"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle`  モジュール"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — モジュール"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — モジュール"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — モジュール"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — モジュール"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — モジュール"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — モジュール"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — モジュール"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — モジュール"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — モジュール"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — モジュール"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — モジュール"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — モジュール"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — モジュール"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — モジュール"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — モジュール"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — モジュール"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — モジュール"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — モジュール"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — モジュール"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — モジュール"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — モジュール"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — モジュール"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — モジュール"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — モジュール"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — モジュール"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — モジュール"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — モジュール"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — モジュール"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — モジュール"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — モジュール"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — モジュール"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — モジュール"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — モジュール"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — モジュール"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — モジュール"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — モジュール"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — モジュール"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — モジュール"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — モジュール"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — モジュール"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — モジュール"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — モジュール"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — モジュール"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — モジュール"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — モジュール"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — モジュール"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — モジュール"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — モジュール"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — モジュール"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — モジュール"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — モジュール"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — モジュール"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — モジュール"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — モジュール"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — モジュール"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — モジュール"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — モジュール"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — モジュール"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — モジュール"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — モジュール"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — モジュール"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — モジュール"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — モジュール"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — モジュール"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — モジュール"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — モジュール"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — モジュール"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — モジュール"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — モジュール"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — モジュール"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — モジュール"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem`  モジュール"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected`  モジュール"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected`  モジュール"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — モジュール"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — モジュール"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — モジュール"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders`  モジュール"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl`  モジュール"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue`  モジュール"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — モジュール"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig`  モジュール"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — モジュール"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — モジュール"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — モジュール"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — モジュール"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — モジュール"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse`  モジュール"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — モジュール"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — モジュール"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — モジュール"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — モジュール"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — モジュール"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — モジュール"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — モジュール"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — モジュール"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — モジュール"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — モジュール"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout`  モジュール"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount`  モジュール"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed`  モジュール"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge`  モジュール"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild`  モジュール"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree`  モジュール"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew`  モジュール"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild`  モジュール"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge`  モジュール"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum`  モジュール"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap`  モジュール"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc`  モジュール"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber`  モジュール"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc`  モジュール"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — モジュール"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — インスタンス _(class: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — モジュール"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — モジュール"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — モジュール"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — モジュール"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — モジュール"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — モジュール"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — モジュール"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — モジュール"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — モジュール"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — モジュール"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — モジュール"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — モジュール"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — モジュール"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — モジュール"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — モジュール"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — モジュール"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — モジュール"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — モジュール"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — モジュール"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — モジュール"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — モジュール"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — モジュール"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — モジュール"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — モジュール"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — モジュール"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — モジュール"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — モジュール"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — モジュール"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — モジュール"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — モジュール"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — モジュール"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — モジュール"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — モジュール"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — モジュール"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — モジュール"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — モジュール"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — モジュール"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — モジュール"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — モジュール"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — モジュール"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — モジュール"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — モジュール"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — モジュール"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — モジュール"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — モジュール"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — モジュール"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — モジュール"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — モジュール"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — モジュール"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — モジュール"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — モジュール"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — モジュール"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — モジュール"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — モジュール"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — モジュール"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — モジュール"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — モジュール"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  インスタンスは"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  インスタンスは"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  インスタンスは"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  インスタンスは"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — モジュール"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — モジュール"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — モジュール"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — モジュール"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — モジュール"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — インスタンス"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — インスタンス"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — インスタンス"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — インスタンス"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — モジュール"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — インスタンス"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — インスタンス"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — インスタンス"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — インスタンス"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — インスタンス"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — インスタンス"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — インスタンス"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -43929,43 +44226,43 @@ msgstr ""
 "取らない.そして .write() は数値文字,文脈検索,単一の'+'を評価する.実際の JS "
 "evalループ (#4916) はありません"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — モジュール"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -43975,1459 +44272,1459 @@ msgstr ""
 "い.そして .write() は数値文字,文脈検索,単一の'+'を評価する.実際の JS evalルー"
 "プ (#4916) はありません"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — インスタンス _(クラス: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — モジュール"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — モジュール"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — モジュール"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — モジュール"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — モジュール"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  インスタンスは"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  インスタンスは"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — インスタンス"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  インスタンスは"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  インスタンスは"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  インスタンスは"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — インスタンス"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — インスタンス"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — インスタンス"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — インスタンス"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — インスタンス"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — インスタンス"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — インスタンス"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — インスタンス"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — インスタンス"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — モジュール"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  インスタンスは"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — インスタンス"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — インスタンス"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  インスタンスは"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — インスタンス"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — インスタンス"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — インスタンス"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — モジュール"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — モジュール"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — インスタンス"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — インスタンス _(クラス: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — インスタンス"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — モジュール"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — インスタンス"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — インスタンス"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — インスタンス _(クラス: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  インスタンスは"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — インスタンス _(クラス: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — インスタンス"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — インスタンス"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — インスタンス _(クラス: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — インスタンス"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — インスタンス"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — インスタンス"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — インスタンス"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — インスタンス"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — インスタンス"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — インスタンス"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  インスタンスは"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — インスタンス"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — インスタンス"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — インスタンス _(クラス: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — インスタンス"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — インスタンス"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — インスタンス _(クラス: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — インスタンス"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — モジュール"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — モジュール"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — モジュール"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — モジュール"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — インスタンス"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — インスタンス"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — モジュール"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — インスタンス"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — インスタンス"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — インスタンス"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — モジュール"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — インスタンス"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — モジュール"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — モジュール"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — モジュール"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — モジュール"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — モジュール"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — インスタンス"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — モジュール"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — モジュール"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — インスタンス"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — モジュール"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — インスタンス"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — インスタンス"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — インスタンス"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — インスタンス"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — インスタンス"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — インスタンス"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — インスタンス"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — インスタンス"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — インスタンス"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — インスタンス"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — インスタンス"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — モジュール"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — インスタンス"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — インスタンス"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — インスタンス"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — インスタンス"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — インスタンス"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — インスタンス"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — インスタンス"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — インスタンス"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — インスタンス"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — インスタンス"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — インスタンス"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — インスタンス"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — モジュール"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — モジュール"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — モジュール"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — モジュール"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — モジュール"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — モジュール"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — インスタンス _(クラス: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — インスタンス _(クラス: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — モジュール"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — モジュール"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — モジュール"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — モジュール"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — モジュール"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — モジュール"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — モジュール"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — モジュール"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — モジュール"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — モジュール"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — モジュール"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — モジュール"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — モジュール"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — モジュール"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — モジュール"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — モジュール"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — モジュール"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — モジュール"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — モジュール"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — モジュール"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — モジュール"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — モジュール"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — モジュール"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — モジュール"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — モジュール"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — モジュール"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — モジュール"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — モジュール"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — モジュール"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — モジュール"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — モジュール"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — モジュール"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — モジュール _(クラス: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — モジュール"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — モジュール"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — モジュール"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — モジュール _(クラス: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — モジュール _(クラス: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — モジュール _(クラス: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — モジュール _(クラス: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — モジュール _(クラス: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — モジュール"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — モジュール"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — モジュール"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — モジュール _(クラス: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — モジュール"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — モジュール"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — モジュール"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — モジュール"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — モジュール"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — モジュール"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — モジュール"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — モジュール"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — モジュール"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — モジュール"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — モジュール"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — モジュール"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — モジュール"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — モジュール"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — モジュール"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols`  モジュール"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — モジュール"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — モジュール"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms`  モジュール"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — モジュール"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — インスタンス _(クラス: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — モジュール"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — モジュール"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — モジュール"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — インスタンス _(クラス: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — インスタンス _(クラス: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — インスタンス"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — インスタンス"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — インスタンス"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — インスタンス"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — インスタンス"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText`  モジュール"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule`  モジュール"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent`  モジュール"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close` インスタンスの _ ((クラス: `ProxyAgent`) _"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy` インスタンスの _ ((クラス: `ProxyAgent`) _"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch`  モジュール"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher`  モジュール"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher`  モジュール"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — モジュール"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — モジュール"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — モジュール"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — インスタンス _(クラス: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — モジュール"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — モジュール"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — インスタンス _(クラス: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — モジュール"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — モジュール"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — モジュール"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — モジュール"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — モジュール"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — モジュール"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — モジュール"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — モジュール"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — モジュール"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — モジュール"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — モジュール"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — モジュール"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — モジュール"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — モジュール"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — モジュール"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — モジュール"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — モジュール"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — モジュール"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — モジュール"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — モジュール"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — モジュール"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — モジュール"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — モジュール"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — モジュール"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — モジュール"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — モジュール"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — モジュール"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — モジュール"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — モジュール"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — モジュール"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — モジュール"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — モジュール"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — モジュール"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — モジュール"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — モジュール"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — モジュール"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — モジュール"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — モジュール"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — モジュール"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — モジュール"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — モジュール"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — モジュール"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — モジュール"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — モジュール"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — モジュール"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3`  モジュール"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — モジュール"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5`  モジュール"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — モジュール"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — インスタンス _(クラス: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — インスタンス _(クラス: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — モジュール"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — インスタンス _(クラス: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — モジュール"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — モジュール"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45435,11 +45732,11 @@ msgstr ""
 "`getHeapCodeStatistics`  モジュール **スタブ** すべてのフィールド 0; Perry "
 "は AOT をコンパイルし,JIT コード ヒップ (#4916) は存在しない"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — モジュール"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45449,7 +45746,7 @@ msgstr ""
 "に帰属したすべてのライブ使用のノードスペース名;他のスペースは0 (#4916) を報告"
 "する"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45462,88 +45759,88 @@ msgstr ""
 "アリーナ,total_physical_size=RSS,heap_size_limit固定 ~2GB (強制されない);"
 "\\*\\_実行可能,external_memory,グローバルハンドルとzapフィールドは0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — インスタンス _(クラス: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — モジュール"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — インスタンス _(クラス: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — インスタンス _(クラス: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — インスタンス _(クラス: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — インスタンス _(クラス: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — モジュール"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — インスタンス _(クラス: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — モジュール"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr ""
 "`setDeserializeMainFunction` — インスタンス _(クラス: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — モジュール"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — モジュール"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — インスタンス _(クラス: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — モジュール"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -45551,459 +45848,469 @@ msgstr ""
 "`stop`  インスタンスの _ ((クラス: `GCProfiler`) _ **スタブ** レポートには"
 "ノード形がありますが,統計配列は常に空です (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — モジュール"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — モジュール"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — モジュール"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — インスタンス _(クラス: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — モジュール"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — モジュール"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — モジュール"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — モジュール"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — モジュール"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — モジュール"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — インスタンス"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — モジュール"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — モジュール"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — インスタンス"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — インスタンス"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — インスタンス"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — インスタンス"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — インスタンス"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — インスタンス"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — インスタンス"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — モジュール"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — インスタンス"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — インスタンス"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — モジュール"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — インスタンス"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — インスタンス"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — モジュール"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — モジュール"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — モジュール"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — インスタンス"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — モジュール"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — インスタンス _(クラス: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — インスタンス _(クラス: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — インスタンス _(クラス: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — インスタンス _(クラス: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — モジュール"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — モジュール"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  インスタンスは"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — モジュール"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — モジュール"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — モジュール"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — モジュール"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — モジュール"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — モジュール"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — モジュール"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload` インスタンスの _ ((クラス: `Worker`) _"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  インスタンスは"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — モジュール"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — インスタンス _(クラス: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — モジュール"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — インスタンス _(クラス: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — インスタンス"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — インスタンス"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — インスタンス _(クラス: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — モジュール"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — インスタンス"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — インスタンス _(クラス: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  インスタンスは"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — インスタンス _(クラス: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — モジュール"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — モジュール"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — モジュール"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — モジュール"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — モジュール"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — モジュール"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46011,7 +46318,7 @@ msgstr ""
 "`createBrotliCompress`  モジュール **スタブ** params/quality オプションは受け"
 "入れられたが無視,一度警告 (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46019,7 +46326,7 @@ msgstr ""
 "`createBrotliDecompress`  モジュール **スタブ** params/quality オプションは受"
 "け入れられたが無視,一度警告 (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46027,7 +46334,7 @@ msgstr ""
 "`createDeflate`  モジュール **スタブ** レベルが満たされた; strategy/memLevel"
 "が検証されたが適用されなかった (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46035,11 +46342,11 @@ msgstr ""
 "`createDeflateRaw`  モジュール **スタブ** レベルが満たされた; strategy/"
 "memLevelが検証されたが適用されなかった (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — モジュール"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46047,19 +46354,19 @@ msgstr ""
 "`createGzip`  モジュール **スタブ** レベルが満たされた; strategy/memLevelが検"
 "証されたが適用されなかった (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — モジュール"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — モジュール"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — モジュール"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46067,7 +46374,7 @@ msgstr ""
 "`createZstdCompress`  モジュール **スタブ** params/quality オプションは受け入"
 "れられたが無視,一度警告 (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46075,79 +46382,71 @@ msgstr ""
 "`createZstdDecompress`  モジュール **スタブ** params/quality オプションは受け"
 "入れられたが無視,一度警告 (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — モジュール"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — モジュール"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — モジュール"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — モジュール"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — モジュール"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — モジュール"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — モジュール"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — モジュール"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — モジュール"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — モジュール"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — モジュール"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — モジュール"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — モジュール"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — モジュール"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — モジュール"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — モジュール"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — モジュール"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — モジュール"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -46675,9 +46974,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "`docker-compose.yaml` ファイルを使用するような場合。"
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "同じプログラムで混ぜることができます e.g. 使う `perry/compose` 長期間のスタッ"
@@ -47204,12 +47504,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` は `docker rm -f` と同等です。"
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**`logs` と `exec` の返信形に関する注釈:** 現在,FFIはJSオブジェクトではなく "
 "`Vec<ContainerLogs>`にレジストリIDハンドルを返します. 返した値を不透明として"
@@ -47335,9 +47636,10 @@ msgstr ""
 "はキャッシュされた `OnceLock` にヒットして即座に返ります。"
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` は非同期で,エントリごとに `{ name, available, reason, "
@@ -48094,9 +48396,10 @@ msgstr ""
 "するには："
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**`healthcheck` ブロックをサービス上で使用する** (内蔵で実行時に処理されま"
@@ -48474,8 +48777,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "Forgejo の例では,このポータブルパターン (`container_name:  'forgejo-db'` + "
@@ -48547,8 +48851,9 @@ msgid "Single-network shorthand"
 msgstr "単一ネットワークの省略記法"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -48957,9 +49262,10 @@ msgid "External volumes"
 msgstr "外部ボリューム"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "ボリューム `external: true` をマークしてスタック間で共有するか,別のプロセス "
@@ -48981,8 +49287,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49052,15 +49359,18 @@ msgstr ""
 "ム CLI で確認してください："
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# アプリが先行するボリュームをリストする"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# マウントポイント,ドライバー,ラベル"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# マウント + インスペクト 内容"
 
 #: src/container/volumes.md:160
@@ -49227,9 +49537,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49413,8 +49724,9 @@ msgstr ""
 "トに対するその後の実行はコストゼロです。"
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -49681,8 +49993,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**非 root で実行する**（`user: \"nobody\"` または数値 UID）。"
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**すべての機能を削除し,特定のものを戻す** (`cap_drop:  [\"ALL\"]` +最小"
@@ -49831,7 +50144,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "URL と「解体方法」を含むオペレーター向けバナーを表示する。"
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr "0番出口 `restart:  unless-stopped`のおかげでコンテナは動いています"
 
 #: src/container/production-patterns.md:42
@@ -50050,11 +50364,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "ヘルスチェックによる依存サービスの起動順制御"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres は最初の実行で初期化するのに ~510秒かかります (initdb + listener "
 "bind). ゲーティングがなければ フォージョはすぐに起動し 接続できず 再試予算を"
@@ -50224,7 +50539,8 @@ msgstr ""
 "値に設定**してください:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# . env"
 
 #: src/container/production-patterns.md:225
@@ -50237,7 +50553,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50297,11 +50614,13 @@ msgstr ""
 "環境変数値）を行う場合は、先に明示的に `--down` を実行してください:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# 保存量"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# 新しいバージョンで再展開"
 
 #: src/container/production-patterns.md:268
@@ -50319,35 +50638,42 @@ msgid "Running it"
 msgstr "実行方法"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# ペリーを一度作る"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# 模範 を 作り出せ"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# バックエンド:ドッカー"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# ブラウザで http://localhost:3000/ を参照してください."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# 停止（再デプロイ用のボリュームは保持）:"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# 壊す + 降ろす 音量 (破壊データ):"
 
 #: src/container/production-patterns.md:300
@@ -50654,19 +50980,23 @@ msgstr ""
 "開します. フィールド名はバックエンド全体で安定している. 値が異なる."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// テスト + 状態のまま発信"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// エンジンがホスト側をエミュレート"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// 削除 + 警告"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// 制限されたサブセット; 理由は文書化"
 
 #: src/container/determinism.md:156
@@ -50790,7 +51120,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "各プロトコルは,`capabilities()` 方法から一定の値を返します"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "/... 建築家"
 
 #: src/container/determinism.md:192
@@ -50816,7 +51147,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"バックエンドの仕様欄 dropped/translated\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- クリーンスペック"
 
 #: src/container/determinism.md:212
@@ -50828,15 +51160,18 @@ msgstr ""
 "`Vec<NormalizationWarning>` を生成します"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// フィールドは削除"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// 同等にマッピング"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// エンジンは代わりにエミュレート"
 
 #: src/container/determinism.md:231
@@ -50844,15 +51179,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. 執行モード 警告の表示方法を選択する"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// デフォルト  静かな追跡::警告!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// TS console.warn に表示される"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// サポートされていないフィールド → ハード up() 失敗"
 
 #: src/container/determinism.md:241
@@ -50915,7 +51253,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "出力標準化  バックエンドに関係なく同じ形"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker形 (NDJSON行)"
 
 #: src/container/determinism.md:292
@@ -50923,7 +51262,8 @@ msgid "/* docker JSON */"
 msgstr "/* ドッカー JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Apple shape (`configuration`-wrappedオブジェクトのJSON配列)"
 
 #: src/container/determinism.md:294
@@ -50931,7 +51271,8 @@ msgid "/* apple JSON */"
 msgstr "/* アップル JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// どちらも同じフィールドセマンティックで ContainerInfo を生成します:"
 
 #: src/container/determinism.md:301
@@ -51261,7 +51602,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51274,7 +51616,8 @@ msgid "\"Back\""
 msgstr "\"戻る\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (空値 = 翻訳が必要)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -51499,7 +51842,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -51615,7 +51959,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (ポーランド語: 一,数,多くの)"
 
 #: src/i18n/interpolation.md:65
@@ -52384,20 +52729,24 @@ msgid "Typical translation workflow:"
 msgstr "典型的な翻訳ワークフロー:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. 英語文字列でコードを書く"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. ローカルファイルに文字列を抽出する"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 "# 3. locales/de.json を翻訳者に送信する (空の値は記入する必要があります)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Perry を構築する"
 
 #: src/i18n/cli.md:49
@@ -53072,55 +53421,22 @@ msgstr ""
 "る認証されたマニフェストにサインする."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) 単一のキーペア生成 kp.json をモード 0600 で保存し,"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) リリースごとに署名する JSON ファイルは"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr ""
-"# 3) マニフェストをアップロードする前に 地元でサインをチェックしてください"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    顧客に確認をします"
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) リリース CI は CLI マニフェストにサインし,アーカイブ URL,プラットフォー"
-"ム,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "`sign` の出力を `jq` 経由で各資産に対して最終的な明示書を作成し,上記の各プ"
@@ -54746,9 +55062,10 @@ msgstr ""
 "声、複数の足音）。"
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** ミキサーグループ 音はバスを経由し,バスは親 (デフォルト:マスター) を"
@@ -55749,6 +56066,7 @@ msgstr ""
 "チごとに駆動され、壁時計比較で 100 ms にスロットルされます。"
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -55758,7 +56076,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -56950,23 +57268,28 @@ msgstr ""
 "す — プラットフォーム固有の言語の知識は不要です。"
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS WidgetKit拡張子"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android アプリウィジェット"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS 複雑性"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOSシミュレーター"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OSタイル"
 
 #: src/widgets/overview.md:60
@@ -57882,10 +58205,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "パディング"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -58480,11 +58799,13 @@ msgid "Build Commands"
 msgstr "ビルドコマンド"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -59365,19 +59686,23 @@ msgid "Build Instructions"
 msgstr "ビルド手順"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# app/src/main/java/com/example/app/ に .kt ファイルをコピーする"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# AndroidManifest_snippet.xml を AndroidManifest.xml に合併する"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Wear OS モジュールに .kt ファイルをコピーする"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# AndroidManifest_snippet.xml を合併する"
 
 #: src/widgets/watchos.md:3
@@ -59568,11 +59893,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "バックグラウンドリフレッシュは`BackgroundTask`フレームワークを使用"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Apple Watch デバイスのために"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Apple Watch シミュレーター"
 
 #: src/widgets/watchos.md:70
@@ -61171,11 +61498,13 @@ msgstr ""
 "た関数を実装する `staticlib` です:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry実行時間 FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ...プラットフォーム API を呼び出し,完了すると約束を解決 ..."
 
 #: src/plugins/native-extensions.md:200
@@ -61306,25 +61635,17 @@ msgstr ""
 "正しいプラットフォーム SDK を対象とします:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (簡略化)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// 標的を検知する: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// コンパイルする: swiftc -emit-library -static -target ... -sdk ... "
-"-framework StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "/ リンク: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -61351,7 +61672,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "結果でPerry promiseを解決"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// PerryBridge からアクティビティを取得"
 
 #: src/plugins/native-extensions.md:266
@@ -61367,7 +61689,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "JNI経由で API を呼び出す"
 
 #: src/plugins/native-extensions.md:275
@@ -61981,15 +62304,18 @@ msgstr ""
 "す."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# ゲート"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# 対象と対象でないもの"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# ゲートが失敗する可能性があることを証明する"
 
 #: src/testing/test-registration.md:18
@@ -62327,32 +62653,39 @@ msgstr ""
 "すると、サーバーは自動的に起動します。"
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. Geisterhand が有効でコンパイルする (libs は最初の使用時に自動ビルド)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. アプリを実行する"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. 別のターミナルで  アプリとやり取りする"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# すべてのウィジェットのリスト"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# ハンドル3のボタンをクリック"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# ウィンドウのスクリーンショットをキャプチャ"
 
 #: src/testing/geisterhand.md:25
@@ -62368,7 +62701,8 @@ msgstr ""
 "は `--enable-geisterhand` を含意するので、両方のフラグは不要です）:"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# ペリーランで"
 
 #: src/testing/geisterhand.md:35
@@ -62512,8 +62846,8 @@ msgid "Menu item"
 msgstr "メニューアイテム"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -62525,8 +62859,8 @@ msgstr "キーボードショートカット"
 msgid "Data table"
 msgstr "データテーブル"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -62640,17 +62974,6 @@ msgstr ""
 "テキストフィールドの内容を設定し、新しいテキストを NaN-boxed 文字列として "
 "`onChange` コールバックを発火させます。"
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"コンテンツタイプ:application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "\"こんにちは 世界\""
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "スライダーを移動"
@@ -62674,10 +62997,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "スライダーの位置を設定し、数値で`onChange`を発火します。"
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"値\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -62728,10 +63047,6 @@ msgstr ""
 "ウィジェットコールバックをバイパスして、`State` セルの値を直接設定します。こ"
 "れにより、その state にアタッチされたあらゆるリアクティブバインディング（バイ"
 "ンドされたテキストラベル、可視性、forEach ループなど）がトリガーされます。"
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "\"{\"値\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -62809,10 +63124,6 @@ msgstr ""
 "れたキー文字列と一致します（例: Cmd+S では `\"s\"`、Cmd+Shift+S では "
 "`\"S\"`、Cmd+N では `\"n\"`）。"
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "{\"ショートカット\":\"s\"}"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -62847,10 +63158,6 @@ msgid ""
 msgstr ""
 "ScrollViewウィジェットのスクロールオフセットを設定します。`x`と`y`の両方がポ"
 "イント単位です。"
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -62951,12 +63258,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# ランダムな入力を 200ms ごとに発射する"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -63097,12 +63401,16 @@ msgstr ""
 "トワーク）が必要、または `libimobiledevice` の `iproxy` を使用してください:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Xcode/devicectl でインストールして起動"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP 番号:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -63130,7 +63438,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# APK にパッケージを組み込み,インストールする"
 
 #: src/testing/geisterhand.md:381
@@ -63138,7 +63447,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "まずGTK4開発ライブラリをインストールします:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -63162,15 +63472,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "bashを使用したシンプルなエンドツーエンドテスト:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# 精神的な手を使って作る"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# バックグラウンドでアプリを起動"
 
 #: src/testing/geisterhand.md:419
@@ -63182,33 +63495,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"$APP_PID 2>/dev/null を削除する\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# 準備が整うまで待って"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# ウィジェットを取得"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# \"送信\"というボタンを検索します"
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# クリックする"
 
 #: src/testing/geisterhand.md:436
@@ -63216,7 +63533,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# インタラクション後にスクリーンショットを撮る"
 
 #: src/testing/geisterhand.md:441
@@ -63228,7 +63546,8 @@ msgid "Python Test Example"
 msgstr "Pythonテストの例"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# アプリを起動"
 
 #: src/testing/geisterhand.md:450
@@ -63236,11 +63555,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# 起動を待つ"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# リストウィジェット"
 
 #: src/testing/geisterhand.md:455
@@ -63248,11 +63569,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# ラベルでウィジェットを検索"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# 最初のテキストフィールドに入力"
 
 #: src/testing/geisterhand.md:464
@@ -63272,7 +63595,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# 最初のボタンをクリックします"
 
 #: src/testing/geisterhand.md:470
@@ -63280,7 +63604,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# 視覚回帰のためにスクリーンショットをキャプチャ"
 
 #: src/testing/geisterhand.md:473
@@ -63296,7 +63621,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# アプリがまだ有効だと確認する"
 
 #: src/testing/geisterhand.md:478
@@ -63328,40 +63654,14 @@ msgstr ""
 "状態を見つけます:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# 構築と打ち上げ"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# 攻撃的な混沌を始める (毎50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# 30秒間動かして"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# 統計をチェック"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"実行\":true,\"events_fired\":600,\"uptime_secs\"30} 実行する"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# 最終状態を見るためにスクリーンショットをとる"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# 混沌を止める"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# アプリがまだ動いているか確認します"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -63375,11 +63675,13 @@ msgstr ""
 "較します:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# 初期状態"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -63387,24 +63689,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# 相互作用後の捕獲"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# 比較 (ImageMagick を使って)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "CIパイプライン統合"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# GitHub 動作の例"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# GitHub Actions の例\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -63453,7 +63757,8 @@ msgid "Run UI tests"
 msgstr "UIテストを実行"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# テストスクリプトを実行"
 
 #: src/testing/geisterhand.md:568
@@ -63631,20 +63936,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "`--enable-geisterhand`でコンパイルして実行した後:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# すべてのインタラクティブなウィジェットを表示"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"ハンドル\"4,\"widget_type\":0,\"callback_kind\":0,\"ラベル\":\"リセッ"
 "ト\"}"
@@ -63654,8 +63962,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"ハンドル\":6,\"widget_type\":2,\"callback_kind\":1,\"ラベル\":\"\"}"
 
@@ -63664,19 +63973,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# 3回インクリメントをクリックします"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# カウンターラベルは\"数:3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# 名前を入力"
 
 #: src/testing/geisterhand.md:669
@@ -63684,7 +63996,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# スライダーを80%に設定"
 
 #: src/testing/geisterhand.md:672
@@ -63692,11 +64005,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# ダークモードをオンにする"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64004,16 +64319,13 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr "自動ビルドが失敗するか、手動でクロスコンパイルしたい場合:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# macOS のために Geisterhand のリブを作成する"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# iOS (クロスコンパイル) のビルド"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -64199,15 +64511,18 @@ msgstr ""
 "+実行だけです. 狭める"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# 数つのモジュール"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# この輸出のみ"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# mod.export 組み合わせた形式"
 
 #: src/testing/node-compat-matrix.md:30
@@ -64227,15 +64542,18 @@ msgid "Full sweep and the CI gate"
 msgstr "完全な掃描と CIゲート"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# 全行列 + 概要表"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# バランスラインに対する回帰の出口1"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# コミットされたベースラインを書き直す"
 
 #: src/testing/node-compat-matrix.md:43
@@ -64512,7 +64830,7 @@ msgstr ""
 "事は`needs: plan`で `fromJSON(needs.plan.outputs.plan).jobs.<name>`にゲートさ"
 "れています"
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -64608,11 +64926,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -64637,94 +64955,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6倍速く"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3倍速く"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8倍満タン"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "デプスのみ"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "国内で **pr** 変更されたファイルのリストはプランをさらに絞ります"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -64733,14 +65064,14 @@ msgstr ""
 "`,`.claude/`, ...  `ci_plan.py`で`NON_CORE_GLOBS`を参照) → `lint`のみを実行す"
 "る."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
 msgstr ""
 "**コア** (コンパイラ,実行時間,またはテスト結果を変更できるもの) →PR層全体."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -64748,7 +65079,7 @@ msgstr ""
 "**デプス** (ロックファイル,マニフェスト,`deny.toml`,`package.json`,`.claude/"
 "`,`skills/`, ...) →さらに`security-audit`再利用可能なワークフロー."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -64762,7 +65093,7 @@ msgstr ""
 "失敗しない場合は失敗する. これは,doc-only PR に Rust の設定を追加することな"
 "く,HIR,transform,または他の依存関係で作成された修正をキャッチします."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -64772,11 +65103,11 @@ msgstr ""
 "します 壊れたプランナーは決して\"すべてスキップ,したがって緑\"になることはあ"
 "りません."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "なぜこんな感じなのか (2026年8月16日測定)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -64788,11 +65119,11 @@ msgstr ""
 "業 / ~ 650 ランナー分**`main`は1日に ~66 PR プッシュと ~58 合併がありました "
 "これは 1.52×総容量です"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr "待ち時間37時間 (`conformance-smoke`ショード:中間4時間)"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -64800,7 +65131,7 @@ msgstr ""
 "**66 の 0** `Tests` ワークフローの PR 実行はサンプルウィンドウで終了しまし"
 "た  8 失敗し,次回のプッシュで 56 がキャンセルされました"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -64812,7 +65143,7 @@ msgstr ""
 "complete`) が含まれていました **過去12回の合併のどれも管理者バイパスでした** "
 "`lint`と`cargo-test`がまだ列に並んでいる."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -64826,11 +65157,11 @@ msgstr ""
 "test` が Linux を転送できるようにし, #8187 は上述の単一の `pr-gate` ファンの"
 "インで断片化された required-context リストを置き換えました."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "2つの特別のコストが主たる:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -64848,7 +65179,7 @@ msgstr ""
 "て同じテストを実行します. 8シェード自動最適化モードは,自動最適化のみのリンク"
 "バグを見る唯一のブームであるため,完全な層に保持されています."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -64862,7 +65193,19 @@ msgstr ""
 "からのみ保存し,PRは最新のメインラインブロブを復元します. `cache-warm.yml`は行"
 "方不明です. スイープは `main`のキャッシュ生成ビルドです."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -64884,75 +65227,75 @@ msgstr ""
 "上に実行します レーベルが付いていないPRは 逃した仕事ごとに ランナー・スロット"
 "が付きます"
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "典型的な仕事"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "典型的なランナー分"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "目標の壁時計"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (コア)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6つのギャップ・シャード)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "列に並べた場合 ≤ 30分"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (ドキュメントのみ)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤5分"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "合体する"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "ターゲットじゃない"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -64979,11 +65322,20 @@ msgstr ""
 "ンナースロットを取らない. スウィープの失敗は窓 (`previous sweep SHA .. this "
 "sweep SHA`) によって6時間ゲートと同じです."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "広報を優先する"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -64996,7 +65348,7 @@ msgstr ""
 "ンの変更や,フルレベルだけのスーツに触れるもののために使用します. ラベルを適用"
 "すると実行が再起動します (`labeled`トリガー)"
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -65005,7 +65357,7 @@ msgstr ""
 "(`crates/` の変更は,他の場合は `changelog.d/<PR>-<slug>.md` のフラグメントを"
 "追加する必要があります)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -65013,11 +65365,11 @@ msgstr ""
 "**`workflow_dispatch`** どの支店でも: `tier` (`pr` / `sweep` / `full`) と "
 "`update_gap_snapshot`"
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "ギャップスナップショットを再設定する"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -65029,15 +65381,17 @@ msgstr ""
 "された回帰,オラクルの変更),それを再生します **CIから**ノートパソコンではなく "
 "(必要なベースラインは Linux,`fast`モード)"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# 走るのを待って"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# `issue` / `reason` を入力し,次に commit を入力します"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -65047,11 +65401,11 @@ msgstr ""
 "由を指定します. スナップショットにクラッシュを駐車することは決してありません "
 "(`run_gap_tests.sh`は拒否します)"
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "枝の保護"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -65067,11 +65421,11 @@ msgstr ""
 "の結果を生成することを監視します.ゲートの実行は,その結果が通過するか失敗する"
 "かに関わらず実行されます."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -65083,7 +65437,7 @@ msgstr ""
 "緑色スウィープや PR レベルの実行はカウントされません. [Releasing](../"
 "contributing/releasing.md) を参照してください."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -65098,6 +65452,173 @@ msgstr ""
 "アである); 値最小値とモジュール毎のマトリックストレンドは,合併レポート "
 "(`scripts/parity_report_merge.py`では,スイートを縮小する代わりに欠落した"
 "シャードを拒否する) において,`parity-aggregate`で一度実行される."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "チェックが送るもの"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "ローカルで実行する:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"コマンド\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -65215,36 +65736,13 @@ msgid "Reproduce the core of it with:"
 msgstr "その核を:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# 雇用レベルでは実際に実行されているもの"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "\"仕事\" | select(.status==\"in_progress\") | (ラベル)|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# 排列の深さ,そしてどのプールで:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "\"仕事\" | select(.status==\"queued\") | (ラベル)|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -65421,24 +65919,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# 変化しない  すべてのPRは測定され続けている"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * * *\" # 揺れ動いている.下記の表を参照してください"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -65449,12 +65945,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# 放出は個別に閉じ込めておく"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -65723,11 +66218,13 @@ msgstr ""
 "を 飛ばした電話は そうではありません"
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# 失敗する可能性があることを証明します"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# 実際のAPI,問題書き込みはありません"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -65759,10 +66256,49 @@ msgstr ""
 "う意味です 何も試されなかったわけではありません"
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "日程の前の列 (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -65770,57 +66306,57 @@ msgstr ""
 "6時間ごとに掃討するだけで 6時間以上で排列が尽きるだけです 2026年8月12日 ゲー"
 "トではなく"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "列に並ぶ走行"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "同期走行が観察されている"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "イベントによって並べた"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "列に並ぶPR実行の間には,異なる頭枝があります"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**まだ存在している枝**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -65836,11 +66372,12 @@ msgstr ""
 "ゲート10の前にランナースロットを保持しています. 廃棄物を取り除く必要がありま"
 "す 廃棄物を取り除く必要があります"
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -65855,7 +66392,7 @@ msgstr ""
 "フォーク PR を安全にするのは フォークのヘッド・ブランチが レポのリフに表示さ"
 "れないことです"
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -65867,13 +66404,13 @@ msgstr ""
 "reap_stale_ci_runs.py --apply` (ドライランはデフォルト) で,スケジュールはその"
 "後はクリアに保ちます."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr "なぜ\"門は暗かった\"とは \"門は捕まえただろう\"とは違うのか"
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -65884,7 +66421,7 @@ msgstr ""
 "の門が 通過させたという 誘惑的な結論は 事件よりも重要な理由を 確認し記録して"
 "も 生き残れないのです"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -65897,7 +66434,7 @@ msgstr ""
 "つではありません. レポのゲートはコレクション_kind_カウントをラッチェットしま"
 "せん."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -65907,7 +66444,7 @@ msgstr ""
 "移動した2つの次元は,`shared_ci`プロフィールCIで`\"gating\": false`とRSSは"
 "`tolerances.json`に記録されている. ゲートは`pinned_host`で CIは使わない"
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -65915,7 +66452,7 @@ msgstr ""
 "`retain`,`deeplist`, ...) を表示したワークロードは,`gc-ratchet`の固定 14 探査"
 "機ではなく,gc-handoff コルプスです."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -66139,14 +66676,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "TypeScriptをネイティブ実行ファイルにコンパイルします。"
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# あるいは簡略化 (自動検出コンパイル):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "フラグ"
 
@@ -66175,7 +66713,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable`(デフォルト)または`dylib`(プラグイン)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -66183,7 +66721,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "HIR中間表現を出力"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -66195,7 +66733,7 @@ msgstr ""
 "オブジェクト file (s) を生成するのみ,リンクをスキップする. `-o` に書き込む "
 "([コンパイラフラグ](flags.md) を参照)"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -66203,7 +66741,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "`.o`と`.asm`ファイルを保持"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -66211,7 +66749,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "V8 JavaScriptランタイムフォールバックを有効化"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -66223,8 +66761,8 @@ msgstr ""
 "wasmi WebAssembly ホストランタイムを強制リンクします（`WebAssembly.*` の使用"
 "時に自動検出）"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -66232,15 +66770,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "tsgo経由の型チェックを有効化"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "出力をミニファイおよび難読化(`--target web`の場合は自動的に有効)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -66248,7 +66786,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID(ウィジェットターゲットに必要)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -66257,23 +66795,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "ディレクトリからTypeScript拡張機能をバンドル"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# 基本コンパイル"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# iOS シミュレーターのクロスコンパイル"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# プラグインを作成"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# デバッグ: 中間表示を表示する"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# iOS ウィジェットを作成する"
 
 #: src/cli/commands.md:82
@@ -66281,23 +66824,28 @@ msgid "Compile and launch your app in one step."
 msgstr "1ステップでアプリをコンパイルして起動します。"
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# 自動検知入力ファイル"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# iOS device/simulator で実行する"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Apple Vision Pro simulator/device で実行する"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Android デバイスで実行する"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# プログラムにArgを転送する"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -66431,19 +66979,23 @@ msgstr ""
 "local` または `--remote` でいずれかのパスを強制してください。"
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# CLI プログラムを実行する"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# 特定のシミュレーターで実行"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# フォースリモコン構築"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Web ターゲットを実行する"
 
 #: src/cli/commands.md:131
@@ -66459,19 +67011,23 @@ msgstr ""
 "す。"
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# ウォッチ + 再構築 + 保存で再起動"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# 子供に前向きな args"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# 追加ディレクトリを見る"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# オーバーライド出力経路"
 
 #: src/cli/commands.md:144
@@ -66604,7 +67160,7 @@ msgid ""
 "target."
 msgstr "再ビルド / HMR間の状態保持 — \"高速再起動\"が正直なターゲットです。"
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -66669,19 +67225,23 @@ msgid "Include medium-confidence fixes"
 msgstr "中信頼度の修正を含める"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# 単一のファイルをチェックする"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# 依存度分析で確認する"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# 自動修正の問題"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# 適用せずに修正をプレビューする"
 
 #: src/cli/commands.md:207
@@ -66973,27 +67533,33 @@ msgstr ""
 "ツールチェーンセットアップ。"
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# プラットフォームメニューを表示"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# macOS の設定 (署名証明書)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# iOS の設定 (署名証明書)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# visionOS の設定 (署名証明書)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Android の設定 (署名証明書)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windowsツールチェイン (xwin経由でMS CRT + Windows SDKをダウンロード)"
 
 #: src/cli/commands.md:318
@@ -67022,19 +67588,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# 最新の更新"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# インストールせずに確認"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# キャッシュされた応答を無視します"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# アップデートの動作を保存し,終了する"
 
 #: src/cli/commands.md:333
@@ -67052,7 +67622,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` は `~/.perry/config.toml` に `[update] mode` を書き込みます"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -67165,14 +67735,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "新しいネイティブバインディングパッケージのスキャフォールド:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"libfooのネイティブバインド\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\"\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -67706,10 +68268,21 @@ msgstr ""
 "出力実行ファイル,バンド,共有ライブラリ,アーカイブ,またはオブジェクトパス"
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -67717,16 +68290,16 @@ msgstr ""
 "Linux libc/linkage を選択します. `musl` は対応する Linux ターゲットを完全静的"
 "ヘッドレスビルドにアップグレードします."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "ホームスクリーンウィジェットターゲットに必要なバンドル識別子"
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "ディレクトリからネイティブ拡張パッケージを発見し,静的にバンドルします."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -67734,31 +68307,31 @@ msgstr ""
 "コードゲン前にネイティブ TypeScript チェック (`@typescript/native-preview`) "
 "を実行します."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Windows PE の互換性レベルを設定する.Windows 以外のターゲットでは無視する."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
 msgstr "輸入ベースの自動検出に頼る代わりに,Windows PEサブシステムを選択する."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -67766,46 +68339,79 @@ msgstr ""
 "Apple ウィジェット ターゲットでは,`swiftc` を呼び出さずに SwiftUI ソースとメ"
 "タデータを発信します."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
 msgstr ""
 "HarmonyOS HAP 署名材料を選択する. environment/configの情報源を優先します"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS アプリケーション証明書チェーン"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS 署名したプロフィール"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOSキーストア別名;デフォルトは `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — モジュール"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "アセットを組み込む"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -67813,11 +68419,11 @@ msgstr ""
 "スタティックファイル (SPA `dist/`,画像,JSON,フォント, ...) をスタンドアロン実"
 "行ファイルに焼いて,ディスク (# 5731) の外部ファイルなしで実行します."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -67827,11 +68433,23 @@ msgstr ""
 "を埋め込む. Repeatable. `perry.embed` (package.json) と `[compile] embed` "
 "(perry.toml) と合併した."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -67840,19 +68458,20 @@ msgstr ""
 "のすべてのファイルを安定した `$perryfs` ハンドルにマッピングする. 繰り返すこ"
 "とができます.ソースマップは除外されます."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# 記憶から dist/ を使います. dist/ フォルダは必要ありません"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "組み込みファイルは,実行時に3つの方法でアクセスできます"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -67884,7 +68503,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -67896,7 +68515,7 @@ msgstr ""
 "`node:fs` は,`$perryfs/<path>` の仮想経路 または 埋め込み相対キー を 受け入れ"
 "ます."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -67904,7 +68523,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -67914,7 +68533,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -67928,7 +68575,7 @@ msgstr ""
 "エッジを保存し,チェックアウトを変更するのではなく生成されたソースをキャッシュ"
 "に保持します."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -67936,11 +68583,7 @@ msgstr ""
 "固定された OpenCode ソースグラフでは,まずアップストリーム Web UI を構築し,そ"
 "の後 `packages/opencode` のパッケージルートからコンパイルします:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -67954,7 +68597,7 @@ msgstr ""
 "失敗します. 生成された入力が老朽化できないように,各ソース修正に対して"
 "preparationコマンドを実行します."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -67966,7 +68609,7 @@ msgstr ""
 "のハンドル,プロジェクト関連ソースの起源,バイトサイズ,SHA-256ダイジェスト,およ"
 "び発生資産モジュールを記録します."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -67979,7 +68622,7 @@ msgstr ""
 "ディスクに存在する場合でも. 完全なパスで本物のディスク上のファイルを読み,埋め"
 "込まれたコピーを特に意味すると,明示的な `$perryfs/<path>` 形式を使用します."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -67991,19 +68634,19 @@ msgstr ""
 "ラングが `PATH` で最初にない場合, `PERRY_LLVM_CLANG` を設定します. クロスター"
 "ゲットの埋め込みは現在サポートされていません."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "デバッグフラグ"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "HIR(中間表現)をstdoutに出力"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -68012,11 +68655,11 @@ msgstr ""
 "`hir`（変換後 HIR）、`llvm`（モジュールごとの `.ll` を `.perry-trace/llvm/` "
 "へ出力）、または `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -68026,7 +68669,7 @@ msgstr ""
 "import/export/init のノイズを抑制します。ステージが指定されていない場合は `--"
 "trace hir` を暗黙的に有効にします"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -68040,11 +68683,11 @@ msgstr ""
 "ことができない. `-o` が存在しない場合 現在のディレクトリに入ります 各経路は"
 "`Wrote object file: <path>`として印刷されます"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -68054,77 +68697,77 @@ msgstr ""
 "（`PERRY_SKIP_CODEGEN=1` でも同様）。[プロジェクト設定](../getting-started/"
 "project-config.md)を参照してください"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "`.o`と`.asm`中間ファイルを保持"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr ""
 "symbols/DWARF を保持し (結果を取り除く代わりに Windows PDB を発信します)"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "このビルド用のモジュール単位オブジェクトキャッシュを無効にする.ま"
 "た,`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "マシンローカルキャッシュのルーツをオーバーライドする.[キャッシュディレクトリ]"
 "(cache-dir.md)を参照."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
 msgstr ""
 "ネイティブ表現を起動し キャッシュの再利用の代わりに コードゲンを強制します"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 "ネイティブを無効にする Buffer/Uint8Array load/store 降ろして A/B 診断する"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr "低減型証拠報告を出す.原産地域検証を意味する."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -68134,11 +68777,11 @@ msgstr ""
 "ルトでテキスト; `--opt-report=json` はツール用の安定したスキーマを発信しま"
 "す. また,`PERRY_OPT_REPORT=1` を使って設定できます"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -68150,7 +68793,7 @@ msgstr ""
 "ライブ・ルーツの幅. 研究専用.`PERRY_RS4GC=1`,ネイティブルートバックエンドが必"
 "要. (シンプルなスタックマップと明示的なブリッジモードも削除)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -68167,11 +68810,11 @@ msgstr ""
 "キャッシュは変更のないモジュールの codegen をスキップするため、そのままではト"
 "レースディレクトリが空になります）。"
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  なぜ値がボックスに留まるのか"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -68188,11 +68831,11 @@ msgstr ""
 "ある.何が証明されたのか,何が証明されなかったのか,どのルールが呼び出しを行った"
 "かを印刷する."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "拒否された値には,"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -68201,13 +68844,13 @@ msgstr ""
 "**位置** `local`,`param`,`return`,`field`,または`alloc-site` (決してローカル"
 "に縛られていないオブジェクトリテラル,`.map(x => ({...}))`イディオム)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
 msgstr "**拒否した規則**名前のあるソースファイルと比較して確認できます."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -68218,7 +68861,7 @@ msgstr ""
 "しないでください), _ 固有多形_ (正しくボックスに 動作なし),または _ ペリー制"
 "限_ (あなたのコードではありません. 存在しているトラッキング問題の名前)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -68232,13 +68875,13 @@ msgstr ""
 "行されるので,ループ深さだけで最後にランク付けされる. 静的プロキシです 静的プ"
 "ロキシです"
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
 msgstr "勝算は敗算と共に報告されるので 苦情だけではなく 比率が目に見えるのです"
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -68252,7 +68895,7 @@ msgstr ""
 "からです. 報告書はこう述べています **ストッダー**`--format json`のペイプアウ"
 "トプットに 混じらないようにします"
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -68265,15 +68908,15 @@ msgstr ""
 "report=json` は `schema_version: 1` において同じデータを持ち,異なる 2 つのビ"
 "ルドの JSON は,無音でゼロに回帰する表現に対する安価な CI チェックです."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "出力最適化"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -68293,11 +68936,11 @@ msgstr ""
 "march` を使って設定することもできます. `[build] native_tuning = false` は "
 "`generic` の略です. runtime/stdlibの自動最適化再構築に適用されます"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -68305,11 +68948,11 @@ msgstr ""
 "デッドコードを削除するために,コンパイルタイム `__feature_NAME__` のコンスタン"
 "タをコンマで分離して定義する."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -68317,24 +68960,24 @@ msgstr ""
 "最小のアクセス可能な機能セットを再構築するのではなく,プリビルドした完全な "
 "runtime/stdlib を使用します."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr "浮動小数点再結合を許可する.[Fast-math](fast-math.md)を参照."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "コントロールは再結合から別々に複合縮約を融合させた."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -68342,11 +68985,11 @@ msgstr ""
 "Minification はコメントを取り除き、空白を縮め、ローカル変数/パラメータ/非エク"
 "スポート関数の名前を mangle して出力を小さくします。"
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "サイズ最適化ビルド"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -68357,11 +69000,11 @@ msgstr ""
 "イズに調整された自動最適化された runtime/stdlib アーカイブを再構築します (残"
 "りの自動最適化と同様に Perry ワークスペースチェックアウトが必要です):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -68373,11 +69016,11 @@ msgstr ""
 "部ループは~2-3倍遅くなる). サイズ最適化と通常のアーカイブは独立してキャッシュ"
 "されます."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -68385,11 +69028,11 @@ msgstr ""
 "さらに,再構築されたアーカイブ (再構築が遅い,バイナリが小さい) の上に全アーカ"
 "イブ脂肪 LTO を実行します. `PERRY_SIZE_OPT` と一緒の意味があるだけです"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -68407,7 +69050,7 @@ msgstr ""
 "および`uncaughtException`が影響を受けないシンボル化されたバックトラースなしで"
 "中止されます."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -68419,15 +69062,15 @@ msgstr ""
 "immediate` を追加します. ランタイムを多く使ったプログラムは 比例して縮小しま"
 "す"
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "テストフラグ"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -68435,25 +69078,25 @@ msgstr ""
 "プログラム的な UI テストのために [Geisterhand](../testing/geisterhand.md) "
 "HTTP サーバーを埋め込みます（デフォルトポート 7676）"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Geisterhandサーバ用のカスタムポートを設定(`--enable-geisterhand`を意味)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "ランタイムフラグ"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "サポートされていないnpmパッケージ用にV8 JavaScriptランタイムを有効化"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -68463,15 +69106,15 @@ msgstr ""
 "される場合に自動検出。静的参照なしに dlopen / FFI 経由でロードする場合のみ必"
 "要）"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "tsgo IPC経由の型チェックを有効化"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -68488,11 +69131,11 @@ msgstr ""
 "ます. [Limitations](../language/limitations.md#no-eval-or-dynamic-code) を参"
 "照してください."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -68514,11 +69157,11 @@ msgstr ""
 "ローブ) は影響を受けない. [Limitations](../language/limitations.md#no-eval-"
 "or-dynamic-code) を参照してください."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -68526,53 +69169,53 @@ msgstr ""
 "認識されているが実装されていない Node/stdlib API がリファレンスを出していると"
 "きに,遅延実行時のエラーを発する代わりにコンパイル時に失敗する."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr "`<binary>.attest.json`を発信する.[二重証明書](emit-attest.md)を参照."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "プラットフォームのサンドボックスのサイドカーを放出する.[サンドボックスのプロ"
 "ファイル](emit-sandbox.md)を参照."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
 msgstr ""
 "アクセス可能な任意のコード実行表面を拒否する.[Lockdown](lockdown.md)を参照."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "環境変数"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "`perry publish`用のPerry Hubライセンスキー"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr ".p12証明書のパスワード"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -68580,59 +69223,59 @@ msgstr ""
 "生成されたマシンコードのCPUベースライン (`--march`と同じ値;フラグと"
 "perry.toml `[build] march`が環境を上回る)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "自動更新チェックを無効化"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "システム全体のスペルを使って"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr "`off`/`notify`/`prompt`/`auto` 1回実行  [Updates](updates.md)を参照"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "カスタム更新サーバURL"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr "更新チェックを自動スキップ(ほとんどのCIシステムで設定される)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "デバッグログレベル(`debug`、`info`、`trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -68640,7 +69283,7 @@ msgstr ""
 "`1`/`text` または `json`  `--opt-report[=json]` と同じで,フラグを追加するのが"
 "不快な環境からレポートを実行するために"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -68654,15 +69297,15 @@ msgstr ""
 "のない第5のGC envノブであり,CLAUDE.mdのGCノブキットキットポリシーの下で削除さ"
 "れました."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "設定ファイル"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml(プロジェクト)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -68742,11 +69385,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml(グローバル)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -68768,58 +69411,254 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# シンプルなCLIプログラム"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# iOS アプリのシミュレーター"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# visionOS アプリのシミュレーター"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Web アプリ (WASM と DOM ブリッジ  偽名: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# プラグイン共有ライブラリ"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# バンド ID の iOS ウィジェット"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# デバッグコンパイル"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# 単語のまとめ"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# タイプチェックによるコンパイル"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# 原始WASMバイナリ (HTMLラッピングなし)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# ミニ化Web出力 (埋め込みJSブリッジを圧縮)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[コマンド](commands.md) — すべてのCLIコマンド"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr ""
 "[プラットフォーム概要](../platforms/overview.md) — プラットフォームターゲット"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"モジュール\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "キャッシュの識別子"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"モジュール\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"ソース\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"ロダッシュ\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"ターゲット\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"関数\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"caption\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -69059,15 +69898,18 @@ msgid "CLI flag wins over env var, env var wins over package.json:"
 msgstr "CLIフラグはenv変数より優先、env変数はpackage.jsonより優先:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. 構成ごとに CLI フラグ"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. シェルごとに環境"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. プロジェクトごとに package.json (最も一般的な)"
 
 #: src/cli/fast-math.md:35
@@ -69083,17 +69925,20 @@ msgid "Contraction is separate from reassociation:"
 msgstr "縮約は再結合とは独立しています:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# FMA収縮のみを許可する."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr "# フロントエンドの最も攻撃的な収縮モードを 再結合せずに許可します"
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# --fast-mathから再結合を続けるが FMA収縮をブロックする."
 
 #: src/cli/fast-math.md:55
@@ -70081,7 +70926,8 @@ msgid "Emit"
 msgstr "出力"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -70168,7 +71014,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"サイズ\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -71381,10 +72227,6 @@ msgstr ""
 msgid "produces:"
 msgstr "出力："
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"モジュール\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -71467,9 +72309,10 @@ msgstr ""
 "ストソースは `<host source>` として報告されます。"
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "マニフェストがまだ存在していない場合,明確なエラーを返します. `perry  "
 "compile` または `perry run` は,すべての成功したビルドにそれを書き込みます."
@@ -73605,7 +74448,7 @@ msgstr "Perryは両方のファイルから設定を読み取ります。何が�
 msgid "Setting"
 msgstr "設定"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "ファイル"
 
@@ -73689,15 +74532,18 @@ msgstr ""
 "`perry.toml` と `~/.perry/config.toml` の両方に書き戻します:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# iOS 署名 (証明書,プロビジョニング プロファイル) を設定する"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Androidサインを設定する (キーストア,プレイストアキー)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# macOS ディストリビューション (App Store,公認) を設定する"
 
 #: src/cli/perry-toml.md:605
@@ -73734,8 +74580,11 @@ msgstr ""
 "CI環境では、`perry.toml`に認証情報を保存する代わりに環境変数を使用します:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# GitHub 動作の例"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -74943,19 +75792,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Perry 船舶 **2つの独立したオプトインチャンネル** `~/.perry/config.toml`に "
-"`enabled = true` または `on` が明示されない限り コンピュータから何も出ません "
-"`PERRY_NO_TELEMETRY=1`と`CI=true`の両方を尊重します"
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. 一般的な使用分析  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. 一般的な使用分析  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -74966,14 +75816,16 @@ msgstr ""
 "`linux`/...), Perry バージョン, success/error ステータス,匿名クライアント "
 "UUID を送信する."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. 互換性レポート  `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -74984,15 +75836,15 @@ msgstr ""
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "3つのモード:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr "`off`  送信しない 洗面台も設置されていない オーバーヘッドはゼロ"
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -75000,99 +75852,99 @@ msgstr ""
 "`ask` (デフォルト)  合格診断が起動すると,セッションごとに1回`[y] just this "
 "once / [a] always / [n] not this time / [N] never`を提示する."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  いつも送信する (デデップ + 編集後). 指示がない"
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**送信されたもの (全積載スケジュール):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"UID\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"コード\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"カテゴリー\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"ギャップ・カテゴリー\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"ステージ\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"ヒール・ローヤー\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"デコレーター\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"ノード:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\" は"
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"ダーウィン・アーム64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -75107,7 +75959,7 @@ msgstr ""
 "(`console`,`Math`,`Promise`のような内蔵を除く) → `<id1>`,`<id2>`,200文字に制"
 "限され,任意の変数が失敗した場合,ハード拒否."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -75115,33 +75967,37 @@ msgstr ""
 "`~/.perry/.report-cache` のローカル 30 日デデップキャッシュは,毎回再充電時に"
 "同じ `snippet_hash` を再送信するのを防ぐ."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "検査と管理"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# 現在のモードを示し,sent/queuedをカウントします"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# この実行にキューに載せたペイロードをプリントした"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# 30日間のデデップキャッシュを消す"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr ""
 "ファイルレベルでのオフを選択するには,`~/.perry/config.toml`を編集します:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -75150,7 +76006,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -75398,15 +76254,18 @@ msgstr ""
 "gc/types.rs`) で前記される"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "標識されている | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// アリーナブロックウォーキングに使用される総割り当てサイズ"
 
 #: src/internals/memory-model.md:69
@@ -75732,7 +76591,7 @@ msgstr ""
 "アをベンチマーク/デバッグ二分法のために無効にします。未設定、`=1`、`=on`、"
 "`=true`はバリアを有効のままにします。"
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -75909,10 +76768,11 @@ msgstr ""
 "に `[gc-fromspace-protect] retired_set=#N` の行をチェックする."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -76128,10 +76988,24 @@ msgstr ""
 "でそのようなページを数え続けます."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "ソースマップ"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -76139,183 +77013,183 @@ msgstr ""
 "行番号ではなく,パスです.行番号は,何も再発しない主張であり,この表の各行は,もは"
 "や存在しない `gc.rs` に指さされています."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "トピック"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "探す記号"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaNボックスタグ"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`、型/フラグ定数"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "シャドウフレーム (フォールバックルート降ろ)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "登録済みルートスキャナー"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "コピーマイナー"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "区画全体でのプロモーション"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "促進政策"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "適性的な任期制限値"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "障壁を書き出す"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "明確に固定する"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "保守的なピンの前提"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "採集のトリガーとペース設定"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "現在の操作ページ"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "設計計画 (歴史)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -76728,12 +77602,18 @@ msgstr ""
 "よって得られます"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "制限のない desktop/server プロセスで device/container 予算の 8 分の 1 にス"
 "ケールされ 1 MiB のフロアがあります オーバーフローはアロケーターに戻され,ス"
@@ -76741,7 +77621,7 @@ msgstr ""
 "deferred期間に生き残り,欠金の完全な収集がアリーナリクレーメーションを終えたと"
 "きにプールを空くします."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -76751,100 +77631,214 @@ msgstr ""
 "収集後の正確なデータです **生計調査** ブロックの高水位オフセットの合計ではあ"
 "りません"
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "サポートされたコントロール"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr "コレクター開発の外で最も有用な操作制御は以下の通りです"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "切断のバックバック 完全なマークスイープ"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtimeバリア分割;また,完全なマーク掃描を強制する"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "ペース比較のために直接の保育園の掃除を無効にする"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "ブロック全体のプロモーションを 対象別避難に戻す"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "ベースベビーキャップをセット"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "MiB でのプロセスハップ予算をオーバーライドする"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "ネイティブ・ルーツ対応のターゲットで影根を選択する"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "診断 完全なネイティブ・スタックスキャン; コピーを無効にする"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "周期ごとに構造化された追跡記録を発信する"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "ヒトが読み取れるコレクター診断機を発信する"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -76853,10 +77847,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "ルーティングストレス"
 "は,`PERRY_GC_SCHEDULE_SEED`,`PERRY_GC_SCHEDULE_RATE`,`PERRY_GC_SCHEDULE_ALLOC_KB`,`PERRY_GC_FORCE_EVACUATE`,`PERRY_GC_VERIFY_EVACUATION`,`PERRY_GC_PROTECT_FROMSPACE`,`PERRY_GC_PROTECT_FROMSPACE_DEPTH`,`PERRY_GC_FROMSPACE_SCAN`,"
@@ -76866,7 +77861,7 @@ msgstr ""
 "および`PERRY_STACKMAP_WALKER` が受け入れられるが,追加のサポートされているコレ"
 "クターモードではない."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -76892,11 +77887,11 @@ msgstr ""
 "します. このページが古いものを主張し続けると,どちらも静かになることはできませ"
 "ん."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "検証機関とIC機関"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -76908,36 +77903,36 @@ msgstr ""
 "さい.層ポリシーは`scripts/ci_plan.py`です). GC特有のカバーは意図的に分割され"
 "ています:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "流れる場所"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "必要な状態"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr "このページのpath/numberの主張"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "はい (`pr-gate` を使って)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "実行時間ユニット・スーツと`run_memory_stability_tests.sh` 4モードマトリックス"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -76945,31 +77940,31 @@ msgstr ""
 "はい (`pr-gate` を使って; PR 層は diff-scoped で, sweep/full 層はワークスペー"
 "スを実行します)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
 msgstr "GC × 表現選択マトリックス,ルーティングバグ機器,書き込み障害ストレス"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "はい (`pr-gate` を使って;PR のPR サブセット,スイープで完全な行列)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "ネイティブ状態点 IR を含む,放射された根支配性"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -76977,27 +77972,27 @@ msgstr ""
 "支店必須ではない.PRアームのオプトインは`run-extended-tests`で,`main`で6時間ご"
 "とに"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "固定コレクター counters/RSS/wall マトリックス"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "スレッドローカル mechanism/policy 予算"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "有用なローカルプレフライトコマンド:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -77006,11 +78001,11 @@ msgstr ""
 "performance/rooting専用ワークフローには,より広範なコンパイラとホストの要件が"
 "あり,そのワークフローファイルは正確なコマンドと関連性フィルターの権威である."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "歴史的証拠"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -77018,7 +78013,7 @@ msgstr ""
 "[世代全体計画](https://github.com/PerryTS/perry/blob/main/docs/generational-"
 "gc-plan.md):オリジナルの設計と段階別着陸日記"
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -77028,7 +78023,7 @@ msgstr ""
 "statepoint-gc-experiment.md): 原型の年代測定と修正によりネイティブルートデ"
 "フォルトが作られる."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -77036,7 +78031,7 @@ msgstr ""
 "[GC根源変数](gc-rooting-invariant.md):現在のコードゲンの健全性ルール,チェック"
 "モード,既知の盲点,デバッグツール."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -77349,7 +78344,8 @@ msgstr ""
 "4つのケースが1日で出荷されました 検知遅延ではなく 修正が毎回コストでした"
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "5つの方法が実際に壊れた"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -77500,14 +78496,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` で `gc/mod.rs` で登録します."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "仕事 を チェック する 方法"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. 静的チェックは,これを実行します"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -77517,7 +78554,7 @@ msgstr ""
 "または非ルーテッドアロカ. この範囲内では 衝突する前に 欠陥を察知する 唯一の装"
 "置です だから最初に動きます"
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -77525,7 +78562,7 @@ msgstr ""
 "**3つのクラスに盲目だ すべては難しい方法で見つかった 清潔な報告は 証拠ではな"
 "い**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -77533,7 +78570,7 @@ msgstr ""
 "**実行時間表と内蔵キャッシュ** (#7231)  放射したIRを読み,実行時のセルを見るこ"
 "とはできません. 10/10が不合格で,間歇的に"
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -77543,7 +78580,7 @@ msgstr ""
 "トストラップに1行`GcSuppressScope`を修正した 本物のバグの両側にも `0 "
 "violations`が表示されていました"
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -77560,7 +78597,7 @@ msgstr ""
 "古い用途は`--moving-only`によって削除されました. **#7227が`ALLOC_RE`を監査す"
 "るように**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -77570,7 +78607,7 @@ msgstr ""
 "ムと _dependence-scale_ ワークロード  #7280で, 25 つのキュレーションされた"
 "コープスファイルが通過し, 20 行のストックゾードが失敗します."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -77587,29 +78624,13 @@ msgstr ""
 "レームのターゲットで デフォルトで設定されていない 低下に関する声明です. **両"
 "方を走らせて**どれを走らせたか"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# SHADOW (PERRY_RS4GC=0):arm64_32,watchOS,ARM64の値下げが続いている"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr ""
-"# NATIVE (PERRY_RS4GC=1):他のすべての場所ではデフォルトです アンカーが付いて"
-"いる"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` ルーツアロカと LLVM 安全なポイントを後に挿入します"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -77619,11 +78640,11 @@ msgstr ""
 "るので `--min-binds`は失敗し シェード・コープスにはセーフポイントが0つあるの"
 "で `--min-statepoints`は失敗します"
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "`--statepoints` のチェックと,その違い"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -77635,7 +78656,7 @@ msgstr ""
 "値は Safepoint のルートです. \"根の貯蔵庫が後者の収集地点を 支配しなければな"
 "らない\"と"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -77643,7 +78664,7 @@ msgstr ""
 "GC オブジェクトを命名するレジスタは,移動された値でない限り,安全点以下には使用"
 "できません."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -77656,23 +78677,23 @@ msgstr ""
 "は生命の大半を `double`- わかった 2つの判定の種類があります 2つの異なる解決法"
 "があるからです"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -77680,15 +78701,15 @@ msgstr ""
 "レジスタのキャストチェーンの `ptr addrspace(1)` 値はセーフポイントのライブバ"
 "ンケットにはありません. 標識も書き換えもできません"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "根付く"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -77696,11 +78717,11 @@ msgstr ""
 "対象はバンドに入っていて,移動されますが,移動前の住所の原始コピーが下記で使用"
 "されます"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "移動した値 (`OperandProtection::Reload`) から再導出する"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -77715,7 +78736,7 @@ msgstr ""
 "**`--moving-only`は`llvm.experimental.gc.statepoint.p0`ではなく,実際のシンボ"
 "ルに基づいて分類されます."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -77735,15 +78756,15 @@ msgstr ""
 "ティングされているレジスタは,すべてのパスで生成された命令です. 認識されていな"
 "い通話が収集されるので モデル内のギャップは誤陽性で 見逃したバグはありません"
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "繰り返しているファイルは:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "環境のノブは2つとも 異なる理由から重要です"
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -77757,7 +78778,7 @@ msgstr ""
 "は何も呼び出しません 集合は繰り返しに一度だけ 集合します 集積が必要とするバグ"
 "は 集積なしでは 集積できないのです"
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -77778,19 +78799,19 @@ msgstr ""
 "例えば `js_object_set_field_by_name`, `js_object_get_field_ic_miss`,および "
 "`js_closure_call1`. 近くには 投票がなく 動いている"
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
 msgstr "コルプスが表現できる範囲を広げますが 投票無関数は安全とは考えません"
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME`はEXACTによって発信されたシンボルで,それは2回噛まれた"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -77801,7 +78822,8 @@ msgstr ""
 "ンのシンボルを命名するエントリは,永遠に何も分類しません. そして,それをすると"
 "きにカバーのように見えます. 計測は2回行いました"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -77812,7 +78834,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -77828,7 +78850,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` に決定的に誤った形状を含む. 守護者と"
 "チェックは違いました チェックは間違っていました"
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -77848,7 +78870,7 @@ msgstr ""
 "`js_closure_callN`で,同じファイルの`RECEIVER_SINKS`は既に正しく綴られていま"
 "す."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -77867,60 +78889,60 @@ msgstr ""
 "ストを短く停止したため,形状はモードCI実行下で決して捕まえることができませんで"
 "した. その正確なコードを再植え,すべてのモード (#7616) を実行します"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (支配)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (下ろしにして送る)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (フィルタリングされていない)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (フィルタリングされていない)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -77931,7 +78953,7 @@ msgstr ""
 "た 正確に他の3つは,輸送降ろしに盲目だったからです. 1つの名前を足すと 破壊され"
 "た武器は13と8になり 清潔な武器は2と2になります"
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -77958,7 +78980,7 @@ msgstr ""
 "り当てたりできる 実行時のヘルパーを追加すると 同じコンミットで "
 "`POLL_CAPABLE_RUNTIME` に追加します** 頼まれるものはない"
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -77968,7 +78990,7 @@ msgstr ""
 "のゲートで ラウンド4にはゲートがない `gc-root-dominance.yml` はビルドの前に "
 "`--audit-alloc-re` と同時に実行されます"
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -77992,7 +79014,7 @@ msgstr ""
 "fn js_*` が表示されない項目に失敗します. 赤い光が当たる時 **置き換える** 削除"
 "すると監査が緑色に変化し 穴を外します"
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -78018,19 +79040,15 @@ msgstr ""
 "した後に再実行するとさらに10個が見つかりました),コメントと文字列文字は最初に"
 "剥がされ,散文で言及されている名前が前提になることはできません."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr "信頼性の高い名前だけでは不十分です 放出されたIRに対して確認:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -78038,7 +79056,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0`はすべてのルートストアに `js_shadow_slot_bind`"
 "コールフォームのチェックアングルをオンにします"
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -78052,7 +79070,7 @@ msgstr ""
 "す 運ばれてるけど **上のゲートコマンドはそれを渡さない**このモードを手動で実"
 "行するときに 3 と 4 のケースが表面になるだけです."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -78067,7 +79085,7 @@ msgstr ""
 "スキャンでは,関数はクリーンと呼ばれます. `lower_call/new.rs`のインライン矢印 "
 "`this_slot`は 実行時の探査機とは無関係に 発見されました"
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -78083,15 +79101,15 @@ msgstr ""
 "た `collectors/pointer_locals.rs` 機密 `Type::Symbol` すぐさま,そう `Symbol` "
 "地元には影がない `alloca_entry` サイトに触ると手動で実行します"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. ランタイム機器 秒,そして深さを注意"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "7196号から"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -78105,7 +79123,7 @@ msgstr ""
 "追加します. 探しているウィンドウが実行されるのは一度だけなので,文字どおりのす"
 "べてのアンケートモードです."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -78113,11 +79131,12 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1`  `mprotect` 避難後 宇宙から 古い読み書きの誤差"
 "をすぐに読み取ります"
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT`  が実行されます"
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -78125,7 +79144,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -78139,7 +79158,7 @@ msgstr ""
 "`scripts/gc_schedule_fuzz.sh <binary> [seed-count]`はシードを掃い,失敗ごとに"
 "再現コマンドをプリントします"
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -78153,7 +79172,7 @@ msgstr ""
 "は,1.7% のバグに縛られています. 2.5%  証拠はありません. 虫が実際に住んでいる"
 "空間を探検する 唯一安価な方法です"
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -78165,7 +79184,7 @@ msgstr ""
 "クの位置が変更されるまでには, **800を使え** デフォルト深さでのクリーンランは "
 "意味がない"
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -78189,7 +79208,7 @@ msgstr ""
 "置に疑う理由ではありません 静的チェックと一致しない場合は まずチェックをご覧"
 "ください ゾード`clone`の不協和は 解決されました"
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -78200,7 +79219,7 @@ msgstr ""
 "レームではなく,古い値を DEREFERENCEしたフレームを命名します. 値は通常,それを"
 "古いものにする呼び出し者から引数として到着します."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -78210,11 +79229,11 @@ msgstr ""
 "唯一のコピーがレジスタにある間に 集合が起こると 実行時間の探査機に気付くもの"
 "は何もないのです この装置は後から結果を捉えます 静止チェックが原因を把握する"
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "鏡像: 書き込みバリアが欠けている (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -78225,43 +79244,43 @@ msgstr ""
 "は,コーナーが決して **教えてくれた**. この2つは二重で,これは人々を捕まえてく"
 "れる部分です **検出器が交換された**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "根付いた虫"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted 書き込み障害"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "何が悪いのか"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "実行値はルートスキャンには見えない"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "old→young エッジが記憶されたセットに欠けている"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "うまくいかないとき"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "集まったとき,静かに"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "店では全くない"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "検出器"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -78270,30 +79289,30 @@ msgstr ""
 "実行時の計測器 (`PERRY_GC_SCHEDULE_RATE`,`PERRY_GC_PROTECT_FROMSPACE`) とIR可"
 "視半分の静的チェック"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **静的IR断言**それ以外は"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "盲点"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "静的チェックは,ハップポインタのランタイムサイドキャッシュを見ることができな"
 "い (§5参照)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**実行時間の探査機がすべて**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "なぜ実行時間の探査機がそれを見ることができないのか"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -78306,16 +79325,16 @@ msgstr ""
 "セットは単に _incomplete_ です. 観察可能な失敗に変えるには プログラムが自分で"
 "提供しなければならない 結合が必要です"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr "親が老後まで生き延びなければならない (または定住者) **前から** 店舗"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "子供はまだ保育室にいる必要があります **次のマイナーで**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -78323,13 +79342,13 @@ msgstr ""
 "a **軽い** その窓に着く必要があります. そして,すべてのクラス全体ですべてと紙"
 "をリトラスする,完全なマークスイープではなく,"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
 msgstr "他のルートがとにかくそれを見つけ,コレクションはクリーンです."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -78337,7 +79356,7 @@ msgstr ""
 "プログラムが正しい答えを印刷し 探査機が成功報告します 探査機が正しい答えを印"
 "刷し 探査機が正しい答えを印刷します 何も試されなかった."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -78346,7 +79365,7 @@ msgstr ""
 "3つのノブが全く異なる性質を狙っているので, 証拠として緑色を読み取るのは簡単で"
 "す"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -78359,7 +79378,7 @@ msgstr ""
 "が追跡しなかった スロットが 書き換えに失敗した スロットではありません 確認者"
 "は2つ目の特性についてだけ尋ねます 確認者は2つ目の特性についてだけ尋ねます"
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -78370,7 +79389,7 @@ msgstr ""
 "照しません**. 虫は目に見えなくなり 虫は届かない状態になります 緑の走行は 3つ"
 "の証拠の中で 最も強く見えた証拠です"
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -78381,7 +79400,7 @@ msgstr ""
 "ング側で,移動したオブジェクト_ 条件 (4) の後, _stale 読み取りをキャッチしま"
 "す. 宇宙からぶら下がるポインタに 欠陥があるんだ"
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -78395,7 +79414,7 @@ msgstr ""
 "険 4 を報告し,レベルアップします. このドキュメントのすべての名前は ゲートで確"
 "認された 活気のあるパーサーが所有しているものです"
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -78406,7 +79425,7 @@ msgstr ""
 "対象は逆転しています: **プログラムを実行することで障壁がないことが確認できま"
 "せん.** \"バリアが走らなかった\"という 区別がつかない事件はありません"
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -78425,11 +79444,11 @@ msgstr ""
 "れた強制収集 **バイト同一出力,出力 0**ギャップ・フィクチャーとより大きな対抗"
 "装置の両方で 静的IRテストは 唯一断られた"
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "GCスロットに店舗を追加したり移動したりするPRは"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -78438,7 +79457,7 @@ msgstr ""
 "障害となる証拠は **静的IR断言**行動テストじゃない 4つのことを固定する必要があ"
 "ります. それぞれが,それをスキップした妨害が捕まらなかったからです:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -78447,7 +79466,7 @@ msgstr ""
 "**簿記担当者がいる** 書き込みバリア,レイアウトノート,文字列addref 3人のうち1"
 "人が行方不明になるのは 沈黙の家族5094/7511です"
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -78459,7 +79478,7 @@ msgstr ""
 "パーにルーティング 腕を後ろに置いて **死んだIR** すべての内容の主張は 喜んで"
 "検査され,最初には通過しました コードの存在は 実行される証拠ではない"
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -78469,7 +79488,7 @@ msgstr ""
 "障害物が漏れると 差別化器が差別するのを止め \"最適化\"は何も測定しないという"
 "ことです"
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -78478,9 +79497,10 @@ msgstr ""
 "**サボタージ・ランスが報告された** 各要素を次々に削除し,テストが赤色になるこ"
 "とを記録します. 失敗したことがないテストは 失敗モードが不明のテストです"
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -78496,34 +79516,25 @@ msgstr ""
 "expr/class_field_barrier_tests.rs`,`index_set_barrier_tests.rs`と"
 "`write_pic_barrier_tests.rs`は形状です"
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "`GC_STORE_AUDIT`マーカー,そしてそれが何を証明するか,証明しない"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "すべての原材料のCG関連店舗サイトには 近くのマーカーがあり その判断を表示して"
 "います"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "GC_STORE_AUDIT(BARRIERED): スロット書き込みは無条件で,バリア"
-
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// 保存されたビットにヒップがないことを確認するライブテストによってのみ保護さ"
-"れます"
 
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "//ポインタはバリアの最初のテストです"
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -78536,7 +79547,7 @@ msgstr ""
 "サイトをスキャンし,マーカーがない場合失敗します **新しい** この質問に答えられ"
 "ないままに サイトが着陸できません"
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -78544,7 +79555,7 @@ msgstr ""
 "#8185が第2期に着陸したので 脚本は **請求**誤った主張が物件を連結する2つのクラ"
 "スについて:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -78582,7 +79593,7 @@ msgstr ""
 "が別のクローンで完ぺきである. 4つの赤外線手術 (電話を削除 ゲートを固定し ブ"
 "ロックの外へ移動し ゲートを回避)"
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -78606,7 +79617,7 @@ msgstr ""
 "(同じ機能の2つのバリアストアと1つのバリアコールがまだ通過する) で,スクリプト"
 "はそれを制限します."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -78628,11 +79639,11 @@ msgstr ""
 "( `gc_rekeyed_key_tables.py` 規律や `--self-test` 植物には15の形があり それぞ"
 "れが判断されなければならない."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "コルプス問題と2つのコルプス (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -78640,7 +79651,7 @@ msgstr ""
 "**手書きのコープスは この種のバグを 依存度スケールで表現できません しばらくは"
 "誰も分からなかったのです 緑色だったからです**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -78654,7 +79665,7 @@ msgstr ""
 "では決定的に失敗している間に 0 を読みます. #7280 はそれを1 文で表します: _25 "
 "キュレーションされたファイルが通過し, 20 行のストック zod fail._ は"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -78662,39 +79673,39 @@ msgstr ""
 "サイズの問題ではありません `--stale-registers --moving-only`で同じコンパイラ"
 "で測定しました"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "古い用途"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "支配的なもの"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "キュレーション, 124 ソース / 144 モジュール"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "property-GET ヘルパー ウィンドウ,`js_number_coerce`,`js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "依存度スケール, 81 モジュール / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -78702,7 +79713,7 @@ msgstr ""
 "`js_object_assign_one` (オブジェクト・スプレッド) "
 "137,`js_new_function_construct` 102,`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -78720,7 +79731,7 @@ msgstr ""
 "コープスは 形状のないコープスは 形状のないコープスは 形状のないコープスは 形"
 "状のないコープスは 形状のないコープスは 形状のないコープスは"
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -78728,11 +79739,12 @@ msgstr ""
 "この場合のために書かれたものではなく,実際の npm依存から生成された 2番目のコー"
 "プスがあります"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod は package.json devDependency です"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -78745,7 +79757,7 @@ msgstr ""
 "レクトリ内のすべての `.ts` がモジュールを生成すると主張します** `zod` のモ"
 "ジュールが 90 〜40 行のソースが欠落した数値を超えると"
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -78756,11 +79768,11 @@ msgstr ""
 "は指示数で線形だからです. ゲートアームは,指示数で線形だからです. `--stale-"
 "registers`の予算は高価なものです (~5分): スキャンは超線形で,62MBは62MBです."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "CIゲート"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -78771,16 +79783,16 @@ msgstr ""
 "ます 全体の作業は数分プラスコンパイラビルドです. 2つのゲートチェックはそれぞ"
 "れ ~2000と ~12900関数で約3秒です."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr "CLAUDE.mdの4つの危険に対して 失敗する能力を持つように設計されています"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr "検査者の出口状態は 作業の `continue-on-error`なし パイプなし"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -78788,7 +79800,7 @@ msgstr ""
 "`concurrency`は pull-request の実行のみをキャンセルするので,`main` の実行は決"
 "して空腹状態になることはありません"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -78798,7 +79810,7 @@ msgstr ""
 "かったので,クリーンな判断を拒否し,実行は `checked N functions / M modules` を"
 "プリントして,静かに空っぽの実行が表示されます"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -78808,7 +79820,7 @@ msgstr ""
 "`--self-test`は,まだ植えられた装置に火を放つことを証明し, `--seeded-"
 "violations 40`は, **本物** チェックが静かにペリーの出力を読む能力を失う腕です"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -78823,11 +79835,11 @@ msgstr ""
 "されます. どちらも静的であり,瞬時に実行され, どちらも死んだエントリを送信して"
 "います. `ALLOC_RE`では2ラウンドで9回, `POLL_CAPABLE_RUNTIME`では10回."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "許容リストは,なぜそれは数ではない"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -78836,7 +79848,7 @@ msgstr ""
 "`scripts/gc_root_dominance_allowlist.json`に 既知の残った違反が載っています "
 "指紋と問題と 文献上の理由が載っています"
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -78847,11 +79859,11 @@ msgstr ""
 "ラーを導入すると 合計は変わらず ゲートは緑のままです 最低価格で緑色に変えられ"
 "るのは \"人増やすことで 差は何も書かれていません"
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "チェックは3つの性質を強制します"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -78861,7 +79873,7 @@ msgstr ""
 "エントリを削除します 固定されたバグは 墓石を残すことはできません 後に 静かに "
 "覆いを広げます"
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -78869,12 +79881,12 @@ msgstr ""
 "**エントリでは,`count`を削除します.** 同じ機能で同じ形状の2度目の違反は 新し"
 "いもので 失敗します"
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr "**入力失敗のない違反**どれだけのエントリがあるかに関わらず"
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -78882,11 +79894,11 @@ msgstr ""
 "入力を追加することは コードレビューのイベントです `count`をビルドの緑にする"
 "と このファイルが防ぐために存在するものです"
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "このゲートを宣伝する"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -78894,11 +79906,11 @@ msgstr ""
 "**執筆時点では、このジョブはブランチ保護の必須チェックに含まれていません**。"
 "つまり、このジョブによってマージが失敗することはありません — 危険性 2。"
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "7198号の条件は2つとも満たされています"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -78907,7 +79919,7 @@ msgstr ""
 "リンクアンカード支配チェックは緑色で `main` に **空っぽ** allowlist (その "
 "predicate が \\#7226 で固定されたときに #7211 のエントリが削除されました)"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -78917,7 +79929,7 @@ msgstr ""
 "(#7236). 注目すべきのは,#7235の前に98点,その後2点,そして`Type::Symbol`が即座"
 "に分類されなくなると0点でした."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -78925,7 +79937,7 @@ msgstr ""
 "余ったステップは **レポ管理者** `gc-root-dominance` をブランチ保護の必要な文"
 "脈に追加するには:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -78938,7 +79950,7 @@ msgstr ""
 "unrooted-allocas`のステップが含まれていました  現在の形では決して緑ではなかっ"
 "たゲートは,必要な日にすべてのオープンPRをブロックします."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -78958,11 +79970,11 @@ msgstr ""
 "います. 人口が固定されるにつれて 引き下げます 予算を凍結するプロモーションは "
 "変数ではなく 数値を買ったのです"
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "原則として"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -78975,7 +79987,7 @@ msgstr ""
 "が提供した初期化器についてのみ尋ねました. ローイングの独自の"
 "`js_object_set_field_by_name`コールについて決して尋ねませんでした."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -78983,7 +79995,7 @@ msgstr ""
 "**集合点ごとに根を再読します** 呼び出し中にルーツスロットから 負荷をキャッ"
 "シュするな `rooted_handle_get`はこれのために存在します."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -78992,7 +80004,7 @@ msgstr ""
 "**リスクは\"評価して分配する\"です** 2つ以上のオペランドを持つ低化で,もう1つ"
 "を下げる前に1つが物質化される場合,最初のオペランドが根付く必要があります."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -79000,7 +80012,7 @@ msgstr ""
 "**`--trace llvm` を読み取りましょう** 3秒で`not a function`を5サイクル下流に"
 "割った日です"
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -79244,6 +80256,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "ローカルで実行する:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "コンパイル時検証"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "ユーザがワークロードごとにバックエンドを選択する"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -79671,7 +80852,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: 文字列 -- レジスタ名 e.g \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -79708,33 +80890,31 @@ msgid "Three types and one rule."
 msgstr "3つのタイプと1つのルール"
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr "/// ルーティングされていないGC管理値を持つレジスタ."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// 永久に発射器を借りる クローンでも コピーでもない"
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr "/// 影穴の根 採集点より長生きし,直接読み取れない."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// ShadowFrame::alloc_slot からのみ取得できます"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr "/// GC が管理できないものを保持するレジスタ: i32, double, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// スロットインデックス 自由にクローンできる 寿命なし エミッターも借りられな"
-"い"
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -79743,22 +80923,27 @@ msgid ""
 msgstr "デザインは **エミッターが収集できるかどうかによって 方法の分割**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr "/// 回収できない. `Raw`のハンドルが有効です."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr "/// 集めることができます. `Raw`の借入が終了します. 借入が終了すると,"
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr "/// スロットを再読み. 返されたRawは次の&mutが送信されるまで有効です."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr "/// このレジスタを根源に消費する. ルーテッドを作る唯一の方法だ"
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -79775,24 +80960,22 @@ msgstr ""
 "収集点で使用できません** コンパイラが拒否します"
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// ロー<'_>,eを借りる"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// 必要なもの"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// OBJ は E を借りる"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// 変数式で"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// 上から借りた"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -79800,7 +80983,8 @@ msgid ""
 msgstr "修正は正しいコードで 誤りから抜け出す 最短の方法です"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// 読み直し,正しい"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -80400,8 +81584,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**脱出口**連絡先がある限り"
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -81955,18 +83140,36 @@ msgstr ""
 "ん."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "このサイドカーモデルには初実行書き込みがないため,読み込みのみのインストール"
 "ディレクトリがサポートされています. 実行ファイルを移動するには `.perry-"
 "native` の兄弟を移動する必要があります `dlopen` の前に欠落したファイルやハッ"
 "シュが不一致したファイルはパッケージングエラーで失敗します"
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -81982,7 +83185,7 @@ msgstr ""
 "リースし,それらを1つのアーカイブに送信します. Perry は実行時に信頼されていな"
 "いダウンロードされたバイナリから隔離属性を削除しません."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -82000,11 +83203,11 @@ msgstr ""
 "`.node` ファイルがターゲットアーティファクトに入ることを防止しながら,パッケー"
 "ジマネージャでレジストリ認証と依存度解決を維持します."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "キャッシュの識別子"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -82012,31 +83215,31 @@ msgstr ""
 "コンパイルタイムアドオン・マニフェストは決定的にソートされ,ビルドとリンク"
 "キャッシュのアイデンティティに以下のものを貢献します"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "ポリシースキーマバージョンと広告されたノードAPIバージョン"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "目標タプルと標準化許容リスト"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "選択されたパッケージ name/version と相対入路"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256と各サイドカー用荷物ファイルのサイズ"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "注文された輸出記号の在庫"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "輸送モデル (`sidecar-v1`)"
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -82050,11 +83253,11 @@ msgstr ""
 "シュ変更は,すべてのTypeScriptとオブジェクトファイルが変更されていない場合で"
 "も,トップレベルのビルドキャッシュを見逃す必要があります."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -82073,22 +83276,15 @@ msgstr ""
 "エクスポートすることを意味しますが,指定されたサポートされていない機能を決定的"
 "に報告します."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`:バージョン4までのコア"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "入国点"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -82096,49 +83292,56 @@ msgstr "入国点"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "安定した環境保存"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "シングルトン値は通常のスケープハンドルを受け取る"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Perry object/arrayアロケーター"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -82146,11 +83349,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaNボックス変換"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -82158,37 +83361,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "長さ限定 `NAPI_AUTO_LENGTH` サポート"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "ネイティブコールバックはホストレコードを使用します"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code`が供給されたときにインストールされます"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "機能,外部,シンボル,ビギントの区別を含みます"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -82196,11 +83399,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "type/status 動作をチェックした"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -82208,11 +83411,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "クエリ長度とNUL終了セマンティクスは含まれています"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -82220,19 +83423,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "ユーザコードは例外に閉じ込められている"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "一般的なオブジェクトセマンティクス"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -82240,11 +83443,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "文字列,シンボル,数値キー"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -82252,11 +83455,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "UTF-8 名前"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -82264,43 +83467,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "配列とエキゾチックなインデックスされたオブジェクト"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "データ,方法,アクセサルの記述子"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "ポインタ識別のショートカットがない"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "一般 Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "コールバック情報 ライフタイムはネイティブコールです"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -82308,11 +83511,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "ネイティブオブジェクトメタデータ表"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -82320,11 +83523,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "強い基準と弱い基準の設計"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -82334,11 +83537,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "厳格な巣を作ることと生成の検証"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -82346,19 +83549,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "待機スロットモデル"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "待機中"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -82366,37 +83569,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "安定したバックポインタ"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "指定された11種類のタイプ配列"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "バックリング・アイデンティティとオフセットが保持される"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "返信 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -82404,19 +83607,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "延期された記録は環境所有のルーツです"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -82424,40 +83627,40 @@ msgstr ""
 "`napi_generic_failure` を返します.任意のランタイムソース実行は,ランタイムエン"
 "ジンモデルを侵害します"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "コレクター圧力会計"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`:バージョン 5 から 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "GC の後の最終化"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -82465,11 +83668,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "任意の精度"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -82477,23 +83680,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "正確な`lossless`と単語数挙動"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "コレクションモード,フィルター,キー変換が有効"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -82501,46 +83704,46 @@ msgstr ""
 "環境ごとに 1 つのレコード; 前回の finalizer を呼び出すことなく置き換え書き換"
 "え"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "現存する脱離伝播"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "オブジェクトメタデータにおける128ビットタグ"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Perry 記述機"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`:バージョン 9,バージョン 10,実験版"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -82548,16 +83751,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "完全なバージョン-9の表面でのみ広告を"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -82565,11 +83768,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "外部の文字列 lifetime/accounting 作業が必要です"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -82577,29 +83780,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "バージョン10 ファースト・パス"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "広告された安定型ABIの一部ではない"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -82607,33 +83810,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "レガシー登録と中止経路"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "既存のアシンクフックの統合"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -82641,11 +83844,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` アイデンティティと安定バイト"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -82653,15 +83856,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "明らかに状態マシン"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -82669,16 +83872,16 @@ msgstr ""
 "リリース文字列 `perry` で Perry の semver コンポーネントを返します.ノード リ"
 "リースを要求しません"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "`napi_generic_failure`とゼロループを返します. Perryにはリブvがありません"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -82686,19 +83889,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "メインスレッドのライフサイクル"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "アシンクコンテキストと厳格なネスト"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -82706,11 +83909,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "イベントポンプ支援TSFN"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -82718,35 +83921,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "スレッド数とイベントループ維持"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "シャットダウンが完了を待っている"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "環境は既に将来の価値を記録しています"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "バージョン10で広告"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -82756,16 +83959,16 @@ msgstr ""
 "`napi_register_module_v1` をエクスポートします.これらはアドオンで検索され,ホ"
 "ストエクスポートではありません."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "必要なゲート"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr "下のゲートが独立して失敗するまで実装は完了しません"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -82777,7 +83980,7 @@ msgstr ""
 "残る.古いハンドルは生成の検証に失敗する.ルートホルダーと rekey-tableの監査ス"
 "クリプトはクリーンである."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -82787,7 +83990,7 @@ msgstr ""
 "コールバックはすべて,Perryが引き上げる前にCを通って戻ります. 計器付きアドオン"
 "では,フレームに解き込みがないと断言します."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -82797,7 +84000,7 @@ msgstr ""
 "し,テストはアドレスが Perry 実行ファイルに属していることを証明します 煙の呼び"
 "出し数は0より大きい必要があります."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -82809,7 +84012,7 @@ msgstr ""
 "タ,wrap/finalizers,およびバッファ サポートされていない NAPI バージョン,NAN/"
 "V8,および `uv_*` 装置は正確な診断を主張します."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -82819,7 +84022,7 @@ msgstr ""
 "フィクチャーツリーを観察し,同一の結合ストリームを発信します. 両側も,彼らのネ"
 "イティブ実装が実際に実行されたと主張します."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -82829,7 +84032,7 @@ msgstr ""
 "動し,順次読み込み;サイドカーの削除または変異は,マニフェストハッシュチェックに"
 "失敗する."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -82837,7 +84040,7 @@ msgstr ""
 "**キャッシュゲート:** アドオンバイトまたはポリシーのみを変更するとビルド"
 "キャッシュが失われます. 変更されていない入力を再構築するとヒットします."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -82845,7 +84048,7 @@ msgstr ""
 "**サイズゲート:** バイト同一の hello-world アドオングラフが空いている. アドオ"
 "ンビルドのホスト専用デルタを報告し,0.6 MB 予算を強制する."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -83390,28 +84593,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "より広い範囲で明示的なコマンドを使用します:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# 製品 feedbackループ"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# ホスト互換性のあるワークスペースメンバー (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$パッケージ\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# ワークスペースのアーキテクチャを検査または検証する"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -83558,7 +84747,8 @@ msgstr ""
 "ために `--no-default-features` でビルドするときにのみ使用する."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# デフォルトプロダクトとその依存性の終了をビルドする"
 
 #: src/contributing/building.md:37
@@ -83681,7 +84871,8 @@ msgstr ""
 "て,Cargo をラッピングで実行します"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# スリムで最適化された開発者 CLI"
 
 #: src/contributing/building.md:80
@@ -83714,24 +84905,29 @@ msgid "Build Specific Crates"
 msgstr "特定のクレートのビルド"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# 実行時間のみ (stdlibも再構築する必要があります!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr "# .a 静的アーカイブは,別々の包装箱 (#5422) によって放出されます"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# libperry_runtime.a / libperry_stdlib.a (e.g. をリンクするには) が必要になる"
 "場合"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# コデゲンのみ"
 
 #: src/contributing/building.md:106
@@ -83777,16 +84973,20 @@ msgid "Run Tests"
 msgstr "テストを実行"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# 製品単位目標"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# 夜間 CI テスト範囲を検査する (すべての Linux 互換性のあるテストキャスト)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# 特定の箱"
 
 #: src/contributing/building.md:137
@@ -83794,11 +84994,13 @@ msgid "Compile and Run TypeScript"
 msgstr "TypeScriptをコンパイルして実行"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# TypeScript ファイルをコンパイルする"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# デバッグ: HIR をプリント"
 
 #: src/contributing/building.md:148
@@ -83863,19 +85065,23 @@ msgstr ""
 "移動するか,公的レジストリが異なる場合はタグ付けを拒否します."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# チェックアウトが更新され 清潔であることを確認してください"
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# 0 を印刷する必要があります"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# 何も印刷してはならない"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# 迅速なポリシーとスクリプトのチェック"
 
 #: src/contributing/releasing.md:23
@@ -83883,7 +85089,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr "# ホストで実行できる 行動チェック ターンオーバーを向上させるが,"
 
 #: src/contributing/releasing.md:38
@@ -83907,7 +85115,8 @@ msgstr ""
 "セスで起動します."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Cargo.toml で既に存在するバージョンを入れ替える."
 
 #: src/contributing/releasing.md:48
@@ -83927,7 +85136,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" #何も印刷してはならない"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -84028,9 +85238,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "許可された行動: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -84060,21 +85271,15 @@ msgstr ""
 "定する必要があります. 放出パイプラインは 意図的に部分的なセットを拒否します"
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# 1つのリリース パッケージを実行:exact-SHA gates/builds"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # OIDC を通して 9 つ全部を検証し,作成します"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub 最後のリリース"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# commit/run/package/Socketの領収書を確認する"
 
 #: src/contributing/releasing.md:128
@@ -84290,11 +85495,13 @@ msgstr ""
 "`xcrun simctl` と組み合わせて,doc-例が人間なしで実行されるかを確認します:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# シミュレーターにコンパイルする"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# デバイスを起動する (一回用,実行中にUDIDを再使用する)"
 
 #: src/contributing/releasing.md:178
@@ -84302,22 +85509,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# テストモードでインストール + 起動"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# レンダリング後にアプリが0を出ます.スクリーンショットはカウンター-ios.pngに"
-"表示されます"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -84581,6 +85775,10 @@ msgid "patch distance"
 msgstr "パッチ距離"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -84615,15 +85813,18 @@ msgstr ""
 "す."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# 失敗する可能性があることを証明します"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# 本物の登録,問題がない"
 
 #: src/contributing/releasing.md:289
@@ -84677,6 +85878,370 @@ msgstr ""
 "リースパッケージの配送レグを再試するには,それを`existing_tag=vX.Y.Z`で送信し"
 "ます. idempotent npmレグ自体も再試しが必要な場合にのみ `publish_npm=true`を追"
 "加します."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr "# src/lib.rsを編集する  `js_*`関数を追加する"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# src/index.ts を編集する  TS 表面ユーザコードの輸入を宣言する"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# package.json を編集する"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ マニフェストがスタティックリブと一致する"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# スキャフォルド release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # すべてのターゲットにプリビルドを建設"
+#~ "します"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr ""
+#~ "                                    # そして,それらを解放に結びつけます"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"<upstream crate>のネイティブバインド\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  PDFバッファからテキストを抽出します"
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # セキュリティ"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` は NULL または `buf_len` バイトで有効である必要があります. "
+#~ "Perryが通過する"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// このペアは `buffer+len` マニフェストパラメータから"
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr ""
+#~ "// const の結果 = spawn を待つ (x) => heavyComputation (x) inputData)"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "パディングとインセット"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64スライス (デフォルトデバイスのターゲット)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. ミノス + フューズを調整する"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"プラットフォーム\" \"Android-35\" \"ビルドツール\" \"35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"システム画像 アンドロイド34 アンドロイドウェア アーム64V8A\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Rustクロスターゲット"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Wear OS エミュレーターを作成 + 起動 (ラウンドウォッチ)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Perry がサポートする追加の npm パッケージと Node.js API です。ここに掲載す"
+#~ "るすべては Perry の well-known native bindings レジストリ（#466）を介して"
+#~ "配線されており、JavaScript ランタイムを介在させずにネイティブコードにコン"
+#~ "パイルされます。"
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr ""
+#~ "# 3) マニフェストをアップロードする前に 地元でサインをチェックしてください"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    顧客に確認をします"
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) リリース CI は CLI マニフェストにサインし,アーカイブ URL,プラット"
+#~ "フォーム,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// 標的を検知する: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// コンパイルする: swiftc -emit-library -static -target ... -sdk ... "
+#~ "-framework StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "/ リンク: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"コンテンツタイプ:application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "\"こんにちは 世界\""
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"値\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "\"{\"値\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "{\"ショートカット\":\"s\"}"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP 番号:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# 30秒間動かして"
+
+#~ msgid "# Check stats"
+#~ msgstr "# 統計をチェック"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"実行\":true,\"events_fired\":600,\"uptime_secs\"30} 実行する"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# 最終状態を見るためにスクリーンショットをとる"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# 混沌を止める"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# アプリがまだ動いているか確認します"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# iOS (クロスコンパイル) のビルド"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "\"仕事\" | select(.status==\"in_progress\") | (ラベル)|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# 排列の深さ,そしてどのプールで:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "\"仕事\" | select(.status==\"queued\") | (ラベル)|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"libfooのネイティブバインド\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\"\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Perry 船舶 **2つの独立したオプトインチャンネル** `~/.perry/config.toml`に "
+#~ "`enabled = true` または `on` が明示されない限り コンピュータから何も出ませ"
+#~ "ん `PERRY_NO_TELEMETRY=1`と`CI=true`の両方を尊重します"
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "ヒトが読み取れるコレクター診断機を発信する"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr ""
+#~ "# NATIVE (PERRY_RS4GC=1):他のすべての場所ではデフォルトです アンカーが付い"
+#~ "ている"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` ルーツアロカと LLVM 安全なポイントを後に挿入します"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr "GC_STORE_AUDIT(BARRIERED): スロット書き込みは無条件で,バリア"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// 保存されたビットにヒップがないことを確認するライブテストによってのみ保"
+#~ "護されます"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "//ポインタはバリアの最初のテストです"
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// 永久に発射器を借りる クローンでも コピーでもない"
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// スロットインデックス 自由にクローンできる 寿命なし エミッターも借りら"
+#~ "れない"
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// OBJ は E を借りる"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// 変数式で"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// 上から借りた"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$パッケージ\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# ワークスペースのアーキテクチャを検査または検証する"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# 1つのリリース パッケージを実行:exact-SHA gates/builds"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # OIDC を通して 9 つ全部を検証し,作成します"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub 最後のリリース"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# レンダリング後にアプリが0を出ます.スクリーンショットはカウンター-ios.png"
+#~ "に表示されます"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -85747,9 +87312,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "`LANG` / `LC_ALL` / `LC_MESSAGES`環境変数"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "コンパイル時検証"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""
 #~ "Perryはコンパイル中にすべてのロケールにわたってパラメータを検証します:"
@@ -85841,13 +87403,6 @@ msgstr ""
 #~ "StoreKit の [`SKStoreReviewController.requestReview(in:)`](https://"
 #~ "developer.apple.com/documentation/storekit/skstorereviewcontroller/"
 #~ "requestreview(in:)) を使用します。"
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# GitHub Actions の例\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "オブジェクトファイルのみを生成、リンクをスキップ"

--- a/docs/po/ko.po
+++ b/docs/po/ko.po
@@ -214,7 +214,7 @@ msgstr "Hook"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "예시"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "CI 단계(PR 검사 / 스윕 / 전체 스위트)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "CI 검사 일정"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "CLI 레퍼런스"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "명령어"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "컴파일러 플래그"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "캐시 디렉터리"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "동적 Stdlib 디스패치"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS 런타임 옵트인"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (바이너리 증명 사이드카)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "이그레스 허용 목록 (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "패키지별 권한 (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "호스트 허용 목록 (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "perry.toml 레퍼런스"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "앱의 업데이트 확인"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "개인 정보 보호 및 텔레미터"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "내부 구조"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "메모리 모델"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "가비지 컬렉터"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "명시적 메모리 관리"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "GC 루팅 불변 조건(코드 생성)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "로컬 바인딩의 타입 근거"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "증분 GC 단계 한계"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: 구조에 의한 GC 루팅"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "기여"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "아키텍처"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "크레이트 정책"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "소스에서 빌드하기"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Perry 릴리스"
 
@@ -929,7 +937,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# 네이티브 macOS/Windows/Linux 창을 열고"
 
 #: src/introduction.md:79
@@ -961,11 +970,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -974,9 +983,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -986,7 +995,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "다음 단계"
@@ -1057,27 +1066,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux 링크어 툴 체인 분포:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# 데비안 / 우분투 / 팝!_OS / 민트"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# 아치 / 만자로 / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS 스트림"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# 알프인 / 무스 (musl) 에 기반한"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# 무효 Linux"
 
 #: src/getting-started/installation.md:41
@@ -1116,15 +1131,18 @@ msgstr ""
 "+ musl, Windows x64) 를 모두 하나의 명령으로 커버하는 유일한 경로입니다"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# 프로젝트 로컬 (Perry의 버전을 deps 옆에 핀)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# 무선 설치, 한 번 촬영"
 
 #: src/getting-started/installation.md:66
@@ -1318,7 +1336,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "바이너리는 `target/release/perry`에 있습니다. PATH에 추가하세요:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# ~/.zshrc 또는 ~/.bashrc에 추가"
 
 #: src/getting-started/installation.md:129
@@ -1452,16 +1471,14 @@ msgstr ""
 "로 크로스 컴파일하는 경우에는 필요하지 않습니다.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# 우분투 / 데비안"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2135,24 +2152,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "동일한 코드가 6개의 모든 플랫폼에서 실행됩니다:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (디폴트)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOS 시뮬레이터"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# 웹 (WebAssembly + DOM 브릿지로 컴파일하는 자율 HTML 파일)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# 위명: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# 다른 플랫폼"
 
 #: src/getting-started/first-app.md:138
@@ -2391,7 +2413,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2409,7 +2431,7 @@ msgstr "\"페리\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2627,7 +2649,8 @@ msgstr ""
 "다:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2659,7 +2682,8 @@ msgid "\"port\""
 msgstr "\"항만\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// 독립된 소스"
 
 #: src/getting-started/project-config.md:122
@@ -2904,19 +2928,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "필드"
 
@@ -2931,9 +2956,9 @@ msgstr "필드"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3051,11 +3076,13 @@ msgid ""
 msgstr "Perry는 별도 설정 없이 많은 인기 npm 패키지를 네이티브로 지원합니다:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3110,7 +3137,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3118,7 +3145,7 @@ msgstr ""
 "이들은 Perry의 내장 구현을 사용하여 네이티브 코드로 컴파일됩니다. 전체 목록"
 "은 [표준 라이브러리](../stdlib/overview.md)를 참조하세요."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3127,44 +3154,47 @@ msgstr ""
 "`compilePackages`를 사용하거나 복잡한 패키지에는 JavaScript 런타임 폴백을 사"
 "용하세요."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "프로젝트 구조"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry는 프로젝트 구조에 대해 유연합니다. 일반적인 패턴:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "UI 앱의 경우:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "컴파일"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# 파일 컴파일"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# 특정 타겟으로 컴파일"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# 디버그: 인쇄 중간 표현"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "모든 옵션은 [CLI 명령](../cli/commands.md)을 참조하세요."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr "[CLI 명령](../cli/commands.md) — 모든 컴파일러 명령과 플래그"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3172,7 +3202,7 @@ msgstr ""
 "[지원되는 기능](../language/supported-features.md) — 어떤 TypeScript 기능이 "
 "작동하는지"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[표준 라이브러리](../stdlib/overview.md) — 지원되는 npm 패키지"
 
@@ -3310,32 +3340,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "클래스"
 
@@ -5332,6 +5363,7 @@ msgstr ""
 "지원합니다:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5341,7 +5373,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "Nest 스타일 DI 및 라우트 메타데이터 용도의 **레거시 클래스 데코레이터, 메서"
 "드 데코레이터, 프로퍼티 데코레이터, 생성자 파라미터 데코레이터, 메서드 파라미"
@@ -5353,7 +5389,7 @@ msgstr ""
 "서드에 `design:paramtypes`를, 데코레이트된 프로퍼티에 `design:type`을 emit합"
 "니다."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5365,15 +5401,15 @@ msgstr ""
 "이터 기계는 전혀 없습니다. 구현은 `crates/perry-hir/src/decorator_log.rs`를 "
 "참조하세요."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "작동하지 않는 것"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Accessor 데코레이터 및 descriptor 교체"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5388,15 +5424,15 @@ msgstr ""
 "코레이터는 Perry 호환 포팅이 필요합니다. lowered 클래스는 IR에 고정되어 있어 "
 "런타임에 교체할 수 없습니다."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr "데코레이터 문법 외부에서의 일반 `Reflect.metadata(...)` 헬퍼 호출"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "메타데이터 키로서의 `Symbol(...)`"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5404,7 +5440,7 @@ msgstr ""
 "클래스/메서드 `design:paramtypes` 및 프로퍼티 `design:type`을 초과하는 "
 "`emitDecoratorMetadata`"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5413,12 +5449,12 @@ msgstr ""
 "축소된 클래스 생성자 canary(`tsyringe`, 전체 NestJS 인젝터 동작, Angular 루"
 "트 인젝터)를 넘어 타입으로 의존성을 해결하는 런타임 DI 컨테이너"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "`class-validator`, `type-graphql`, `TypeORM`의 런타임 메타데이터 플로우"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5428,11 +5464,11 @@ msgstr ""
 "AOT 변환이며, 전체 레거시 TypeScript 데코레이터 런타임에 의존하는 것이 아닙니"
 "다."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "권장 패턴: 명시적 생성"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5443,7 +5479,7 @@ msgstr ""
 "된 일반 클래스입니다. 이는 Go 또는 Rust 프로그램이 서비스를 구성하는 방식이"
 "며, 데코레이터 없는 TS 프레임워크가 따르는 방식입니다."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5459,7 +5495,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5468,11 +5504,11 @@ msgstr ""
 "컨테이너도, `@Injectable`도, `providedIn: 'root'`도 없습니다 — 생성 순서 _가"
 "_ 종속성 그래프이며, TypeScript 컴파일러가 검사합니다."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "마이그레이션 레시피: Angular 서비스"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5481,19 +5517,19 @@ msgstr ""
 "아래 예시는 sharity-app의 실제 서비스 (`src/app/services/rating.service.ts`, "
 "약 80줄)로, 원래 Angular 형식과 Perry로 포팅된 형식으로 보여집니다."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "이전 — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "이후 — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "세 가지 기계적 변경:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5501,7 +5537,7 @@ msgstr ""
 "**`@Injectable`을 제거하세요.** 클래스 형태가 이미 가지고 있지 않은 정보는 담"
 "지 않았습니다."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5511,7 +5547,7 @@ msgstr ""
 "Angular HTTP-from-Observable은 단일 값이며 Promise처럼 동작합니다. (다중 값 "
 "스트림의 경우 `AsyncIterable`을 사용하세요.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5522,11 +5558,11 @@ msgstr ""
 "교체하세요. Perry는 매개변수 속성을 지원하지만, 클래스가 손으로 와이어링될 때"
 "는 명시적 필드가 더 명확하게 읽힙니다."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "연결"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5546,7 +5582,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5564,7 +5600,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5574,11 +5610,11 @@ msgstr ""
 "'root'` 토큰, 암묵적 컨테이너 조회 — 이 모든 것이 `services.ts` 안의 단일 "
 "`new RatingService(api)` 줄로 축약됩니다."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "Angular 컴포넌트, NestJS 컨트롤러, TypeORM 엔티티는 어떻게 합니까?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5599,11 +5635,11 @@ msgstr ""
 "장식자를 떨어뜨리고, 동등한 명시적인 구조를 작성하고, 경로 또는 스키마를 단순"
 "한 함수 호출 / 모듈 레벨 상수로 등록하십시오."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "향후 방향"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6282,12 +6318,13 @@ msgstr ""
 "한 표면을 사용하고 링크 시간에 아무것도 필요하지 않습니다."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**문자 그대로 정적 호출** (`WebAssembly.instantiate(bytes)`는 글로벌에 반대하"
@@ -7819,54 +7856,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "바인딩 작성 — 60초 투어"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF 렌더링 바인딩\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr "# src/lib.rs를 편집  `js_*` 기능을 추가, 모든 사용"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# Edit src/index.ts  TS 표면 사용자 코드 수입을 선언"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# package.json를 편집합니다"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ 명표는 정적 리브와 일치합니다"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# 스캐폴드 release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # 모든 목표물을 위해 미리 만든 건물을 만"
-"듭니다"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # 그리고 그 가늘을 풀기 위해"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8244,7 +8240,7 @@ msgstr "현재 상태"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8264,7 +8260,7 @@ msgstr "묶여있으며, 이동이 기다리고 있습니다"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8316,7 +8312,7 @@ msgstr "묶여있으며 이동이 기다리고 있습니다"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8376,7 +8372,7 @@ msgstr "업스트림 패키지 소스를 컴파일"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8384,7 +8380,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8392,7 +8388,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8400,7 +8396,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8432,7 +8428,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8440,7 +8436,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8448,7 +8444,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8480,7 +8476,7 @@ msgstr "뭉쳐져 있고, 보관되어 있다"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8488,7 +8484,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8520,7 +8516,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8528,7 +8524,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8536,7 +8532,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8544,7 +8540,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8560,7 +8556,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8568,7 +8564,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8576,7 +8572,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8584,7 +8580,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8608,7 +8604,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8616,7 +8612,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8624,7 +8620,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8632,7 +8628,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8640,7 +8636,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8648,7 +8644,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8656,7 +8652,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8664,7 +8660,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8672,7 +8668,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8680,7 +8676,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8688,7 +8684,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8696,7 +8692,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8749,14 +8745,6 @@ msgstr "사전 빌드 릴리스 CI 스캐폴드가 그냥 작동하기를 원한
 msgid "1. Scaffold"
 msgstr "1. 스캐폴드"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"<upstream crate>에 대한 네이티브 결합\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "이는 다음을 만듭니다:"
@@ -8788,28 +8776,14 @@ msgstr ""
 "\"C\" fn`, `perry_ffi`의 타입 **만** 사용:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  PDF 버퍼에서 텍스트를 추출"
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "안전성"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr`는 NULL 또는 `buf_len` 바이트에 유효해야 합니다. Perry가 통과합"
-"니다"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// 이 쌍은 `buffer+len` 표시 매개 변수에서"
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -8943,7 +8917,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"자유로운\""
 
@@ -9178,7 +9152,8 @@ msgid "In a separate directory:"
 msgstr "별도의 디렉터리에서:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# 또는 당신의 도구가 지원하는 모든 경로"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9567,7 +9542,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "이벤트 리스너 (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// 닫는 포인터, 아래의 GC 스캐너에 의해 살아있는 유지"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -9994,7 +9970,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... 파일을 읽고, 설정 환경, 반환 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10293,8 +10270,8 @@ msgstr "필수"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "주의"
 
@@ -10352,14 +10329,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12055,29 +12032,36 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "도구  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr "# 특정 버전으로 하나의 핀을 제공하거나 붐 (예정: 최신 안정)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# 현재 고정되지 않은 모든 결합을 최신 안정에서 제공"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# 오프라인 게이트 (CI): 핀이 존재하고, 잠금 단계, 상자가 존재합니다. 1번 출구"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr "# 조언: 추가로 플래그 핀의 상류는 더 새로운 안정적인 풀이"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# 핑드 리프에서 업스트림 리포를 gitignored 업스트림/<name>로 구현합니다"
 
@@ -12305,15 +12289,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "부분 포장을 절대 대체할 수 없는 CI의 경우, 세트:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12464,7 +12448,7 @@ msgstr "현실"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12481,7 +12465,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14437,19 +14421,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "Node.js worker_threads와 비교"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~15 줄, 별도의 파일 필요"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14469,12 +14453,11 @@ msgid "/* handle */"
 msgstr "/* 핸들 */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// ── Perry: 1 줄 ────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const result = wait spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14688,13 +14671,14 @@ msgid "Mental Model"
 msgstr "정신 모델"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "Perry의 UI는 SwiftUI와 Flutter와 동일한 모델을 따르고 있습니다. 스택 기반 레"
 "이아웃 컨테이너 (`VStack`, `HStack`, `ZStack`) 를 사용하여 네이티브 위젯을 구"
@@ -14779,7 +14763,7 @@ msgstr "`App({})`은 다음 속성을 가진 구성 객체를 받습니다:"
 msgid "Property"
 msgstr "속성"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15221,7 +15205,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15243,7 +15227,7 @@ msgid ""
 "Platform-specific behavior is noted on each widget's documentation page."
 msgstr "플랫폼 특정 동작은 각 위젯의 문서 페이지에 명시되어 있습니다."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -16848,7 +16832,8 @@ msgid "Double-click handler"
 msgstr "더블 클릭 핸들러"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -16910,12 +16895,13 @@ msgstr ""
 "는 모든 PR에서 그것을 컴파일하고 실행합니다."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "레이아웃 도움말은 무료 함수입니다: `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17389,7 +17375,7 @@ msgstr "효과"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17402,7 +17388,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "자식이 leading (왼쪽) 가장자리에 정렬됨"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17415,7 +17401,7 @@ msgid "Children centered horizontally"
 msgstr "자식이 수평으로 가운데 정렬됨"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17436,7 +17422,7 @@ msgstr "**HStack 정렬** (교차축 = 수직):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17463,8 +17449,8 @@ msgstr "자식이 수직으로 가운데 정렬됨"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17518,9 +17504,9 @@ msgstr "동작"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17543,11 +17529,11 @@ msgstr "모든 자식이 동일한 크기를 받음"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -17741,9 +17727,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "내장 패딩이 있는 스택"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "단일 호출로 패딩이 있는 스택을 만듭니다. 순서는 top/right/bottom/left가 아닌 "
 "**top, left, bottom, right** (CSS 약어 스타일)입니다:"
@@ -17767,11 +17754,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)`는 수평 카운터파트입니"
 "다. 스택을 만든 다음 `widgetSetEdgeInsets`를 호출하는 것과 동등하지만 더 간결"
@@ -18057,8 +18045,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18438,6 +18427,7 @@ msgstr ""
 "실행합니다 — 그래서 여기에 그려진 API는 항상 컴파일러가 받아들이는 API입니다."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18449,7 +18439,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18477,11 +18466,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "색상"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18497,11 +18486,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "폰트"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18517,15 +18506,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "시스템 monospaced 폰트에는 `\"monospaced\"`를 사용하세요."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "모서리 반경"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18537,21 +18526,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "테두리"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "패딩과 인셋"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18561,11 +18550,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "크기 조정"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18581,11 +18578,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "불투명도"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18597,11 +18594,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "배경 그라데이션"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18623,11 +18620,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "컨트롤 크기"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18639,7 +18636,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -18647,11 +18644,11 @@ msgstr ""
 "**macOS**: `NSControl.ControlSize`에 매핑됩니다. 다른 플랫폼은 다르게 해석할 "
 "수 있습니다."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "툴팁"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18663,7 +18660,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18671,11 +18668,11 @@ msgstr ""
 "**macOS/Windows/Linux**: 네이티브 툴팁. **iOS/Android**: 툴팁 지원 없음. "
 "**Web**: HTML `title` 속성."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "활성화/비활성화"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -18687,11 +18684,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "완전한 명령형 예시"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -18711,7 +18709,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -18739,10 +18737,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -18815,15 +18813,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "스타일 구성 (명령형 헬퍼 함수)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "헬퍼 함수를 만들어 반복을 줄이세요:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -18833,11 +18831,11 @@ msgstr ""
 "성하기 위해 `perry-styling` 패키지를 사용하세요. 전체 워크플로우에 대해서는 "
 "[Theming](theming.md)을 참조하세요."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "플랫폼 지원"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -18847,7 +18845,7 @@ msgstr ""
 "`crates/perry-ui/src/styling_matrix.rs`에서 자동 생성되며 모든 PR에서 각 백엔"
 "드의 `lib.rs` export에 대해 CI 검사됩니다."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -18865,15 +18863,15 @@ msgstr ""
 "210)에 기록됩니다. 수치를 다른 손으로 유지 된 테이블에 복사하지 마십시오; 매"
 "트릭스를 참조하여 문서가 백엔드 인벤토리에서 이동할 수 없습니다."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — 레이아웃 컨테이너"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — 스타일 변경 애니메이션"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — `perry-styling` 패키지를 통한 디자인 토큰"
 
@@ -20201,8 +20199,8 @@ msgstr "구현"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "상태"
 
@@ -23683,7 +23681,7 @@ msgstr ""
 msgid "Options"
 msgstr "옵션"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25240,7 +25238,7 @@ msgstr "ink와의 동등성"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -25961,15 +25959,18 @@ msgid "Cross-Compilation"
 msgstr "크로스 컴파일"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# 기본 설정: 현재 플랫폼에 대한 컴파일"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# 특정 목표물에 대한 컴파일"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  시계에 Android"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26181,7 +26182,8 @@ msgid "Building"
 msgstr "빌딩"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS는 기본 목표입니다"
 
 #: src/platforms/macos.md:18
@@ -26282,7 +26284,8 @@ msgid "App Store Distribution"
 msgstr "App Store 배포"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# 앱 스토어 인증서로 서명"
 
 #: src/platforms/macos.md:60
@@ -26290,7 +26293,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -26418,15 +26422,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "iOS에서 빌드하고 실행하는 가장 쉬운 방법은 `perry run`입니다:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# 자동 감지 device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# 라이브 스트리밍 stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Perry 허브 빌드 서버를 사용"
 
 #: src/platforms/ios.md:40
@@ -27063,7 +27070,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "이는 물리적 Apple TV 하드웨어용 ARM64 바이너리를 생성합니다."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# 자동 탐지 부팅 애플 TV 시뮬레이터"
 
 #: src/platforms/tvos.md:39
@@ -27541,11 +27549,13 @@ msgstr ""
 "위한 건축](#building-for-device) 참조):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# 시뮬레이터 (2급)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -27653,20 +27663,14 @@ msgstr ""
 "오"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (시리즈 9+ / watchOS 26+)"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (시리즈 4-8 / SE)  PERRY_WATCHOS_ARM64_32로 선택"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -27683,7 +27687,7 @@ msgid "Build environment variables"
 msgstr "환경 변수를 생성"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "변수"
@@ -27800,7 +27804,8 @@ msgstr ""
 "습니다."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# 자동 탐지 부팅 시계 시뮬레이터"
 
 #: src/platforms/watchos.md:126
@@ -28383,36 +28388,13 @@ msgstr ""
 "께:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 공유 배포 목표 (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 슬라이스 (디폴트 장치 목표)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. 미노스 + 피지"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -28530,19 +28512,8 @@ msgstr ""
 "서"
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"애플 배급: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -28555,6 +28526,10 @@ msgid ""
 msgstr ""
 "`altool`는 시계 앱을 업로드 할 수 없습니다 (\"플랫폼을 결정할 수 없습니다"
 "\"). 트랜스포터 사용:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -28900,18 +28875,21 @@ msgid "One-time setup (macOS example)"
 msgstr "일회성 설정 (macOS 예제)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (Homebrew의 `gradle`는 9.x  핀 8.x일 수 있습니다.)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# 또는 어떤 Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr "# 2. SDK / NDK / JDK 17에 env를 지향 (당신의 셸 프로필에 추가)"
 
 #: src/platforms/wearos.md:40
@@ -28919,7 +28897,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "$ANDROID_HOME/ndk/<installed-version> # e.g 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -28931,32 +28910,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. SDK 패키지 + Wear OS arm64 이미지"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"플랫폼 도구\" \"에뮬레이터\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"플랫폼;안드로이드-35\" \"빌드 도구;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"시스템 이미지, 안드로이드-34, 안드로이드 웨어, ARM64-V8A\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Rust 크로스 타겟"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Wear OS 에뮬레이터를 생성 + 부팅 (글라운드 시계)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -28981,7 +28941,8 @@ msgstr ""
 "시간 (아래) 에 발생합니다."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# 연결된 시계 / 부팅된 웨어 에뮬레이터를 자동으로 감지합니다"
 
 #: src/platforms/wearos.md:82
@@ -30918,7 +30879,8 @@ msgstr ""
 "를 위해 `WidgetPaintable` + `GskRenderer`를 사용합니다."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# 다른 터미널에서:"
 
 #: src/platforms/linux.md:82
@@ -30938,7 +30900,8 @@ msgstr ""
 "합니다."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# --target wasm와 같은 출력"
 
 #: src/platforms/web.md:10
@@ -31013,15 +30976,18 @@ msgstr ""
 "딩을 \"무료로\" 얻을 수 있도록 WASM 타겟으로 통합되었습니다."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# 자립 HTML (예정)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# 같은 일이야"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# RAW .wasm 바이너리 (HTML 래퍼가 없습니다)"
 
 #: src/platforms/wasm.md:21
@@ -31336,11 +31302,13 @@ msgid "Provide them when instantiating:"
 msgstr "인스턴스화할 때 그것들을 제공하세요:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// __ffi를 통해 글로벌을 가져옵니다 (부팅 전에 설정)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// 또는 bootPerryWasm 두 번째 인수를 통해"
 
 #: src/platforms/wasm.md:95
@@ -31879,7 +31847,7 @@ msgstr "전체 stdlib"
 msgid "The compiler links only the required runtime components."
 msgstr "컴파일러는 필요한 런타임 구성 요소만 링크합니다."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "외부 네이티브 바인딩"
 
@@ -31993,7 +31961,7 @@ msgstr "[File System](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Networking](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Databases](database.md)"
 
@@ -32215,8 +32183,8 @@ msgstr ""
 "스레드 경계를 넘어 파일 경로를 전달하고 워커 내부에서 파일을 다시 열어야 합니"
 "다."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Overview](overview.md) — 모든 stdlib 모듈"
 
@@ -32313,10 +32281,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "`IncomingMessage`에서 지원되는: `.method`, `.url`, `.headers`, "
@@ -32325,10 +32294,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`"
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -32920,10 +32890,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / S3 호환 객체 저장소"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -32938,11 +32934,11 @@ msgstr ""
 "`perry.compilePackages` 아래에서 네이티브로 컴파일됩니다 — `bun`과 SigV4 사"
 "전 서명 URL 바이트 동일 매치로 검증됨 (issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33016,77 +33012,77 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "같은 코드가 모든 S3 호환 서비스에 대해 작동합니다 — `endPoint`만 변경됩니다:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "서비스"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (테스팅)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33102,7 +33098,7 @@ msgstr ""
 "터에 대해 `bun`과 바이트 동일하게 검증되었으며 실제 S3에 대해 인증할 것입니"
 "다."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33114,7 +33110,7 @@ msgstr ""
 "싱 — 그 경로는 컴파일되지만 여기에서 핀된 벡터에 대해 독립적으로 검증되지 않"
 "았습니다."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -33752,9 +33748,10 @@ msgstr ""
 "`minBy`, `inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "이름의 수입을 사용: 기본 수입 수신자 양식 (`import _ from \"lodash\";  "
@@ -33963,19 +33960,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Perry가 지원하는 추가 npm 패키지 및 Node.js API. 여기 나열된 모든 것은 Perry"
-"의 well-known 네이티브 바인딩 레지스트리 (#466)를 통해 배선되며 JavaScript 런"
-"타임 관여 없이 네이티브 코드로 컴파일됩니다."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (이미지 처리)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -33983,7 +33976,7 @@ msgstr ""
 "`perry-ext-sharp` (v0.5.551)을 통한 네이티브 바인딩. 리사이즈, 형식 변환, 버"
 "퍼/파일 출력이 모두 작동합니다."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34033,15 +34026,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (HTML 파싱)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "`perry-ext-cheerio` (v0.5.550)를 통한 네이티브 바인딩."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34059,11 +34052,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (이메일)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34103,15 +34096,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (압축)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "`perry-ext-zlib` (v0.5.541)을 통한 네이티브 바인딩."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34129,11 +34122,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (작업 스케줄링)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34141,7 +34134,7 @@ msgstr ""
 "`perry-ext-cron` (v0.5.564)을 통한 네이티브 바인딩. `cron`과 `node-cron` 패키"
 "지 이름 모두 같은 백엔드로 라우트됩니다."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34161,11 +34154,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34175,7 +34168,7 @@ msgstr ""
 "+ Buffer 표면을 통해 [`ethers-rs`](https://github.com/gakonst/ethers-rs) 스타"
 "일 ABI 배관에 의해 지원됨."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34193,11 +34186,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -34205,7 +34198,7 @@ msgstr ""
 "`perry-ext-events` (v0.5.546)을 통한 네이티브 바인딩. `EventEmitter` 형태는 "
 "Node.js와 일치합니다 — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -34223,15 +34216,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (재시도 로직)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "`perry-ext-exponential-backoff` (v0.5.542)를 통한 네이티브 바인딩."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -34253,11 +34246,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (임의 정밀도)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -34265,7 +34258,7 @@ msgstr ""
 "`perry-ext-decimal` (v0.5.547)을 통한 네이티브 바인딩. 두 패키지 이름 모두 같"
 "은 백엔드로 라우트됩니다 — `Decimal`과 `BigNumber` 둘 다 노출됩니다."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -34301,11 +34294,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (날짜 조작)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -34313,7 +34306,7 @@ msgstr ""
 "`perry-ext-dayjs` (v0.5.548)를 통한 네이티브 바인딩. 두 패키지 이름 모두 같"
 "은 Rust 백엔드로 라우트됩니다 — 동일한 parse/format/diff 표면."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -34331,11 +34324,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (레거시 날짜)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -34345,7 +34338,7 @@ msgstr ""
 "서 유지보수 모드입니다 — 새 코드에는 `dayjs`를 선호하지만, Perry는 기존 코드"
 "베이스를 위해 둘 다 지원합니다."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -34361,11 +34354,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -34373,7 +34366,7 @@ msgstr ""
 "`perry-ext-ratelimit` (v0.5.552)를 통한 네이티브 바인딩. 인메모리 limiter는 "
 "배선되어 있습니다; Redis / 클러스터 백킹 스토어는 후속 작업입니다."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -34397,11 +34390,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -34418,7 +34411,7 @@ msgstr ""
 "`perry/thread`에서 `parallelMap` / `parallelFilter` / `spawn`는 더 간단한 인"
 "터페이스로 남아 있습니다 ([Threading](../threading/overview.md) 참조)."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -34456,12 +34449,12 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr "웹 작업자 모듈 URL은 수입 소스 파일과 관련하여 발견됩니다:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -34494,10 +34487,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (CLI 파싱)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -34539,11 +34705,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -34563,7 +34729,7 @@ msgstr ""
 "`peek`는 존중됩니다; `maxSize`/`sizeCalculation`, `dispose`, `fetch`, "
 "`allowStale` 및 반복 표면은 아직 구현되지 않았습니다."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -34593,11 +34759,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -34647,11 +34813,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -34665,7 +34831,7 @@ msgstr ""
 "(macOS + Linux); 다른 호스트에서 `spawn`는 소비자의 비 빈 재발 경로를 유발합"
 "니다."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -34677,7 +34843,7 @@ msgstr ""
 "드-프티처럼 `SIGHUP`로 기본 설정됩니다. 아이의 `TERM`는 `name`에서 유래했습니"
 "다."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -34723,11 +34889,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -34742,7 +34908,7 @@ msgstr ""
 "존 플랫폼 `require`는 컴파일 시간에 네이티브 표면으로 접어. `@parcel/"
 "watcher` 2.5.1와 비교해서"
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -34761,7 +34927,7 @@ msgstr ""
 "다. 새 경로를 위해 `delete` 더하기 `create`로 이름을 변경합니다. 백엔드 "
 "overflow/rescan 알림은 신선한 트리 스냅샷을 트리거하고 그 차이를 발산합니다."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -34779,7 +34945,7 @@ msgstr ""
 "를 활성화시킵니다. `writeSnapshot`와 `getEventsSince`는 오버플로우 복구와 같"
 "은 스냅샷 디프 시맨틱을 사용합니다."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -34789,7 +34955,7 @@ msgstr ""
 "npm 패키지처럼 `bun add`로 import되지만, Rust 지원이며 `perry-ffi`를 통해 네"
 "이티브로 컴파일됩니다:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -34798,7 +34964,7 @@ msgstr ""
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)를 참"
 "조하세요."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -34806,11 +34972,11 @@ msgstr ""
 "**`@perryts/iroh`** — Iroh 피어투피어 네트워킹. [PerryTS/iroh-bindings]"
 "(https://github.com/PerryTS/iroh-bindings)를 참조하세요."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "`compilePackages`를 통해 컴파일된 순수 TypeScript 드라이버:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -34820,7 +34986,7 @@ msgstr ""
 "**`@perryts/redis`** — Node.js 및 Bun에서도 변경 없이 실행되는 wire-protocol "
 "클라이언트."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -34828,11 +34994,11 @@ msgstr ""
 "이러한 외부 패키지가 따르는 계약에 대해서는 [Native Bindings — Overview](../"
 "native-libraries/overview.md)를 참조하세요."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[File System](fs.md) — fs와 path API"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[Native Bindings](../native-libraries/overview.md) — 자신만의 작성"
 
@@ -34855,7 +35021,8 @@ msgstr ""
 "그것들은 깨끗하게 링크되지만 선택한 타겟에서 런타임에 no-op됩니다."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "총: 138개의 모듈에 3019개의 항목이 있습니다."
 
 #: src/api/reference.md:9
@@ -34952,4831 +35119,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "메서드"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — 모듈"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "속성"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount`  모듈"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince`  모듈"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — 모듈"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — 모듈"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot`  모듈"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — 모듈"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — 모듈"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — 모듈"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — 모듈"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — 모듈"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — 인스턴스"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — 인스턴스"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — 인스턴스"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — 인스턴스"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — 인스턴스"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — 인스턴스"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — 인스턴스"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — 모듈"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — 모듈"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — 모듈"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — 모듈"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — 모듈"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — 모듈"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — 모듈"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — 모듈"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — 모듈"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — 모듈"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — 모듈"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — 모듈"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — 모듈"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — 모듈"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — 모듈"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — 모듈"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — 모듈"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — 모듈"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — 모듈"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — 모듈"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — 모듈"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — 모듈"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — 인스턴스 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — 모듈 _(클래스: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — 모듈 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — 인스턴스 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — 모듈"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — 인스턴스"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — 인스턴스 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — 인스턴스 _(클래스: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — 인스턴스"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — 모듈"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — 모듈"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — 인스턴스"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — 인스턴스"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — 인스턴스"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — 인스턴스 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — 모듈 _(클래스: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — 모듈"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — 인스턴스 _(클래스: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — 모듈"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — 모듈"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — 모듈"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — 모듈"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — 모듈"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — 모듈"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — 모듈"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — 모듈"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — 모듈"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — 모듈"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — 모듈"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — 인스턴스"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — 인스턴스"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — 인스턴스"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — 인스턴스"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — 인스턴스"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — 인스턴스"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — 인스턴스"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — 인스턴스"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — 인스턴스"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — 인스턴스"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — 인스턴스"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — 모듈"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — 모듈"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — 모듈"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — 모듈"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — 모듈"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — 모듈"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "전송"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob`  모듈"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — 모듈"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — 모듈"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — 모듈"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — 모듈"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — 모듈"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — 모듈"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file`  모듈"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — 모듈"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — 모듈"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — 모듈"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — 모듈"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — 모듈"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — 인스턴스 _(클래스: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — 인스턴스 _(클래스: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — 모듈"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth`  모듈"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — 모듈"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — 인스턴스 _(클래스: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction`  인스턴스 _ (클래스: `Database`)"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported`  모듈"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — 모듈"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — 모듈"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — 모듈"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — 모듈"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — 모듈"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction`  모듈"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString`  모듈"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback`  모듈"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — 모듈"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols`  모듈"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr`  모듈"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer`  모듈"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer`  모듈"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource`  모듈"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — 모듈"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database`  모듈"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction`  인스턴스 _ (클래스: `Database`)"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values`  인스턴스 _ (클래스: `Statement`)"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — 인스턴스"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — 인스턴스"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — 인스턴스"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — 인스턴스"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — 인스턴스"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — 인스턴스"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — 인스턴스"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — 인스턴스"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — 인스턴스"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — 모듈"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — 인스턴스"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — 인스턴스"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — 인스턴스"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — 모듈"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — 모듈"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — 모듈"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — 모듈"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — 모듈"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — 모듈"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — 모듈"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — 모듈"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — 모듈"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — 모듈"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — 인스턴스"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  인스턴스"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  인스턴스"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — 인스턴스"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — 인스턴스"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — 인스턴스"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — 인스턴스"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — 인스턴스"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — 인스턴스"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — 인스턴스"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — 인스턴스"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — 모듈"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — 모듈"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — 모듈"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — 모듈"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — 모듈"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — 모듈"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — 모듈"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — 모듈"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — 모듈"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — 모듈"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — 모듈"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — 모듈"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — 모듈"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — 모듈"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — 모듈"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — 모듈"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — 모듈"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — 모듈"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — 모듈"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — 모듈"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — 모듈"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — 모듈"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — 모듈"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — 모듈"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — 모듈"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — 인스턴스"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — 인스턴스"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — 모듈"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — 인스턴스"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — 인스턴스"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — 모듈"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — 모듈"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — 모듈"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — 모듈"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — 모듈"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — 모듈"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — 모듈"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — 모듈"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — 모듈"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — 모듈"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — 모듈"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — 모듈"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — 모듈"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — 모듈"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — 모듈"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — 모듈"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — 모듈"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — 모듈"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — 모듈"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — 모듈"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — 모듈"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — 모듈"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — 모듈"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — 모듈"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — 모듈"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — 모듈"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — 모듈"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — 모듈"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — 모듈"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — 모듈"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — 모듈"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — 모듈"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — 모듈"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — 모듈"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — 모듈"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — 모듈"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — 모듈"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — 모듈"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — 모듈"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — 모듈"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — 모듈"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — 모듈"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — 모듈"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — 모듈"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — 모듈"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — 모듈"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — 모듈"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — 모듈"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — 모듈"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — 모듈"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — 모듈"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — 모듈"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — 모듈"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — 모듈"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — 모듈"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — 모듈"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — 모듈"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — 모듈"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — 모듈"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — 모듈"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — 모듈"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — 모듈"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — 모듈"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — 모듈"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — 모듈"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — 모듈"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — 모듈"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — 모듈"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — 인스턴스"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — 인스턴스"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — 인스턴스"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — 인스턴스"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — 모듈"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — 인스턴스"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — 인스턴스"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — 인스턴스"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — 인스턴스"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — 인스턴스"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — 인스턴스"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — 인스턴스"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — 인스턴스"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — 인스턴스"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — 인스턴스"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — 인스턴스"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — 인스턴스"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — 인스턴스"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — 인스턴스"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — 인스턴스"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — 인스턴스"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — 인스턴스"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — 인스턴스"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — 인스턴스"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — 인스턴스"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — 인스턴스"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — 인스턴스"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — 인스턴스"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — 인스턴스"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — 인스턴스"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — 인스턴스"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — 인스턴스"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — 인스턴스"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — 인스턴스"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — 인스턴스"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — 인스턴스"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — 인스턴스"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — 인스턴스"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — 인스턴스"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — 인스턴스"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — 인스턴스"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — 인스턴스"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — 인스턴스"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — 인스턴스"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — 인스턴스"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — 인스턴스"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — 모듈"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — 모듈"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — 모듈"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — 모듈"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — 모듈"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — 모듈"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — 모듈"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — 모듈"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — 모듈"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — 모듈"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — 모듈"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — 모듈"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — 모듈"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — 모듈"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — 모듈"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — 모듈"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — 모듈"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — 모듈"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — 모듈"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — 모듈"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — 모듈"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — 모듈"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — 모듈"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — 모듈"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — 모듈"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — 모듈"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — 모듈"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — 모듈"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — 인스턴스 _(클래스: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — 모듈"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — 인스턴스"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — 인스턴스"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — 모듈"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — 인스턴스"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — 인스턴스"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — 인스턴스"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — 인스턴스"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — 인스턴스"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — 모듈"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — 모듈"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — 모듈 _(클래스: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — 모듈"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — 모듈"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — 모듈"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — 모듈"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — 모듈"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — 모듈"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — 모듈"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — 모듈"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — 인스턴스 _(클래스: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — 인스턴스 _(클래스: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — 인스턴스"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — 인스턴스 _(클래스: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — 인스턴스"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — 모듈"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — 인스턴스"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — 모듈"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — 모듈"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — 인스턴스"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — 모듈"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — 인스턴스"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — 인스턴스"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — 모듈"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — 인스턴스"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — 모듈"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — 인스턴스"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — 인스턴스"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — 인스턴스"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — 인스턴스"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — 인스턴스"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — 인스턴스"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — 모듈"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — 인스턴스 _(클래스: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — 모듈"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — 인스턴스"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — 인스턴스"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — 인스턴스"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — 인스턴스"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — 인스턴스"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — 인스턴스"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — 인스턴스"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — 인스턴스"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — 인스턴스"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — 인스턴스"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — 인스턴스"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — 인스턴스"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — 인스턴스"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — 인스턴스"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — 인스턴스"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — 인스턴스"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — 인스턴스"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — 인스턴스"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — 인스턴스"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — 인스턴스"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — 인스턴스"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — 인스턴스"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — 인스턴스"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — 인스턴스"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — 인스턴스"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — 인스턴스"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — 인스턴스"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — 인스턴스"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer`  모듈"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString`  모듈"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — 모듈"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — 모듈"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — 모듈"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — 모듈"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — 모듈"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — 모듈"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — 모듈"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — 모듈"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — 모듈"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — 모듈"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — 모듈"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — 모듈"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — 모듈"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — 모듈"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — 모듈"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — 모듈"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — 모듈"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — 모듈"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — 모듈"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — 모듈"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — 모듈"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — 모듈"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — 모듈"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — 모듈"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — 모듈"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — 모듈"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — 모듈"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — 모듈"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — 모듈"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — 모듈"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — 모듈"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — 모듈"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — 모듈"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — 모듈"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — 모듈"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — 모듈"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — 모듈"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — 모듈"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — 모듈"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — 모듈"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — 모듈"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — 모듈"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — 모듈"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — 모듈"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — 모듈"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — 모듈"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — 모듈"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — 모듈"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — 모듈"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — 모듈"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — 모듈"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — 모듈"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — 모듈"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — 모듈"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — 모듈"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — 모듈"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — 모듈"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — 모듈"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — 모듈"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — 모듈"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — 모듈"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — 모듈"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — 모듈"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — 모듈"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — 모듈"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — 모듈"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — 모듈"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — 모듈"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — 모듈"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — 모듈"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — 모듈"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — 모듈"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — 모듈"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — 모듈"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — 모듈"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — 모듈"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — 모듈"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — 모듈"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — 모듈"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — 모듈"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — 모듈"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — 모듈"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — 모듈"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — 모듈"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — 모듈"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — 모듈"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — 모듈"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — 모듈"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — 모듈"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — 모듈"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — 모듈"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — 모듈"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — 모듈"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — 모듈"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — 인스턴스 _(클래스: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — 인스턴스 _(클래스: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — 인스턴스 _(클래스: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — 모듈"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — 모듈"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening`  인스턴스 _ (클래스: `HttpServer`)"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — 모듈"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — 모듈"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -39784,103 +40098,103 @@ msgstr ""
 "`keepSocketAlive`  인스턴스 _ ((클래스: `Agent`) _ **stub** reqwest는 생을 유"
 "지 풀을 소유합니다; 매 소켓 갈고리는 no-ops입니다, 한 번 경고 (# 4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening`  인스턴스 _ (클래스: `HttpServer`)"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once`  인스턴스 _ (클래스: `ClientRequest`)"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref`  인스턴스 _ (클래스: `HttpServer`)"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -39888,375 +40202,369 @@ msgstr ""
 "`reuseSocket`  인스턴스 _ ((클래스: `Agent`) _ **stub** reqwest는 생을 유지 "
 "풀을 소유합니다; 매 소켓 갈고리는 no-ops입니다, 한 번 경고 (# 4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — 모듈"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — 모듈"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket`  인스턴스 _ (클래스: `IncomingMessage`)"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — 인스턴스 _(클래스: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — 인스턴스 _(클래스: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — 인스턴스 _(클래스: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref`  인스턴스 _ (클래스: `HttpServer`)"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — 인스턴스 _(클래스: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — 모듈"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — 모듈"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — 인스턴스 _(클래스: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — 모듈"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — 모듈"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — 모듈"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — 모듈"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — 모듈"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — 모듈"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening`  인스턴스 _ (클래스: `HttpsServer`)"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening`  인스턴스 _ (클래스: `HttpsServer`)"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref`  인스턴스 _ (클래스: `HttpsServer`)"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — 인스턴스 _(클래스: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref`  인스턴스 _ (클래스: `HttpsServer`)"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — 모듈"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  모듈 _ (클래스: `console`)"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  모듈 _ (클래스: `console`)"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  모듈 _ (클래스: `console`)"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  모듈 _ (클래스: `console`)"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -40264,7 +40572,7 @@ msgstr ""
 "`open`  모듈 **stub** port/host를 받아들이지만 실제 WebSocket 검사자 엔드포인"
 "트를 묶지 않습니다. 세션은 과정 속 가짜입니다 (#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -40274,7 +40582,7 @@ msgstr ""
 "Runtime.evaluate 하위 집합만 응답; 모든 다른 프로토콜 방법은 검사 오류 "
 "-32601 (#4916) 를 던집니다"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -40282,7 +40590,7 @@ msgstr ""
 "`url`  모듈 **stub** 항상 정의되지 않습니다: Perry는 실제 검사자 최종 지점을 "
 "노출하지 않습니다 (# 4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -40290,3285 +40598,3276 @@ msgstr ""
 "`waitForDebugger`  모듈 **stub** open의 바로 뒤에 반환 ((); 기다릴 수 있는 디"
 "버거가 없습니다 (# 4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  모듈 _ (클래스: `console`)"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — 인스턴스 _(클래스: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — 인스턴스"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — 모듈"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — 인스턴스"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — 인스턴스"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — 인스턴스"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — 인스턴스"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — 인스턴스"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — 인스턴스"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — 인스턴스"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — 인스턴스"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — 인스턴스"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — 인스턴스"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — 모듈"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — 인스턴스"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — 인스턴스"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — 인스턴스"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — 인스턴스"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — 인스턴스"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — 인스턴스"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — 모듈"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — 모듈"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — 모듈"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — 모듈"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — 모듈"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — 모듈"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — 모듈"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — 모듈"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — 모듈"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — 모듈"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — 모듈"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — 모듈"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — 모듈"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — 모듈"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — 모듈"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — 모듈"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — 모듈"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — 모듈"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — 모듈"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — 모듈"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — 모듈"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — 모듈"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — 모듈"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — 모듈"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — 모듈"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — 모듈"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — 모듈"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — 인스턴스"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — 인스턴스"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  인스턴스"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — 인스턴스"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — 모듈"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — 모듈"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — 모듈"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — 모듈"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — 모듈"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — 모듈"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — 모듈"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — 모듈"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — 모듈"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — 모듈"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — 모듈"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — 모듈"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — 모듈"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — 모듈"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — 모듈"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — 모듈"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — 모듈"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — 모듈"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — 모듈"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — 모듈"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — 모듈"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — 모듈"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — 모듈"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  인스턴스"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  인스턴스"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — 모듈"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  인스턴스"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — 인스턴스"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — 인스턴스"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — 인스턴스"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — 인스턴스"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — 인스턴스"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — 인스턴스"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — 인스턴스"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — 인스턴스"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — 인스턴스"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — 인스턴스"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — 인스턴스"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — 인스턴스"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — 모듈"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — 모듈"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — 인스턴스 _(클래스: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — 인스턴스"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — 인스턴스 _(클래스: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — 인스턴스 _(클래스: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — 인스턴스"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — 인스턴스"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — 인스턴스 _(클래스: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — 인스턴스 _(클래스: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — 인스턴스"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — 인스턴스"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — 모듈"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — 모듈"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — 모듈"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — 모듈"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — 모듈"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — 모듈"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — 인스턴스 _(클래스: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — 인스턴스 _(클래스: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — 인스턴스 _(클래스: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — 모듈"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — 모듈"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — 모듈 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — 모듈"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — 모듈"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — 모듈"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — 모듈 _(클래스: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — 인스턴스 _(클래스: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — 모듈"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — 모듈"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert`  인스턴스 _ (클래스: `Socket`)"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — 인스턴스 _(클래스: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — 인스턴스 _(클래스: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem`  모듈"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem`  모듈"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate`  모듈"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem`  모듈"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem`  모듈"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem`  모듈"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions`  인스턴스 _ (클래스: `Certificate`)"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer`  인스턴스 _ (클래스: `Certificate`)"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject`  인스턴스 _ (클래스: `Certificate`)"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign`  인스턴스 _ (클래스: `Certificate`)"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — 모듈"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — 인스턴스"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — 인스턴스"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — 모듈"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — 모듈"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — 모듈"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — 모듈"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — 모듈"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — 모듈"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — 모듈"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — 모듈"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — 모듈"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — 모듈"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — 모듈"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — 모듈"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — 모듈"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — 모듈"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — 모듈"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — 모듈"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — 모듈"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — 모듈"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — 모듈"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — 모듈"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — 모듈"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — 모듈"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — 모듈"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — 모듈"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — 모듈"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — 모듈"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — 모듈"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — 모듈"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — 모듈"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — 모듈"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — 모듈"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — 인스턴스 _(클래스: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization`  모듈"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — 모듈"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — 인스턴스 _(클래스: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — 인스턴스 _(클래스: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — 모듈"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles`  모듈"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded`  모듈"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — 모듈"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — 모듈"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — 모듈"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — 모듈"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent`  모듈"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — 모듈"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — 모듈"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — 모듈"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — 모듈"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — 모듈"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — 모듈"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — 모듈"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — 모듈"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — 모듈"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — 모듈"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — 모듈"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — 모듈"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — 모듈"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — 모듈"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — 모듈"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — 모듈"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — 모듈"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — 모듈"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — 모듈"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — 모듈"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — 모듈"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — 모듈"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — 모듈"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — 모듈"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — 모듈"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — 모듈"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — 모듈"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — 모듈"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — 모듈"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — 모듈"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — 모듈"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — 모듈"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — 모듈"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — 모듈"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — 모듈"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — 모듈"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — 모듈"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — 모듈"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — 모듈"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — 모듈"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — 모듈"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — 모듈"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — 모듈"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — 모듈"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — 모듈"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — 모듈"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — 모듈"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — 모듈"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — 모듈"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — 모듈"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — 모듈"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — 모듈"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect`  모듈"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint`  모듈"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor`  모듈"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — 모듈"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — 모듈"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — 모듈"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — 모듈"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — 모듈"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — 모듈"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — 모듈"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — 모듈"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession`  모듈"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession`  모듈"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability`  모듈"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment`  모듈"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange`  모듈"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange`  모듈"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond`  모듈"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — 모듈"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — 모듈"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — 모듈"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — 모듈"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — 모듈"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — 모듈"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — 모듈"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — 모듈"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  모듈 _ (내성)"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32`  모듈"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64`  모듈"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16`  모듈"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32`  모듈"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64`  모듈"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8`  모듈"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize`  모듈"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  모듈 _ (내성)"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  모듈 _ (내성)"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16`  모듈"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32`  모듈"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64`  모듈"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8`  모듈"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize`  모듈"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — 모듈"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — 모듈"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — 모듈"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — 모듈"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — 모듈"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — 모듈"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — 모듈"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — 모듈"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — 모듈"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — 모듈"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — 모듈"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — 모듈"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — 모듈"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — 모듈"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — 모듈"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — 모듈"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — 모듈"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — 모듈"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — 모듈"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — 모듈"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — 모듈"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — 모듈"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — 모듈"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — 모듈"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — 모듈"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — 모듈"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — 모듈"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — 모듈"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — 모듈"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — 모듈"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — 모듈"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — 모듈"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — 모듈"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — 모듈"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — 모듈"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — 모듈"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — 모듈"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — 모듈"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — 모듈"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — 모듈"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay`  모듈"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — 모듈"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — 모듈"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — 모듈"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — 모듈"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — 모듈"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — 모듈"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — 모듈"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — 모듈"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — 모듈"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — 모듈"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — 모듈"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — 모듈"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — 모듈"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — 모듈"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — 모듈"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — 모듈"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — 모듈"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — 모듈"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — 모듈"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — 모듈"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — 모듈"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — 모듈"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — 모듈"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — 모듈"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — 모듈"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — 모듈"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — 모듈"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — 모듈"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — 모듈"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — 모듈"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — 모듈"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — 모듈"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — 모듈"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — 모듈"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — 모듈"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — 모듈"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — 모듈"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — 모듈"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — 모듈"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — 모듈"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — 모듈"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — 모듈"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — 모듈"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — 모듈"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — 모듈"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — 모듈"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — 모듈"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — 모듈"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — 모듈"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — 모듈"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — 인스턴스 _(클래스: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — 모듈"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — 모듈"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — 인스턴스 _(클래스: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — 모듈"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — 인스턴스 _(클래스: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — 모듈"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — 인스턴스 _(클래스: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — 모듈"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — 인스턴스 _(클래스: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — 인스턴스 _(클래스: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — 인스턴스 _(클래스: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — 모듈"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — 인스턴스 _(클래스: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — 인스턴스 _(클래스: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — 인스턴스 _(클래스: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — 모듈"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — 모듈"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — 모듈"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — 모듈"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — 모듈"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — 모듈"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — 모듈"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — 모듈"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — 모듈"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — 모듈"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — 모듈"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — 모듈"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — 모듈"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — 인스턴스 _(클래스: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — 인스턴스 _(클래스: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — 모듈"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — 모듈"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView`  모듈"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — 모듈"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — 모듈"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — 모듈"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — 모듈"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — 모듈"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — 모듈"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — 모듈"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — 모듈"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — 모듈"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — 모듈"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — 모듈"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — 모듈"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — 모듈"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — 모듈"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — 모듈"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — 모듈"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — 모듈"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — 모듈"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — 모듈"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — 모듈"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — 모듈"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — 모듈"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — 모듈"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — 모듈"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — 모듈"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — 모듈"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — 모듈"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — 모듈"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker`  모듈"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — 모듈"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — 모듈"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — 모듈"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — 모듈"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — 모듈"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy`  모듈"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — 모듈"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — 모듈"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — 모듈"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — 모듈"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — 모듈"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd`  모듈"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle`  모듈"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — 모듈"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — 모듈"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — 모듈"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — 모듈"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — 모듈"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — 모듈"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — 모듈"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — 모듈"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — 모듈"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — 모듈"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — 모듈"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — 모듈"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — 모듈"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — 모듈"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — 모듈"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — 모듈"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — 모듈"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — 모듈"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — 모듈"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — 모듈"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — 모듈"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — 모듈"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — 모듈"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — 모듈"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — 모듈"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — 모듈"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — 모듈"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — 모듈"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — 모듈"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — 모듈"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — 모듈"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — 모듈"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — 모듈"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — 모듈"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — 모듈"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — 모듈"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — 모듈"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — 모듈"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — 모듈"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — 모듈"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — 모듈"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — 모듈"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — 모듈"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — 모듈"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — 모듈"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — 모듈"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — 모듈"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — 모듈"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — 모듈"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — 모듈"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — 모듈"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — 모듈"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — 모듈"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — 모듈"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — 모듈"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — 모듈"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — 모듈"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — 모듈"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — 모듈"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — 모듈"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — 모듈"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — 모듈"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — 모듈"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — 모듈"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — 모듈"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — 모듈"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — 모듈"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — 모듈"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — 모듈"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — 모듈"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — 모듈"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem`  모듈"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected`  모듈"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected`  모듈"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — 모듈"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — 모듈"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — 모듈"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders`  모듈"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl`  모듈"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue`  모듈"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — 모듈"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig`  모듈"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — 모듈"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — 모듈"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — 모듈"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — 모듈"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — 모듈"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse`  모듈"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — 모듈"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — 모듈"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — 모듈"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — 모듈"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — 모듈"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — 모듈"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — 모듈"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — 모듈"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — 모듈"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — 모듈"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout`  모듈"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount`  모듈"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed`  모듈"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge`  모듈"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild`  모듈"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree`  모듈"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew`  모듈"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild`  모듈"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge`  모듈"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum`  모듈"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap`  모듈"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc`  모듈"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber`  모듈"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc`  모듈"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — 모듈"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — 인스턴스 _(클래스: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — 모듈"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — 모듈"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — 모듈"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — 모듈"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — 모듈"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — 모듈"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — 모듈"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — 모듈"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — 모듈"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — 모듈"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — 모듈"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — 모듈"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — 모듈"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — 모듈"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — 모듈"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — 모듈"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — 모듈"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — 모듈"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — 모듈"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — 모듈"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — 모듈"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — 모듈"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — 모듈"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — 모듈"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — 모듈"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — 모듈"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — 모듈"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — 모듈"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — 모듈"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — 모듈"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — 모듈"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — 모듈"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — 모듈"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — 모듈"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — 모듈"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — 모듈"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — 모듈"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — 모듈"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — 모듈"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — 모듈"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — 모듈"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — 모듈"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — 모듈"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — 모듈"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — 모듈"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — 모듈"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — 모듈"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — 모듈"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — 모듈"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — 모듈"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — 모듈"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — 모듈"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — 모듈"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — 모듈"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — 모듈"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — 모듈"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — 모듈"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  인스턴스"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  인스턴스"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  인스턴스"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  인스턴스"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — 모듈"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — 모듈"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — 모듈"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — 모듈"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — 모듈"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — 인스턴스"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — 인스턴스"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — 인스턴스"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — 인스턴스"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — 모듈"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — 인스턴스"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — 인스턴스"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — 인스턴스"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — 인스턴스"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — 인스턴스"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — 인스턴스"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — 인스턴스"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -43578,43 +43877,43 @@ msgstr ""
 "며, .write (()) 는 숫자 문자, 컨텍스트 검색 및 단일 '+'를 평가합니다. 실제 "
 "JS eval 루프 (# 4916) 가 없습니다"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — 모듈"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -43624,1459 +43923,1459 @@ msgstr ""
 "(()) 는 숫자 문자, 컨텍스트 검색 및 단일 '+'를 평가합니다. 실제 JS eval 루프 "
 "(# 4916) 가 없습니다"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — 인스턴스 _(클래스: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — 모듈"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — 모듈"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — 모듈"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — 모듈"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — 모듈"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  인스턴스"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  인스턴스"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — 인스턴스"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  인스턴스"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  인스턴스"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  인스턴스"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — 인스턴스"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — 인스턴스"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — 인스턴스"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — 인스턴스"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — 인스턴스"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — 인스턴스"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — 인스턴스"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — 인스턴스"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — 인스턴스"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — 모듈"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  인스턴스"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — 인스턴스"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — 인스턴스"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  인스턴스"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — 인스턴스"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — 인스턴스"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — 인스턴스"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — 모듈"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — 모듈"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — 인스턴스"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — 인스턴스 _(클래스: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — 인스턴스"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — 모듈"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — 인스턴스"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — 인스턴스"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — 인스턴스 _(클래스: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  인스턴스"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — 인스턴스 _(클래스: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — 인스턴스"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — 인스턴스"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — 인스턴스 _(클래스: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — 인스턴스"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — 인스턴스"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — 인스턴스"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — 인스턴스"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — 인스턴스"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — 인스턴스"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — 인스턴스"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  인스턴스"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — 인스턴스"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — 인스턴스"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — 인스턴스 _(클래스: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — 인스턴스"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — 인스턴스"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — 인스턴스 _(클래스: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — 인스턴스"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — 모듈"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — 모듈"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — 모듈"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — 모듈"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — 인스턴스"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — 인스턴스"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — 모듈"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — 인스턴스"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — 인스턴스"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — 인스턴스"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — 모듈"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — 인스턴스"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — 모듈"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — 모듈"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — 모듈"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — 모듈"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — 모듈"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — 인스턴스"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — 모듈"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — 모듈"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — 인스턴스"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — 모듈"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — 인스턴스"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — 인스턴스"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — 인스턴스"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — 인스턴스"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — 인스턴스"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — 인스턴스"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — 인스턴스"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — 인스턴스"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — 인스턴스"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — 인스턴스"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — 인스턴스"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — 모듈"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — 인스턴스"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — 인스턴스"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — 인스턴스"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — 인스턴스"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — 인스턴스"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — 인스턴스"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — 인스턴스"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — 인스턴스"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — 인스턴스"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — 인스턴스"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — 인스턴스"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — 인스턴스"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — 모듈"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — 모듈"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — 모듈"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — 모듈"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — 모듈"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — 모듈"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — 인스턴스 _(클래스: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — 인스턴스 _(클래스: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — 모듈"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — 모듈"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — 모듈"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — 모듈"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — 모듈"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — 모듈"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — 모듈"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — 모듈"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — 모듈"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — 모듈"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — 모듈"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — 모듈"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — 모듈"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — 모듈"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — 모듈"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — 모듈"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — 모듈"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — 모듈"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — 모듈"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — 모듈"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — 모듈"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — 모듈"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — 모듈"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — 모듈"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — 모듈"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — 모듈"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — 모듈"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — 모듈"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — 모듈"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — 모듈"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — 모듈"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — 모듈"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — 모듈 _(클래스: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — 모듈"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — 모듈"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — 모듈"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — 모듈 _(클래스: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — 모듈 _(클래스: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — 모듈 _(클래스: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — 모듈 _(클래스: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — 모듈 _(클래스: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — 모듈"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — 모듈"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — 모듈"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — 모듈 _(클래스: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — 모듈"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — 모듈"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — 모듈"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — 모듈"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — 모듈"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — 모듈"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — 모듈"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — 모듈"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — 모듈"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — 모듈"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — 모듈"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — 모듈"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — 모듈"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — 모듈"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — 모듈"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols`  모듈"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — 모듈"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — 모듈"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms`  모듈"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — 모듈"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — 인스턴스 _(클래스: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — 모듈"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — 모듈"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — 모듈"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — 인스턴스 _(클래스: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — 인스턴스 _(클래스: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — 인스턴스"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — 인스턴스"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — 인스턴스"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — 인스턴스"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — 인스턴스"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText`  모듈"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule`  모듈"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent`  모듈"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close`  인스턴스 _ (클래스: `ProxyAgent`)"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy`  인스턴스 _ (클래스: `ProxyAgent`)"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch`  모듈"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher`  모듈"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher`  모듈"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — 모듈"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — 모듈"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — 모듈"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — 인스턴스 _(클래스: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — 모듈"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — 모듈"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — 인스턴스 _(클래스: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — 모듈"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — 모듈"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — 모듈"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — 모듈"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — 모듈"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — 모듈"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — 모듈"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — 모듈"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — 모듈"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — 모듈"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — 모듈"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — 모듈"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — 모듈"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — 모듈"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — 모듈"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — 모듈"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — 모듈"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — 모듈"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — 모듈"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — 모듈"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — 모듈"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — 모듈"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — 모듈"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — 모듈"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — 모듈"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — 모듈"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — 모듈"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — 모듈"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — 모듈"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — 모듈"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — 모듈"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — 모듈"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — 모듈"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — 모듈"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — 모듈"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — 모듈"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — 모듈"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — 모듈"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — 모듈"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — 모듈"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — 모듈"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — 모듈"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — 모듈"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — 모듈"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — 모듈"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3`  모듈"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — 모듈"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5`  모듈"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — 모듈"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — 인스턴스 _(클래스: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — 인스턴스 _(클래스: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — 모듈"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — 인스턴스 _(클래스: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — 모듈"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — 모듈"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45084,11 +45383,11 @@ msgstr ""
 "`getHeapCodeStatistics`  모듈 **stub** 모든 필드 0; Perry는 AOT를 컴파일합니"
 "다. JIT 코드 힙 (#4916) 이 없습니다"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — 모듈"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45097,7 +45396,7 @@ msgstr ""
 "`getHeapSpaceStatistics`  모듈 **stub** Perry 아레나에서 old_space에 속하는 "
 "모든 라이브 사용과 함께 노드 공간 이름; 다른 공간은 0 (#4916) 를 보고합니다"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45110,87 +45409,87 @@ msgstr ""
 "total_physical_size=RSS, heap_size_limit 고정 ~ 2GB (집행되지 않습니다); "
 "\\*\\_ 실행, external_memory, 글로벌-수처 및 zap 필드는 0 (# 4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — 인스턴스 _(클래스: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — 모듈"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — 인스턴스 _(클래스: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — 인스턴스 _(클래스: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — 인스턴스 _(클래스: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — 인스턴스 _(클래스: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — 모듈"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — 인스턴스 _(클래스: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — 모듈"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — 인스턴스 _(클래스: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — 모듈"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — 모듈"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — 인스턴스 _(클래스: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — 모듈"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -45198,459 +45497,469 @@ msgstr ""
 "`stop`  인스턴스 _ ((클래스: `GCProfiler`) _ **stub** 보고서는 노드 형태가 있"
 "지만 통계 배열은 항상 비어 있습니다 (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — 모듈"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — 모듈"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — 모듈"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — 인스턴스 _(클래스: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — 모듈"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — 모듈"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — 모듈"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — 모듈"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — 모듈"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — 모듈"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — 인스턴스"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — 모듈"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — 모듈"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — 인스턴스"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — 인스턴스"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — 인스턴스"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — 인스턴스"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — 인스턴스"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — 인스턴스"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — 인스턴스"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — 모듈"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — 인스턴스"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — 인스턴스"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — 모듈"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — 인스턴스"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — 인스턴스"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — 모듈"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — 모듈"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — 모듈"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — 인스턴스"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — 모듈"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — 인스턴스 _(클래스: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — 인스턴스 _(클래스: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — 인스턴스 _(클래스: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — 인스턴스 _(클래스: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — 모듈"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — 모듈"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  인스턴스"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — 모듈"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — 모듈"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — 모듈"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — 모듈"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — 모듈"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — 모듈"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — 모듈"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload`  인스턴스 _ (클래스: `Worker`)"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  인스턴스"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — 모듈"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — 인스턴스 _(클래스: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — 모듈"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — 인스턴스 _(클래스: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — 인스턴스"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — 인스턴스"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — 인스턴스 _(클래스: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — 모듈"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — 인스턴스"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — 인스턴스 _(클래스: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  인스턴스"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — 인스턴스 _(클래스: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — 모듈"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — 모듈"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — 모듈"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — 모듈"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — 모듈"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — 모듈"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45658,7 +45967,7 @@ msgstr ""
 "`createBrotliCompress`  모듈 **stub** params/quality 옵션은 받아들여졌지만 무"
 "시, 한 번 경고 (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -45666,7 +45975,7 @@ msgstr ""
 "`createBrotliDecompress`  모듈 **stub** params/quality 옵션은 받아들여졌지만 "
 "무시, 한 번 경고 (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45674,7 +45983,7 @@ msgstr ""
 "`createDeflate`  모듈 **stub** 레벨이 정수; strategy/memLevel가 검증되었지만 "
 "적용되지 않았습니다 (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45682,11 +45991,11 @@ msgstr ""
 "`createDeflateRaw`  모듈 **stub** 레벨이 정수; strategy/memLevel가 검증되었지"
 "만 적용되지 않았습니다 (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — 모듈"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45694,19 +46003,19 @@ msgstr ""
 "`createGzip`  모듈 **stub** 레벨이 정수; strategy/memLevel가 검증되었지만 적"
 "용되지 않았습니다 (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — 모듈"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — 모듈"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — 모듈"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45714,7 +46023,7 @@ msgstr ""
 "`createZstdCompress`  모듈 **stub** params/quality 옵션은 받아들여졌지만 무"
 "시, 한 번 경고 (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45722,79 +46031,71 @@ msgstr ""
 "`createZstdDecompress`  모듈 **stub** params/quality 옵션은 받아들여졌지만 무"
 "시, 한 번 경고 (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — 모듈"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — 모듈"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — 모듈"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — 모듈"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — 모듈"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — 모듈"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — 모듈"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — 모듈"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — 모듈"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — 모듈"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — 모듈"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — 모듈"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — 모듈"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — 모듈"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — 모듈"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — 모듈"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — 모듈"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — 모듈"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -46315,9 +46616,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "`docker-compose.yaml` 파일을 사용하고자 할 때."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "두 모듈은 실행 시간을 공유합니다. 같은 프로그램에서 혼합할 수 있습니다 e.g. "
@@ -46840,12 +47142,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true`는 `docker rm -f`와 동일합니다."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**`logs`와 `exec` 반환 형태에 대한 참고:** 현재 FFI는 JS 객체 대신 "
 "`Vec<ContainerLogs>`로 레지스트리 ID 핸들을 반환합니다. 반환 값을 불투명으로 "
@@ -46972,9 +47275,10 @@ msgstr ""
 "`OnceLock`을 통해 즉시 반환됩니다."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()`는 비동기이며 입력당 `{ name, available, reason, version, "
@@ -47718,9 +48022,10 @@ msgstr ""
 "될 때까지 기다리지 않습니다. 스택이 서비스 요청을 처리할 때까지 블로킹하려면:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**서비스에 `healthcheck` 블록을 사용** (중장, 실행시간이 처리합니다.) "
@@ -48092,8 +48397,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "Forgejo 예제에서는 이 휴대 패턴 (`container_name:  'forgejo-db'` + "
@@ -48164,8 +48470,9 @@ msgid "Single-network shorthand"
 msgstr "단일 네트워크 축약 표기"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -48573,9 +48880,10 @@ msgid "External volumes"
 msgstr "외부 볼륨"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "화면 `external: true`를 표시하여 스택을 공유하거나 다른 프로세스에 의해 생성"
@@ -48596,8 +48904,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -48665,15 +48974,18 @@ msgstr ""
 "제공하지 않습니다 — 지금은 기본 런타임 CLI로 확인하세요:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# 앱 앞선 볼륨 목록"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# 장착점, 드라이버, 라벨"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# 장착 + 검사 내용"
 
 #: src/container/volumes.md:160
@@ -48835,9 +49147,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49018,8 +49331,9 @@ msgstr ""
 "한 이후 실행은 비용이 들지 않습니다."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -49282,8 +49596,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**비루트로 실행** (`user: \"nobody\"` 또는 숫자 UID)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**모든 기능을 삭제하고 특정 기능을 추가합니다** (`cap_drop:  [\"ALL\"]` + 최"
@@ -49425,7 +49740,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "URL과 \"종료 방법\"을 포함한 운영자용 배너 출력."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 "0번 출구 컨테이너들은 `restart:  unless-stopped` 덕분에 계속 작동합니다."
 
@@ -49645,11 +49961,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "헬스체크 기반 의존성 시작 순서"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "포스트그레스는 첫 실행에서 초기화 (initdb + listener bind) 하는 데 ~510초가 "
 "걸립니다. 게팅이 없으면 포지조는 즉시 시작해서 연결할 수 없고 재시험 예산이 "
@@ -49818,7 +50135,8 @@ msgstr ""
 "정하세요**:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -49831,7 +50149,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -49891,11 +50210,13 @@ msgstr ""
 "이드의 경우 먼저 명시적으로 `--down`을 수행하세요:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# 저장 부피"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# 새로운 버전으로 재배포"
 
 #: src/container/production-patterns.md:268
@@ -49913,35 +50234,42 @@ msgid "Running it"
 msgstr "실행 방법"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# 페리를 한 번 만들자"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# 본 을 세우십시오"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# 백엔드: 도커"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# 브라우저에서 http://localhost:3000/를 방문합니다."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# 종료(재배포를 위해 볼륨 유지):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# 분해 + 분해 부피 (파괴 데이터):"
 
 #: src/container/production-patterns.md:300
@@ -50245,19 +50573,23 @@ msgstr ""
 "지정합니다. 필드 이름은 백엔드에서 안정적입니다."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// 테스트 + 상태 그대로 발산"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// 엔진은 호스트 측을 모방합니다"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// 삭제 + 경고"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// 제한된 하위 집합; 이유 문서화"
 
 #: src/container/determinism.md:156
@@ -50381,7 +50713,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "각 프로토콜은 `capabilities()` 메소드에서 상수를 반환합니다"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... 아르그 빌더"
 
 #: src/container/determinism.md:192
@@ -50407,7 +50740,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"백엔드용 dropped/translated 사양 필드\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- 깨끗한 스펙트럼"
 
 #: src/container/determinism.md:212
@@ -50419,15 +50753,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`를 생성합니다"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// 필드 삭제"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// 대등한으로 매핑"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// 엔진은 대신 에뮬레이션"
 
 #: src/container/determinism.md:231
@@ -50435,15 +50772,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. 집행 모드  경고가 어떻게 표시되는지 선택"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// 기본  조용한 추적:: 경고!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// TS console.warn로 표면"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// 지원되지 않는 필드 → 하드 up() 실패"
 
 #: src/container/determinism.md:241
@@ -50505,7 +50845,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "출력 정상화  백엔드와 상관없이 같은 모양"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker 모양 (NDJSON 라인)"
 
 #: src/container/determinism.md:292
@@ -50513,7 +50854,8 @@ msgid "/* docker JSON */"
 msgstr "/* 도커 JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// 애플 모양 (`configuration`-wrapped 객체의 JSON 배열)"
 
 #: src/container/determinism.md:294
@@ -50521,7 +50863,8 @@ msgid "/* apple JSON */"
 msgstr "/* 애플 JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// 둘 다 같은 필드 의미와 함께 ContainerInfo를 생성:"
 
 #: src/container/determinism.md:301
@@ -50843,7 +51186,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -50856,7 +51200,8 @@ msgid "\"Back\""
 msgstr "\"돌아\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (무료 값 = 번역 필요)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -51082,7 +51427,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -51197,7 +51543,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (폴란드어: 하나, 몇, 많은)"
 
 #: src/i18n/interpolation.md:65
@@ -51959,19 +52306,23 @@ msgid "Typical translation workflow:"
 msgstr "일반적인 번역 워크플로:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. 영어 문자열로 코드를 작성"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. 로컬 파일로 문자열을 추출"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr "# 3. 번역자에게 locales/de.json를 보내 (공백 값은 채워야 합니다)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. 빌드  Perry 모든 것을 확인"
 
 #: src/i18n/cli.md:49
@@ -52641,54 +52992,22 @@ msgstr ""
 "에 서명합니다."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) 단번에 키패를 생성하는 것 모드 0600과 kp.json를 저장"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) 발매 전 서명 출력 JSON 봉투는 모든"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 3) 마니페스트를 업로드하기 전에 현지에서 사인 체계를 확인합니다"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    여기서는 고객에 대한 검증을 통과하는 것을 예측합니다."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-"# 4) 리리즈 CI는 CLI 매니페스트에 서명하고, 그 아카이브 URL, 플랫폼을 연결합"
-"니다"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "각 자산에 대해 `sign` 출력을 `jq`로 파이프하여 최종 선언을 작성하고, 위에 표"
@@ -54302,9 +54621,10 @@ msgstr ""
 "수 있습니다(예: 여러 발의 총소리, 여러 발자국 소리)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** 믹서 그룹 소리는 버스를 통해 경로를, 버스는 부모를 통해 경로를 (예"
@@ -55300,6 +55620,7 @@ msgstr ""
 "구동되며, 벽시계 비교를 통해 100 ms로 조절됩니다."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -55309,7 +55630,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -56486,23 +56807,28 @@ msgstr ""
 "별 언어 지식이 필요하지 않습니다."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS WidgetKit 확장"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android 앱 위젯"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS 복잡성"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOS 시뮬레이터"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS 타일"
 
 #: src/widgets/overview.md:60
@@ -57403,10 +57729,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -57995,11 +58317,13 @@ msgid "Build Commands"
 msgstr "빌드 명령어"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -58868,19 +59192,23 @@ msgid "Build Instructions"
 msgstr "빌드 방법"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# app/src/main/java/com/example/app/에 .kt 파일을 복사"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# AndroidManifest_snippet.xml를 AndroidManifest.xml로 통합합니다"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Wear OS 모듈에 .kt 파일을 복사"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# AndroidManifest_snippet.xml를 병합합니다"
 
 #: src/widgets/watchos.md:3
@@ -59068,11 +59396,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "백그라운드 새로 고침은 `BackgroundTask` 프레임워크를 사용합니다"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# 애플 워치 장치"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# 애플 워치 시뮬레이터"
 
 #: src/widgets/watchos.md:70
@@ -60642,11 +60972,13 @@ msgstr ""
 "를 구현하는 `staticlib`입니다:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry 런타임 FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... 플랫폼 API를 호출, 완료되면 약속을 해결 ..."
 
 #: src/plugins/native-extensions.md:200
@@ -60777,24 +61109,21 @@ msgstr ""
 "올바른 플랫폼 SDK를 대상으로 합니다:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (간단화)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr "// 표적을 감지: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// 컴파일: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// 링크: cargo:rustc-link-lib=static=review_bridge"
+"// 타겟 감지: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // 컴파일: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // 링크:    cargo:rustc-link-lib=static=review_bridge\n"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -60821,7 +61150,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "결과로 Perry promise 해결"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// PerryBridge에서 활동을 얻으십시오"
 
 #: src/plugins/native-extensions.md:266
@@ -60837,7 +61167,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "JNI를 통해 플랫폼 API를 호출합니다."
 
 #: src/plugins/native-extensions.md:275
@@ -61436,15 +61767,18 @@ msgstr ""
 "러, 노드, 빌드도 필요 없습니다."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# 게이트"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# 범위에 포함되는 것과 그렇지 않은 것"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# 그 게이트가 여전히 실패할 수 있다는 것을 증명하라"
 
 #: src/testing/test-registration.md:18
@@ -61786,33 +62120,40 @@ msgstr ""
 "동으로 시작됩니다."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. geisterhand가 활성화되어 있는 상태에서 컴파일합니다 (libs는 첫 사용 시 "
 "자동으로 생성됩니다)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. 응용 프로그램을 실행"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. 다른 터미널에서  응용 프로그램과 상호 작용"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# 모든 위젯 목록"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# 손잡이 3와 함께 버튼을 클릭"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# 창 화면 촬영"
 
 #: src/testing/geisterhand.md:25
@@ -61829,7 +62170,8 @@ msgstr ""
 "다):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# 또는 페리 런과 함께:"
 
 #: src/testing/geisterhand.md:35
@@ -61972,8 +62314,8 @@ msgid "Menu item"
 msgstr "메뉴 항목"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -61985,8 +62327,8 @@ msgstr "키보드 단축키"
 msgid "Data table"
 msgstr "데이터 테이블"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -62100,17 +62442,6 @@ msgstr ""
 "텍스트 필드의 내용을 설정하고 새 텍스트를 NaN-boxed 문자열로 사용하여 "
 "`onChange` 콜백을 발생시킵니다."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"콘텐츠 타입: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "'{\"텍스트\":\"세상 안녕\"}'"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "슬라이더 이동"
@@ -62134,10 +62465,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "슬라이더 위치를 설정하고 숫자 값으로 `onChange`를 발생시킵니다."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"value\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -62188,10 +62515,6 @@ msgstr ""
 "위젯 콜백을 우회하여 `State` 셀의 값을 직접 설정합니다. 이는 상태에 연결된 모"
 "든 반응형 바인딩을 트리거합니다(바인딩된 텍스트 레이블, 가시성, forEach 루프 "
 "등)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "'{\"값\":42}'"
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -62269,10 +62592,6 @@ msgstr ""
 "다(예: Cmd+S에 대해 `\"s\"`, Cmd+Shift+S에 대해 `\"S\"`, Cmd+N에 대해 "
 "`\"n\"`)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "'{\"편단\":\"s\"}'"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -62307,10 +62626,6 @@ msgid ""
 msgstr ""
 "ScrollView 위젯의 스크롤 오프셋을 설정합니다. `x`와 `y`는 모두 포인트 단위입"
 "니다."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -62410,12 +62725,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# 200ms마다 무작위 입력"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -62554,12 +62866,16 @@ msgstr ""
 "나 `libimobiledevice`의 `iproxy`를 사용해야 합니다:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Xcode/devicectl를 통해 설치 및 시작"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -62586,7 +62902,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# APK로 패키지 및 설치"
 
 #: src/testing/geisterhand.md:381
@@ -62594,7 +62911,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "먼저 GTK4 개발 라이브러리를 설치하세요:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -62618,15 +62936,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "bash를 사용한 간단한 엔드투엔드 테스트:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# 기스터핸드로 건축"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# 백그라운드에서 앱을 시작"
 
 #: src/testing/geisterhand.md:419
@@ -62638,33 +62959,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"kill $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# 응용 프로그램이 준비 될 때까지 기다립니다"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# 위젯을 가져와"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# \"Submit\"라는 버튼을 찾으세요"
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# 클릭하세요"
 
 #: src/testing/geisterhand.md:436
@@ -62672,7 +62997,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# 상호 작용 후 화면 촬영"
 
 #: src/testing/geisterhand.md:441
@@ -62684,7 +63010,8 @@ msgid "Python Test Example"
 msgstr "Python 테스트 예제"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# 앱을 시작하세요"
 
 #: src/testing/geisterhand.md:450
@@ -62692,11 +63019,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# 시작을 기다리세요"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# 목록 위젯"
 
 #: src/testing/geisterhand.md:455
@@ -62704,11 +63033,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# 라벨에 따라 위젯을 검색"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# 첫 번째 텍스트 필드에 입력"
 
 #: src/testing/geisterhand.md:464
@@ -62728,7 +63059,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# 첫 번째 버튼을 클릭합니다"
 
 #: src/testing/geisterhand.md:470
@@ -62736,7 +63068,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# 시각 회귀를 위한 화면 촬영"
 
 #: src/testing/geisterhand.md:473
@@ -62752,7 +63085,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# 앱이 여전히 작동하는지 확인합니다"
 
 #: src/testing/geisterhand.md:478
@@ -62783,40 +63117,14 @@ msgstr ""
 "카오스 모드를 앱에 실행하여 크래시, 정지, 예상치 못한 상태를 찾아내세요:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# 구축 및 발사"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# 공격적인 혼돈을 시작하라 (각 50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# 30초 동안 켜면 됩니다"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# 통계 확인"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"운동\": true, \"events_fired\": 600, \"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# 최종 상태를 보기 위해 화면 촬영"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# 혼돈을 막아"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# 앱이 아직 작동하는지 확인하세요"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -62828,11 +63136,13 @@ msgid ""
 msgstr "주요 상호작용 지점에서 스크린샷을 캡처하고 기준값과 비교합니다:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# 초기 상태"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -62840,24 +63150,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# 상호 작용 후 포착"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# 비교 (ImageMagick를 사용)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "CI 파이프라인 통합"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# GitHub 액션 예제"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# GitHub Actions 예제\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -62906,7 +63218,8 @@ msgid "Run UI tests"
 msgstr "UI 테스트 실행"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# 테스트 스크립트를 실행하세요"
 
 #: src/testing/geisterhand.md:568
@@ -63084,20 +63397,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "`--enable-geisterhand`로 컴파일하고 실행한 후:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# 모든 인터랙티브 위젯을 보기"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"핸들\":4,\"widget_type\":0,\"callback_kind\":0,\"레벨\":\"리셋\"}"
 
@@ -63106,8 +63422,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
 
@@ -63116,19 +63433,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# 인크리먼트를 3번 클릭하세요"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# 카운터 표지판은 이제 \"3\"를 표시합니다"
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# 이름 입력"
 
 #: src/testing/geisterhand.md:669
@@ -63136,7 +63456,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# 80%로 슬라이더를 설정"
 
 #: src/testing/geisterhand.md:672
@@ -63144,11 +63465,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# 암흑 모드를 켜"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -63448,16 +63771,13 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr "자동 빌드가 실패하거나 수동으로 크로스 컴파일하려는 경우:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# macOS를 위한 기스터핸드 리브를 만들자"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# iOS (크로스 컴파일) 를 위한 빌드"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -63639,15 +63959,18 @@ msgstr ""
 "Perry 컴파일 + 실행입니다. 좀 더 좁혀라"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# 몇 개의 모듈"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# 이 수출만"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# 복합 mod.export 양식"
 
 #: src/testing/node-compat-matrix.md:30
@@ -63667,15 +63990,18 @@ msgid "Full sweep and the CI gate"
 msgstr "전체 스파이와 CI 게이트"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# 전체 매트릭스 + 요약 테이블"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# 기준값에 대한 회귀에서 1번 출구"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# 약속된 기준값을 다시 작성합니다"
 
 #: src/testing/node-compat-matrix.md:43
@@ -63945,7 +64271,7 @@ msgstr ""
 "`scripts/ci_plan.py`라는 스크립트로 결정됩니다. 다른 모든 작업은 `needs: "
 "plan`이고 `fromJSON(needs.plan.outputs.plan).jobs.<name>`에 게이트됩니다."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -64040,11 +64366,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -64069,94 +64395,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6배 더 빨리"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3배 더 빨리"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8배 가득"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "스만"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "그 안에서 **p** 계층 변경 파일 목록은 계획을 더 좁히고 있습니다:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -64165,7 +64504,7 @@ msgstr ""
 "`.claude/`, ...  `ci_plan.py`에서 `NON_CORE_GLOBS` 참조) → `lint`만 실행됩니"
 "다."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -64173,7 +64512,7 @@ msgstr ""
 "**원자** (컴파일러, 실행 시간, 또는 테스트 결과를 변경할 수 있는 모든 것) → "
 "전체 PR 계층"
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -64181,7 +64520,7 @@ msgstr ""
 "**스** (lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, `skills/"
 "`, ...) → 추가로 `security-audit` 재사용 작업 흐름."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -64195,7 +64534,7 @@ msgstr ""
 "하지 않으면 실패합니다. 이것은 Rust 설정을 추가하지 않고 HIR, 변환 또는 다른 "
 "의존성에서 수행된 수정 사항을 포착합니다."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -64205,11 +64544,11 @@ msgstr ""
 "히 실패합니다. 고장난 플래너는 절대 \"모든 것이 건너뛰어, 따라서 녹색\"으로 "
 "변해서는 안됩니다."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "왜 이렇게 보이는지 (2026-08-16 측정)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -64221,11 +64560,11 @@ msgstr ""
 "개의 워크플로우 / 48개의 작업 / ~650개의 러너 분**, 그리고 `main`는 하루에 "
 "~66 PR 푸시와 ~58 융합을 보았습니다. 즉 1.52 × 전체 용량, 그래서:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr "직무 대기시간은 37 h (`conformance-smoke` 셔드: 중위 4 h)"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -64233,7 +64572,7 @@ msgstr ""
 "**66 중 0** `Tests` 워크플로우의 PR 실행은 샘플 창에서 결론에 도달했습니다. "
 "8 건은 실패했고, 56 건은 다음 푸시에 의해 취소되었습니다"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -64245,7 +64584,7 @@ msgstr ""
 "complete`) 을 포함했습니다 **지난 12번의 합병 모두 관리자 우회였습니다** "
 "`lint`와 `cargo-test`가 여전히 대기열에 있습니다."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -64259,11 +64598,11 @@ msgstr ""
 "test`가 Linux를 전달 할 수 있었고 #8187은 위에 설명된 단일 `pr-gate` 팬-인으"
 "로 분쇄된 필요한 컨텍스트 목록을 대체했습니다."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "두 가지 특정 비용은 지배적이었다:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -64282,7 +64621,7 @@ msgstr ""
 "층이 사용하는 `fast` 간격 모드입니다. 8 셔드 자동 최적화 모드는 자동 최적화 "
 "단 링크 버그를 볼 수 있는 유일한 팔이기 때문에 전체 계층에 유지됩니다."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -64296,7 +64635,19 @@ msgstr ""
 "제 메인 라인 실행에서만 저장합니다. PR는 최신 메인 라인 블로브를 복원합니다. "
 "`cache-warm.yml`가 사라졌습니다. 스웨이는 `main`의 캐시 생성 빌드입니다."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -64317,75 +64668,75 @@ msgstr ""
 "extended-tests` 라벨을 적용하고 `test.yml`의 `full` 계층과 함께 실행합니다. "
 "비표시된 PR는 여전히 매번 을 회수합니다."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "전형적인 직업"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "전형적인 주행 분"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "목표 벽 시계"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (핵)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6개의 간격 조각)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "대기열에 있는 경우 ≤ 30분"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (독일 문서)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5분"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "목표가 아니라  합쳐집니다"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "목표가 아니죠"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -64411,11 +64762,20 @@ msgstr ""
 "웨이 실패의 배정 창 (`previous sweep SHA .. this sweep SHA`) 에 의해, 정확히 "
 "6 시간 게이트와 같은."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "더 많은 PR를 선택"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -64428,7 +64788,7 @@ msgstr ""
 "변경을 위해 사용하며, 전체 계층 단 하나의 제품군에 영향을 미치는 모든 것을 위"
 "해 사용하십시오. 레이블을 적용하면 실행을 다시 시작합니다 (`labeled` 트리거)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -64436,7 +64796,7 @@ msgstr ""
 "**`skip-changelog` 라벨** `lint`의 변경 세트 단계를 건너뛰고 (`crates/` 변경"
 "은 그렇지 않으면 `changelog.d/<PR>-<slug>.md` 조각을 추가해야합니다)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -64444,11 +64804,11 @@ msgstr ""
 "**`workflow_dispatch`** 모든 지점에서: `tier` (`pr` / `sweep` / `full`) 및 "
 "`update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "격차 스냅샷을 다시 설정"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -64460,15 +64820,17 @@ msgstr ""
 "(조정 회귀, 오라클 변경), 재생 **CI에서**, 노트북이 아니라 (필요한 기준은 "
 "Linux, `fast` 모드)"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# 그 다음엔 비행기를 기다리세요"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# 모든 새 항목에 대해 `issue` / `reason`를 채우고,"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -64478,11 +64840,11 @@ msgstr ""
 "와 이유를 알려주세요. 스냅샷에 충돌 차량을 주차할 수 없습니다 "
 "(`run_gap_tests.sh` 거부)"
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "가지 보호"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -64498,11 +64860,11 @@ msgstr ""
 "하는지 확인합니다. 게이트의 자체 실행은 그 결과가 통과되었든 실패했든 상관없"
 "이 수행됩니다."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -64514,7 +64876,7 @@ msgstr ""
 "같은 SHA에서 그린 스파이 또는 PR 레벨 실행은 계산되지 않습니다. [Releasing]"
 "(../contributing/releasing.md) 참조"
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -64529,6 +64891,173 @@ msgstr ""
 "전); 임계 최소와 모듈 매트릭스 트렌드는 합병 보고서에서 `parity-aggregate`에"
 "서 한 번 실행됩니다 (`scripts/parity_report_merge.py`, 쉐어드를 축소하기보다"
 "는 부족한 쉐어드를 거부합니다)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "크가 보내는"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "로컬로 실행하세요:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"명령\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -64647,36 +65176,13 @@ msgid "Reproduce the core of it with:"
 msgstr "그 핵을 재현해 보세요"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# 실제적으로 실행되고 있는 것은 직무 수준에서"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "\"직업\" | select(.status==\"in_progress\") | 라벨|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# 줄을 얼마나 깊고, 어떤 수영장에서"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "\"직업\" | select(.status==\"queued\") | 라벨|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -64857,24 +65363,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# 변함없이 모든 PR가 여전히 측정됩니다"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # 흔들림; 아래 표를 참조"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -64885,12 +65389,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# 방출은 개별적으로 격리됩니다"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -65157,11 +65660,13 @@ msgstr ""
 "지 않습니다."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# 여전히 실패할 수 있다는 것을 증명합니다"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# 실제 API, 문제가 없습니다 기록"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -65194,10 +65699,49 @@ msgstr ""
 "닙니다."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "스케줄 앞에 있는 줄을 (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -65205,57 +65749,57 @@ msgstr ""
 "6시간 간격의 수색은 6시간 이상 대기열이 더 빨리 마감되면 도움이 됩니다. 2026"
 "년 8월 12일에는 그렇지 않았고 그 이유는 게이트가 아니었습니다"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "대기열"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "동시 실행이 관찰되었습니다"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "이벤트에 따라 대기열"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "대기열에 있는 PR 실행 중 다른 머리 가지"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**아직 존재하고 있는 가지들**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -65270,11 +65814,12 @@ msgstr ""
 "의 `main` 게이트보다 앞선 러너 슬롯을 보유하고 있습니다. 그로부터 어느 정도"
 "의 스케줄링 속도가 회복되지 않습니다. 쓰레기는 제거되어야 합니다."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -65289,7 +65834,7 @@ msgstr ""
 "에 대한 프레디케이트 키, 이것이 포크 PR를 안전하게 유지하는 것입니다.  포크"
 "의 헤드 브랜크는 이 리포의 참조에 나타나지 않습니다."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -65301,13 +65846,13 @@ msgstr ""
 "동 `python3 scripts/reap_stale_ci_runs.py --apply` (드라이 러닝은 기본) 이"
 "다. 스케줄은 나중에 그것을 깨끗하게 유지합니다."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr "왜 \"문 은 어두웠다\"는 \"문 이 잡았을 것\"과 같은 말 이 아닌지"
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -65318,7 +65863,7 @@ msgstr ""
 "#7965와 함께 착륙했습니다. 유혹적인 결론은  어둠의 문이 그것을 통과시켰다는 "
 "것입니다.  검사를 통해 살아남지 못하고, 사건보다 더 중요한 이유를 기록합니다"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -65330,7 +65875,7 @@ msgstr ""
 "(`collection_kind: \"full\"` 0 → 2) 를 찾은 카운터는 그 중 하나가 아닙니다. "
 "리포에 있는 게이트는 컬렉션_타임_ 카운트를 래치하지 않습니다."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -65341,7 +65886,7 @@ msgstr ""
 "로 `\"gating\": false`이며, 이 이유는 `tolerances.json`에 기록되어 있습니다. "
 "그들은 `pinned_host`로만 게이트를 합니다. CI는 절대 사용하지 않습니다."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -65349,7 +65894,7 @@ msgstr ""
 "그것을 보여준 워크로드 (`retain`, `deeplist`, ...) 는 gc-handoff corpus이며, "
 "`gc-ratchet`의 고정된 14개의 프로브가 아닙니다."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -65571,14 +66116,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "TypeScript를 네이티브 실행 파일로 컴파일합니다."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# 또는 단축 (자동 감지 컴파일):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "플래그"
 
@@ -65607,7 +66153,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable`(기본값) 또는 `dylib`(플러그인)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -65615,7 +66161,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "HIR 중간 표현 출력"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -65627,7 +66173,7 @@ msgstr ""
 "객체 file (s) 를 생성, 링크를 건너가; `-o`에 기록 ([컴파일러 플래그]"
 "(flags.md) 참조)"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -65635,7 +66181,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "`.o` 및 `.asm` 파일 보존"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -65643,7 +66189,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "V8 JavaScript 런타임 폴백 활성화"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -65655,8 +66201,8 @@ msgstr ""
 "wasmi WebAssembly 호스트 런타임을 강제 링크합니다 (`WebAssembly.*` 사용 시 자"
 "동 감지)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -65664,15 +66210,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "tsgo를 통한 타입 검사 활성화"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "출력을 최소화 및 난독화(`--target web`의 경우 자동 활성화)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -65680,7 +66226,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "번들 ID(위젯 타겟에 필수)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -65689,23 +66235,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "디렉터리에서 TypeScript 확장 번들링"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# 기본 컴파일"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# iOS 시뮬레이터의 크로스 컴파일"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# 플러그인을 만들자"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# 디버그: 중간 표현을 보기"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# iOS 위젯을 만들자"
 
 #: src/cli/commands.md:82
@@ -65713,23 +66264,28 @@ msgid "Compile and launch your app in one step."
 msgstr "한 단계로 앱을 컴파일하고 실행합니다."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# 자동 탐지 입력 파일"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# iOS device/simulator로 실행"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# 애플 비전 프로 simulator/device에서 실행"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Android 장치에서 실행"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# 프로그램으로 Args를 전송합니다"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -65862,19 +66418,23 @@ msgstr ""
 "습니다. 둘 중 한 경로를 강제하려면 `--local` 또는 `--remote`를 사용하세요."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# CLI 프로그램을 실행"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# 특정 시뮬레이터에서 실행"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# 원격 구축을 강요"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# 웹 타겟 실행"
 
 #: src/cli/commands.md:131
@@ -65890,19 +66450,23 @@ msgstr ""
 "다."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# 경비 + 재건 + 재발사"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# 아이에게 앞뒤로"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# 추가 디렉토리를 보고"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# 출력 경로를 오버라이드"
 
 #: src/cli/commands.md:144
@@ -66033,7 +66597,7 @@ msgid ""
 "target."
 msgstr "재빌드 간 상태 보존 / HMR — \"빠른 재시작\"이 솔직한 목표입니다."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -66098,19 +66662,23 @@ msgid "Include medium-confidence fixes"
 msgstr "중간 신뢰도 수정 사항 포함"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# 단일 파일을 확인"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# 의존성 분석을 확인하세요"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# 자동 수정 문제"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# 적용하지 않고 미리 보기 수정"
 
 #: src/cli/commands.md:207
@@ -66400,27 +66968,33 @@ msgid ""
 msgstr "앱 배포를 위한 대화형 자격 증명 마법사와 Windows용 툴체인 설정입니다."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# 플랫폼 메뉴 표시"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# macOS 설정 (서명 자격증)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# iOS 설정 (서명 자격증)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# visionOS 설정 (서명 자격증)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Android 설정 (서명 자격증)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows 툴 체인 (xwin을 통해 MS CRT + Windows SDK를 다운로드)"
 
 #: src/cli/commands.md:318
@@ -66448,19 +67022,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# 최신 업데이트"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# 설치하지 않고 확인"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# 캐시된 응답을 무시합니다"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# 업데이트가 어떻게 동작해야 하는지 저장하고 종료"
 
 #: src/cli/commands.md:333
@@ -66477,7 +67055,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode`는 `[update] mode`를 `~/.perry/config.toml`로 입력합니다"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -66588,14 +67166,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "새 네이티브 바인딩 패키지를 스캐폴딩합니다:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"libfoo에 대한 네이티브 결합\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\"'"
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -67126,10 +67696,21 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr "출력 실행 파일, 펀들, 공유 라이브러리, 아카이브 또는 객체 경로"
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -67137,47 +67718,47 @@ msgstr ""
 "Linux libc/linkage를 선택; `musl`는 해당 Linux 타겟을 완전히 정적 인 헤드리"
 "스 빌드로 업그레이드합니다."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "홈 화면 위젯 타겟에 필요한 펀들 식별자"
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "디렉토리에서 네이티브 확장 패키지를 발견하고 정적으로 묶어줍니다."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
 msgstr ""
 "코딩 전에 TypeScript 검사기 (`@typescript/native-preview`) 를 실행합니다."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Windows PE 호환성 바닥을 설정합니다. 윈도우 이외의 타겟에서는 무시됩니다."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
 msgstr "수입 기반 자동 탐지 대신 Windows PE 서브시스템을 선택합니다."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -67185,11 +67766,11 @@ msgstr ""
 "애플 위젯 타겟의 경우 SwiftUI 소스와 메타데이터를 `swiftc`를 호출하지 않고 발"
 "산합니다."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -67197,35 +67778,68 @@ msgstr ""
 "HarmonyOS HAP 서명 자료를 선택합니다. 비밀에 대한 대응 environment/config 소"
 "스를 선호합니다."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS 애플리케이션 인증서 체인"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS 서명된 프로비저닝 프로필"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS 키스토어 별명; `debugKey`로 기본 설정됩니다."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — 모듈"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "자산을 삽입"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -67233,11 +67847,11 @@ msgstr ""
 "정적 파일 (SPA `dist/`, 이미지, JSON, 폰트, ...) 를 독립 실행 파일로 구워서 "
 "디스크에 외부 파일 (# 5731) 없이 실행합니다."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -67247,11 +67861,23 @@ msgstr ""
 "Repeatable. `perry.embed` (package.json) 와 `[compile] embed` (perry.toml) "
 "와 통합되었습니다."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -67259,19 +67885,20 @@ msgstr ""
 "`dir` 아래의 모든 파일을 안정적인 `$perryfs` 핸들로 기본으로 내보내는 가상 모"
 "듈을 생성합니다. 반복 가능; 원본 지도는 제외됩니다."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# 메모리에서 dist/를 사용 합니다. dist/ 폴더가 필요 없습니다"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "임베디드 파일은 실행시 3가지 방법으로 접근할 수 있습니다"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -67303,7 +67930,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -67314,7 +67941,7 @@ msgstr ""
 "배열 메소드가 그 결과로 전송됩니다. `readEmbedded(path)`와 `node:fs`는 "
 "`$perryfs/<path>` 가상 경로 또는 임베드 상대 키를 허용합니다."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -67322,7 +67949,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -67332,7 +67959,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -67345,7 +68000,7 @@ msgstr ""
 "를 정렬하고, 각 `{ type: \"file\" }` 엣지를 보존하고, 체크아웃을 수정하는 대"
 "신 생성된 소스를 캐시에 보관합니다."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -67353,11 +68008,7 @@ msgstr ""
 "고정된 OpenCode 소스 그래프를 위해, 먼저 상류 웹 UI를 구축하고, `packages/"
 "opencode`의 패키지 루트에서 컴파일합니다:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -67370,7 +68021,7 @@ msgstr ""
 "입은 해결되지 않은 수입 경고가 아닌 복구 메시지로 실패합니다. 생성된 입력들"
 "이 구식일 수 없도록 각 소스 개정에 대한 준비 명령어를 실행합니다."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -67382,7 +68033,7 @@ msgstr ""
 "련 소스 오리지, 바이트 크기, SHA-256 다이게스트 및 발생 자산 모듈을 기록합니"
 "다."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -67396,7 +68047,7 @@ msgstr ""
 "는 실제 파일을 절대 경로로 읽고, 임베디드된 복사본을 구체적으로 의미할 때 명"
 "시적인 `$perryfs/<path>` 형식을 사용하세요."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -67408,19 +68059,19 @@ msgstr ""
 "`PATH`에 처음 없을 때 `PERRY_LLVM_CLANG`를 설정합니다. 현재 크로스 타겟 임베"
 "디션은 지원되지 않습니다."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "디버그 플래그"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "HIR(중간 표현)을 stdout에 출력"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -67428,11 +68079,11 @@ msgstr ""
 "하나 이상의 파이프라인 단계에서 IR을 덤프합니다. 쉼표로 구분: `hir` (변환 후 "
 "HIR), `llvm` (모듈별 `.ll`을 `.perry-trace/llvm/`에 저장), 또는 `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -67442,7 +68093,7 @@ msgstr ""
 "export/init 노이즈를 억제합니다. 스테이지가 지정되지 않은 경우 `--trace hir`"
 "를 암시합니다"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -67455,11 +68106,11 @@ msgstr ""
 "됩니다. 하나의 `-o`는 여러 파일을 명명할 수 없기 때문입니다. `-o`가 없으면 현"
 "재 디렉토리에 도착합니다. 각 경로는 `Wrote object file: <path>`로 인쇄됩니다"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -67469,44 +68120,44 @@ msgstr ""
 "(`PERRY_SKIP_CODEGEN=1`도 동일). [프로젝트 구성](../getting-started/project-"
 "config.md) 참조"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "`.o` 및 `.asm` 중간 파일 유지"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr ""
 "symbols/DWARF를 유지 (그리고 Windows PDB를 발산) 하는 대신 결과를 제거합니다."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr "이 빌드에 대한 모듈 개체 캐시를 비활성화; 또한 `PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr "기계 로컬 캐시 루트를 오버라이드; [캐시 디렉터리](cache-dir.md) 참조."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -67514,28 +68165,28 @@ msgstr ""
 "네이티브 표현을 하락하는 변수를 실행하고 캐시 재사용 대신 코디젠을 강제합니"
 "다."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr "Buffer/Uint8Array load/store 로저를 비활성화하면 A/B 진단이 가능합니다"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr "유형 감소 증거 보고서를 발급합니다. 원산지 확인을 의미합니다."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -67545,11 +68196,11 @@ msgstr ""
 "것을 고칠 수 있는지. 기본적으로 텍스트; `--opt-report=json`는 툴링에 대한 안"
 "정적인 스키마를 발산합니다. 또한 `PERRY_OPT_REPORT=1`를 통해 설정"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -67561,7 +68212,7 @@ msgstr ""
 "`PERRY_RS4GC=1`, 원본 루트 백엔드를 필요로 합니다. (스탠 스택 맵과 익스플리시"
 "트 브리지 모드도 사라졌습니다.)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -67577,11 +68228,11 @@ msgstr ""
 "파일을 강제합니다 (변경되지 않은 모듈의 경우 오브젝트 캐시가 코드젠을 건너뛰"
 "어 trace 디렉터리가 비어 있을 수 있음)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  값이 박스에 표시된 이유는"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -67598,11 +68249,11 @@ msgstr ""
 "missed` 언급의 표현-선택 아날로그입니다: 무엇이 증명되었는지, 무엇이 아닌지, "
 "그리고 어떤 규칙이 호출을 했는지 인쇄합니다."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "모든 거부 값은:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -67611,7 +68262,7 @@ msgstr ""
 "**위치** `local`, `param`, `return`, `field`, 또는 `alloc-site` (언제도 로"
 "컬, `.map(x => ({...}))` 아이디엄에 묶이지 않는 객체 문자)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -67619,7 +68270,7 @@ msgstr ""
 "**그것을 부정하는 규칙**, 수집자의 자신의 번호에, 그래서 당신은 이름의 소스 "
 "파일과 비교할 수 있습니다."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -67631,7 +68282,7 @@ msgstr ""
 "없다), 또는 _페리 제한_ (당신의 코드가 아닙니다; 하나 존재하는 경우 추적 문제"
 "를 명명합니다)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -67645,7 +68296,7 @@ msgstr ""
 "만 마지막으로 순위를 차지합니다. 프로파일도 아닙니다. 그들은 정적 프록시입니"
 "다."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -67653,7 +68304,7 @@ msgstr ""
 "이기는 경우와 실패한 경우를 함께 보고하기 때문에 불평만 하는 것이 아니라 그 "
 "비율이 눈에 띄게 됩니다."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -67667,7 +68318,7 @@ msgstr ""
 "다. 보고서는 **sderr**, 그래서 `--format json`의 유료물량이나 프로그램의 파이"
 "프 출력으로 섞이지 않습니다."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -67680,15 +68331,15 @@ msgstr ""
 "report=json`는 `schema_version: 1`와 동일한 데이터를 가지고 있습니다. 두 빌"
 "드 JSON의 차이점은 침묵으로 0으로 회귀하는 표현에 대한 저렴한 CI 검사입니다."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "출력 최적화"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -67708,22 +68359,22 @@ msgstr ""
 "다. `[build] native_tuning = false`는 `generic`의 약자입니다. 앱 코드와 자동 "
 "최적화된 runtime/stdlib 재구성에 적용됩니다."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
 msgstr ""
 "죽은 코드 제거를 위해 `__feature_NAME__` 컴파일 시간 상수를 정의합니다."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -67731,25 +68382,25 @@ msgstr ""
 "가장 작은 접근 가능한 기능 세트를 재구성하는 대신 미리 만들어진 전체 runtime/"
 "stdlib를 사용하십시오."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 "부동 소수점 재결합을 허용합니다. [Fast-math](fast-math.md) 참조하십시오."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "통제는 재연합에서 분리된 복제 합병을 융합합니다."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -67757,11 +68408,11 @@ msgstr ""
 "최소화는 주석을 제거하고, 공백을 축소하며, 더 작은 출력을 위해 로컬 변수/매개"
 "변수/비내보내기 함수 이름을 변환합니다."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "크기에 최적화된 빌드"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -67772,11 +68423,11 @@ msgstr ""
 "화 된 runtime/stdlib 아카이브를 속도 대신 크기로 조정하여 재구성합니다 (다른 "
 "자동 최적화와 마찬가지로 Perry 작업 영역 체크아웃이 필요합니다):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -67788,11 +68439,11 @@ msgstr ""
 "(컴퓨터 중량의 내부 루프는 ~2-3배 더 느리게 실행될 수 있습니다.) 크기를 최적"
 "화하고 정상적인 아카이브는 독립적으로 캐시됩니다."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -67800,11 +68451,11 @@ msgstr ""
 "추가로 전체 아카이브 FAT LTO를 재구성된 아카이브 위에 실행합니다. (더 느린 재"
 "구성, 더 작은 바이너리). `PERRY_SIZE_OPT`와 함께만 의미있는 것입니다."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -67821,7 +68472,7 @@ msgstr ""
 "다. 추종자: JS `throw`/`catch`, `finally`, 오류 스택 및 `uncaughtException`"
 "가 영향을 받지 않습니다."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -67833,15 +68484,15 @@ msgstr ""
 "immediate`를 추가합니다. 실행시간을 더 많이 사용하는 프로그램은 비례적으로 줄"
 "어듭니다."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "테스트 플래그"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -67849,25 +68500,25 @@ msgstr ""
 "프로그래밍 방식의 UI 테스트를 위해 [Geisterhand](../testing/geisterhand.md) "
 "HTTP 서버를 임베드 (기본 포트 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Geisterhand 서버의 사용자 정의 포트 설정 (`--enable-geisterhand`를 암시)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "런타임 플래그"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "지원되지 않는 npm 패키지를 위한 V8 JavaScript 런타임 활성화"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -67876,15 +68527,15 @@ msgstr ""
 "wasmi WebAssembly 호스트 런타임을 강제 링크합니다 (`WebAssembly.*`가 참조될 "
 "때 자동 감지; 정적 참조 없이 dlopen / FFI를 통해 로드하는 경우에만 필요)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "tsgo IPC를 통한 타입 검사 활성화"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -67900,11 +68551,11 @@ msgstr ""
 "다. `PERRY_ALLOW_EVAL=1`는 그것을 꺼내야 합니다. [Limitations](../language/"
 "limitations.md#no-eval-or-dynamic-code) 참조"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -67926,33 +68577,33 @@ msgstr ""
 "니온 타입의 유니트 파람, glob) 는 영향을 받지 않습니다. [Limitations](../"
 "language/limitations.md#no-eval-or-dynamic-code) 참조"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
 msgstr ""
 "인식된 하지만 실행되지 않은 Node/stdlib API를 참조할 때 컴파일 시간에 실패"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr "`<binary>.attest.json`를 발산합니다; [이중 증명](emit-attest.md) 참조."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "플랫폼 샌드박스 사이드카를 발산한다. [샌드박스 프로파일](emit-sandbox.md) 참"
 "조."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -67960,31 +68611,31 @@ msgstr ""
 "접근 가능한 임의 코드 실행 표면을 거부합니다. [Lockdown](lockdown.md) 참조하"
 "십시오."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "환경 변수"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "`perry publish`용 Perry Hub 라이선스 키"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr ".p12 인증서용 비밀번호"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -67992,60 +68643,60 @@ msgstr ""
 "생성된 기계 코드 (`--march`와 동일한 값; 플래그와 perry.toml `[build] march`"
 "가 환경을 이긴다)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "자동 업데이트 확인 비활성화"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "생태계 전체의 철자법을 사용하여"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "한 번 실행을 위한 `off`/`notify`/`prompt`/`auto`  [Updates](updates.md) 참조"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "사용자 지정 업데이트 서버 URL"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr "업데이트 확인 자동 건너뛰기 (대부분의 CI 시스템에서 설정됨)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "디버그 로깅 수준 (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -68053,7 +68704,7 @@ msgstr ""
 "`1`/`text` 또는 `json`  `--opt-report[=json]`와 동일, 플래그 추가가 불편한 환"
 "경에서 보고를 실행하기 위해"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -68067,15 +68718,15 @@ msgstr ""
 "다. 그것은 CI 팔이없는 다섯 번째 GC env 버튼이었고 CLAUDE.md의 GC 버튼 킬 정"
 "책에 따라 삭제되었습니다."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "구성 파일"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (프로젝트)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -68155,11 +68806,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (전역)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -68181,57 +68832,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# 간단한 CLI 프로그램"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# 시뮬레이터용 iOS 앱"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# 시뮬레이터용 visionOS 앱"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# 웹 앱 (WASM와 DOM 브릿지  위명: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# 플러그인 공유 라이브러리"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# 펀들 ID와 함께 iOS 위젯"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# 디버그 컴파일"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# 어휘 집합"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# 타입 검사 된 컴파일"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# RAW WASM 바이너리 (HTML 래퍼가 없습니다)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# 소형 웹 출력 (임베디드 JS 브릿지를 압축)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Commands](commands.md) — 모든 CLI 명령어"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[Platform Overview](../platforms/overview.md) — 플랫폼 타겟"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"모듈\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "캐시 아이덴티티"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"모듈\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"원\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"로다시\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"목표\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "'함수'"
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"caption\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -68466,15 +69313,18 @@ msgstr ""
 "CLI 플래그가 환경 변수보다 우선하고, 환경 변수가 package.json보다 우선합니다:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. 빌드별 CLI 플래그"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. 각  환경"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. 프로젝트당 package.json (가장 흔한)"
 
 #: src/cli/fast-math.md:35
@@ -68490,17 +69340,20 @@ msgid "Contraction is separate from reassociation:"
 msgstr "수축은 재결합과 별개입니다:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# FMA 수축만 허용합니다."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr "# 재연결 없이 가장 공격적인 수축 모드를 허용합니다."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# --fast-math에서 재연결을 유지하지만 FMA 수축을 차단합니다."
 
 #: src/cli/fast-math.md:55
@@ -69471,7 +70324,8 @@ msgid "Emit"
 msgstr "발행"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -69557,7 +70411,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "크기"
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -70748,10 +71602,6 @@ msgstr ""
 msgid "produces:"
 msgstr "다음을 생성합니다:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"모듈\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -70833,9 +71683,10 @@ msgstr ""
 "`<host source>` 아래에 표시됩니다."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "`perry  compile` 또는 `perry run`가 모든 성공적인 빌드에 작성되는 경우 아직 "
 "매니페스트가 존재하지 않는 경우 명확한 오류를 반환합니다."
@@ -72957,7 +73808,7 @@ msgstr ""
 msgid "Setting"
 msgstr "설정"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "파일"
 
@@ -73041,15 +73892,18 @@ msgstr ""
 "`perry.toml`과 `~/.perry/config.toml` 양쪽에 다시 기록합니다:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# iOS 서명을 구성 (인증서, 프로비저닝 프로필)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Android 서명 (키스토어, 플레이 스토어 키) 를 구성"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# macOS 배포판을 구성 (앱 스토어, 공인인증서)"
 
 #: src/cli/perry-toml.md:605
@@ -73085,8 +73939,11 @@ msgstr ""
 "요:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# GitHub 액션 예제"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -74296,20 +75153,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Perry 선박 **두 개의 독립적인 선택 채널** 데이터 전송을 위해 집  아무것도 명"
-"확한 없이 당신의 컴퓨터를 떠납니다 `enabled = true` 아니면 `on` 들어와 "
-"`~/.perry/config.toml`... 둘 다 `PERRY_NO_TELEMETRY=1`와 `CI=true`를 존중합니"
-"다."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. 일반 사용 분석  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. 일반 사용 분석  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -74319,14 +75176,16 @@ msgstr ""
 "합니다. 명령어 이름, 플랫폼 (`darwin`/`linux`/...), Perry 버전, success/"
 "error 상태, 익명 클라이언트 UUID"
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. 호환성 보고서  `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -74336,15 +75195,15 @@ msgstr ""
 "`UnsupportedBinaryOp`, `UnsupportedExpression`, `UnsupportedStatement`, "
 "`DynamicPropertyAccess`, `ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "3가지 모드:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr "`off`  절대 보내지 마세요. 싱크대 설치도 안 돼, 오버헤드도 없네"
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -74352,99 +75211,99 @@ msgstr ""
 "`ask` (디폴트)  적정 진단 신호가 발사되면 세션당 한 번 `[y] just this once / "
 "[a] always / [n] not this time / [N] never`를 입력합니다."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  항상 보내 (절단 + 편집 후) 별다른 요청이 없습니다."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**전송된 내용 (전용 화물 스키마):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"코드\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"분류\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"갈프 카테고리\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"단계\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"하하하\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"장장관\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"노드:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"Darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -74459,7 +75318,7 @@ msgstr ""
 "장된 것 외에는) → `<id1>`, `<id2>`, 200 자로 제한되며, 어떤 변수가 실패할 경"
 "우 하드 거부가 있습니다."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -74467,32 +75326,36 @@ msgstr ""
 "`~/.perry/.report-cache`에 있는 로컬 30일 데듀프 캐시는 모든 재부하에 동일한 "
 "`snippet_hash`를 다시 보내지 못하게 합니다."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "검사 및 관리"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# 현재 모드를 보여, sent/queued를 계산"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# 이 실행에 대기열에 인쇄 편집된 유료물"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# 30일 캐시 삭제"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "파일 수준에서 거부하려면 `~/.perry/config.toml`를 편집합니다"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -74501,7 +75364,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -74747,15 +75610,18 @@ msgstr ""
 "types.rs`) 로 앞당겨집니다"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// 표시 | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// 아레나 블록 걷기 위해 사용되는 총 할당 크기"
 
 #: src/internals/memory-model.md:69
@@ -75072,7 +75938,7 @@ msgstr ""
 "런타임의 정확 헬퍼 barrier를 비활성화합니다. 설정 해제, `=1`, `=on`, `=true`"
 "는 barrier를 활성화된 상태로 유지합니다."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -75251,10 +76117,11 @@ msgstr ""
 "다."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -75472,10 +76339,24 @@ msgstr ""
 "유지되는 것을 과장합니다."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "소스 맵"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -75483,183 +76364,183 @@ msgstr ""
 "경로, 줄 번호가 아닙니다: 줄 번호는 아무것도 재-추적되지 않는 주장이며, 이 테"
 "이블의 모든 행은 더 이상 존재하지 않는 `gc.rs`로 가리키고 있습니다."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "주제"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "검색해야 할 기호"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaN-박스 태그"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, 타입/플래그 상수"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "그림자 프레임 (복귀 뿌리 낮추기)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "등록된 루트 스캐너"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "비중이 작은 복사"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "전체 블록 현장 홍보"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "홍보 정책"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "적응적 임기 기준"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "장벽을 작성하세요"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "명시적 연결"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "보수적인 핀 전조"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "수집 트리거 및 페이징"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "현재 운영 페이지"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "설계 계획 (역사적)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -76073,12 +76954,18 @@ msgstr ""
 "heap_budget.rs`: 64 MiB로 도출됩니다"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "제한 없이 desktop/server 프로세스를 사용해서 device/container 예산의 8분의 1"
 "에 1 MiB 바닥으로 확장합니다. 오버플로우가 할당기에 반환되고, 스레드 출구는 "
@@ -76086,7 +76973,7 @@ msgstr ""
 "deferred 기간을 생존하고 채용된 전체 컬렉션이 아레나 복구를 완료하면 풀을 비"
 "어냅니다."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -76096,100 +76983,214 @@ msgstr ""
 "후의 정확한 사용입니다 **살아있는 인구 조사** 더하기 증가하는 델타, 블록 높"
 "은 물 오프셋의 합이 아닙니다."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "지원된 컨트롤"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr "이것은 수집기 개발 외부에서 가장 유용한 운영 제어입니다:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "전체 마크 스파이프로 분단 재발"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime 장벽 분단; 또한 완전한 마크 을 강요"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "페이징 비교를 위해 직접 보육소 스카버링을 비활성화"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "전체 블록의 승진을 객체별 대피로 되돌려"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "기아용 모자를 설정"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "MiB에서 프로세스 힙 예산을 대체"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "네이티브 루트-능력 있는 목표에 그림자 뿌리를 선택"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "진단 전체 네이티브 스택 스캔; 복사 비활성화"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "주기별로 구조화된 추적 기록을 발산합니다"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "인간으로 읽을 수 있는 수집기 진단기를 발산합니다"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -76198,10 +77199,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "루팅 스트레스는 `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -76214,7 +77216,7 @@ msgstr ""
 "`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, "
 "`PERRY_STACKMAP_WALKER`와 같이 허용되지만 추가 지원되는 수집 모드가 아닙니다."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -76240,11 +77242,11 @@ msgstr ""
 "면 `lint`가 실패하고, 행동을 변경하면 `cargo-test`가 실패합니다. 이 페이지가 "
 "오래된 것을 주장하는 동안 둘 다 침묵할 수 없습니다."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "인증 및 CI 기관"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -76255,35 +77257,35 @@ msgstr ""
 "의 PR 계층의 팬인 (`docs/src/testing/ci-tiers.md` 참조; 계층 정책은 `scripts/"
 "ci_plan.py`) 을 요구합니다. GC 특유의 커버리는 의도적으로 나뉘어 있습니다"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "흐르는 곳"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "필요한 상태"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr "루트 홀더 유치, GC-knob drift, 그리고 이 페이지의 path/number 주장"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "네 (`pr-gate`를 통해)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr "런타임 유닛 스위트 및 `run_memory_stability_tests.sh` 네 모드 매트릭스"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -76291,31 +77293,31 @@ msgstr ""
 "네 (`pr-gate`를 통해; PR 계층은 디프 스코프, sweep/full 계층은 작업 공간을 실"
 "행합니다)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
 msgstr "GC × 표현 선택 행렬, 루팅 버그 도구, 쓰기 장벽 스트레스"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "네 (`pr-gate`를 통해; PR에 대한 PR 하위 집합, 스웨어에서 전체 행렬)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "내성 상태점 IR를 포함하여 방출된 뿌리 지배"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -76323,27 +77325,27 @@ msgstr ""
 "지부에서 요구되지 않습니다. `run-extended-tests`를 통해 PR 팔의 선택, `main`"
 "에서 6시간마다"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "픽터 counters/RSS/wall 매트릭스"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "스레드 로컬 mechanism/policy 예산"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "유용한 로컬 비행 전 명령어:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -76352,11 +77354,11 @@ msgstr ""
 "전용 performance/rooting 워크플로우에는 더 넓은 컴파일러와 호스트 요구 사항"
 "이 있습니다. 워크플로우 파일은 정확한 명령어와 관련 필터의 권한입니다."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "역사적 증거"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -76364,7 +77366,7 @@ msgstr ""
 "[세대별 GC 계획](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): 원래 설계 및 단계별 착륙 로그"
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -76374,7 +77376,7 @@ msgstr ""
 "gc-experiment.md): 원형의 시간적 측정과 수정으로 원본 루트 기본값이 나타납니"
 "다."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -76382,7 +77384,7 @@ msgstr ""
 "[GC 근원 변수](gc-rooting-invariant.md): 현재 코드젠 건전성 규칙, 체크 모드, "
 "알려진 맹점 및 디버깅 도구."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -76697,7 +77699,8 @@ msgid ""
 msgstr "하루 동안 4건을 배송했어요 감지 지연이 매번의 비용이었죠."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "5가지 방법이 실제로 깨졌습니다"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -76847,14 +77850,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner`에 `gc/mod.rs`에 등록합니다."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "일 을 확인 하는 방법"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. 정적 검증기  이 하나를 실행"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -76864,13 +77908,13 @@ msgstr ""
 "리가 없는 알로카. 그 범위 내에서 충돌하기 전에 결함을 감지하는 유일한 도구입"
 "니다. 그래서 먼저 실행됩니다."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
 msgstr "**3가지 종류에 눈이 멀어요 청결한 보고서는 그 어떤 증거도 아닙니다**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -76878,7 +77922,7 @@ msgstr ""
 "**런타임 테이블 및 내장 캐시** (#7231)  방출된 IR를 읽고 실행 시 셀을 볼 수 "
 "없습니다. 말: 10/10가 중단되는 대신 실패합니다"
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -76888,7 +77932,7 @@ msgstr ""
 "랩에 한 줄의 `GcSuppressScope`가 수정된 실제 버그의 양쪽에 `0 violations`가 "
 "적혀 있었습니다."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -76906,7 +77950,7 @@ msgstr ""
 "이 집합을 실제로 발산되는 코드에 비교해 보세요. #7227이 `ALLOC_RE`를 검사하"
 "는 것처럼요.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -76916,7 +77960,7 @@ msgstr ""
 "_dependency-scale_ 워크로드  #7280가 25개의 커레이션된 코퍼스 파일을 기록하"
 "는 동안 20개의 주식 조드가 실패합니다."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -76933,27 +77977,13 @@ msgstr ""
 "목표물에도 기본이 되지 않는 하락에 대한 진술입니다. **둘 다 실행**그리고 어"
 "느 쪽을 실행했는지 알아:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# SHADOW (PERRY_RS4GC=0): 여전히 arm64_32 watchOS 및 ARM64의 낮출"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# NATIVE (PERRY_RS4GC=1): 다른 모든 곳에서 기본 어"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` 루트 할당 및 LLVM는 나중에 안전 포인트를 삽입, 그래서"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -76963,11 +77993,11 @@ msgstr ""
 "코퍼스는 루트 스토어가 0개, 그래서 `--min-binds`는 실패하고, 그림자 코퍼스는 "
 "안전 포인트가 0개, 그래서 `--min-statepoints`는 실패합니다."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "`--statepoints`가 검사하는 기능과 차이점"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -76978,7 +78008,7 @@ msgstr ""
 "면 안전 포인트의 루트이며 안전 포인트 아래의 동일성은 `gc.relocate` 결과입니"
 "다. 그래서 \"뿌리 저장소는 모든 후속 수집 지점을 지배해야합니다\"는:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -76986,7 +78016,7 @@ msgstr ""
 "GC 객체를 지칭하는 레지스터는 이동된 값이 아니라면 안전점 아래에서 사용될 수 "
 "없습니다."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -77000,23 +78030,23 @@ msgstr ""
 "`double`로 대부분의 시간을 보내고 있습니다. 두 종류의 판결이 있습니다. 왜냐하"
 "면 두 가지 다른 해결책이 있기 때문입니다"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -77024,26 +78054,26 @@ msgstr ""
 "세이프포인트의 라이브 펀들에는 레지스터의 캐스트 체인에서 `ptr addrspace(1)` "
 "값이 없습니다. 어떤 것도 표지하거나 재구성하지 않습니다."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "뿌리"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
 msgstr ""
 "물체는 팩에 있고, 이동이 되지만, 이동 전 주소의 원본이 아래에서 사용됩니다"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "이전 값 (`OperandProtection::Reload`) 에서 다시 도출"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -77059,7 +78089,7 @@ msgstr ""
 "only`는 `llvm.experimental.gc.statepoint.p0`보다는 실제 기호에 따라 분류됩니"
 "다."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -77080,15 +78110,15 @@ msgstr ""
 "는 명령어입니다. 그것은 일방적입니다. 인식되지 않은 호출은 수집으로 간주되므"
 "로 모델의 격차는 잘못된 양성으로, 결코 놓친 버그로 치러집니다."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "반복되는 단일 파일의 경우:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "둘 다 다른 이유에서 중요하죠."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -77103,7 +78133,7 @@ msgstr ""
 "번만요. 그리고 이 만 켜면 됩니다. 그래서 다른 방법으로는 무활성 루프 몸의 두 "
 "지점 사이의 수집이 필요한 버그는 그 없이는 코퍼스 안에 나타나지 못합니다."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -77125,7 +78155,7 @@ msgstr ""
 "`js_object_get_field_ic_miss` 및 `js_closure_call1`. 그 사람들은 근처에 조사"
 "가 없는 상태에서 움직이고 있습니다."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -77133,14 +78163,14 @@ msgstr ""
 "그래서: 버튼을 켜면 커포스가 표현할 수 있는 것을 넓힐 수 있지만, 투표 없는 함"
 "수를 안전한 것으로 읽지 마세요."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME`는 EXACT에 의해 발산 된 기호입니다. 그리고 두 번 뜯어 "
 "먹었습니다"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -77151,7 +78181,8 @@ msgstr ""
 "름을 붙이는 항목은 영원히 아무 것도 분류하지 않습니다. 이제 두 개의 라운드가 "
 "측정되었습니다"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -77162,7 +78193,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -77178,7 +78209,7 @@ msgstr ""
 "결정적으로 오류가 발생하는 모양을 포함합니다. 보호자와 체크인은 동의하지 않았"
 "습니다. 체크인은 틀렸습니다."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -77199,7 +78230,7 @@ msgstr ""
 "입력 포인트는 `js_closure_callN`이며, 같은 파일의 `RECEIVER_SINKS`는 이미 올"
 "바르게 철자되었습니다."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -77219,60 +78250,60 @@ msgstr ""
 "는 모드 CI 실행 하에서 결코 잡을 수 없었습니다. 그 정확한 코드를 다시 심고 모"
 "든 모드를 실행합니다 (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (우승)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (배를 내리는 낮추기)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (필터링되지 않은)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (필터링되지 않은)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -77284,7 +78315,7 @@ msgstr ""
 "멀었기 때문입니다. 하나의 이름을 더하면 13과 8에 해킹된 팔이 있고 2과 2에 깨"
 "끗한 팔이 남습니다."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -77311,7 +78342,7 @@ msgstr ""
 "를 통해 할당할 수 있는 런타임 헬퍼를 추가할 때, 같은 커밋에서 "
 "`POLL_CAPABLE_RUNTIME`에 추가합니다.** 아무 것도 부탁하지 않을 거야"
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -77321,7 +78352,7 @@ msgstr ""
 "드 3의 게이트입니다. 라운드 4에는 게이트가 없습니다. `gc-root-dominance.yml`"
 "는 빌드 전에 `--audit-alloc-re`와 함께 실행됩니다."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -77346,7 +78377,7 @@ msgstr ""
 "변하면 **대체** 을 삭제하는 대신 실제로 방출하는 기호의 유령은 감사를 녹색으"
 "로 바꾸고 구멍을 남깁니다."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -77373,20 +78404,16 @@ msgstr ""
 "후 다시 실행하면 10개가 더 발견되었습니다.) 그리고 코멘트와 문자열 리터얼은 "
 "먼저 제거되므로 시사에서 언급된 이름이 전제가 될 수 없습니다."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 "_성실한_명을 확인하는 것은 충분하지 않습니다. 방출된 IR에 대해 확인합니다"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -77394,7 +78421,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0`는 모든 루트 스토어에서 `js_shadow_slot_bind` 호"
 "출 형태를 커 앵커로 만듭니다."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -77409,7 +78436,7 @@ msgstr ""
 "은 허용 목록에 의해 기본 라인 된 팔입니다. 그래서 3 및 4 케이스는 당신이 손으"
 "로이 모드를 실행 할 때만 표면입니다."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -77424,7 +78451,7 @@ msgstr ""
 "은 기능을 깨끗하게합니다. `lower_call/new.rs`의 인라인 벡터 `this_slot`를 구"
 "했습니다."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -77442,15 +78469,15 @@ msgstr ""
 "은 그림자 슬롯이 전혀 없었습니다. `alloca_entry` 사이트에 닿을 때 수동으로 실"
 "행합니다"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. 런타임 도구  초, 깊이에 주의"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "#7196에서:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -77463,17 +78490,18 @@ msgstr ""
 "히, 철저히 `PERRY_GC_SCHEDULE_ALLOC_KB=0`를 추가하면 문자 그대로의 모든 투표 "
 "모드가 됩니다."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
 msgstr "`PERRY_GC_PROTECT_FROMSPACE=1`  `mprotect` 대공간에서 대피 후"
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT` 는 이제 실제로 실행됩니다."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -77481,7 +78509,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -77495,7 +78523,7 @@ msgstr ""
 "gc_schedule_fuzz.sh <binary> [seed-count]`는 씨앗을 스캔하고 실패에 따라 재"
 "생 명령어를 인쇄합니다."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -77509,7 +78537,7 @@ msgstr ""
 "에서 전혀 입증하지 않는다. 소화기를 이용하면 벌레가 실제로 사는 공간을 탐색"
 "할 수 있는 유일한 값싼 방법이 됩니다."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -77521,7 +78549,7 @@ msgstr ""
 "터가 삭제될 때에도 블록을 유지하기에는 충분하지 않습니다. **800을 사용하세"
 "요.** 기본 깊이에서 순수한 실행은 아무것도 의미하지 않습니다."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -77546,7 +78574,7 @@ msgstr ""
 "에서만\"는 보호기에 의심을 가질 이유가 없습니다. 정적 검사기와 일치하지 않을 "
 "때, 먼저 검사기를 보세요. 그렇게 ZOD `clone`의 불협정이 해결되었습니다."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -77556,7 +78584,7 @@ msgstr ""
 "그리고 오류가 발생하면, **무더기를 위로 걸어**. 리포터는 레지스터를 소유하는 "
 "프레임이 아닌 구형값을 DEREFERENCE한 프레임에 이름을 붙인다."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -77567,11 +78595,11 @@ msgstr ""
 "동안 수집이 이루어지면, 그 순간 어떤 런타임 탐사도 알아차릴 수 있는 것은 없습"
 "니다. 이 장비들은 나중에 결과를 잡습니다. 정적 검사는 그 원인을 감지합니다."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "거울 이미지: 사라진 쓰기 장벽 (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -77582,43 +78610,43 @@ msgstr ""
 "은 수집가 결코 가장자리에 대해 **이야기**. 이 둘은 이 사람들을 계속 붙잡는 부"
 "분입니다 **탐지기가 바뀐다**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "뿌리를 내리는 버그"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted 기록 장벽"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "무엇이 잘못되었는지"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "라이브 값은 루트 스캔에 보이지 않습니다"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "old→young edge가 기억된 세트에서 없어집니다"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "문제가 생기면"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "집합회에서, 조용히"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "매장에서는 아니죠"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "탐지기"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -77627,28 +78655,28 @@ msgstr ""
 "런타임 기기 (`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_PROTECT_FROMSPACE`) 과 IR 가"
 "시 반의 정적 검사기"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **정적 IR 진술**, 그리고 그 밖의 아무것도"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "맹점"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr "정적 검사기는 힙 포인터의 실행 시측 캐시를 볼 수 없습니다 (§5 참조)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**우리가 가지고 있는 모든 런타임 탐사**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "왜 실행시간 탐사선이 그것을 볼 수 없는지"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -77661,17 +78689,17 @@ msgstr ""
 "의 항목이 기록되지 않게 되므로 집합은 단지 불완전합니다. 이를 관찰 가능한 실"
 "패로 바꾸는 것은 프로그램이 스스로 공급해야 하는 결합이 필요합니다"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 "부모님이 노인생에 생존해야 합니다 (또는 임직원일 수 있습니다) **이전** 매장"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "아이가 아직 유치실에서 있어야 합니다 **다음 소년에**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -77679,7 +78707,7 @@ msgstr ""
 "a **소규모** 수집  전체 클래스 전체에 대한 모든 것을 추적하고 종이를  그 창"
 "에 착륙해야 하는 완전한 마크- sweep하지 않습니다; 그리고"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -77687,7 +78715,7 @@ msgstr ""
 "그 가장자리는 아이로 가는 유일한 경로여야 합니다. 아니면 다른 뿌리가 그것을 "
 "찾아서 컬렉션이 깨끗해집니다."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -77695,7 +78723,7 @@ msgstr ""
 "어떤 것도 놓치면 미성년자가 올바르게 수집하고, 프로그램이 올바른 답을 인쇄하"
 "고, 탐사선은 성공 보고를 합니다. 아무것도 시도되지 않았습니다."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -77704,7 +78732,7 @@ msgstr ""
 "개별 단추는 단순히 무감각보다 더 나쁘다 그들 중 세는 완전히 다른 특성을 목표"
 "로 하고 있으며 증거로 녹색을 읽는 것이 쉽습니다"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -77717,7 +78745,7 @@ msgstr ""
 "찾아내지 못한 슬롯은 다시 쓸 수 없는 슬롯이 아닙니다. 기억하고 다시 쓰는 것"
 "은 서로 다른 특성이고, 검증자는 두 번째에 대해서만 묻습니다."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -77728,7 +78756,7 @@ msgstr ""
 "지 않습니다**. 그것은 버그를 눈에 띄게 만들지 않습니다. 버그를 접근할 수 없"
 "게 만듭니다. 여기 있는 녹색은 세 가지 중 가장 강력하고 빈 증거입니다."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -77740,7 +78768,7 @@ msgstr ""
 "에서 흔들리는 포인터에 대해 잘못, 결코 추적되지 않은 살아있는 물체에 대해하"
 "지 않습니다."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -77754,7 +78782,7 @@ msgstr ""
 "하기 때문입니다. 이 문서의 모든 이름은 게이트가 실시간 분석자가 소유하고 있다"
 "고 확인한 이름입니다."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -77766,7 +78794,7 @@ msgstr ""
 "찰할 수 없습니다.** \"장벽이 달리지 않았다\"는 구별 가능한 사건이 없는 처형"
 "은 없습니다."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -77784,11 +78812,11 @@ msgstr ""
 "제 수집 **바이트 동일 출력, 출력 0**, 두 개의 간격 고정 장치와 더 큰 대립 장"
 "치. 정적 적외선 검사는 거절한 유일한 결과였습니다."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "GC 슬롯에 매장을 추가하거나 옮기는 PR는"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -77797,7 +78825,7 @@ msgstr ""
 "그 장벽 증거는 **정적 IR 진술**행동 테스트가 아닙니다. 4가지가 있는데, 모두 "
 "빗나간 토레이션이 잡히지 않았기 때문이에요"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -77806,7 +78834,7 @@ msgstr ""
 "**회계 담당자가 있습니다** 포인터 기능의 팔 에 쓰기 장벽, 레이아웃 노트, 문자"
 "열 addref 3명 중 하나라도 사라진다면, 5094/7511호의 가족입니다."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -77819,7 +78847,7 @@ msgstr ""
 "하게 검사되고 처음에는 통과되었습니다. 코드의 존재는 실행되는 증거가 아닙니"
 "다."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -77829,7 +78857,7 @@ msgstr ""
 "합니다. 장애물이 침투하면 차별화가 차별화를 멈추고 \"최적화\"는 아무것도 측정"
 "하지 않는다는 것을 의미합니다."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -77839,9 +78867,10 @@ msgstr ""
 "는 것을 기록합니다. 실패하지 않은 테스트는 실패 모드가 알려지지 않은 테스트입"
 "니다."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -77857,33 +78886,24 @@ msgstr ""
 "`index_set_barrier_tests.rs` 그리고 `write_pic_barrier_tests.rs`는 모양입니"
 "다."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "`GC_STORE_AUDIT` 마커, 그리고 그것이 무엇을 하고 무엇을 증명하지 않는"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "모든 GC 관련 매장 사이트는 그 판결을 표시하는 인근 마커를 가지고 있습니다"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "// GC_STORE_AUDIT(BARRIERED): 슬롯 기록 조건이 없습니다; 장벽"
-
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// 아래는 저장된 비트들이 무더기를 가지고 있지 않다는 라이브 테스트로만 보호"
-"됩니다"
 
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// 포인터, 이것은 장벽의 첫 번째 테스트입니다."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -77895,7 +78915,7 @@ msgstr ""
 "당사 매장 사이트를 스캔하고 마커가 없으므로 실패합니다 **새로운** 이 질문에 "
 "답하지 않고는 상점 사이트가 착륙할 수 없습니다."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -77903,7 +78923,7 @@ msgstr ""
 "#8185이 후반에 착륙했기 때문에, 스크립트는 **청구서**, 단지 언급이 아니라, 거"
 "짓 주장이 사물을 묶는 두 가지 클래스:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -77939,7 +78959,7 @@ msgstr ""
 "문 클론에서 우회된 장애물이 다른 클론에서 손상되지 않습니다. 4개의 IR 수술 해"
 "독 (선거를 삭제하고, 게이트를 연결하고,"
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -77962,7 +78982,7 @@ msgstr ""
 "함수 안에 있는 두 개의 장벽 저장소와 하나의 장벽 호출이 여전히 통과) 이며, 스"
 "크립트는 그 한계를 인쇄합니다."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -77983,11 +79003,11 @@ msgstr ""
 "(`gc_rekeyed_key_tables.py` 학문) 로 읽기 보다는, 그리고 그것의 `--self-test`"
 "는 각각을 판단해야하는 15개의 모양을 만듭니다."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "코퍼스 문제, 그리고 두 코퍼스 (# 7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -77996,7 +79016,7 @@ msgstr ""
 "다. 그리고 한동안 아무도 알 수 없었습니다. 왜냐하면 그것은 초록색이었기 때문"
 "입니다.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -78010,7 +79030,7 @@ msgstr ""
 "는 동안 0을 읽습니다. #7280은 한 문장으로 표현합니다: _25 큐레이션 파일이 통"
 "과하고 스코드 fail._의 20 줄이 ZOD"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -78018,39 +79038,39 @@ msgstr ""
 "크기가 문제가 아닙니다. 두 몸체는 같은 컴파일러에서 `--stale-registers --"
 "moving-only`로 측정되었습니다"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "노후 사용"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "무엇이 지배적인가"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "큐레이션, 124 소스 / 144 모듈"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "property-GET 도움말 창, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "의존도 규모, 81 모듈 / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -78058,7 +79078,7 @@ msgstr ""
 "`js_object_assign_one` (물질 스프레드) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -78074,17 +79094,18 @@ msgstr ""
 "리를 내리는 위험 요소는**, 그래서 모양이 없는 코퍼스는 아무리 많은 파일이라"
 "도 표현할 수 없습니다."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
 msgstr "그래서 두 번째 코퍼스가 있습니다. 실제 npm 의존성에서 생성된 것입니다"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod는 package.json devDependency입니다"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -78098,7 +79119,7 @@ msgstr ""
 "크입니다. `zod` 습지의 ~90 모듈은 40줄의 소스가 없는 모든 수를 넘을 수 있기 "
 "때문입니다."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -78110,11 +79131,11 @@ msgstr ""
 "때문입니다. `--stale-registers` 예산은 가장 비싸다 (~5분): 스캔은 초선형이며 "
 "62 MB는 62 MB이다."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "CI 게이트"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -78125,19 +79146,19 @@ msgstr ""
 "체 작업은 몇 분 더하여 컴파일러 빌드; 두 게이트 체크는 각각 ~2000 및 ~12900 "
 "함수에 약 3 초입니다."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "CLAUDE.md의 네 가지 위험 요소에 대비하여 실패할 수 있도록 설계되었습니다"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "검사자의 출구 상태는 작업의  `continue-on-error`가 없습니다, 파이프가 없습니"
 "다"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -78145,7 +79166,7 @@ msgstr ""
 "`concurrency`는 풀 요청 실행만을 취소합니다. 그래서 `main` 실행은 절대 굶주리"
 "지 않습니다"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -78155,7 +79176,7 @@ msgstr ""
 "로 얇은 코퍼스에 대한 깨끗한 판결을 거부하고 실행은 `checked N functions / M "
 "modules`를 인쇄하여 조용한 빈 실행이 표시됩니다"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -78167,7 +79188,7 @@ msgstr ""
 "야 합니다. 즉, 페리의 출력을 읽을 수 있는 능력을 침묵으로 잃는 검사를 잡는 팔"
 "입니다"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -78182,11 +79203,11 @@ msgstr ""
 "둘 다 죽은 항목을 전송했습니다. `ALLOC_RE`에서 두 라운드에 걸쳐 9개, "
 "`POLL_CAPABLE_RUNTIME`에서 10개."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "허용 목록, 그리고 왜 그것은 숫자가 아닙니다"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -78195,7 +79216,7 @@ msgstr ""
 "남아있는 위반은 `scripts/gc_root_dominance_allowlist.json`에 있습니다. 손가"
 "락 표지, 문제, 서면적인 설명이 있는 항목 하나씩"
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -78208,11 +79229,11 @@ msgstr ""
 "으로 높이는 것입니다. 그리고 그 차이점은 무엇이 허용되었는지에 대해 아무 것"
 "도 말하지 않습니다."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "그래서 검사자는 세 가지 특성을 강제합니다"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -78222,7 +79243,7 @@ msgstr ""
 "PR에 있는 항목을 삭제하세요. 이것이 바로 래치입니다. 그래서 고정된 버그는 나"
 "중에 조용히 커버리지를 넓히는 무덤돌을 남길 수 없습니다."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -78230,12 +79251,12 @@ msgstr ""
 "**항목은 최대 `count`를 삭제합니다.** 같은 형태와 같은 기능의 두 번째 위반은 "
 "새롭고 실패합니다."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr "**출입이 안 되는 위반**, 얼마나 많은 항목이 있는지 상관없이."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -78243,11 +79264,11 @@ msgstr ""
 "항목을 추가하는 것은 코드 검토 이벤트입니다. `count`를 green build로 만드는 "
 "것은 바로 이 파일이 방지하기 위해 존재하는 것입니다."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "이 게이트를 홍보합니다"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -78255,11 +79276,11 @@ msgstr ""
 "**이 글을 쓰는 시점에는 이 작업이 브랜치 보호의 필수 검사에 포함되어 있지 않"
 "습니다**. 따라서 이 작업은 병합을 실패 처리할 수 없습니다 — 위험 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "두 가지 조건 # 7198은 이제 충족됩니다:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -78268,7 +79289,7 @@ msgstr ""
 "bind-anchored 지배성 검사는 `main`에 녹색으로 표시되어 있습니다 **비어있는** "
 "allowlist (이 전조가 \\#7226에 고정되었을 때 #7211 항목이 삭제되었습니다.)"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -78278,7 +79299,7 @@ msgstr ""
 "다 (#7236). 그 중 가장 주목할 만한 것은 78735번이 나오기 전, 2번이 나왔고, "
 "`Type::Symbol`가 즉각적으로 분류되는 것을 중단했을 때 0번이었습니다."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -78286,7 +79307,7 @@ msgstr ""
 "그래서 남은 단계는 **리포 관리자** `gc-root-dominance`를 가맹점 보호의 필요"
 "한 컨텍스트에 추가하기 위해:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -78299,7 +79320,7 @@ msgstr ""
 "서 `--unrooted-allocas` 단계로 작업의 첫 번째 녹색 실행은  현재 모양으로 녹색"
 "이 없었던 게이트가 필요한 날 모든 열린 PR를 차단합니다."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -78320,11 +79341,11 @@ msgstr ""
 "에 그것을 낮추십시오. 예산이 있는 곳에 봉쇄되는 승진은 변수가 아닌 숫자를 샀"
 "습니다."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "엄지손가락 규칙"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -78338,7 +79359,7 @@ msgstr ""
 "그리고 저자가 제공 한 초기화자에 대해만 물어보고, 저하하는 자신의 발산 "
 "`js_object_set_field_by_name` 호출에 대해 결코 묻지 않았습니다."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -78346,7 +79367,7 @@ msgstr ""
 "**모음점마다 뿌리를 다시 읽어야 합니다.** 호출 중 루트 슬롯에서 로드를 캐시하"
 "지 마세요. `rooted_handle_get`는 이것을 위해 존재합니다."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -78356,7 +79377,7 @@ msgstr ""
 "는 것은 다른 연산자를 낮추기 전에 하나가 물질화되는 경우 첫 번째 연산자가 뿌"
 "리를 내리는 것이 필요합니다."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -78364,7 +79385,7 @@ msgstr ""
 "**`--trace llvm`를 읽고** 3초는 `not a function`를 5주기를 하류로 나누는 하루"
 "보다 낫습니다."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -78606,6 +79627,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "로컬로 실행하세요:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "컴파일 타임 검증"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "사용자가 작업 부하에 따라 백엔드를 선택합니다"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -79043,7 +80233,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: 문자열 -- 레지스터 이름, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -79080,33 +80271,31 @@ msgid "Three types and one rule."
 msgstr "세 가지 유형과 한 가지 규칙."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr "/// GC가 관리하는 값을 보유한 레지스터가 루팅되지 않습니다."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// 방출기를 계속 빌려 클론도 아니고 복사도 아니고"
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr "/// 그림자 슬롯 뿌리. 수집 지점을 초월합니다. 직접 읽을 수 없습니다."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// ShadowFrame::alloc_slot에서만 얻을 수 있습니다"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr "/// GC가 관리하지 않는 것을 저장하는 레지스터: i32, 더블, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// 슬롯 인덱스. 자유로이 복제할 수 있고, 평생 사용이 없고, 발사자를 빌리지 "
-"않습니다."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -79116,24 +80305,29 @@ msgstr ""
 "전체 디자인은 **방출자의 방법을 수집할 수 있는지 여부에 따라 분할하는**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr "/// 수령할 수 없습니다. &self를 취하기 때문에 `Raw` 핸들은 유효합니다."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// 수령할 수 있습니다. 자금을 &mut, 모든 외환 `Raw` 대출을 종료합니다."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// 슬롯을 다시 읽어보세요. 반환된 RAW는 다음 &mut emit까지 유효합니다."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr "/// 이 레지스트를 뿌리로 삼아 루티를 만드는 유일한 방법이야"
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -79151,24 +80345,22 @@ msgstr ""
 "니다** 컴파일러가 거부합니다."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// RAW<'_>, 빌려 e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// 필요"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "OBJ는 E를 빌리고,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// 이는 변동적으로"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// 위에서 빌린"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -79176,7 +80368,8 @@ msgid ""
 msgstr "바로는 올바른 코드입니다. 그리고 가장 짧은 오류 해결 경로입니다"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// 다시 읽어, 맞습니다"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -79786,8 +80979,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**탈출구**전화하는 사람이 사용하는 한"
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -81328,17 +82522,35 @@ msgstr ""
 "결코 컨설팅하지 않습니다."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "이 사이드카 모델은 첫 실행 기록이 없으므로 읽기 전용 설치 디렉토리가 지원됩니"
 "다. 실행 파일을 이동하려면 `.perry-native` 형제를 이동해야 합니다. 빠진 파일 "
 "또는 해시가 맞지 않는 파일은 `dlopen` 전에 패킹 오류로 실패합니다."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -81353,7 +82565,7 @@ msgstr ""
 "전에 각 사이드카를 표시하고 하나의 아카이브에 전송합니다. Perry는 실행시 신뢰"
 "할 수 없는 다운로드된 바이너리로부터 격리 속성을 제거하지 않습니다."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -81370,11 +82582,11 @@ msgstr ""
 "은 호스트 `.node` 파일의 목표 유물 입력을 방지하는 동시에 패키지 관리자에서 "
 "레지스트리 인증서 및 의존성 해결을 유지합니다."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "캐시 아이덴티티"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -81382,31 +82594,31 @@ msgstr ""
 "컴파일 타임 애드온 매니페스트는 결정적으로 정렬되며 빌드 및 링크 캐시 아이덴"
 "티티에 다음을 기여합니다"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "정책 스키마 버전과 광고된 Node-API 버전"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "목표 튜플과 표준화된 허용 목록"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "선택된 name/version 패키지와 상대적인 입력 경로"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 및 각 사이드카 유료 화물 파일의 크기"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "주문한 수출 상징 재고"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "운송 모델 (`sidecar-v1`)"
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -81420,11 +82632,11 @@ msgstr ""
 "변경은 모든 TypeScript 및 객체 파일이 변경되지 않더라도 상위 수준의 빌드 캐시"
 "를 놓쳐야합니다."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -81442,22 +82654,15 @@ msgstr ""
 "리 해상도를 위해 필요한 경우 버전-8 기호를 내보내는 것을 의미합니다. 그러나 "
 "결정적으로 명시된 지원되지 않는 기능을 보고합니다."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: 코어 버전 4까지"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "입국 지점"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -81465,49 +82670,56 @@ msgstr "입국 지점"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "환경별로 안정적인 저장"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "싱글톤 값은 일반적인 스코프 핸들을 받습니다"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Perry object/array 할당자"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -81515,11 +82727,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN 박스 변환"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -81527,37 +82739,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "길이 제한; `NAPI_AUTO_LENGTH` 지원"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "네이티브 콜백은 호스트 레코드를 사용합니다"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code`는 공급될 때 설치됩니다"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "함수, 외부, 기호 및 빅인트 구별을 포함한다"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -81565,11 +82777,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "type/status 동작 확인"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -81577,11 +82789,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "쿼리 길이와 NUL 종료 시맨틱이 포함됩니다"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -81589,19 +82801,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "사용자 코드는 예외 함정에 있습니다"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "일반 객체 의미론"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -81609,11 +82821,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "문자열, 기호, 숫자 키"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -81621,11 +82833,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "UTF-8 이름"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -81633,43 +82845,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "배열 및 이국적인 인덱스 대상"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "데이터, 방법 및 액세서리 설명자"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "포인터 식별 단축키가 없습니다"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "일반 Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "콜백-정보 평생은 네이티브 호출입니다"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -81677,11 +82889,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "네이티브 객체 메타데이터 테이블"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -81689,11 +82901,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "위쪽의 강하고 약한 참조 설계"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -81703,11 +82915,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "엄격한 둥지 설치 및 생성 검증"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -81715,19 +82927,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "대기 슬롯 모델"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "대기 중입니다"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -81735,37 +82947,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "안정적인 뒷받침 포인터"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "모든 11개의 지정된 타입 배열 종류"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "뒷받침 동일성 및 오프셋을 보존"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "반환 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -81773,19 +82985,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "연기된 기록은 환경 소유의 뿌리입니다"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -81793,40 +83005,40 @@ msgstr ""
 "`napi_generic_failure`를 반환합니다; 임의의 실행 시간 소스 실행은 실행 시간 "
 "엔진이 없는 모델을 위반합니다"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "콜렉터 압력 회계"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: 버전 5 ~ 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "GC 후 큐 완료"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -81834,11 +83046,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "임의의 정확성"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -81846,68 +83058,68 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "정확한 `lossless` 및 단어 수 동작"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "수집 모드, 필터, 키 변환이 허용"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
 msgstr "환경당 한 레코드; 이전 파이널라이저를 호출하지 않고 교체 덮어쓰기"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "현존하는 분리 증식"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "객체 메타데이터에 있는 128비트 태그"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Perry 디스크립터 기계"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: 버전 9, 버전 10, 실험용"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -81915,16 +83127,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "전체 버전-9 표면으로만 광고"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -81932,11 +83144,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "외부 문자열 lifetime/accounting 작업이 필요합니다"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -81944,29 +83156,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "버전-10 빠른 경로 별명"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "광고된 안정적인 ABI의 일부가 아닙니다"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -81974,33 +83186,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "레거시 등록 및 중단 경로"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "기존의 비동기 의 통합"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -82008,11 +83220,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` 정체성 및 안정적인 바이트"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -82020,15 +83232,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "위의 명시적인 상태 기계"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -82036,16 +83248,16 @@ msgstr ""
 "릴리스 문자열 `perry`와 Perry의 semver 구성 요소를 반환; 그것은 노드 릴리스"
 "를 요구하지 않습니다"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "`napi_generic_failure`와 null 루프를 반환합니다. Perry는 libuv가 없습니다"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -82053,19 +83265,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "메인 스레드의 라이프 사이클"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "비동기 컨텍스트와 엄격한 넥팅"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -82073,11 +83285,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "이벤트 펌프 지원 TSFN"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -82085,35 +83297,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "스레드 수와 이벤트 루프 유지"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "종료 완료를 기다리고 있습니다"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "환경은 이미 미래의 가치를 기록하고 있습니다"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "10 버전으로 광고"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -82123,16 +83335,16 @@ msgstr ""
 "`napi_register_module_v1`를 내보냅니다. 이들은 애드온에서 검색되며 호스트 수"
 "출이 아닙니다."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "필요한 게이트"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr "다음 게이트가 독립적으로 실패할 때까지 구현이 완료되지 않습니다"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -82144,7 +83356,7 @@ msgstr ""
 "을 수 있습니다. 구제된 핸들은 생성 검증에 실패합니다. 루트 홀더와 rekey 테이"
 "블 감사 스크립트는 깨끗합니다."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -82154,7 +83366,7 @@ msgstr ""
 "두 C를 통해 Perry를 올리기 전에 반환됩니다. 기구화된 애드온은 프레임에 해제되"
 "지 않았다고 주장합니다."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -82164,7 +83376,7 @@ msgstr ""
 "테스트는 주소가 Perry 실행 파일에 속한다는 것을 증명합니다. 흡연 호출 횟수는 "
 "0보다 크어야 합니다."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -82176,7 +83388,7 @@ msgstr ""
 "버퍼를 포함합니다. 지원되지 않는 NAPI 버전, NAN/V8 및 `uv_*` 장치는 정확한 진"
 "단 기능을 주장합니다."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -82186,7 +83398,7 @@ msgstr ""
 "트리 (fixure tree) 를 관찰하고 동일한 결합된 스트림을 방출합니다. 양쪽 모두 "
 "그들의 네이티브 구현이 실제로 실행되었다고 주장합니다."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -82196,7 +83408,7 @@ msgstr ""
 "적으로 로드합니다. 사이드카의 삭제 또는 돌연변이는 매니페스트 해시 검사를 실"
 "패합니다."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -82204,7 +83416,7 @@ msgstr ""
 "**캐시 게이트:** 추가 바이트 또는 정책만 변경하면 빌드 캐시를 놓칠 수 있습니"
 "다. 변경되지 않은 입력값을 재구성하면 타격됩니다."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -82212,7 +83424,7 @@ msgstr ""
 "**크기 게이트:** 바이트 동일 헬로 월드 출력 빈 애드온 그래프와 함께; 호스트 "
 "전용 델타를 추가 빌드에서 보고하고 0.6 MB 예산을 적용합니다."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -82755,28 +83967,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "더 넓은 범위에서 명시적인 명령어를 사용하세요:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# 제품 feedback 루프"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# 호스트 호환 작업 공간 구성원 (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$ 패키지\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# 작업 공간 아키텍처를 검사하거나 검증합니다"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -82922,7 +84120,8 @@ msgstr ""
 "치합니다."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# 기본 제품 및 의존성 폐쇄를 구축"
 
 #: src/contributing/building.md:37
@@ -83044,7 +84243,8 @@ msgstr ""
 "해 실행합니다:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# 가늘고 최적화된 개발자 CLI"
 
 #: src/contributing/building.md:80
@@ -83076,23 +84276,28 @@ msgid "Build Specific Crates"
 msgstr "특정 크레이트 빌드"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# 런타임만 (stdlib도 재구성해야 합니다!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr "# .a 정적 아카이브는 별도의 포장 상자 (# 5422) 에 의해 방출됩니다"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# libperry_runtime.a / libperry_stdlib.a (e.g.를 연결해야 할 때 명시적으로"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# 코데겐만"
 
 #: src/contributing/building.md:106
@@ -83138,15 +84343,19 @@ msgid "Run Tests"
 msgstr "테스트 실행"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# 제품 단위 목표"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr "# 야간 CI 테스트 범위를 검사 (모든 리눅스 호환 테스트 캐스트)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# 특정 상자"
 
 #: src/contributing/building.md:137
@@ -83154,11 +84363,13 @@ msgid "Compile and Run TypeScript"
 msgstr "TypeScript 컴파일 및 실행"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# TypeScript 파일을 컴파일합니다"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# 디버그: HIR를 인쇄"
 
 #: src/contributing/building.md:148
@@ -83222,19 +84433,23 @@ msgstr ""
 "가 이동하거나 공공 레지스트리 shasum이 다르면 태그를 거부합니다."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# 체크아웃이 깨끗하고 최신인지 확인해"
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# 0을 인쇄해야 합니다"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# 아무 것도 인쇄해서는 안 됩니다"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# 빠른 정책과 스크립트 검사"
 
 #: src/contributing/releasing.md:23
@@ -83242,7 +84457,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr "# 호스트가 실행할 수 있는 행동 검사 이 방법들은 회전율을 향상시키지만"
 
 #: src/contributing/releasing.md:38
@@ -83265,7 +84482,8 @@ msgstr ""
 "다면, 먼저 새로운 버전을 정상 병합 프로세스를 통해 가져오세요."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# 이미 Cargo.toml에 있는 버전을 대체합니다."
 
 #: src/contributing/releasing.md:48
@@ -83285,7 +84503,8 @@ msgid "'[0-9]*.md'"
 msgstr "[0-9]*.md"
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # 아무것도 인쇄해서는 안 됩니다"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -83386,9 +84605,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "허용된 행동: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -83419,21 +84639,15 @@ msgstr ""
 "니다."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# 1개의 릴리스 패키지 실행: exact-SHA gates/builds"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # OIDC를 통해 모든 9을 게시 + 확인, 그리고 생성"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub 마지막 발매"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# commit/run/package/Socket 영수증을 확인합니다"
 
 #: src/contributing/releasing.md:128
@@ -83647,11 +84861,13 @@ msgstr ""
 "이 doc-예본 실행을 확인합니다:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# 시뮬레이터에 컴파일"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# 장치 부팅 (일회용; 실행 중 UDID를 재사용)"
 
 #: src/contributing/releasing.md:178
@@ -83659,20 +84875,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# 테스트 모드로 설치 + 시작"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr "# 렌더링 후 앱 종료 0; 화면 촬영 카운터-ios.png에 착륙"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -83935,6 +85140,10 @@ msgid "patch distance"
 msgstr "패치 거리"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -83969,15 +85178,18 @@ msgstr ""
 "자동으로 닫습니다."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# 실패할 수 있다는 것을 증명합니다"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# 실제 등록, 어떤 문제도 쓰지 않습니다"
 
 #: src/contributing/releasing.md:289
@@ -84032,6 +85244,363 @@ msgstr ""
 "거시 릴리스 패키지 배포 다리를 다시 시도하려면 `existing_tag=vX.Y.Z`로 전송합"
 "니다. idempotent npm 다리가 다시 시도해야 할 때만 `publish_npm=true`를 추가하"
 "십시오."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr "# src/lib.rs를 편집  `js_*` 기능을 추가, 모든 사용"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# Edit src/index.ts  TS 표면 사용자 코드 수입을 선언"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# package.json를 편집합니다"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ 명표는 정적 리브와 일치합니다"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# 스캐폴드 release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # 모든 목표물을 위해 미리 만든 건물을 "
+#~ "만듭니다"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # 그리고 그 가늘을 풀기 위해"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"<upstream crate>에 대한 네이티브 결합\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  PDF 버퍼에서 텍스트를 추출"
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "안전성"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr`는 NULL 또는 `buf_len` 바이트에 유효해야 합니다. Perry가 통과"
+#~ "합니다"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// 이 쌍은 `buffer+len` 표시 매개 변수에서"
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const result = wait spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "패딩과 인셋"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 슬라이스 (디폴트 장치 목표)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. 미노스 + 피지"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"플랫폼;안드로이드-35\" \"빌드 도구;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"시스템 이미지, 안드로이드-34, 안드로이드 웨어, ARM64-V8A\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Rust 크로스 타겟"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Wear OS 에뮬레이터를 생성 + 부팅 (글라운드 시계)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Perry가 지원하는 추가 npm 패키지 및 Node.js API. 여기 나열된 모든 것은 "
+#~ "Perry의 well-known 네이티브 바인딩 레지스트리 (#466)를 통해 배선되며 "
+#~ "JavaScript 런타임 관여 없이 네이티브 코드로 컴파일됩니다."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr "# 3) 마니페스트를 업로드하기 전에 현지에서 사인 체계를 확인합니다"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    여기서는 고객에 대한 검증을 통과하는 것을 예측합니다."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) 리리즈 CI는 CLI 매니페스트에 서명하고, 그 아카이브 URL, 플랫폼을 연결"
+#~ "합니다"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// 표적을 감지: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// 컴파일: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// 링크: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"콘텐츠 타입: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "'{\"텍스트\":\"세상 안녕\"}'"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"value\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "'{\"값\":42}'"
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "'{\"편단\":\"s\"}'"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# 30초 동안 켜면 됩니다"
+
+#~ msgid "# Check stats"
+#~ msgstr "# 통계 확인"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"운동\": true, \"events_fired\": 600, \"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# 최종 상태를 보기 위해 화면 촬영"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# 혼돈을 막아"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# 앱이 아직 작동하는지 확인하세요"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# iOS (크로스 컴파일) 를 위한 빌드"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr "\"직업\" | select(.status==\"in_progress\") | 라벨|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# 줄을 얼마나 깊고, 어떤 수영장에서"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "\"직업\" | select(.status==\"queued\") | 라벨|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"libfoo에 대한 네이티브 결합\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\"'"
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Perry 선박 **두 개의 독립적인 선택 채널** 데이터 전송을 위해 집  아무것도 "
+#~ "명확한 없이 당신의 컴퓨터를 떠납니다 `enabled = true` 아니면 `on` 들어와 "
+#~ "`~/.perry/config.toml`... 둘 다 `PERRY_NO_TELEMETRY=1`와 `CI=true`를 존중"
+#~ "합니다."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "인간으로 읽을 수 있는 수집기 진단기를 발산합니다"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# NATIVE (PERRY_RS4GC=1): 다른 모든 곳에서 기본 어"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` 루트 할당 및 LLVM는 나중에 안전 포인트를 삽입, 그래서"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr "// GC_STORE_AUDIT(BARRIERED): 슬롯 기록 조건이 없습니다; 장벽"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// 아래는 저장된 비트들이 무더기를 가지고 있지 않다는 라이브 테스트로만 보"
+#~ "호됩니다"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// 포인터, 이것은 장벽의 첫 번째 테스트입니다."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// 방출기를 계속 빌려 클론도 아니고 복사도 아니고"
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// 슬롯 인덱스. 자유로이 복제할 수 있고, 평생 사용이 없고, 발사자를 빌리"
+#~ "지 않습니다."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "OBJ는 E를 빌리고,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// 이는 변동적으로"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// 위에서 빌린"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$ 패키지\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# 작업 공간 아키텍처를 검사하거나 검증합니다"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# 1개의 릴리스 패키지 실행: exact-SHA gates/builds"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # OIDC를 통해 모든 9을 게시 + 확인, 그리고 생"
+#~ "성"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub 마지막 발매"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr "# 렌더링 후 앱 종료 0; 화면 촬영 카운터-ios.png에 착륙"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -85043,9 +86612,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "`LANG` / `LC_ALL` / `LC_MESSAGES` env 변수"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "컴파일 타임 검증"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr "Perry는 컴파일 중 모든 로케일에서 매개변수를 검증합니다:"
 
@@ -85129,17 +86695,6 @@ msgstr ""
 #~ msgstr "특정 엣지에 패딩 적용:"
 
 #~ msgid ""
-#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
-#~ "    // Compile: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
-#~ msgstr ""
-#~ "// 타겟 감지: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
-#~ "    // 컴파일: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // 링크:    cargo:rustc-link-lib=static=review_bridge\n"
-
-#~ msgid ""
 #~ "Uses [`SKStoreReviewController.requestReview(in:)`](https://"
 #~ "developer.apple.com/documentation/storekit/skstorereviewcontroller/"
 #~ "requestreview(in:)) from StoreKit."
@@ -85153,13 +86708,6 @@ msgstr ""
 
 #~ msgid "`SKStoreReviewController.requestReview()`"
 #~ msgstr "`SKStoreReviewController.requestReview()`"
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# GitHub Actions 예제\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "오브젝트 파일만 생성하고 링킹은 건너뛰기"

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -214,7 +214,7 @@ msgstr ""
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr ""
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr ""
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr ""
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr ""
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr ""
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr ""
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr ""
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr ""
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr ""
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr ""
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr ""
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr ""
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr ""
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr ""
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr ""
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr ""
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr ""
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr ""
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr ""
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr ""
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr ""
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr ""
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr ""
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr ""
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr ""
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr ""
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr ""
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr ""
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr ""
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr ""
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr ""
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr ""
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr ""
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr ""
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr ""
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr ""
 
@@ -868,7 +876,7 @@ msgid ""
 msgstr ""
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr ""
 
 #: src/introduction.md:79
@@ -895,11 +903,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -908,9 +916,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -920,7 +928,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr ""
@@ -980,27 +988,27 @@ msgid "Linux linker toolchain by distribution:"
 msgstr ""
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr ""
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr ""
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr ""
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+msgid "# openSUSE\n"
 msgstr ""
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+msgid "# Alpine / musl-based\n"
 msgstr ""
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+msgid "# Void Linux\n"
 msgstr ""
 
 #: src/getting-started/installation.md:41
@@ -1032,15 +1040,15 @@ msgid ""
 msgstr ""
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr ""
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+msgid "# Global\n"
 msgstr ""
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+msgid "# Zero-install, one-shot\n"
 msgstr ""
 
 #: src/getting-started/installation.md:66
@@ -1209,7 +1217,7 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr ""
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr ""
 
 #: src/getting-started/installation.md:129
@@ -1331,15 +1339,11 @@ msgid ""
 msgstr ""
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+msgid "# Ubuntu / Debian\n"
 msgstr ""
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
-msgstr ""
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
+msgid "# Fedora\n"
 msgstr ""
 
 #: src/getting-started/installation.md:196
@@ -1814,24 +1818,24 @@ msgid "The same code runs on all 6 platforms:"
 msgstr ""
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+msgid "# macOS (default)\n"
 msgstr ""
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+msgid "# iOS Simulator\n"
 msgstr ""
 
 #: src/getting-started/first-app.md:127
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr ""
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+msgid "# alias: --target wasm\n"
 msgstr ""
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+msgid "# Other platforms\n"
 msgstr ""
 
 #: src/getting-started/first-app.md:138
@@ -2016,7 +2020,7 @@ msgstr ""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2034,7 +2038,7 @@ msgstr ""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2208,7 +2212,7 @@ msgid ""
 msgstr ""
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+msgid "// scripts/generate-validators.mjs\n"
 msgstr ""
 
 #: src/getting-started/project-config.md:108
@@ -2240,7 +2244,7 @@ msgid "\"port\""
 msgstr ""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+msgid "// standalone source\n"
 msgstr ""
 
 #: src/getting-started/project-config.md:122
@@ -2472,19 +2476,20 @@ msgstr ""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr ""
 
@@ -2499,9 +2504,9 @@ msgstr ""
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -2624,6 +2629,7 @@ msgid ""
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -2650,62 +2656,62 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
 msgstr ""
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
 msgstr ""
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr ""
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr ""
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr ""
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr ""
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+msgid "# Compile a file\n"
 msgstr ""
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+msgid "# Compile with a specific target\n"
 msgstr ""
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+msgid "# Debug: print intermediate representation\n"
 msgstr ""
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr ""
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
 msgstr ""
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr ""
 
@@ -2796,32 +2802,33 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr ""
 
@@ -4181,10 +4188,14 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -4192,15 +4203,15 @@ msgid ""
 "See `crates/perry-hir/src/decorator_log.rs` for the implementation."
 msgstr ""
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr ""
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr ""
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -4210,43 +4221,43 @@ msgid ""
 "runtime."
 msgstr ""
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr ""
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
 msgstr ""
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
 "Angular's root injector)"
 msgstr ""
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
 "decorator runtime."
 msgstr ""
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr ""
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -4254,7 +4265,7 @@ msgid ""
 "tRPC servers, Drizzle apps) already work."
 msgstr ""
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -4264,50 +4275,50 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
 "TypeScript compiler."
 msgstr ""
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr ""
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app "
 "(`src/app/services/rating.service.ts`, ~80 lines), shown in its original "
 "Angular form and ported to Perry."
 msgstr ""
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr ""
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr ""
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr ""
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
 msgstr ""
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For "
 "multi-value streams, use `AsyncIterable`.)"
 msgstr ""
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -4315,11 +4326,11 @@ msgid ""
 "rather than by a container."
 msgstr ""
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr ""
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -4331,7 +4342,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -4342,18 +4353,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
 "`new RatingService(api)` line in `services.ts`."
 msgstr ""
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr ""
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style "
 "constructor-injection and route-metadata canaries, but it is not full "
@@ -4366,11 +4377,11 @@ msgid ""
 "register routes or schema as plain function calls / module-level constants."
 msgstr ""
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr ""
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 "
 "form](https://github.com/tc39/proposal-decorators) because it aligns better "
@@ -4854,7 +4865,7 @@ msgid ""
 "the global) lower to the opt-in wasmi host runtime (issue #76, "
 "`--enable-wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 
@@ -6012,51 +6023,11 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr ""
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+msgid "# Scaffold\n"
 msgstr ""
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
-msgstr ""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr ""
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr ""
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr ""
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr ""
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr ""
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr ""
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr ""
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
 msgstr ""
 
 #: src/native-libraries/overview.md:319
@@ -6343,7 +6314,7 @@ msgstr ""
 msgid "`perry-ext-ads`"
 msgstr ""
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr ""
 
@@ -6363,7 +6334,7 @@ msgstr ""
 msgid "`perry-ext-argon2`"
 msgstr ""
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr ""
 
@@ -6415,7 +6386,7 @@ msgstr ""
 msgid "`perry-ext-axios`"
 msgstr ""
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr ""
 
@@ -6475,7 +6446,7 @@ msgstr ""
 msgid "`perry-ext-bcrypt`"
 msgstr ""
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr ""
 
@@ -6483,7 +6454,7 @@ msgstr ""
 msgid "`perry-ext-better-sqlite3`"
 msgstr ""
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr ""
 
@@ -6491,7 +6462,7 @@ msgstr ""
 msgid "`perry-ext-cheerio`"
 msgstr ""
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr ""
 
@@ -6499,7 +6470,7 @@ msgstr ""
 msgid "`perry-ext-commander`"
 msgstr ""
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr ""
 
@@ -6531,7 +6502,7 @@ msgstr ""
 msgid "`perry-ext-dotenv`"
 msgstr ""
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr ""
 
@@ -6539,7 +6510,7 @@ msgstr ""
 msgid "`perry-ext-ethers`"
 msgstr ""
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr ""
 
@@ -6547,7 +6518,7 @@ msgstr ""
 msgid "`perry-ext-events`"
 msgstr ""
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr ""
 
@@ -6579,7 +6550,7 @@ msgstr ""
 msgid "`perry-ext-exponential-backoff`"
 msgstr ""
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr ""
 
@@ -6587,7 +6558,7 @@ msgstr ""
 msgid "`perry-ext-fastify`"
 msgstr ""
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr ""
 
@@ -6619,7 +6590,7 @@ msgstr ""
 msgid "`perry-ext-jsonwebtoken`"
 msgstr ""
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr ""
 
@@ -6627,7 +6598,7 @@ msgstr ""
 msgid "`perry-ext-lru-cache`"
 msgstr ""
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr ""
 
@@ -6635,7 +6606,7 @@ msgstr ""
 msgid "`perry-ext-moment`"
 msgstr ""
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr ""
 
@@ -6643,7 +6614,7 @@ msgstr ""
 msgid "`perry-ext-mongodb`"
 msgstr ""
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr ""
 
@@ -6659,7 +6630,7 @@ msgstr ""
 msgid "`perry-ext-nanoid`"
 msgstr ""
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr ""
 
@@ -6667,7 +6638,7 @@ msgstr ""
 msgid "`perry-ext-net`"
 msgstr ""
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr ""
 
@@ -6675,7 +6646,7 @@ msgstr ""
 msgid "`perry-ext-node-forge`"
 msgstr ""
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr ""
 
@@ -6683,7 +6654,7 @@ msgstr ""
 msgid "`perry-ext-nodemailer`"
 msgstr ""
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr ""
 
@@ -6700,7 +6671,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr ""
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr ""
 
@@ -6708,7 +6679,7 @@ msgstr ""
 msgid "`perry-ext-pg`"
 msgstr ""
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr ""
 
@@ -6716,7 +6687,7 @@ msgstr ""
 msgid "`perry-ext-qs`"
 msgstr ""
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr ""
 
@@ -6724,7 +6695,7 @@ msgstr ""
 msgid "`perry-ext-ratelimit`"
 msgstr ""
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr ""
 
@@ -6732,7 +6703,7 @@ msgstr ""
 msgid "`perry-ext-sharp`"
 msgstr ""
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr ""
 
@@ -6740,7 +6711,7 @@ msgstr ""
 msgid "`perry-ext-streams`"
 msgstr ""
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr ""
 
@@ -6748,7 +6719,7 @@ msgstr ""
 msgid "`perry-ext-typescript`"
 msgstr ""
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr ""
 
@@ -6756,7 +6727,7 @@ msgstr ""
 msgid "`perry-ext-undici`"
 msgstr ""
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr ""
 
@@ -6764,7 +6735,7 @@ msgstr ""
 msgid "`perry-ext-uuid`"
 msgstr ""
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr ""
 
@@ -6772,7 +6743,7 @@ msgstr ""
 msgid "`perry-ext-validator`"
 msgstr ""
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr ""
 
@@ -6780,7 +6751,7 @@ msgstr ""
 msgid "`perry-ext-ws`"
 msgstr ""
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr ""
 
@@ -6788,7 +6759,7 @@ msgstr ""
 msgid "`perry-ext-zlib`"
 msgstr ""
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr ""
 
@@ -6833,14 +6804,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr ""
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr ""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr ""
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr ""
@@ -6867,25 +6830,13 @@ msgid ""
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr ""
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr ""
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr ""
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
-msgstr ""
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:65
@@ -7003,7 +6954,7 @@ msgstr ""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr ""
 
@@ -7214,7 +7165,7 @@ msgid "In a separate directory:"
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+msgid "# or any path your tooling supports\n"
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:219
@@ -7555,7 +7506,7 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr ""
 
 #: src/native-libraries/authoring-guide.md:458
@@ -7897,7 +7848,7 @@ msgid "\".env\""
 msgstr ""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr ""
 
 #: src/native-libraries/abi.md:165
@@ -8118,8 +8069,8 @@ msgstr ""
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr ""
 
@@ -8177,14 +8128,14 @@ msgstr ""
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -9657,27 +9608,29 @@ msgstr ""
 
 #: src/native-libraries/upstream-pins.md:52
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr ""
 
 #: src/native-libraries/upstream-pins.md:57
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 
 #: src/native-libraries/upstream-pins.md:61
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 
 #: src/native-libraries/upstream-pins.md:65
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored "
-"upstream/<name>"
+"upstream/<name>\n"
 msgstr ""
 
 #: src/native-libraries/upstream-pins.md:71
@@ -9846,15 +9799,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr ""
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -9957,7 +9910,7 @@ msgstr ""
 msgid "**Node.js**"
 msgstr ""
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr ""
 
@@ -9972,7 +9925,7 @@ msgid "**Deno**"
 msgstr ""
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr ""
 
@@ -11290,11 +11243,9 @@ msgid "Compared to Node.js worker_threads"
 msgstr ""
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
-msgstr ""
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr ""
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
@@ -11302,7 +11253,7 @@ msgid "\"worker_threads\""
 msgstr ""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+msgid "// main.js\n"
 msgstr ""
 
 #: src/threading/spawn.md:176
@@ -11322,11 +11273,9 @@ msgid "/* handle */"
 msgstr ""
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
-msgstr ""
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr ""
 
 #: src/threading/spawn.md:189
@@ -11469,8 +11418,8 @@ msgid ""
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 
 #: src/ui/overview.md:33
@@ -11530,7 +11479,7 @@ msgstr ""
 msgid "Property"
 msgstr ""
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr ""
 
@@ -11886,7 +11835,7 @@ msgstr ""
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr ""
@@ -11907,7 +11856,7 @@ msgstr ""
 msgid "Platform-specific behavior is noted on each widget's documentation page."
 msgstr ""
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -12988,7 +12937,7 @@ msgid "Double-click handler"
 msgstr ""
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr ""
 
 #: src/ui/widgets.md:678
@@ -13046,10 +12995,10 @@ msgstr ""
 #: src/ui/layout.md:8
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 
 #: src/ui/layout.md:14 src/platforms/watchos.md:141 src/platforms/android.md:34
@@ -13396,7 +13345,7 @@ msgstr ""
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr ""
 
@@ -13409,7 +13358,7 @@ msgid "Children align to the leading (left) edge"
 msgstr ""
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr ""
 
@@ -13422,7 +13371,7 @@ msgid "Children centered horizontally"
 msgstr ""
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr ""
 
@@ -13443,7 +13392,7 @@ msgstr ""
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr ""
 
@@ -13470,8 +13419,8 @@ msgstr ""
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr ""
 
@@ -13515,9 +13464,9 @@ msgstr ""
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr ""
 
@@ -13540,11 +13489,11 @@ msgstr ""
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr ""
 
@@ -13695,7 +13644,7 @@ msgstr ""
 #: src/ui/layout.md:298
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 
 #: src/ui/layout.md:301
@@ -13712,9 +13661,9 @@ msgstr ""
 #: src/ui/layout.md:309
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 
 #: src/ui/layout.md:314
@@ -13929,7 +13878,7 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr ""
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
+msgid "`setPadding`"
 msgstr ""
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
@@ -14260,7 +14209,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -14270,11 +14218,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr ""
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -14284,11 +14232,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr ""
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -14298,15 +14246,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr ""
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr ""
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -14314,29 +14262,36 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr ""
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
 msgstr ""
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr ""
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -14346,11 +14301,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr ""
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -14358,11 +14313,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr ""
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -14375,11 +14330,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr ""
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -14387,17 +14342,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
 msgstr ""
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr ""
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -14405,17 +14360,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
 msgstr ""
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr ""
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -14423,11 +14378,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr ""
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -14447,7 +14402,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -14475,10 +14430,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -14491,26 +14446,26 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr ""
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr ""
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
 "workflow."
 msgstr ""
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr ""
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling "
 "matrix](styling-matrix.md) — auto-generated from "
@@ -14518,7 +14473,7 @@ msgid ""
 "backend's `lib.rs` exports on every PR."
 msgstr ""
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -14530,15 +14485,15 @@ msgid ""
 "documentation cannot drift from the backend inventory."
 msgstr ""
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr ""
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr ""
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr ""
 
@@ -15590,8 +15545,8 @@ msgstr ""
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr ""
 
@@ -18267,7 +18222,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr ""
@@ -19464,7 +19419,7 @@ msgstr ""
 msgid "ink"
 msgstr ""
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr ""
 
@@ -19974,15 +19929,15 @@ msgid "Cross-Compilation"
 msgstr ""
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+msgid "# Default: compile for current platform\n"
 msgstr ""
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+msgid "# Compile for a specific target\n"
 msgstr ""
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+msgid "# Wear OS — Android on a watch\n"
 msgstr ""
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -20169,7 +20124,7 @@ msgid "Building"
 msgstr ""
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+msgid "# macOS is the default target\n"
 msgstr ""
 
 #: src/platforms/macos.md:18
@@ -20268,7 +20223,7 @@ msgid "App Store Distribution"
 msgstr ""
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+msgid "# Sign with App Store certificate\n"
 msgstr ""
 
 #: src/platforms/macos.md:60
@@ -20276,7 +20231,7 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr ""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+msgid "# Package\n"
 msgstr ""
 
 #: src/platforms/macos.md:62
@@ -20389,15 +20344,15 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr ""
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+msgid "# Auto-detect device/simulator\n"
 msgstr ""
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+msgid "# Stream live stdout/stderr\n"
 msgstr ""
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+msgid "# Use Perry Hub build server\n"
 msgstr ""
 
 #: src/platforms/ios.md:40
@@ -20870,7 +20825,7 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr ""
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr ""
 
 #: src/platforms/tvos.md:39
@@ -21275,11 +21230,11 @@ msgid ""
 msgstr ""
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+msgid "# simulator (tier 2)\n"
 msgstr ""
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+msgid "# for device build-std\n"
 msgstr ""
 
 #: src/platforms/watchos.md:20
@@ -21369,19 +21324,11 @@ msgid ""
 msgstr ""
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
-msgstr ""
-
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr ""
 
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
-msgstr ""
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr ""
 
 #: src/platforms/watchos.md:77
@@ -21396,7 +21343,7 @@ msgid "Build environment variables"
 msgstr ""
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr ""
@@ -21476,7 +21423,7 @@ msgid ""
 msgstr ""
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+msgid "# Auto-detect booted watch simulator\n"
 msgstr ""
 
 #: src/platforms/watchos.md:126
@@ -21961,35 +21908,11 @@ msgid ""
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:57
@@ -22093,18 +22016,7 @@ msgid ""
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr ""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:123
@@ -22115,6 +22027,10 @@ msgstr ""
 msgid ""
 "`altool` cannot upload watch apps (\"cannot determine platform\"). Use "
 "Transporter:"
+msgstr ""
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
 msgstr ""
 
 #: src/platforms/watchos-app-store.md:133
@@ -22416,15 +22332,17 @@ msgid "One-time setup (macOS example)"
 msgstr ""
 
 #: src/platforms/wearos.md:35
-msgid "# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+msgid ""
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+msgid "# or any Gradle 8.10.2+\n"
 msgstr ""
 
 #: src/platforms/wearos.md:38
-msgid "# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+msgid ""
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr ""
 
 #: src/platforms/wearos.md:40
@@ -22432,7 +22350,7 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr ""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr ""
 
 #: src/platforms/wearos.md:42
@@ -22444,31 +22362,11 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr ""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr ""
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
-msgstr ""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr ""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr ""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr ""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr ""
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
 msgstr ""
 
 #: src/platforms/wearos.md:61
@@ -22487,7 +22385,7 @@ msgid ""
 msgstr ""
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr ""
 
 #: src/platforms/wearos.md:82
@@ -24048,7 +23946,7 @@ msgid ""
 msgstr ""
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+msgid "# In another terminal:\n"
 msgstr ""
 
 #: src/platforms/linux.md:82
@@ -24063,7 +23961,7 @@ msgid ""
 msgstr ""
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+msgid "# same output as --target wasm\n"
 msgstr ""
 
 #: src/platforms/web.md:10
@@ -24124,15 +24022,15 @@ msgid ""
 msgstr ""
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+msgid "# Self-contained HTML (default)\n"
 msgstr ""
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+msgid "# Same thing\n"
 msgstr ""
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr ""
 
 #: src/platforms/wasm.md:21
@@ -24401,11 +24299,11 @@ msgid "Provide them when instantiating:"
 msgstr ""
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr ""
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr ""
 
 #: src/platforms/wasm.md:95
@@ -24850,7 +24748,7 @@ msgstr ""
 msgid "The compiler links only the required runtime components."
 msgstr ""
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr ""
 
@@ -24941,7 +24839,7 @@ msgstr ""
 msgid "[HTTP & Networking](http.md)"
 msgstr ""
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr ""
 
@@ -25101,8 +24999,8 @@ msgid ""
 "Pass file paths across thread boundaries and reopen files inside the worker."
 msgstr ""
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr ""
 
@@ -25166,14 +25064,14 @@ msgstr ""
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 
 #: src/stdlib/http.md:52
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
-"(set), `.setHeader/.getHeader/.removeHeader/.hasHeader/  "
+"(set), `.setHeader/.getHeader/.removeHeader/.hasHeader/ "
 ".getHeaders/.getHeaderNames`, `.headersSent`, `.writableEnded`, "
 "`.writableFinished`, `.writeHead(status, msg?, headers?)`, `.write(chunk)`, "
 "`.end(chunk?)`, `.flushHeaders()`, `.on('finish'|'close', cb)`. Auto "
@@ -25534,10 +25432,36 @@ msgid ""
 msgstr ""
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr ""
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-lite-client) "
 "is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, derived from the "
@@ -25547,11 +25471,11 @@ msgid ""
 "#551)."
 msgstr ""
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr ""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -25590,76 +25514,76 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr ""
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr ""
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr ""
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr ""
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr ""
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr ""
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr ""
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr ""
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr ""
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr ""
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr ""
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr ""
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr ""
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr ""
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr ""
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr ""
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -25669,7 +25593,7 @@ msgid ""
 "authenticate against real S3."
 msgstr ""
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -25677,7 +25601,7 @@ msgid ""
 "against pinned vectors here."
 msgstr ""
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -26080,7 +26004,7 @@ msgstr ""
 #: src/stdlib/utilities.md:13
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 
@@ -26221,22 +26145,21 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr ""
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
 msgstr ""
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -26263,15 +26186,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr ""
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr ""
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -26282,11 +26205,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr ""
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -26308,15 +26231,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr ""
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr ""
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -26327,17 +26250,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr ""
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
 msgstr ""
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -26349,18 +26272,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr ""
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by "
 "[`ethers-rs`](https://github.com/gakonst/ethers-rs)\\-style ABI plumbing "
 "through `perry-ffi`'s BigInt + Buffer surfaces."
 msgstr ""
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -26371,17 +26294,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr ""
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 msgstr ""
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -26392,15 +26315,15 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr ""
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr ""
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -26413,17 +26336,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr ""
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
 msgstr ""
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -26443,17 +26366,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr ""
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
 msgstr ""
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -26464,18 +26387,18 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr ""
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
 "both for existing codebases."
 msgstr ""
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -26485,17 +26408,17 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr ""
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
 msgstr ""
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -26509,11 +26432,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr ""
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -26524,7 +26447,7 @@ msgid ""
 "[Threading](../threading/overview.md))."
 msgstr ""
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -26545,12 +26468,12 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -26569,10 +26492,174 @@ msgid ""
 msgstr ""
 
 #: src/stdlib/other.md:244
-msgid "commander (CLI Parsing)"
+msgid "bun:jsc"
 msgstr ""
 
 #: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+msgid "Perry meaning"
+msgstr ""
+
+#: src/stdlib/other.md:261
+msgid "`heapSize`"
+msgstr ""
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+msgid "`heapCapacity`"
+msgstr ""
+
+#: src/stdlib/other.md:262
+msgid "Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+msgid "`extraMemorySize`"
+msgstr ""
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+msgid "`objectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+msgid "`objectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+msgid "`globalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+msgid "`mimalloc`"
+msgstr ""
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
+msgid "commander (CLI Parsing)"
+msgstr ""
+
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -26595,11 +26682,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr ""
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -26612,7 +26699,7 @@ msgid ""
 "iterator surface are not yet implemented."
 msgstr ""
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -26629,11 +26716,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr ""
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -26660,11 +26747,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr ""
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -26673,7 +26760,7 @@ msgid ""
 "throws, which triggers consumers' non-pty fallback paths."
 msgstr ""
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -26681,7 +26768,7 @@ msgid ""
 "like node-pty. `TERM` in the child comes from `name`."
 msgstr ""
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -26707,11 +26794,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr ""
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -26721,7 +26808,7 @@ msgid ""
 "2.5.1."
 msgstr ""
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -26733,7 +26820,7 @@ msgid ""
 "snapshot and emit its diff."
 msgstr ""
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -26744,47 +26831,47 @@ msgid ""
 "`getEventsSince` use the same snapshot diff semantics as overflow recovery."
 msgstr ""
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
 "natively via `perry-ffi`:"
 msgstr ""
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 msgstr ""
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See "
 "[PerryTS/iroh-bindings](https://github.com/PerryTS/iroh-bindings)."
 msgstr ""
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr ""
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
 "Bun unchanged."
 msgstr ""
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
 msgstr ""
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr ""
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr ""
 
@@ -26802,7 +26889,7 @@ msgid ""
 msgstr ""
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+msgid "Total: 3051 entries across 139 modules."
 msgstr ""
 
 #: src/api/reference.md:9
@@ -26898,10129 +26985,10239 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr ""
 
 #: src/api/reference.md:32
-msgid "[`bun:sqlite`](#bunsqlite)"
+msgid "[`bun:jsc`](#bunjsc)"
 msgstr ""
 
 #: src/api/reference.md:33
-msgid "[`cheerio`](#cheerio)"
+msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr ""
 
 #: src/api/reference.md:34
-msgid "[`child_process`](#child_process)"
+msgid "[`cheerio`](#cheerio)"
 msgstr ""
 
 #: src/api/reference.md:35
-msgid "[`cluster`](#cluster)"
+msgid "[`child_process`](#child_process)"
 msgstr ""
 
 #: src/api/reference.md:36
-msgid "[`commander`](#commander)"
+msgid "[`cluster`](#cluster)"
 msgstr ""
 
 #: src/api/reference.md:37
-msgid "[`console`](#console)"
+msgid "[`commander`](#commander)"
 msgstr ""
 
 #: src/api/reference.md:38
-msgid "[`constants`](#constants)"
+msgid "[`console`](#console)"
 msgstr ""
 
 #: src/api/reference.md:39
-msgid "[`cron`](#cron)"
+msgid "[`constants`](#constants)"
 msgstr ""
 
 #: src/api/reference.md:40
-msgid "[`crypto`](#crypto)"
+msgid "[`cron`](#cron)"
 msgstr ""
 
 #: src/api/reference.md:41
-msgid "[`date-fns`](#date-fns)"
+msgid "[`crypto`](#crypto)"
 msgstr ""
 
 #: src/api/reference.md:42
-msgid "[`dayjs`](#dayjs)"
+msgid "[`date-fns`](#date-fns)"
 msgstr ""
 
 #: src/api/reference.md:43
-msgid "[`decimal.js`](#decimaljs)"
+msgid "[`dayjs`](#dayjs)"
 msgstr ""
 
 #: src/api/reference.md:44
-msgid "[`dgram`](#dgram)"
+msgid "[`decimal.js`](#decimaljs)"
 msgstr ""
 
 #: src/api/reference.md:45
-msgid "[`diagnostics_channel`](#diagnostics_channel)"
+msgid "[`dgram`](#dgram)"
 msgstr ""
 
 #: src/api/reference.md:46
-msgid "[`dns`](#dns)"
+msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr ""
 
 #: src/api/reference.md:47
-msgid "[`dns/promises`](#dnspromises)"
+msgid "[`dns`](#dns)"
 msgstr ""
 
 #: src/api/reference.md:48
-msgid "[`domain`](#domain)"
+msgid "[`dns/promises`](#dnspromises)"
 msgstr ""
 
 #: src/api/reference.md:49
-msgid "[`dotenv`](#dotenv)"
+msgid "[`domain`](#domain)"
 msgstr ""
 
 #: src/api/reference.md:50
-msgid "[`ethers`](#ethers)"
+msgid "[`dotenv`](#dotenv)"
 msgstr ""
 
 #: src/api/reference.md:51
-msgid "[`events`](#events)"
+msgid "[`ethers`](#ethers)"
 msgstr ""
 
 #: src/api/reference.md:52
-msgid "[`exponential-backoff`](#exponential-backoff)"
+msgid "[`events`](#events)"
 msgstr ""
 
 #: src/api/reference.md:53
-msgid "[`fastify`](#fastify)"
+msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr ""
 
 #: src/api/reference.md:54
-msgid "[`fetch`](#fetch)"
+msgid "[`fastify`](#fastify)"
 msgstr ""
 
 #: src/api/reference.md:55
-msgid "[`ffi`](#ffi)"
+msgid "[`fetch`](#fetch)"
 msgstr ""
 
 #: src/api/reference.md:56
-msgid "[`fs`](#fs)"
+msgid "[`ffi`](#ffi)"
 msgstr ""
 
 #: src/api/reference.md:57
-msgid "[`fs/promises`](#fspromises)"
+msgid "[`fs`](#fs)"
 msgstr ""
 
 #: src/api/reference.md:58
-msgid "[`http`](#http)"
+msgid "[`fs/promises`](#fspromises)"
 msgstr ""
 
 #: src/api/reference.md:59
-msgid "[`http2`](#http2)"
+msgid "[`http`](#http)"
 msgstr ""
 
 #: src/api/reference.md:60
-msgid "[`https`](#https)"
+msgid "[`http2`](#http2)"
 msgstr ""
 
 #: src/api/reference.md:61
-msgid "[`inspector`](#inspector)"
+msgid "[`https`](#https)"
 msgstr ""
 
 #: src/api/reference.md:62
-msgid "[`inspector/promises`](#inspectorpromises)"
+msgid "[`inspector`](#inspector)"
 msgstr ""
 
 #: src/api/reference.md:63
-msgid "[`ioredis`](#ioredis)"
+msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr ""
 
 #: src/api/reference.md:64
-msgid "[`iovalkey`](#iovalkey)"
+msgid "[`ioredis`](#ioredis)"
 msgstr ""
 
 #: src/api/reference.md:65
-msgid "[`iroh`](#iroh)"
+msgid "[`iovalkey`](#iovalkey)"
 msgstr ""
 
 #: src/api/reference.md:66
-msgid "[`jsonwebtoken`](#jsonwebtoken)"
+msgid "[`iroh`](#iroh)"
 msgstr ""
 
 #: src/api/reference.md:67
-msgid "[`lodash`](#lodash)"
+msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr ""
 
 #: src/api/reference.md:68
-msgid "[`lru-cache`](#lru-cache)"
+msgid "[`lodash`](#lodash)"
 msgstr ""
 
 #: src/api/reference.md:69
-msgid "[`module`](#module)"
+msgid "[`lru-cache`](#lru-cache)"
 msgstr ""
 
 #: src/api/reference.md:70
-msgid "[`moment`](#moment)"
+msgid "[`module`](#module)"
 msgstr ""
 
 #: src/api/reference.md:71
-msgid "[`mongodb`](#mongodb)"
+msgid "[`moment`](#moment)"
 msgstr ""
 
 #: src/api/reference.md:72
-msgid "[`mysql2`](#mysql2)"
+msgid "[`mongodb`](#mongodb)"
 msgstr ""
 
 #: src/api/reference.md:73
-msgid "[`mysql2/promise`](#mysql2promise)"
+msgid "[`mysql2`](#mysql2)"
 msgstr ""
 
 #: src/api/reference.md:74
-msgid "[`nanoid`](#nanoid)"
+msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr ""
 
 #: src/api/reference.md:75
-msgid "[`net`](#net)"
+msgid "[`nanoid`](#nanoid)"
 msgstr ""
 
 #: src/api/reference.md:76
-msgid "[`node-cron`](#node-cron)"
+msgid "[`net`](#net)"
 msgstr ""
 
 #: src/api/reference.md:77
-msgid "[`node-fetch`](#node-fetch)"
+msgid "[`node-cron`](#node-cron)"
 msgstr ""
 
 #: src/api/reference.md:78
-msgid "[`node-forge`](#node-forge)"
+msgid "[`node-fetch`](#node-fetch)"
 msgstr ""
 
 #: src/api/reference.md:79
-msgid "[`node-pty`](#node-pty)"
+msgid "[`node-forge`](#node-forge)"
 msgstr ""
 
 #: src/api/reference.md:80
-msgid "[`nodemailer`](#nodemailer)"
+msgid "[`node-pty`](#node-pty)"
 msgstr ""
 
 #: src/api/reference.md:81
-msgid "[`os`](#os)"
+msgid "[`nodemailer`](#nodemailer)"
 msgstr ""
 
 #: src/api/reference.md:82
-msgid "[`path`](#path)"
+msgid "[`os`](#os)"
 msgstr ""
 
 #: src/api/reference.md:83
-msgid "[`path/posix`](#pathposix)"
+msgid "[`path`](#path)"
 msgstr ""
 
 #: src/api/reference.md:84
-msgid "[`path/win32`](#pathwin32)"
+msgid "[`path/posix`](#pathposix)"
 msgstr ""
 
 #: src/api/reference.md:85
-msgid "[`perf_hooks`](#perf_hooks)"
+msgid "[`path/win32`](#pathwin32)"
 msgstr ""
 
 #: src/api/reference.md:86
-msgid "[`perry`](#perry)"
+msgid "[`perf_hooks`](#perf_hooks)"
 msgstr ""
 
 #: src/api/reference.md:87
-msgid "[`perry/ads`](#perryads)"
+msgid "[`perry`](#perry)"
 msgstr ""
 
 #: src/api/reference.md:88
-msgid "[`perry/audio`](#perryaudio)"
+msgid "[`perry/ads`](#perryads)"
 msgstr ""
 
 #: src/api/reference.md:89
-msgid "[`perry/background`](#perrybackground)"
+msgid "[`perry/audio`](#perryaudio)"
 msgstr ""
 
 #: src/api/reference.md:90
-msgid "[`perry/compose`](#perrycompose)"
+msgid "[`perry/background`](#perrybackground)"
 msgstr ""
 
 #: src/api/reference.md:91
-msgid "[`perry/container`](#perrycontainer)"
+msgid "[`perry/compose`](#perrycompose)"
 msgstr ""
 
 #: src/api/reference.md:92
-msgid "[`perry/container-compose`](#perrycontainer-compose)"
+msgid "[`perry/container`](#perrycontainer)"
 msgstr ""
 
 #: src/api/reference.md:93
-msgid "[`perry/gc`](#perrygc)"
+msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr ""
 
 #: src/api/reference.md:94
-msgid "[`perry/i18n`](#perryi18n)"
+msgid "[`perry/gc`](#perrygc)"
 msgstr ""
 
 #: src/api/reference.md:95
-msgid "[`perry/ios`](#perryios)"
+msgid "[`perry/i18n`](#perryi18n)"
 msgstr ""
 
 #: src/api/reference.md:96
-msgid "[`perry/media`](#perrymedia)"
+msgid "[`perry/ios`](#perryios)"
 msgstr ""
 
 #: src/api/reference.md:97
-msgid "[`perry/native`](#perrynative)"
+msgid "[`perry/media`](#perrymedia)"
 msgstr ""
 
 #: src/api/reference.md:98
-msgid "[`perry/plugin`](#perryplugin)"
+msgid "[`perry/native`](#perrynative)"
 msgstr ""
 
 #: src/api/reference.md:99
-msgid "[`perry/system`](#perrysystem)"
+msgid "[`perry/plugin`](#perryplugin)"
 msgstr ""
 
 #: src/api/reference.md:100
-msgid "[`perry/thread`](#perrythread)"
+msgid "[`perry/system`](#perrysystem)"
 msgstr ""
 
 #: src/api/reference.md:101
-msgid "[`perry/tui`](#perrytui)"
+msgid "[`perry/thread`](#perrythread)"
 msgstr ""
 
 #: src/api/reference.md:102
-msgid "[`perry/ui`](#perryui)"
+msgid "[`perry/tui`](#perrytui)"
 msgstr ""
 
 #: src/api/reference.md:103
-msgid "[`perry/updater`](#perryupdater)"
+msgid "[`perry/ui`](#perryui)"
 msgstr ""
 
 #: src/api/reference.md:104
-msgid "[`perry/widget`](#perrywidget)"
+msgid "[`perry/updater`](#perryupdater)"
 msgstr ""
 
 #: src/api/reference.md:105
-msgid "[`perry/workloads`](#perryworkloads)"
+msgid "[`perry/widget`](#perrywidget)"
 msgstr ""
 
 #: src/api/reference.md:106
-msgid "[`perry/yoga`](#perryyoga)"
+msgid "[`perry/workloads`](#perryworkloads)"
 msgstr ""
 
 #: src/api/reference.md:107
-msgid "[`pg`](#pg)"
+msgid "[`perry/yoga`](#perryyoga)"
 msgstr ""
 
 #: src/api/reference.md:108
-msgid "[`process`](#process)"
+msgid "[`pg`](#pg)"
 msgstr ""
 
 #: src/api/reference.md:109
-msgid "[`punycode`](#punycode)"
+msgid "[`process`](#process)"
 msgstr ""
 
 #: src/api/reference.md:110
-msgid "[`qs`](#qs)"
+msgid "[`punycode`](#punycode)"
 msgstr ""
 
 #: src/api/reference.md:111
-msgid "[`querystring`](#querystring)"
+msgid "[`qs`](#qs)"
 msgstr ""
 
 #: src/api/reference.md:112
-msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
+msgid "[`querystring`](#querystring)"
 msgstr ""
 
 #: src/api/reference.md:113
-msgid "[`readline`](#readline)"
+msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr ""
 
 #: src/api/reference.md:114
-msgid "[`readline/promises`](#readlinepromises)"
+msgid "[`readline`](#readline)"
 msgstr ""
 
 #: src/api/reference.md:115
-msgid "[`redis`](#redis)"
+msgid "[`readline/promises`](#readlinepromises)"
 msgstr ""
 
 #: src/api/reference.md:116
-msgid "[`repl`](#repl)"
+msgid "[`redis`](#redis)"
 msgstr ""
 
 #: src/api/reference.md:117
-msgid "[`sea`](#sea)"
+msgid "[`repl`](#repl)"
 msgstr ""
 
 #: src/api/reference.md:118
-msgid "[`sharp`](#sharp)"
+msgid "[`sea`](#sea)"
 msgstr ""
 
 #: src/api/reference.md:119
-msgid "[`sqlite`](#sqlite)"
+msgid "[`sharp`](#sharp)"
 msgstr ""
 
 #: src/api/reference.md:120
-msgid "[`stream`](#stream)"
+msgid "[`sqlite`](#sqlite)"
 msgstr ""
 
 #: src/api/reference.md:121
-msgid "[`stream/consumers`](#streamconsumers)"
+msgid "[`stream`](#stream)"
 msgstr ""
 
 #: src/api/reference.md:122
-msgid "[`stream/promises`](#streampromises)"
+msgid "[`stream/consumers`](#streamconsumers)"
 msgstr ""
 
 #: src/api/reference.md:123
-msgid "[`stream/web`](#streamweb)"
+msgid "[`stream/promises`](#streampromises)"
 msgstr ""
 
 #: src/api/reference.md:124
-msgid "[`streams`](#streams)"
+msgid "[`stream/web`](#streamweb)"
 msgstr ""
 
 #: src/api/reference.md:125
-msgid "[`string_decoder`](#string_decoder)"
+msgid "[`streams`](#streams)"
 msgstr ""
 
 #: src/api/reference.md:126
-msgid "[`sys`](#sys)"
+msgid "[`string_decoder`](#string_decoder)"
 msgstr ""
 
 #: src/api/reference.md:127
-msgid "[`test`](#test)"
+msgid "[`sys`](#sys)"
 msgstr ""
 
 #: src/api/reference.md:128
-msgid "[`test/reporters`](#testreporters)"
+msgid "[`test`](#test)"
 msgstr ""
 
 #: src/api/reference.md:129
-msgid "[`timers`](#timers)"
+msgid "[`test/reporters`](#testreporters)"
 msgstr ""
 
 #: src/api/reference.md:130
-msgid "[`timers/promises`](#timerspromises)"
+msgid "[`timers`](#timers)"
 msgstr ""
 
 #: src/api/reference.md:131
-msgid "[`tls`](#tls)"
+msgid "[`timers/promises`](#timerspromises)"
 msgstr ""
 
 #: src/api/reference.md:132
-msgid "[`tty`](#tty)"
+msgid "[`tls`](#tls)"
 msgstr ""
 
 #: src/api/reference.md:133
-msgid "[`tursodb`](#tursodb)"
+msgid "[`tty`](#tty)"
 msgstr ""
 
 #: src/api/reference.md:134
-msgid "[`typescript`](#typescript)"
+msgid "[`tursodb`](#tursodb)"
 msgstr ""
 
 #: src/api/reference.md:135
-msgid "[`undici`](#undici)"
+msgid "[`typescript`](#typescript)"
 msgstr ""
 
 #: src/api/reference.md:136
-msgid "[`url`](#url)"
+msgid "[`undici`](#undici)"
 msgstr ""
 
 #: src/api/reference.md:137
-msgid "[`util`](#util)"
+msgid "[`url`](#url)"
 msgstr ""
 
 #: src/api/reference.md:138
-msgid "[`util/types`](#utiltypes)"
+msgid "[`util`](#util)"
 msgstr ""
 
 #: src/api/reference.md:139
-msgid "[`uuid`](#uuid)"
+msgid "[`util/types`](#utiltypes)"
 msgstr ""
 
 #: src/api/reference.md:140
-msgid "[`v8`](#v8)"
+msgid "[`uuid`](#uuid)"
 msgstr ""
 
 #: src/api/reference.md:141
-msgid "[`validator`](#validator)"
+msgid "[`v8`](#v8)"
 msgstr ""
 
 #: src/api/reference.md:142
-msgid "[`vm`](#vm)"
+msgid "[`validator`](#validator)"
 msgstr ""
 
 #: src/api/reference.md:143
-msgid "[`wasi`](#wasi)"
+msgid "[`vm`](#vm)"
 msgstr ""
 
 #: src/api/reference.md:144
-msgid "[`worker_threads`](#worker_threads)"
+msgid "[`wasi`](#wasi)"
 msgstr ""
 
 #: src/api/reference.md:145
-msgid "[`ws`](#ws)"
+msgid "[`worker_threads`](#worker_threads)"
 msgstr ""
 
 #: src/api/reference.md:146
+msgid "[`ws`](#ws)"
+msgstr ""
+
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr ""
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr ""
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr ""
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr ""
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr ""
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr ""
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr ""
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr ""
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr ""
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr ""
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr ""
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr ""
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr ""
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr ""
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr ""
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr ""
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr ""
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr ""
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr ""
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr ""
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr ""
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr ""
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr ""
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr ""
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr ""
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr ""
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr ""
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr ""
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr ""
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr ""
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr ""
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr ""
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr ""
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr ""
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr ""
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr ""
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr ""
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr ""
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr ""
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr ""
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr ""
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr ""
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr ""
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr ""
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr ""
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr ""
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr ""
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr ""
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr ""
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr ""
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr ""
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr ""
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr ""
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr ""
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr ""
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr ""
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr ""
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr ""
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr ""
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr ""
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr ""
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr ""
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr ""
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr ""
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr ""
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr ""
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr ""
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr ""
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr ""
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr ""
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr ""
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr ""
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr ""
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr ""
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr ""
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr ""
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr ""
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr ""
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr ""
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr ""
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr ""
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr ""
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr ""
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr ""
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr ""
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr ""
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr ""
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr ""
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr ""
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr ""
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr ""
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr ""
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr ""
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr ""
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr ""
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr ""
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr ""
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr ""
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr ""
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr ""
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr ""
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr ""
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr ""
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr ""
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr ""
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr ""
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr ""
 
-#: src/api/reference.md:423
-msgid "`Glob` — module"
-msgstr ""
-
 #: src/api/reference.md:424
-msgid "`file` — module"
-msgstr ""
-
-#: src/api/reference.md:425 src/api/reference.md:3800
-msgid "`fileURLToPath` — module"
-msgstr ""
-
-#: src/api/reference.md:427 src/api/reference.md:3804
-msgid "`pathToFileURL` — module"
+msgid "`Transpiler`"
 msgstr ""
 
 #: src/api/reference.md:428
-msgid "`stringWidth` — module"
+msgid "`Glob` — module"
 msgstr ""
 
 #: src/api/reference.md:429
-msgid "`unsupported` — module"
+msgid "`SQL` — module"
 msgstr ""
 
-#: src/api/reference.md:430 src/api/reference.md:1549
-msgid "`write` — module"
+#: src/api/reference.md:430
+msgid "`Terminal` — module"
 msgstr ""
 
-#: src/api/reference.md:434 src/api/reference.md:3139
-msgid "`stderr`"
+#: src/api/reference.md:431
+msgid "`Transpiler` — module"
 msgstr ""
 
-#: src/api/reference.md:435 src/api/reference.md:3140
-msgid "`stdin`"
+#: src/api/reference.md:432
+msgid "`build` — module"
 msgstr ""
 
-#: src/api/reference.md:436 src/api/reference.md:3141
-msgid "`stdout`"
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr ""
+
+#: src/api/reference.md:434
+msgid "`deepEquals` — module"
+msgstr ""
+
+#: src/api/reference.md:435
+msgid "`file` — module"
+msgstr ""
+
+#: src/api/reference.md:436 src/api/reference.md:3838
+msgid "`fileURLToPath` — module"
+msgstr ""
+
+#: src/api/reference.md:437
+msgid "`gc` — module"
 msgstr ""
 
 #: src/api/reference.md:438
-msgid "`bun:ffi`"
+msgid "`generateHeapSnapshot` — module"
+msgstr ""
+
+#: src/api/reference.md:440
+msgid "`listen` — module"
+msgstr ""
+
+#: src/api/reference.md:441 src/api/reference.md:3842
+msgid "`pathToFileURL` — module"
 msgstr ""
 
 #: src/api/reference.md:442
-msgid "`CFunction` — module"
+msgid "`scan` — instance _(class: `Transpiler`)_"
 msgstr ""
 
 #: src/api/reference.md:443
-msgid "`CString` — module"
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
 msgstr ""
 
 #: src/api/reference.md:444
-msgid "`JSCallback` — module"
-msgstr ""
-
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
-msgid "`dlopen` — module"
+msgid "`serve` — module"
 msgstr ""
 
 #: src/api/reference.md:446
-msgid "`linkSymbols` — module"
+msgid "`stringWidth` — module"
 msgstr ""
 
 #: src/api/reference.md:447
-msgid "`ptr` — module"
+msgid "`stripANSI` — module"
 msgstr ""
 
-#: src/api/reference.md:448 src/api/reference.md:1437
-msgid "`toArrayBuffer` — module"
+#: src/api/reference.md:448
+msgid "`transform` — instance _(class: `Transpiler`)_"
 msgstr ""
 
-#: src/api/reference.md:449 src/api/reference.md:1438
-msgid "`toBuffer` — module"
+#: src/api/reference.md:449
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
 msgstr ""
 
 #: src/api/reference.md:450
-msgid "`viewSource` — module"
+msgid "`unsupported` — module"
 msgstr ""
 
-#: src/api/reference.md:454
-msgid "`FFIType`"
+#: src/api/reference.md:451
+msgid "`which` — module"
 msgstr ""
 
-#: src/api/reference.md:455
-msgid "`read`"
+#: src/api/reference.md:452
+msgid "`wrapAnsi` — module"
 msgstr ""
 
-#: src/api/reference.md:456 src/api/reference.md:1443
-msgid "`suffix`"
+#: src/api/reference.md:453 src/api/reference.md:1587
+msgid "`write` — module"
 msgstr ""
 
-#: src/api/reference.md:458
-msgid "`bun:sqlite`"
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr ""
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr ""
+
+#: src/api/reference.md:459
+msgid "`JSONL`"
+msgstr ""
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
 msgstr ""
 
 #: src/api/reference.md:462
-msgid "`Database`"
+msgid "`ant`"
 msgstr ""
 
-#: src/api/reference.md:463
-msgid "`Statement`"
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
 msgstr ""
 
-#: src/api/reference.md:467
-msgid "`Database` — module"
+#: src/api/reference.md:464
+msgid "`semver`"
 msgstr ""
 
-#: src/api/reference.md:468
-msgid "`all` — instance _(class: `Statement`)_"
+#: src/api/reference.md:465 src/api/reference.md:3177
+msgid "`stderr`"
 msgstr ""
 
-#: src/api/reference.md:469
-msgid "`close` — instance _(class: `Database`)_"
+#: src/api/reference.md:466 src/api/reference.md:3178
+msgid "`stdin`"
+msgstr ""
+
+#: src/api/reference.md:467 src/api/reference.md:3179
+msgid "`stdout`"
+msgstr ""
+
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
 msgstr ""
 
 #: src/api/reference.md:470
-msgid "`finalize` — instance _(class: `Statement`)_"
-msgstr ""
-
-#: src/api/reference.md:471
-msgid "`get` — instance _(class: `Statement`)_"
-msgstr ""
-
-#: src/api/reference.md:472
-msgid "`loadExtension` — instance _(class: `Database`)_"
-msgstr ""
-
-#: src/api/reference.md:473
-msgid "`prepare` — instance _(class: `Database`)_"
+msgid "`bun:ffi`"
 msgstr ""
 
 #: src/api/reference.md:474
-msgid "`query` — instance _(class: `Database`)_"
+msgid "`CFunction` — module"
 msgstr ""
 
 #: src/api/reference.md:475
-msgid "`run` — instance _(class: `Database`)_"
+msgid "`CString` — module"
 msgstr ""
 
 #: src/api/reference.md:476
-msgid "`run` — instance _(class: `Statement`)_"
+msgid "`JSCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:477
-msgid "`safeIntegers` — instance _(class: `Statement`)_"
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
+msgid "`dlopen` — module"
 msgstr ""
 
 #: src/api/reference.md:478
-msgid "`serialize` — instance _(class: `Database`)_"
+msgid "`linkSymbols` — module"
 msgstr ""
 
 #: src/api/reference.md:479
-msgid "`transaction` — instance _(class: `Database`)_"
+msgid "`ptr` — module"
 msgstr ""
 
-#: src/api/reference.md:480
-msgid "`values` — instance _(class: `Statement`)_"
+#: src/api/reference.md:480 src/api/reference.md:1475
+msgid "`toArrayBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:484
-msgid "`filename`"
+#: src/api/reference.md:481 src/api/reference.md:1476
+msgid "`toBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:485
-msgid "`inTransaction`"
+#: src/api/reference.md:482
+msgid "`viewSource` — module"
 msgstr ""
 
-#: src/api/reference.md:491
-msgid "`attr` — instance"
+#: src/api/reference.md:486
+msgid "`FFIType`"
 msgstr ""
 
-#: src/api/reference.md:492
-msgid "`children` — instance"
+#: src/api/reference.md:487
+msgid "`read`"
 msgstr ""
 
-#: src/api/reference.md:493 src/api/reference.md:999
-msgid "`eq` — instance"
+#: src/api/reference.md:488 src/api/reference.md:1481
+msgid "`suffix`"
 msgstr ""
 
-#: src/api/reference.md:494 src/api/reference.md:2126
-msgid "`find` — instance"
+#: src/api/reference.md:490
+msgid "`bun:jsc`"
 msgstr ""
 
-#: src/api/reference.md:495
-msgid "`first` — instance"
+#: src/api/reference.md:494
+msgid "`heapStats` — module"
 msgstr ""
 
 #: src/api/reference.md:496
-msgid "`hasClass` — instance"
-msgstr ""
-
-#: src/api/reference.md:497 src/api/reference.md:1392
-msgid "`html` — instance"
-msgstr ""
-
-#: src/api/reference.md:498
-msgid "`last` — instance"
-msgstr ""
-
-#: src/api/reference.md:499
-msgid "`length` — instance"
+msgid "`bun:sqlite`"
 msgstr ""
 
 #: src/api/reference.md:500
-msgid "`load` — module"
+msgid "`Database`"
 msgstr ""
 
 #: src/api/reference.md:501
-msgid "`parent` — instance"
-msgstr ""
-
-#: src/api/reference.md:502
-msgid "`select` — instance"
-msgstr ""
-
-#: src/api/reference.md:503 src/api/reference.md:1412
-msgid "`text` — instance"
+msgid "`Statement`"
 msgstr ""
 
 #: src/api/reference.md:505
-msgid "`child_process`"
+msgid "`Database` — module"
+msgstr ""
+
+#: src/api/reference.md:506
+msgid "`all` — instance _(class: `Statement`)_"
+msgstr ""
+
+#: src/api/reference.md:507
+msgid "`close` — instance _(class: `Database`)_"
+msgstr ""
+
+#: src/api/reference.md:508
+msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr ""
 
 #: src/api/reference.md:509
-msgid "`ChildProcess`"
+msgid "`get` — instance _(class: `Statement`)_"
+msgstr ""
+
+#: src/api/reference.md:510
+msgid "`loadExtension` — instance _(class: `Database`)_"
+msgstr ""
+
+#: src/api/reference.md:511
+msgid "`prepare` — instance _(class: `Database`)_"
+msgstr ""
+
+#: src/api/reference.md:512
+msgid "`query` — instance _(class: `Database`)_"
 msgstr ""
 
 #: src/api/reference.md:513
-msgid "`_forkChild` — module"
+msgid "`run` — instance _(class: `Database`)_"
 msgstr ""
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
-msgid "`exec` — module"
+#: src/api/reference.md:514
+msgid "`run` — instance _(class: `Statement`)_"
 msgstr ""
 
 #: src/api/reference.md:515
-msgid "`execFile` — module"
+msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr ""
 
 #: src/api/reference.md:516
-msgid "`execFileSync` — module"
+msgid "`serialize` — instance _(class: `Database`)_"
 msgstr ""
 
 #: src/api/reference.md:517
-msgid "`execSync` — module"
+msgid "`transaction` — instance _(class: `Database`)_"
 msgstr ""
 
-#: src/api/reference.md:518 src/api/reference.md:535
-msgid "`fork` — module"
+#: src/api/reference.md:518
+msgid "`values` — instance _(class: `Statement`)_"
 msgstr ""
 
-#: src/api/reference.md:520
-msgid "`spawnSync` — module"
+#: src/api/reference.md:522
+msgid "`filename`"
 msgstr ""
 
-#: src/api/reference.md:526
-msgid "`cluster`"
+#: src/api/reference.md:523
+msgid "`inTransaction`"
+msgstr ""
+
+#: src/api/reference.md:529
+msgid "`attr` — instance"
+msgstr ""
+
+#: src/api/reference.md:530
+msgid "`children` — instance"
+msgstr ""
+
+#: src/api/reference.md:531 src/api/reference.md:1037
+msgid "`eq` — instance"
+msgstr ""
+
+#: src/api/reference.md:532 src/api/reference.md:2164
+msgid "`find` — instance"
+msgstr ""
+
+#: src/api/reference.md:533
+msgid "`first` — instance"
 msgstr ""
 
 #: src/api/reference.md:534
-msgid "`disconnect` — module"
+msgid "`hasClass` — instance"
+msgstr ""
+
+#: src/api/reference.md:535 src/api/reference.md:1430
+msgid "`html` — instance"
 msgstr ""
 
 #: src/api/reference.md:536
-msgid "`setupMaster` — module"
+msgid "`last` — instance"
 msgstr ""
 
 #: src/api/reference.md:537
-msgid "`setupPrimary` — module"
+msgid "`length` — instance"
 msgstr ""
 
-#: src/api/reference.md:541
-msgid "`SCHED_NONE`"
+#: src/api/reference.md:538
+msgid "`load` — module"
 msgstr ""
 
-#: src/api/reference.md:542
-msgid "`SCHED_RR`"
+#: src/api/reference.md:539
+msgid "`parent` — instance"
 msgstr ""
 
-#: src/api/reference.md:544
-msgid "`isMaster`"
+#: src/api/reference.md:540
+msgid "`select` — instance"
 msgstr ""
 
-#: src/api/reference.md:545
-msgid "`isPrimary`"
+#: src/api/reference.md:541 src/api/reference.md:1450
+msgid "`text` — instance"
 msgstr ""
 
-#: src/api/reference.md:546
-msgid "`isWorker`"
+#: src/api/reference.md:543
+msgid "`child_process`"
 msgstr ""
 
 #: src/api/reference.md:547
-msgid "`schedulingPolicy`"
+msgid "`ChildProcess`"
 msgstr ""
 
-#: src/api/reference.md:548
-msgid "`settings`"
+#: src/api/reference.md:551
+msgid "`_forkChild` — module"
 msgstr ""
 
-#: src/api/reference.md:549
-msgid "`workers`"
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
+msgid "`exec` — module"
+msgstr ""
+
+#: src/api/reference.md:553
+msgid "`execFile` — module"
+msgstr ""
+
+#: src/api/reference.md:554
+msgid "`execFileSync` — module"
 msgstr ""
 
 #: src/api/reference.md:555
-msgid "`action` — instance"
+msgid "`execSync` — module"
 msgstr ""
 
-#: src/api/reference.md:556
-msgid "`args` — instance"
-msgstr ""
-
-#: src/api/reference.md:557
-msgid "`argument` — instance"
+#: src/api/reference.md:556 src/api/reference.md:573
+msgid "`fork` — module"
 msgstr ""
 
 #: src/api/reference.md:558
-msgid "`command` — instance"
-msgstr ""
-
-#: src/api/reference.md:559
-msgid "`description` — instance"
-msgstr ""
-
-#: src/api/reference.md:560
-msgid "`name` — instance"
-msgstr ""
-
-#: src/api/reference.md:561
-msgid "`option` — instance"
-msgstr ""
-
-#: src/api/reference.md:562
-msgid "`opts` — instance"
-msgstr ""
-
-#: src/api/reference.md:563
-msgid "`parse` — instance"
+msgid "`spawnSync` — module"
 msgstr ""
 
 #: src/api/reference.md:564
-msgid "`requiredOption` — instance"
+msgid "`cluster`"
 msgstr ""
 
-#: src/api/reference.md:565
-msgid "`version` — instance"
+#: src/api/reference.md:572
+msgid "`disconnect` — module"
 msgstr ""
 
-#: src/api/reference.md:569
-msgid "`args`"
-msgstr ""
-
-#: src/api/reference.md:571 src/api/reference.md:1914
-msgid "`console`"
+#: src/api/reference.md:574
+msgid "`setupMaster` — module"
 msgstr ""
 
 #: src/api/reference.md:575
-msgid "`Console`"
+msgid "`setupPrimary` — module"
 msgstr ""
 
 #: src/api/reference.md:579
-msgid "`assert` — module"
+msgid "`SCHED_NONE`"
 msgstr ""
 
 #: src/api/reference.md:580
-msgid "`clear` — module"
-msgstr ""
-
-#: src/api/reference.md:581
-msgid "`context` — module"
+msgid "`SCHED_RR`"
 msgstr ""
 
 #: src/api/reference.md:582
-msgid "`count` — module"
+msgid "`isMaster`"
 msgstr ""
 
 #: src/api/reference.md:583
-msgid "`countReset` — module"
+msgid "`isPrimary`"
 msgstr ""
 
 #: src/api/reference.md:584
-msgid "`createTask` — module"
+msgid "`isWorker`"
 msgstr ""
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
-msgid "`debug` — module"
+#: src/api/reference.md:585
+msgid "`schedulingPolicy`"
 msgstr ""
 
 #: src/api/reference.md:586
-msgid "`dir` — module"
+msgid "`settings`"
 msgstr ""
 
 #: src/api/reference.md:587
-msgid "`dirxml` — module"
-msgstr ""
-
-#: src/api/reference.md:588
-msgid "`error` — module"
-msgstr ""
-
-#: src/api/reference.md:589
-msgid "`group` — module"
-msgstr ""
-
-#: src/api/reference.md:590
-msgid "`groupCollapsed` — module"
-msgstr ""
-
-#: src/api/reference.md:591
-msgid "`groupEnd` — module"
-msgstr ""
-
-#: src/api/reference.md:592
-msgid "`info` — module"
+msgid "`workers`"
 msgstr ""
 
 #: src/api/reference.md:593
-msgid "`log` — module"
+msgid "`action` — instance"
 msgstr ""
 
 #: src/api/reference.md:594
-msgid "`profile` — module"
+msgid "`args` — instance"
 msgstr ""
 
 #: src/api/reference.md:595
-msgid "`profileEnd` — module"
+msgid "`argument` — instance"
 msgstr ""
 
 #: src/api/reference.md:596
-msgid "`table` — module"
+msgid "`command` — instance"
 msgstr ""
 
 #: src/api/reference.md:597
-msgid "`time` — module"
+msgid "`description` — instance"
 msgstr ""
 
 #: src/api/reference.md:598
-msgid "`timeEnd` — module"
+msgid "`name` — instance"
 msgstr ""
 
 #: src/api/reference.md:599
-msgid "`timeLog` — module"
+msgid "`option` — instance"
 msgstr ""
 
 #: src/api/reference.md:600
-msgid "`timeStamp` — module"
+msgid "`opts` — instance"
 msgstr ""
 
 #: src/api/reference.md:601
-msgid "`trace` — module"
+msgid "`parse` — instance"
 msgstr ""
 
 #: src/api/reference.md:602
-msgid "`warn` — module"
+msgid "`requiredOption` — instance"
 msgstr ""
 
-#: src/api/reference.md:608
-msgid "`COPYFILE_EXCL`"
+#: src/api/reference.md:603
+msgid "`version` — instance"
 msgstr ""
 
-#: src/api/reference.md:609
-msgid "`COPYFILE_FICLONE`"
+#: src/api/reference.md:607
+msgid "`args`"
 msgstr ""
 
-#: src/api/reference.md:610
-msgid "`COPYFILE_FICLONE_FORCE`"
-msgstr ""
-
-#: src/api/reference.md:611
-msgid "`DH_CHECK_P_NOT_PRIME`"
-msgstr ""
-
-#: src/api/reference.md:612
-msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
+#: src/api/reference.md:609 src/api/reference.md:1952
+msgid "`console`"
 msgstr ""
 
 #: src/api/reference.md:613
-msgid "`DH_NOT_SUITABLE_GENERATOR`"
-msgstr ""
-
-#: src/api/reference.md:614
-msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
-msgstr ""
-
-#: src/api/reference.md:615
-msgid "`E2BIG`"
-msgstr ""
-
-#: src/api/reference.md:616
-msgid "`EACCES`"
+msgid "`Console`"
 msgstr ""
 
 #: src/api/reference.md:617
-msgid "`EADDRINUSE`"
+msgid "`assert` — module"
 msgstr ""
 
 #: src/api/reference.md:618
-msgid "`EADDRNOTAVAIL`"
+msgid "`clear` — module"
 msgstr ""
 
 #: src/api/reference.md:619
-msgid "`EAFNOSUPPORT`"
+msgid "`context` — module"
 msgstr ""
 
 #: src/api/reference.md:620
-msgid "`EAGAIN`"
+msgid "`count` — module"
 msgstr ""
 
 #: src/api/reference.md:621
-msgid "`EALREADY`"
+msgid "`countReset` — module"
 msgstr ""
 
 #: src/api/reference.md:622
-msgid "`EBADF`"
+msgid "`createTask` — module"
 msgstr ""
 
-#: src/api/reference.md:623
-msgid "`EBADMSG`"
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
+msgid "`debug` — module"
 msgstr ""
 
 #: src/api/reference.md:624
-msgid "`EBUSY`"
+msgid "`dir` — module"
 msgstr ""
 
 #: src/api/reference.md:625
-msgid "`ECANCELED`"
+msgid "`dirxml` — module"
 msgstr ""
 
 #: src/api/reference.md:626
-msgid "`ECHILD`"
+msgid "`error` — module"
 msgstr ""
 
 #: src/api/reference.md:627
-msgid "`ECONNABORTED`"
+msgid "`group` — module"
 msgstr ""
 
 #: src/api/reference.md:628
-msgid "`ECONNREFUSED`"
+msgid "`groupCollapsed` — module"
 msgstr ""
 
 #: src/api/reference.md:629
-msgid "`ECONNRESET`"
+msgid "`groupEnd` — module"
 msgstr ""
 
 #: src/api/reference.md:630
-msgid "`EDEADLK`"
+msgid "`info` — module"
 msgstr ""
 
 #: src/api/reference.md:631
-msgid "`EDESTADDRREQ`"
+msgid "`log` — module"
 msgstr ""
 
 #: src/api/reference.md:632
-msgid "`EDOM`"
+msgid "`profile` — module"
 msgstr ""
 
 #: src/api/reference.md:633
-msgid "`EDQUOT`"
+msgid "`profileEnd` — module"
 msgstr ""
 
 #: src/api/reference.md:634
-msgid "`EEXIST`"
+msgid "`table` — module"
 msgstr ""
 
 #: src/api/reference.md:635
-msgid "`EFAULT`"
+msgid "`time` — module"
 msgstr ""
 
 #: src/api/reference.md:636
-msgid "`EFBIG`"
+msgid "`timeEnd` — module"
 msgstr ""
 
 #: src/api/reference.md:637
-msgid "`EHOSTUNREACH`"
+msgid "`timeLog` — module"
 msgstr ""
 
 #: src/api/reference.md:638
-msgid "`EIDRM`"
+msgid "`timeStamp` — module"
 msgstr ""
 
 #: src/api/reference.md:639
-msgid "`EILSEQ`"
+msgid "`trace` — module"
 msgstr ""
 
 #: src/api/reference.md:640
-msgid "`EINPROGRESS`"
-msgstr ""
-
-#: src/api/reference.md:641
-msgid "`EINTR`"
-msgstr ""
-
-#: src/api/reference.md:642
-msgid "`EINVAL`"
-msgstr ""
-
-#: src/api/reference.md:643
-msgid "`EIO`"
-msgstr ""
-
-#: src/api/reference.md:644
-msgid "`EISCONN`"
-msgstr ""
-
-#: src/api/reference.md:645
-msgid "`EISDIR`"
+msgid "`warn` — module"
 msgstr ""
 
 #: src/api/reference.md:646
-msgid "`ELOOP`"
+msgid "`COPYFILE_EXCL`"
 msgstr ""
 
 #: src/api/reference.md:647
-msgid "`EMFILE`"
+msgid "`COPYFILE_FICLONE`"
 msgstr ""
 
 #: src/api/reference.md:648
-msgid "`EMLINK`"
+msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr ""
 
 #: src/api/reference.md:649
-msgid "`EMSGSIZE`"
+msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr ""
 
 #: src/api/reference.md:650
-msgid "`EMULTIHOP`"
+msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr ""
 
 #: src/api/reference.md:651
-msgid "`ENAMETOOLONG`"
+msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr ""
 
 #: src/api/reference.md:652
-msgid "`ENETDOWN`"
+msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr ""
 
 #: src/api/reference.md:653
-msgid "`ENETRESET`"
+msgid "`E2BIG`"
 msgstr ""
 
 #: src/api/reference.md:654
-msgid "`ENETUNREACH`"
+msgid "`EACCES`"
 msgstr ""
 
 #: src/api/reference.md:655
-msgid "`ENFILE`"
+msgid "`EADDRINUSE`"
 msgstr ""
 
 #: src/api/reference.md:656
-msgid "`ENGINE_METHOD_ALL`"
+msgid "`EADDRNOTAVAIL`"
 msgstr ""
 
 #: src/api/reference.md:657
-msgid "`ENGINE_METHOD_CIPHERS`"
+msgid "`EAFNOSUPPORT`"
 msgstr ""
 
 #: src/api/reference.md:658
-msgid "`ENGINE_METHOD_DH`"
+msgid "`EAGAIN`"
 msgstr ""
 
 #: src/api/reference.md:659
-msgid "`ENGINE_METHOD_DIGESTS`"
+msgid "`EALREADY`"
 msgstr ""
 
 #: src/api/reference.md:660
-msgid "`ENGINE_METHOD_DSA`"
+msgid "`EBADF`"
 msgstr ""
 
 #: src/api/reference.md:661
-msgid "`ENGINE_METHOD_EC`"
+msgid "`EBADMSG`"
 msgstr ""
 
 #: src/api/reference.md:662
-msgid "`ENGINE_METHOD_NONE`"
+msgid "`EBUSY`"
 msgstr ""
 
 #: src/api/reference.md:663
-msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
+msgid "`ECANCELED`"
 msgstr ""
 
 #: src/api/reference.md:664
-msgid "`ENGINE_METHOD_PKEY_METHS`"
+msgid "`ECHILD`"
 msgstr ""
 
 #: src/api/reference.md:665
-msgid "`ENGINE_METHOD_RAND`"
+msgid "`ECONNABORTED`"
 msgstr ""
 
 #: src/api/reference.md:666
-msgid "`ENGINE_METHOD_RSA`"
+msgid "`ECONNREFUSED`"
 msgstr ""
 
 #: src/api/reference.md:667
-msgid "`ENOBUFS`"
+msgid "`ECONNRESET`"
 msgstr ""
 
 #: src/api/reference.md:668
-msgid "`ENODATA`"
+msgid "`EDEADLK`"
 msgstr ""
 
 #: src/api/reference.md:669
-msgid "`ENODEV`"
+msgid "`EDESTADDRREQ`"
 msgstr ""
 
 #: src/api/reference.md:670
-msgid "`ENOENT`"
+msgid "`EDOM`"
 msgstr ""
 
 #: src/api/reference.md:671
-msgid "`ENOEXEC`"
+msgid "`EDQUOT`"
 msgstr ""
 
 #: src/api/reference.md:672
-msgid "`ENOLCK`"
+msgid "`EEXIST`"
 msgstr ""
 
 #: src/api/reference.md:673
-msgid "`ENOLINK`"
+msgid "`EFAULT`"
 msgstr ""
 
 #: src/api/reference.md:674
-msgid "`ENOMEM`"
+msgid "`EFBIG`"
 msgstr ""
 
 #: src/api/reference.md:675
-msgid "`ENOMSG`"
+msgid "`EHOSTUNREACH`"
 msgstr ""
 
 #: src/api/reference.md:676
-msgid "`ENOPROTOOPT`"
+msgid "`EIDRM`"
 msgstr ""
 
 #: src/api/reference.md:677
-msgid "`ENOSPC`"
+msgid "`EILSEQ`"
 msgstr ""
 
 #: src/api/reference.md:678
-msgid "`ENOSR`"
+msgid "`EINPROGRESS`"
 msgstr ""
 
 #: src/api/reference.md:679
-msgid "`ENOSTR`"
+msgid "`EINTR`"
 msgstr ""
 
 #: src/api/reference.md:680
-msgid "`ENOSYS`"
+msgid "`EINVAL`"
 msgstr ""
 
 #: src/api/reference.md:681
-msgid "`ENOTCONN`"
+msgid "`EIO`"
 msgstr ""
 
 #: src/api/reference.md:682
-msgid "`ENOTDIR`"
+msgid "`EISCONN`"
 msgstr ""
 
 #: src/api/reference.md:683
-msgid "`ENOTEMPTY`"
+msgid "`EISDIR`"
 msgstr ""
 
 #: src/api/reference.md:684
-msgid "`ENOTSOCK`"
+msgid "`ELOOP`"
 msgstr ""
 
 #: src/api/reference.md:685
-msgid "`ENOTSUP`"
+msgid "`EMFILE`"
 msgstr ""
 
 #: src/api/reference.md:686
-msgid "`ENOTTY`"
+msgid "`EMLINK`"
 msgstr ""
 
 #: src/api/reference.md:687
-msgid "`ENXIO`"
+msgid "`EMSGSIZE`"
 msgstr ""
 
 #: src/api/reference.md:688
-msgid "`EOPNOTSUPP`"
+msgid "`EMULTIHOP`"
 msgstr ""
 
 #: src/api/reference.md:689
-msgid "`EOVERFLOW`"
+msgid "`ENAMETOOLONG`"
 msgstr ""
 
 #: src/api/reference.md:690
-msgid "`EPERM`"
+msgid "`ENETDOWN`"
 msgstr ""
 
 #: src/api/reference.md:691
-msgid "`EPIPE`"
+msgid "`ENETRESET`"
 msgstr ""
 
 #: src/api/reference.md:692
-msgid "`EPROTO`"
+msgid "`ENETUNREACH`"
 msgstr ""
 
 #: src/api/reference.md:693
-msgid "`EPROTONOSUPPORT`"
+msgid "`ENFILE`"
 msgstr ""
 
 #: src/api/reference.md:694
-msgid "`EPROTOTYPE`"
+msgid "`ENGINE_METHOD_ALL`"
 msgstr ""
 
 #: src/api/reference.md:695
-msgid "`ERANGE`"
+msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr ""
 
 #: src/api/reference.md:696
-msgid "`EROFS`"
+msgid "`ENGINE_METHOD_DH`"
 msgstr ""
 
 #: src/api/reference.md:697
-msgid "`ESPIPE`"
+msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr ""
 
 #: src/api/reference.md:698
-msgid "`ESRCH`"
+msgid "`ENGINE_METHOD_DSA`"
 msgstr ""
 
 #: src/api/reference.md:699
-msgid "`ESTALE`"
+msgid "`ENGINE_METHOD_EC`"
 msgstr ""
 
 #: src/api/reference.md:700
-msgid "`ETIME`"
+msgid "`ENGINE_METHOD_NONE`"
 msgstr ""
 
 #: src/api/reference.md:701
-msgid "`ETIMEDOUT`"
+msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr ""
 
 #: src/api/reference.md:702
-msgid "`ETXTBSY`"
+msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr ""
 
 #: src/api/reference.md:703
-msgid "`EWOULDBLOCK`"
+msgid "`ENGINE_METHOD_RAND`"
 msgstr ""
 
 #: src/api/reference.md:704
-msgid "`EXDEV`"
+msgid "`ENGINE_METHOD_RSA`"
 msgstr ""
 
 #: src/api/reference.md:705
-msgid "`F_OK`"
+msgid "`ENOBUFS`"
 msgstr ""
 
 #: src/api/reference.md:706
-msgid "`OPENSSL_VERSION_NUMBER`"
+msgid "`ENODATA`"
 msgstr ""
 
 #: src/api/reference.md:707
-msgid "`O_APPEND`"
+msgid "`ENODEV`"
 msgstr ""
 
 #: src/api/reference.md:708
-msgid "`O_CREAT`"
+msgid "`ENOENT`"
 msgstr ""
 
 #: src/api/reference.md:709
-msgid "`O_DIRECT`"
+msgid "`ENOEXEC`"
 msgstr ""
 
 #: src/api/reference.md:710
-msgid "`O_DIRECTORY`"
+msgid "`ENOLCK`"
 msgstr ""
 
 #: src/api/reference.md:711
-msgid "`O_DSYNC`"
+msgid "`ENOLINK`"
 msgstr ""
 
 #: src/api/reference.md:712
-msgid "`O_EXCL`"
+msgid "`ENOMEM`"
 msgstr ""
 
 #: src/api/reference.md:713
-msgid "`O_NOATIME`"
+msgid "`ENOMSG`"
 msgstr ""
 
 #: src/api/reference.md:714
-msgid "`O_NOCTTY`"
+msgid "`ENOPROTOOPT`"
 msgstr ""
 
 #: src/api/reference.md:715
-msgid "`O_NOFOLLOW`"
+msgid "`ENOSPC`"
 msgstr ""
 
 #: src/api/reference.md:716
-msgid "`O_NONBLOCK`"
+msgid "`ENOSR`"
 msgstr ""
 
 #: src/api/reference.md:717
-msgid "`O_RDONLY`"
+msgid "`ENOSTR`"
 msgstr ""
 
 #: src/api/reference.md:718
-msgid "`O_RDWR`"
+msgid "`ENOSYS`"
 msgstr ""
 
 #: src/api/reference.md:719
-msgid "`O_SYMLINK`"
+msgid "`ENOTCONN`"
 msgstr ""
 
 #: src/api/reference.md:720
-msgid "`O_SYNC`"
+msgid "`ENOTDIR`"
 msgstr ""
 
 #: src/api/reference.md:721
-msgid "`O_TRUNC`"
+msgid "`ENOTEMPTY`"
 msgstr ""
 
 #: src/api/reference.md:722
-msgid "`O_WRONLY`"
+msgid "`ENOTSOCK`"
 msgstr ""
 
 #: src/api/reference.md:723
-msgid "`POINT_CONVERSION_COMPRESSED`"
+msgid "`ENOTSUP`"
 msgstr ""
 
 #: src/api/reference.md:724
-msgid "`POINT_CONVERSION_HYBRID`"
+msgid "`ENOTTY`"
 msgstr ""
 
 #: src/api/reference.md:725
-msgid "`POINT_CONVERSION_UNCOMPRESSED`"
+msgid "`ENXIO`"
 msgstr ""
 
 #: src/api/reference.md:726
-msgid "`PRIORITY_ABOVE_NORMAL`"
+msgid "`EOPNOTSUPP`"
 msgstr ""
 
 #: src/api/reference.md:727
-msgid "`PRIORITY_BELOW_NORMAL`"
+msgid "`EOVERFLOW`"
 msgstr ""
 
 #: src/api/reference.md:728
-msgid "`PRIORITY_HIGH`"
+msgid "`EPERM`"
 msgstr ""
 
 #: src/api/reference.md:729
-msgid "`PRIORITY_HIGHEST`"
+msgid "`EPIPE`"
 msgstr ""
 
 #: src/api/reference.md:730
-msgid "`PRIORITY_LOW`"
+msgid "`EPROTO`"
 msgstr ""
 
 #: src/api/reference.md:731
-msgid "`PRIORITY_NORMAL`"
+msgid "`EPROTONOSUPPORT`"
 msgstr ""
 
 #: src/api/reference.md:732
-msgid "`RSA_NO_PADDING`"
+msgid "`EPROTOTYPE`"
 msgstr ""
 
 #: src/api/reference.md:733
-msgid "`RSA_PKCS1_OAEP_PADDING`"
+msgid "`ERANGE`"
 msgstr ""
 
 #: src/api/reference.md:734
-msgid "`RSA_PKCS1_PADDING`"
+msgid "`EROFS`"
 msgstr ""
 
 #: src/api/reference.md:735
-msgid "`RSA_PKCS1_PSS_PADDING`"
+msgid "`ESPIPE`"
 msgstr ""
 
 #: src/api/reference.md:736
-msgid "`RSA_PSS_SALTLEN_AUTO`"
+msgid "`ESRCH`"
 msgstr ""
 
 #: src/api/reference.md:737
-msgid "`RSA_PSS_SALTLEN_DIGEST`"
+msgid "`ESTALE`"
 msgstr ""
 
 #: src/api/reference.md:738
-msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
+msgid "`ETIME`"
 msgstr ""
 
 #: src/api/reference.md:739
-msgid "`RSA_X931_PADDING`"
+msgid "`ETIMEDOUT`"
 msgstr ""
 
 #: src/api/reference.md:740
-msgid "`RTLD_DEEPBIND`"
+msgid "`ETXTBSY`"
 msgstr ""
 
 #: src/api/reference.md:741
-msgid "`RTLD_GLOBAL`"
+msgid "`EWOULDBLOCK`"
 msgstr ""
 
 #: src/api/reference.md:742
-msgid "`RTLD_LAZY`"
+msgid "`EXDEV`"
 msgstr ""
 
 #: src/api/reference.md:743
-msgid "`RTLD_LOCAL`"
+msgid "`F_OK`"
 msgstr ""
 
 #: src/api/reference.md:744
-msgid "`RTLD_NOW`"
+msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr ""
 
 #: src/api/reference.md:745
-msgid "`R_OK`"
+msgid "`O_APPEND`"
 msgstr ""
 
 #: src/api/reference.md:746
-msgid "`SIGABRT`"
+msgid "`O_CREAT`"
 msgstr ""
 
 #: src/api/reference.md:747
-msgid "`SIGALRM`"
+msgid "`O_DIRECT`"
 msgstr ""
 
 #: src/api/reference.md:748
-msgid "`SIGBUS`"
+msgid "`O_DIRECTORY`"
 msgstr ""
 
 #: src/api/reference.md:749
-msgid "`SIGCHLD`"
+msgid "`O_DSYNC`"
 msgstr ""
 
 #: src/api/reference.md:750
-msgid "`SIGCONT`"
+msgid "`O_EXCL`"
 msgstr ""
 
 #: src/api/reference.md:751
-msgid "`SIGFPE`"
+msgid "`O_NOATIME`"
 msgstr ""
 
 #: src/api/reference.md:752
-msgid "`SIGHUP`"
+msgid "`O_NOCTTY`"
 msgstr ""
 
 #: src/api/reference.md:753
-msgid "`SIGILL`"
+msgid "`O_NOFOLLOW`"
 msgstr ""
 
 #: src/api/reference.md:754
-msgid "`SIGINFO`"
+msgid "`O_NONBLOCK`"
 msgstr ""
 
 #: src/api/reference.md:755
-msgid "`SIGINT`"
+msgid "`O_RDONLY`"
 msgstr ""
 
 #: src/api/reference.md:756
-msgid "`SIGIO`"
+msgid "`O_RDWR`"
 msgstr ""
 
 #: src/api/reference.md:757
-msgid "`SIGIOT`"
+msgid "`O_SYMLINK`"
 msgstr ""
 
 #: src/api/reference.md:758
-msgid "`SIGKILL`"
+msgid "`O_SYNC`"
 msgstr ""
 
 #: src/api/reference.md:759
-msgid "`SIGPIPE`"
+msgid "`O_TRUNC`"
 msgstr ""
 
 #: src/api/reference.md:760
-msgid "`SIGPOLL`"
+msgid "`O_WRONLY`"
 msgstr ""
 
 #: src/api/reference.md:761
-msgid "`SIGPROF`"
+msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr ""
 
 #: src/api/reference.md:762
-msgid "`SIGPWR`"
+msgid "`POINT_CONVERSION_HYBRID`"
 msgstr ""
 
 #: src/api/reference.md:763
-msgid "`SIGQUIT`"
+msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr ""
 
 #: src/api/reference.md:764
-msgid "`SIGSEGV`"
+msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr ""
 
 #: src/api/reference.md:765
-msgid "`SIGSTKFLT`"
+msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr ""
 
 #: src/api/reference.md:766
-msgid "`SIGSTOP`"
+msgid "`PRIORITY_HIGH`"
 msgstr ""
 
 #: src/api/reference.md:767
-msgid "`SIGSYS`"
+msgid "`PRIORITY_HIGHEST`"
 msgstr ""
 
 #: src/api/reference.md:768
-msgid "`SIGTERM`"
+msgid "`PRIORITY_LOW`"
 msgstr ""
 
 #: src/api/reference.md:769
-msgid "`SIGTRAP`"
+msgid "`PRIORITY_NORMAL`"
 msgstr ""
 
 #: src/api/reference.md:770
-msgid "`SIGTSTP`"
+msgid "`RSA_NO_PADDING`"
 msgstr ""
 
 #: src/api/reference.md:771
-msgid "`SIGTTIN`"
+msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr ""
 
 #: src/api/reference.md:772
-msgid "`SIGTTOU`"
+msgid "`RSA_PKCS1_PADDING`"
 msgstr ""
 
 #: src/api/reference.md:773
-msgid "`SIGURG`"
+msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr ""
 
 #: src/api/reference.md:774
-msgid "`SIGUSR1`"
+msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr ""
 
 #: src/api/reference.md:775
-msgid "`SIGUSR2`"
+msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr ""
 
 #: src/api/reference.md:776
-msgid "`SIGVTALRM`"
+msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr ""
 
 #: src/api/reference.md:777
-msgid "`SIGWINCH`"
+msgid "`RSA_X931_PADDING`"
 msgstr ""
 
 #: src/api/reference.md:778
-msgid "`SIGXCPU`"
+msgid "`RTLD_DEEPBIND`"
 msgstr ""
 
 #: src/api/reference.md:779
-msgid "`SIGXFSZ`"
+msgid "`RTLD_GLOBAL`"
 msgstr ""
 
 #: src/api/reference.md:780
-msgid "`SSL_OP_ALL`"
+msgid "`RTLD_LAZY`"
 msgstr ""
 
 #: src/api/reference.md:781
-msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
+msgid "`RTLD_LOCAL`"
 msgstr ""
 
 #: src/api/reference.md:782
-msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
+msgid "`RTLD_NOW`"
 msgstr ""
 
 #: src/api/reference.md:783
-msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
+msgid "`R_OK`"
 msgstr ""
 
 #: src/api/reference.md:784
-msgid "`SSL_OP_CISCO_ANYCONNECT`"
+msgid "`SIGABRT`"
 msgstr ""
 
 #: src/api/reference.md:785
-msgid "`SSL_OP_COOKIE_EXCHANGE`"
+msgid "`SIGALRM`"
 msgstr ""
 
 #: src/api/reference.md:786
-msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
+msgid "`SIGBUS`"
 msgstr ""
 
 #: src/api/reference.md:787
-msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
+msgid "`SIGCHLD`"
 msgstr ""
 
 #: src/api/reference.md:788
-msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
+msgid "`SIGCONT`"
 msgstr ""
 
 #: src/api/reference.md:789
-msgid "`SSL_OP_NO_COMPRESSION`"
+msgid "`SIGFPE`"
 msgstr ""
 
 #: src/api/reference.md:790
-msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
+msgid "`SIGHUP`"
 msgstr ""
 
 #: src/api/reference.md:791
-msgid "`SSL_OP_NO_QUERY_MTU`"
+msgid "`SIGILL`"
 msgstr ""
 
 #: src/api/reference.md:792
-msgid "`SSL_OP_NO_RENEGOTIATION`"
+msgid "`SIGINFO`"
 msgstr ""
 
 #: src/api/reference.md:793
-msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
+msgid "`SIGINT`"
 msgstr ""
 
 #: src/api/reference.md:794
-msgid "`SSL_OP_NO_SSLv2`"
+msgid "`SIGIO`"
 msgstr ""
 
 #: src/api/reference.md:795
-msgid "`SSL_OP_NO_SSLv3`"
+msgid "`SIGIOT`"
 msgstr ""
 
 #: src/api/reference.md:796
-msgid "`SSL_OP_NO_TICKET`"
+msgid "`SIGKILL`"
 msgstr ""
 
 #: src/api/reference.md:797
-msgid "`SSL_OP_NO_TLSv1`"
+msgid "`SIGPIPE`"
 msgstr ""
 
 #: src/api/reference.md:798
-msgid "`SSL_OP_NO_TLSv1_1`"
+msgid "`SIGPOLL`"
 msgstr ""
 
 #: src/api/reference.md:799
-msgid "`SSL_OP_NO_TLSv1_2`"
+msgid "`SIGPROF`"
 msgstr ""
 
 #: src/api/reference.md:800
-msgid "`SSL_OP_NO_TLSv1_3`"
+msgid "`SIGPWR`"
 msgstr ""
 
 #: src/api/reference.md:801
-msgid "`SSL_OP_PRIORITIZE_CHACHA`"
+msgid "`SIGQUIT`"
 msgstr ""
 
 #: src/api/reference.md:802
-msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
+msgid "`SIGSEGV`"
 msgstr ""
 
 #: src/api/reference.md:803
-msgid "`S_IFBLK`"
+msgid "`SIGSTKFLT`"
 msgstr ""
 
 #: src/api/reference.md:804
-msgid "`S_IFCHR`"
+msgid "`SIGSTOP`"
 msgstr ""
 
 #: src/api/reference.md:805
-msgid "`S_IFDIR`"
+msgid "`SIGSYS`"
 msgstr ""
 
 #: src/api/reference.md:806
-msgid "`S_IFIFO`"
+msgid "`SIGTERM`"
 msgstr ""
 
 #: src/api/reference.md:807
-msgid "`S_IFLNK`"
+msgid "`SIGTRAP`"
 msgstr ""
 
 #: src/api/reference.md:808
-msgid "`S_IFMT`"
+msgid "`SIGTSTP`"
 msgstr ""
 
 #: src/api/reference.md:809
-msgid "`S_IFREG`"
+msgid "`SIGTTIN`"
 msgstr ""
 
 #: src/api/reference.md:810
-msgid "`S_IFSOCK`"
+msgid "`SIGTTOU`"
 msgstr ""
 
 #: src/api/reference.md:811
-msgid "`S_IRGRP`"
+msgid "`SIGURG`"
 msgstr ""
 
 #: src/api/reference.md:812
-msgid "`S_IROTH`"
+msgid "`SIGUSR1`"
 msgstr ""
 
 #: src/api/reference.md:813
-msgid "`S_IRUSR`"
+msgid "`SIGUSR2`"
 msgstr ""
 
 #: src/api/reference.md:814
-msgid "`S_IRWXG`"
+msgid "`SIGVTALRM`"
 msgstr ""
 
 #: src/api/reference.md:815
-msgid "`S_IRWXO`"
+msgid "`SIGWINCH`"
 msgstr ""
 
 #: src/api/reference.md:816
-msgid "`S_IRWXU`"
+msgid "`SIGXCPU`"
 msgstr ""
 
 #: src/api/reference.md:817
-msgid "`S_IWGRP`"
+msgid "`SIGXFSZ`"
 msgstr ""
 
 #: src/api/reference.md:818
-msgid "`S_IWOTH`"
+msgid "`SSL_OP_ALL`"
 msgstr ""
 
 #: src/api/reference.md:819
-msgid "`S_IWUSR`"
+msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr ""
 
 #: src/api/reference.md:820
-msgid "`S_IXGRP`"
+msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr ""
 
 #: src/api/reference.md:821
-msgid "`S_IXOTH`"
+msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr ""
 
 #: src/api/reference.md:822
-msgid "`S_IXUSR`"
+msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr ""
 
 #: src/api/reference.md:823
-msgid "`TLS1_1_VERSION`"
+msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr ""
 
 #: src/api/reference.md:824
-msgid "`TLS1_2_VERSION`"
+msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr ""
 
 #: src/api/reference.md:825
-msgid "`TLS1_3_VERSION`"
+msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr ""
 
 #: src/api/reference.md:826
-msgid "`TLS1_VERSION`"
+msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr ""
 
 #: src/api/reference.md:827
-msgid "`UV_DIRENT_BLOCK`"
+msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr ""
 
 #: src/api/reference.md:828
-msgid "`UV_DIRENT_CHAR`"
+msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr ""
 
 #: src/api/reference.md:829
-msgid "`UV_DIRENT_DIR`"
+msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr ""
 
 #: src/api/reference.md:830
-msgid "`UV_DIRENT_FIFO`"
+msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr ""
 
 #: src/api/reference.md:831
-msgid "`UV_DIRENT_FILE`"
+msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr ""
 
 #: src/api/reference.md:832
-msgid "`UV_DIRENT_LINK`"
+msgid "`SSL_OP_NO_SSLv2`"
 msgstr ""
 
 #: src/api/reference.md:833
-msgid "`UV_DIRENT_SOCKET`"
+msgid "`SSL_OP_NO_SSLv3`"
 msgstr ""
 
 #: src/api/reference.md:834
-msgid "`UV_DIRENT_UNKNOWN`"
+msgid "`SSL_OP_NO_TICKET`"
 msgstr ""
 
 #: src/api/reference.md:835
-msgid "`UV_FS_COPYFILE_EXCL`"
+msgid "`SSL_OP_NO_TLSv1`"
 msgstr ""
 
 #: src/api/reference.md:836
-msgid "`UV_FS_COPYFILE_FICLONE`"
+msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr ""
 
 #: src/api/reference.md:837
-msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
+msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr ""
 
 #: src/api/reference.md:838
-msgid "`UV_FS_O_FILEMAP`"
+msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr ""
 
 #: src/api/reference.md:839
-msgid "`UV_FS_SYMLINK_DIR`"
+msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr ""
 
 #: src/api/reference.md:840
-msgid "`UV_FS_SYMLINK_JUNCTION`"
+msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr ""
 
 #: src/api/reference.md:841
-msgid "`W_OK`"
+msgid "`S_IFBLK`"
 msgstr ""
 
 #: src/api/reference.md:842
-msgid "`X_OK`"
+msgid "`S_IFCHR`"
+msgstr ""
+
+#: src/api/reference.md:843
+msgid "`S_IFDIR`"
 msgstr ""
 
 #: src/api/reference.md:844
-msgid "`defaultCoreCipherList`"
+msgid "`S_IFIFO`"
+msgstr ""
+
+#: src/api/reference.md:845
+msgid "`S_IFLNK`"
 msgstr ""
 
 #: src/api/reference.md:846
-msgid "`cron`"
+msgid "`S_IFMT`"
+msgstr ""
+
+#: src/api/reference.md:847
+msgid "`S_IFREG`"
+msgstr ""
+
+#: src/api/reference.md:848
+msgid "`S_IFSOCK`"
+msgstr ""
+
+#: src/api/reference.md:849
+msgid "`S_IRGRP`"
 msgstr ""
 
 #: src/api/reference.md:850
-msgid "`CronJob`"
+msgid "`S_IROTH`"
 msgstr ""
 
-#: src/api/reference.md:854 src/api/reference.md:3596
-msgid "`describe` — module"
+#: src/api/reference.md:851
+msgid "`S_IRUSR`"
+msgstr ""
+
+#: src/api/reference.md:852
+msgid "`S_IRWXG`"
+msgstr ""
+
+#: src/api/reference.md:853
+msgid "`S_IRWXO`"
+msgstr ""
+
+#: src/api/reference.md:854
+msgid "`S_IRWXU`"
 msgstr ""
 
 #: src/api/reference.md:855
-msgid "`isRunning` — instance"
+msgid "`S_IWGRP`"
 msgstr ""
 
 #: src/api/reference.md:856
-msgid "`nextDate` — instance"
+msgid "`S_IWOTH`"
 msgstr ""
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
-msgid "`schedule` — module"
+#: src/api/reference.md:857
+msgid "`S_IWUSR`"
 msgstr ""
 
 #: src/api/reference.md:858
-msgid "`start` — instance"
+msgid "`S_IXGRP`"
 msgstr ""
 
 #: src/api/reference.md:859
-msgid "`stop` — instance"
+msgid "`S_IXOTH`"
 msgstr ""
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
-msgid "`validate` — module"
+#: src/api/reference.md:860
+msgid "`S_IXUSR`"
 msgstr ""
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
-msgid "`crypto`"
+#: src/api/reference.md:861
+msgid "`TLS1_1_VERSION`"
+msgstr ""
+
+#: src/api/reference.md:862
+msgid "`TLS1_2_VERSION`"
+msgstr ""
+
+#: src/api/reference.md:863
+msgid "`TLS1_3_VERSION`"
+msgstr ""
+
+#: src/api/reference.md:864
+msgid "`TLS1_VERSION`"
+msgstr ""
+
+#: src/api/reference.md:865
+msgid "`UV_DIRENT_BLOCK`"
 msgstr ""
 
 #: src/api/reference.md:866
-msgid "`Cipheriv`"
+msgid "`UV_DIRENT_CHAR`"
 msgstr ""
 
 #: src/api/reference.md:867
-msgid "`Decipheriv`"
+msgid "`UV_DIRENT_DIR`"
 msgstr ""
 
 #: src/api/reference.md:868
-msgid "`DiffieHellman`"
+msgid "`UV_DIRENT_FIFO`"
 msgstr ""
 
 #: src/api/reference.md:869
-msgid "`DiffieHellmanGroup`"
+msgid "`UV_DIRENT_FILE`"
 msgstr ""
 
 #: src/api/reference.md:870
-msgid "`ECDH`"
+msgid "`UV_DIRENT_LINK`"
 msgstr ""
 
 #: src/api/reference.md:871
-msgid "`KeyObject`"
+msgid "`UV_DIRENT_SOCKET`"
 msgstr ""
 
 #: src/api/reference.md:872
-msgid "`X509Certificate`"
+msgid "`UV_DIRENT_UNKNOWN`"
+msgstr ""
+
+#: src/api/reference.md:873
+msgid "`UV_FS_COPYFILE_EXCL`"
+msgstr ""
+
+#: src/api/reference.md:874
+msgid "`UV_FS_COPYFILE_FICLONE`"
+msgstr ""
+
+#: src/api/reference.md:875
+msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr ""
 
 #: src/api/reference.md:876
-msgid "`Hash` — module"
+msgid "`UV_FS_O_FILEMAP`"
 msgstr ""
 
 #: src/api/reference.md:877
-msgid "`Hmac` — module"
+msgid "`UV_FS_SYMLINK_DIR`"
 msgstr ""
 
 #: src/api/reference.md:878
-msgid "`Sign` — module"
+msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr ""
 
 #: src/api/reference.md:879
-msgid "`Verify` — module"
+msgid "`W_OK`"
 msgstr ""
 
 #: src/api/reference.md:880
-msgid "`argon2` — module"
-msgstr ""
-
-#: src/api/reference.md:881
-msgid "`argon2Sync` — module"
+msgid "`X_OK`"
 msgstr ""
 
 #: src/api/reference.md:882
-msgid "`checkPrime` — module"
-msgstr ""
-
-#: src/api/reference.md:883
-msgid "`checkPrimeSync` — module"
+msgid "`defaultCoreCipherList`"
 msgstr ""
 
 #: src/api/reference.md:884
-msgid "`createCipheriv` — module"
-msgstr ""
-
-#: src/api/reference.md:885
-msgid "`createDecipheriv` — module"
-msgstr ""
-
-#: src/api/reference.md:886
-msgid "`createDiffieHellman` — module"
-msgstr ""
-
-#: src/api/reference.md:887
-msgid "`createDiffieHellmanGroup` — module"
+msgid "`cron`"
 msgstr ""
 
 #: src/api/reference.md:888
-msgid "`createECDH` — module"
+msgid "`CronJob`"
 msgstr ""
 
-#: src/api/reference.md:889
-msgid "`createHash` — module"
-msgstr ""
-
-#: src/api/reference.md:890
-msgid "`createHmac` — module"
-msgstr ""
-
-#: src/api/reference.md:891
-msgid "`createPrivateKey` — module"
-msgstr ""
-
-#: src/api/reference.md:892
-msgid "`createPublicKey` — module"
+#: src/api/reference.md:892 src/api/reference.md:3634
+msgid "`describe` — module"
 msgstr ""
 
 #: src/api/reference.md:893
-msgid "`createSecretKey` — module"
+msgid "`isRunning` — instance"
 msgstr ""
 
-#: src/api/reference.md:894 src/api/reference.md:895
-msgid "`createSign` — module"
+#: src/api/reference.md:894
+msgid "`nextDate` — instance"
 msgstr ""
 
-#: src/api/reference.md:896 src/api/reference.md:897
-msgid "`createVerify` — module"
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
+msgid "`schedule` — module"
 msgstr ""
 
-#: src/api/reference.md:898
-msgid "`decapsulate` — module"
+#: src/api/reference.md:896
+msgid "`start` — instance"
 msgstr ""
 
-#: src/api/reference.md:899
-msgid "`diffieHellman` — module"
+#: src/api/reference.md:897
+msgid "`stop` — instance"
 msgstr ""
 
-#: src/api/reference.md:900
-msgid "`encapsulate` — module"
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
+msgid "`validate` — module"
 msgstr ""
 
-#: src/api/reference.md:901
-msgid "`generateKey` — module"
+#: src/api/reference.md:900 src/cli/capabilities.md:52
+msgid "`crypto`"
 msgstr ""
 
-#: src/api/reference.md:902 src/api/reference.md:2337
-msgid "`generateKeyPair` — module"
-msgstr ""
-
-#: src/api/reference.md:903 src/api/reference.md:904
-msgid "`generateKeyPairSync` — module"
+#: src/api/reference.md:904
+msgid "`Cipheriv`"
 msgstr ""
 
 #: src/api/reference.md:905
-msgid "`generateKeySync` — module"
+msgid "`Decipheriv`"
 msgstr ""
 
 #: src/api/reference.md:906
-msgid "`generatePrime` — module"
+msgid "`DiffieHellman`"
 msgstr ""
 
 #: src/api/reference.md:907
-msgid "`generatePrimeSync` — module"
+msgid "`DiffieHellmanGroup`"
 msgstr ""
 
 #: src/api/reference.md:908
-msgid "`getCipherInfo` — module"
+msgid "`ECDH`"
 msgstr ""
 
-#: src/api/reference.md:909 src/api/reference.md:3688
-msgid "`getCiphers` — module"
+#: src/api/reference.md:909
+msgid "`KeyObject`"
 msgstr ""
 
 #: src/api/reference.md:910
-msgid "`getCurves` — module"
-msgstr ""
-
-#: src/api/reference.md:911
-msgid "`getDiffieHellman` — module"
-msgstr ""
-
-#: src/api/reference.md:912
-msgid "`getFips` — module"
-msgstr ""
-
-#: src/api/reference.md:913
-msgid "`getHashes` — module"
+msgid "`X509Certificate`"
 msgstr ""
 
 #: src/api/reference.md:914
-msgid "`getRandomValues` — module"
+msgid "`Hash` — module"
+msgstr ""
+
+#: src/api/reference.md:915
+msgid "`Hmac` — module"
 msgstr ""
 
 #: src/api/reference.md:916
-msgid "`hkdf` — module"
+msgid "`Sign` — module"
 msgstr ""
 
 #: src/api/reference.md:917
-msgid "`hkdfSync` — module"
+msgid "`Verify` — module"
 msgstr ""
 
 #: src/api/reference.md:918
-msgid "`pbkdf2` — module"
+msgid "`argon2` — module"
 msgstr ""
 
 #: src/api/reference.md:919
-msgid "`pbkdf2Sync` — module"
+msgid "`argon2Sync` — module"
 msgstr ""
 
 #: src/api/reference.md:920
-msgid "`privateDecrypt` — module"
+msgid "`checkPrime` — module"
 msgstr ""
 
 #: src/api/reference.md:921
-msgid "`privateEncrypt` — module"
+msgid "`checkPrimeSync` — module"
 msgstr ""
 
 #: src/api/reference.md:922
-msgid "`publicDecrypt` — module"
+msgid "`createCipheriv` — module"
 msgstr ""
 
 #: src/api/reference.md:923
-msgid "`publicEncrypt` — module"
+msgid "`createDecipheriv` — module"
 msgstr ""
 
 #: src/api/reference.md:924
-msgid "`randomBytes` — module"
+msgid "`createDiffieHellman` — module"
 msgstr ""
 
 #: src/api/reference.md:925
-msgid "`randomFill` — module"
+msgid "`createDiffieHellmanGroup` — module"
 msgstr ""
 
 #: src/api/reference.md:926
-msgid "`randomFillSync` — module"
+msgid "`createECDH` — module"
 msgstr ""
 
-#: src/api/reference.md:927 src/api/reference.md:928
-msgid "`randomInt` — module"
+#: src/api/reference.md:927
+msgid "`createHash` — module"
+msgstr ""
+
+#: src/api/reference.md:928
+msgid "`createHmac` — module"
 msgstr ""
 
 #: src/api/reference.md:929
-msgid "`randomUUID` — module"
+msgid "`createPrivateKey` — module"
 msgstr ""
 
 #: src/api/reference.md:930
-msgid "`scrypt` — module"
+msgid "`createPublicKey` — module"
 msgstr ""
 
 #: src/api/reference.md:931
-msgid "`scryptSync` — module"
+msgid "`createSecretKey` — module"
 msgstr ""
 
-#: src/api/reference.md:932
-msgid "`secureHeapUsed` — module"
+#: src/api/reference.md:932 src/api/reference.md:933
+msgid "`createSign` — module"
 msgstr ""
 
-#: src/api/reference.md:933
-msgid "`setFips` — module"
+#: src/api/reference.md:934 src/api/reference.md:935
+msgid "`createVerify` — module"
 msgstr ""
 
-#: src/api/reference.md:934 src/api/reference.md:1988
-msgid "`sign` — module"
+#: src/api/reference.md:936
+msgid "`decapsulate` — module"
 msgstr ""
 
-#: src/api/reference.md:935
-msgid "`timingSafeEqual` — module"
+#: src/api/reference.md:937
+msgid "`diffieHellman` — module"
 msgstr ""
 
-#: src/api/reference.md:940
-msgid "`Certificate`"
+#: src/api/reference.md:938
+msgid "`encapsulate` — module"
 msgstr ""
 
-#: src/api/reference.md:942
-msgid "`subtle`"
+#: src/api/reference.md:939
+msgid "`generateKey` — module"
+msgstr ""
+
+#: src/api/reference.md:940 src/api/reference.md:2375
+msgid "`generateKeyPair` — module"
+msgstr ""
+
+#: src/api/reference.md:941 src/api/reference.md:942
+msgid "`generateKeyPairSync` — module"
 msgstr ""
 
 #: src/api/reference.md:943
-msgid "`webcrypto`"
+msgid "`generateKeySync` — module"
+msgstr ""
+
+#: src/api/reference.md:944
+msgid "`generatePrime` — module"
 msgstr ""
 
 #: src/api/reference.md:945
-msgid "`date-fns`"
+msgid "`generatePrimeSync` — module"
+msgstr ""
+
+#: src/api/reference.md:946
+msgid "`getCipherInfo` — module"
+msgstr ""
+
+#: src/api/reference.md:947 src/api/reference.md:3726
+msgid "`getCiphers` — module"
+msgstr ""
+
+#: src/api/reference.md:948
+msgid "`getCurves` — module"
 msgstr ""
 
 #: src/api/reference.md:949
-msgid "`addDays` — module"
+msgid "`getDiffieHellman` — module"
 msgstr ""
 
 #: src/api/reference.md:950
-msgid "`addMonths` — module"
+msgid "`getFips` — module"
 msgstr ""
 
 #: src/api/reference.md:951
-msgid "`addYears` — module"
+msgid "`getHashes` — module"
 msgstr ""
 
 #: src/api/reference.md:952
-msgid "`differenceInDays` — module"
-msgstr ""
-
-#: src/api/reference.md:953
-msgid "`differenceInHours` — module"
+msgid "`getRandomValues` — module"
 msgstr ""
 
 #: src/api/reference.md:954
-msgid "`differenceInMinutes` — module"
+msgid "`hkdf` — module"
 msgstr ""
 
 #: src/api/reference.md:955
-msgid "`endOfDay` — module"
+msgid "`hkdfSync` — module"
 msgstr ""
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
-msgid "`format` — module"
+#: src/api/reference.md:956
+msgid "`pbkdf2` — module"
 msgstr ""
 
 #: src/api/reference.md:957
-msgid "`isAfter` — module"
+msgid "`pbkdf2Sync` — module"
 msgstr ""
 
 #: src/api/reference.md:958
-msgid "`isBefore` — module"
+msgid "`privateDecrypt` — module"
 msgstr ""
 
 #: src/api/reference.md:959
-msgid "`parseISO` — module"
+msgid "`privateEncrypt` — module"
 msgstr ""
 
 #: src/api/reference.md:960
-msgid "`startOfDay` — module"
+msgid "`publicDecrypt` — module"
+msgstr ""
+
+#: src/api/reference.md:961
+msgid "`publicEncrypt` — module"
 msgstr ""
 
 #: src/api/reference.md:962
-msgid "`dayjs`"
+msgid "`randomBytes` — module"
 msgstr ""
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
-msgid "`add` — instance"
+#: src/api/reference.md:963
+msgid "`randomFill` — module"
 msgstr ""
 
-#: src/api/reference.md:967 src/api/reference.md:2087
-msgid "`clone` — instance"
+#: src/api/reference.md:964
+msgid "`randomFillSync` — module"
 msgstr ""
 
-#: src/api/reference.md:968 src/api/reference.md:2088
-msgid "`date` — instance"
+#: src/api/reference.md:965 src/api/reference.md:966
+msgid "`randomInt` — module"
 msgstr ""
 
-#: src/api/reference.md:969 src/api/reference.md:2089
-msgid "`day` — instance"
+#: src/api/reference.md:967
+msgid "`randomUUID` — module"
+msgstr ""
+
+#: src/api/reference.md:968
+msgid "`scrypt` — module"
+msgstr ""
+
+#: src/api/reference.md:969
+msgid "`scryptSync` — module"
 msgstr ""
 
 #: src/api/reference.md:970
-msgid "`dayjs` — module"
+msgid "`secureHeapUsed` — module"
 msgstr ""
 
-#: src/api/reference.md:972 src/api/reference.md:2091
-msgid "`diff` — instance"
+#: src/api/reference.md:971
+msgid "`setFips` — module"
 msgstr ""
 
-#: src/api/reference.md:973 src/api/reference.md:2092
-msgid "`endOf` — instance"
+#: src/api/reference.md:972 src/api/reference.md:2026
+msgid "`sign` — module"
 msgstr ""
 
-#: src/api/reference.md:974 src/api/reference.md:2093
-msgid "`format` — instance"
+#: src/api/reference.md:973
+msgid "`timingSafeEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:975 src/api/reference.md:2095
-msgid "`hour` — instance"
+#: src/api/reference.md:978
+msgid "`Certificate`"
 msgstr ""
 
-#: src/api/reference.md:976 src/api/reference.md:2096
-msgid "`isAfter` — instance"
+#: src/api/reference.md:980
+msgid "`subtle`"
 msgstr ""
 
-#: src/api/reference.md:977 src/api/reference.md:2097
-msgid "`isBefore` — instance"
+#: src/api/reference.md:981
+msgid "`webcrypto`"
 msgstr ""
 
-#: src/api/reference.md:978 src/api/reference.md:2099
-msgid "`isSame` — instance"
+#: src/api/reference.md:983
+msgid "`date-fns`"
 msgstr ""
 
-#: src/api/reference.md:979 src/api/reference.md:2100
-msgid "`isValid` — instance"
+#: src/api/reference.md:987
+msgid "`addDays` — module"
 msgstr ""
 
-#: src/api/reference.md:980 src/api/reference.md:2101
-msgid "`millisecond` — instance"
+#: src/api/reference.md:988
+msgid "`addMonths` — module"
 msgstr ""
 
-#: src/api/reference.md:981 src/api/reference.md:2102
-msgid "`minute` — instance"
+#: src/api/reference.md:989
+msgid "`addYears` — module"
 msgstr ""
 
-#: src/api/reference.md:982 src/api/reference.md:2104
-msgid "`month` — instance"
-msgstr ""
-
-#: src/api/reference.md:983 src/api/reference.md:2105
-msgid "`second` — instance"
-msgstr ""
-
-#: src/api/reference.md:984 src/api/reference.md:2106
-msgid "`startOf` — instance"
-msgstr ""
-
-#: src/api/reference.md:985 src/api/reference.md:2107
-msgid "`subtract` — instance"
-msgstr ""
-
-#: src/api/reference.md:986 src/api/reference.md:2109
-msgid "`toISOString` — instance"
-msgstr ""
-
-#: src/api/reference.md:987 src/api/reference.md:2110
-msgid "`unix` — instance"
-msgstr ""
-
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
-msgid "`valueOf` — instance"
-msgstr ""
-
-#: src/api/reference.md:989 src/api/reference.md:2112
-msgid "`year` — instance"
+#: src/api/reference.md:990
+msgid "`differenceInDays` — module"
 msgstr ""
 
 #: src/api/reference.md:991
-msgid "`decimal.js`"
+msgid "`differenceInHours` — module"
+msgstr ""
+
+#: src/api/reference.md:992
+msgid "`differenceInMinutes` — module"
+msgstr ""
+
+#: src/api/reference.md:993
+msgid "`endOfDay` — module"
+msgstr ""
+
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
+msgid "`format` — module"
 msgstr ""
 
 #: src/api/reference.md:995
-msgid "`abs` — instance"
+msgid "`isAfter` — module"
 msgstr ""
 
 #: src/api/reference.md:996
-msgid "`ceil` — instance"
+msgid "`isBefore` — module"
 msgstr ""
 
 #: src/api/reference.md:997
-msgid "`cmp` — instance"
+msgid "`parseISO` — module"
 msgstr ""
 
 #: src/api/reference.md:998
-msgid "`div` — instance"
+msgid "`startOfDay` — module"
 msgstr ""
 
 #: src/api/reference.md:1000
-msgid "`floor` — instance"
+msgid "`dayjs`"
 msgstr ""
 
-#: src/api/reference.md:1001
-msgid "`gt` — instance"
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
+msgid "`add` — instance"
 msgstr ""
 
-#: src/api/reference.md:1002
-msgid "`gte` — instance"
+#: src/api/reference.md:1005 src/api/reference.md:2125
+msgid "`clone` — instance"
 msgstr ""
 
-#: src/api/reference.md:1003
-msgid "`isNegative` — instance"
+#: src/api/reference.md:1006 src/api/reference.md:2126
+msgid "`date` — instance"
 msgstr ""
 
-#: src/api/reference.md:1004
-msgid "`isPositive` — instance"
-msgstr ""
-
-#: src/api/reference.md:1005
-msgid "`isZero` — instance"
-msgstr ""
-
-#: src/api/reference.md:1006
-msgid "`lt` — instance"
-msgstr ""
-
-#: src/api/reference.md:1007
-msgid "`lte` — instance"
+#: src/api/reference.md:1007 src/api/reference.md:2127
+msgid "`day` — instance"
 msgstr ""
 
 #: src/api/reference.md:1008
-msgid "`minus` — instance"
+msgid "`dayjs` — module"
 msgstr ""
 
-#: src/api/reference.md:1009
-msgid "`mod` — instance"
+#: src/api/reference.md:1010 src/api/reference.md:2129
+msgid "`diff` — instance"
 msgstr ""
 
-#: src/api/reference.md:1010
-msgid "`neg` — instance"
+#: src/api/reference.md:1011 src/api/reference.md:2130
+msgid "`endOf` — instance"
 msgstr ""
 
-#: src/api/reference.md:1011
-msgid "`plus` — instance"
+#: src/api/reference.md:1012 src/api/reference.md:2131
+msgid "`format` — instance"
 msgstr ""
 
-#: src/api/reference.md:1012
-msgid "`pow` — instance"
+#: src/api/reference.md:1013 src/api/reference.md:2133
+msgid "`hour` — instance"
 msgstr ""
 
-#: src/api/reference.md:1013
-msgid "`round` — instance"
+#: src/api/reference.md:1014 src/api/reference.md:2134
+msgid "`isAfter` — instance"
 msgstr ""
 
-#: src/api/reference.md:1014
-msgid "`sqrt` — instance"
+#: src/api/reference.md:1015 src/api/reference.md:2135
+msgid "`isBefore` — instance"
 msgstr ""
 
-#: src/api/reference.md:1015
-msgid "`times` — instance"
+#: src/api/reference.md:1016 src/api/reference.md:2137
+msgid "`isSame` — instance"
 msgstr ""
 
-#: src/api/reference.md:1016
-msgid "`toFixed` — instance"
+#: src/api/reference.md:1017 src/api/reference.md:2138
+msgid "`isValid` — instance"
 msgstr ""
 
-#: src/api/reference.md:1017
-msgid "`toNumber` — instance"
+#: src/api/reference.md:1018 src/api/reference.md:2139
+msgid "`millisecond` — instance"
 msgstr ""
 
-#: src/api/reference.md:1018
-msgid "`toString` — instance"
+#: src/api/reference.md:1019 src/api/reference.md:2140
+msgid "`minute` — instance"
 msgstr ""
 
-#: src/api/reference.md:1021
-msgid "`dgram`"
+#: src/api/reference.md:1020 src/api/reference.md:2142
+msgid "`month` — instance"
 msgstr ""
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
-msgid "`Socket`"
+#: src/api/reference.md:1021 src/api/reference.md:2143
+msgid "`second` — instance"
 msgstr ""
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
-msgid "`Socket` — module"
+#: src/api/reference.md:1022 src/api/reference.md:2144
+msgid "`startOf` — instance"
 msgstr ""
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
-msgid "`addListener` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1023 src/api/reference.md:2145
+msgid "`subtract` — instance"
 msgstr ""
 
-#: src/api/reference.md:1031
-msgid "`addMembership` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1024 src/api/reference.md:2147
+msgid "`toISOString` — instance"
 msgstr ""
 
-#: src/api/reference.md:1032
-msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1025 src/api/reference.md:2148
+msgid "`unix` — instance"
 msgstr ""
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
-msgid "`address` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
+msgid "`valueOf` — instance"
+msgstr ""
+
+#: src/api/reference.md:1027 src/api/reference.md:2150
+msgid "`year` — instance"
+msgstr ""
+
+#: src/api/reference.md:1029
+msgid "`decimal.js`"
+msgstr ""
+
+#: src/api/reference.md:1033
+msgid "`abs` — instance"
 msgstr ""
 
 #: src/api/reference.md:1034
-msgid "`bind` — instance _(class: `Socket`)_"
+msgid "`ceil` — instance"
 msgstr ""
 
 #: src/api/reference.md:1035
-msgid "`close` — instance _(class: `Socket`)_"
+msgid "`cmp` — instance"
 msgstr ""
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
-msgid "`connect` — instance _(class: `Socket`)_"
-msgstr ""
-
-#: src/api/reference.md:1037
-msgid "`createSocket` — module"
+#: src/api/reference.md:1036
+msgid "`div` — instance"
 msgstr ""
 
 #: src/api/reference.md:1038
-msgid "`disconnect` — instance _(class: `Socket`)_"
+msgid "`floor` — instance"
 msgstr ""
 
 #: src/api/reference.md:1039
-msgid "`dropMembership` — instance _(class: `Socket`)_"
+msgid "`gt` — instance"
 msgstr ""
 
 #: src/api/reference.md:1040
-msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
+msgid "`gte` — instance"
 msgstr ""
 
 #: src/api/reference.md:1041
-msgid "`emit` — instance _(class: `Socket`)_"
+msgid "`isNegative` — instance"
 msgstr ""
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
-msgid "`eventNames` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1042
+msgid "`isPositive` — instance"
 msgstr ""
 
 #: src/api/reference.md:1043
-msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
+msgid "`isZero` — instance"
 msgstr ""
 
 #: src/api/reference.md:1044
-msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
+msgid "`lt` — instance"
 msgstr ""
 
 #: src/api/reference.md:1045
-msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
+msgid "`lte` — instance"
 msgstr ""
 
 #: src/api/reference.md:1046
-msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
+msgid "`minus` — instance"
 msgstr ""
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
-msgid "`listenerCount` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1047
+msgid "`mod` — instance"
 msgstr ""
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
-msgid "`off` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1048
+msgid "`neg` — instance"
 msgstr ""
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
-msgid "`on` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1049
+msgid "`plus` — instance"
 msgstr ""
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
-msgid "`once` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1050
+msgid "`pow` — instance"
 msgstr ""
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
-msgid "`ref` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1051
+msgid "`round` — instance"
 msgstr ""
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
-msgid "`remoteAddress` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1052
+msgid "`sqrt` — instance"
 msgstr ""
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
-msgid "`removeListener` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1053
+msgid "`times` — instance"
 msgstr ""
 
 #: src/api/reference.md:1054
-msgid "`send` — instance _(class: `Socket`)_"
+msgid "`toFixed` — instance"
 msgstr ""
 
 #: src/api/reference.md:1055
-msgid "`sendto` — instance _(class: `Socket`)_"
+msgid "`toNumber` — instance"
 msgstr ""
 
 #: src/api/reference.md:1056
-msgid "`setBroadcast` — instance _(class: `Socket`)_"
-msgstr ""
-
-#: src/api/reference.md:1057
-msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
-msgstr ""
-
-#: src/api/reference.md:1058
-msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
+msgid "`toString` — instance"
 msgstr ""
 
 #: src/api/reference.md:1059
-msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
+msgid "`dgram`"
 msgstr ""
 
-#: src/api/reference.md:1060
-msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1063 src/api/reference.md:2231
+msgid "`Socket`"
 msgstr ""
 
-#: src/api/reference.md:1061
-msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1067 src/api/reference.md:2239
+msgid "`Socket` — module"
 msgstr ""
 
-#: src/api/reference.md:1062
-msgid "`setTTL` — instance _(class: `Socket`)_"
-msgstr ""
-
-#: src/api/reference.md:1063 src/api/reference.md:2304
-msgid "`unref` — instance _(class: `Socket`)_"
+#: src/api/reference.md:1068 src/api/reference.md:2247
+msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr ""
 
 #: src/api/reference.md:1069
-msgid "`diagnostics_channel`"
+msgid "`addMembership` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1070
+msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1071 src/api/reference.md:2251
+msgid "`address` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1072
+msgid "`bind` — instance _(class: `Socket`)_"
 msgstr ""
 
 #: src/api/reference.md:1073
-msgid "`BoundedChannel`"
+msgid "`close` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:1074
-msgid "`Channel`"
+#: src/api/reference.md:1074 src/api/reference.md:2261
+msgid "`connect` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1075
+msgid "`createSocket` — module"
+msgstr ""
+
+#: src/api/reference.md:1076
+msgid "`disconnect` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1077
+msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr ""
 
 #: src/api/reference.md:1078
-msgid "`boundedChannel` — module"
+msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr ""
 
 #: src/api/reference.md:1079
-msgid "`channel` — module"
+msgid "`emit` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:1080
-msgid "`hasSubscribers` — module"
+#: src/api/reference.md:1080 src/api/reference.md:2270
+msgid "`eventNames` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1081
+msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr ""
 
 #: src/api/reference.md:1082
+msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1083
+msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1084
+msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1085 src/api/reference.md:2297
+msgid "`listenerCount` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1086 src/api/reference.md:2306
+msgid "`off` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1087 src/api/reference.md:2308
+msgid "`on` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1088 src/api/reference.md:2309
+msgid "`once` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1089 src/api/reference.md:2318
+msgid "`ref` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1090 src/api/reference.md:2319
+msgid "`remoteAddress` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1091 src/api/reference.md:2324
+msgid "`removeListener` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1092
+msgid "`send` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1093
+msgid "`sendto` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1094
+msgid "`setBroadcast` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1095
+msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1096
+msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1097
+msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1098
+msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1099
+msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1100
+msgid "`setTTL` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1101 src/api/reference.md:2342
+msgid "`unref` — instance _(class: `Socket`)_"
+msgstr ""
+
+#: src/api/reference.md:1107
+msgid "`diagnostics_channel`"
+msgstr ""
+
+#: src/api/reference.md:1111
+msgid "`BoundedChannel`"
+msgstr ""
+
+#: src/api/reference.md:1112
+msgid "`Channel`"
+msgstr ""
+
+#: src/api/reference.md:1116
+msgid "`boundedChannel` — module"
+msgstr ""
+
+#: src/api/reference.md:1117
+msgid "`channel` — module"
+msgstr ""
+
+#: src/api/reference.md:1118
+msgid "`hasSubscribers` — module"
+msgstr ""
+
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr ""
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr ""
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr ""
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr ""
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr ""
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr ""
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr ""
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr ""
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr ""
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr ""
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr ""
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr ""
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr ""
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr ""
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr ""
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr ""
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr ""
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr ""
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr ""
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr ""
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr ""
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr ""
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr ""
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr ""
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr ""
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr ""
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr ""
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr ""
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr ""
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr ""
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr ""
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr ""
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr ""
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr ""
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr ""
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr ""
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr ""
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr ""
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr ""
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr ""
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr ""
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr ""
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr ""
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr ""
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr ""
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr ""
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr ""
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr ""
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr ""
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr ""
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr ""
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr ""
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr ""
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr ""
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr ""
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr ""
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr ""
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr ""
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr ""
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr ""
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr ""
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr ""
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr ""
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr ""
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr ""
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr ""
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr ""
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr ""
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr ""
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr ""
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr ""
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr ""
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr ""
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr ""
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr ""
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr ""
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr ""
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr ""
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr ""
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr ""
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr ""
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr ""
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr ""
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr ""
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr ""
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr ""
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr ""
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr ""
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr ""
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr ""
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr ""
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr ""
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr ""
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr ""
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr ""
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr ""
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr ""
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr ""
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr ""
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr ""
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr ""
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr ""
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr ""
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr ""
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr ""
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr ""
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr ""
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr ""
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr ""
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr ""
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr ""
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr ""
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr ""
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr ""
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr ""
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr ""
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr ""
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr ""
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr ""
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr ""
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr ""
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr ""
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr ""
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr ""
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr ""
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr ""
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr ""
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr ""
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr ""
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr ""
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr ""
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr ""
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr ""
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr ""
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr ""
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr ""
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr ""
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr ""
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr ""
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr ""
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr ""
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr ""
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr ""
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr ""
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr ""
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr ""
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr ""
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr ""
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr ""
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr ""
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr ""
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr ""
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr ""
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr ""
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr ""
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr ""
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr ""
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr ""
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr ""
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr ""
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr ""
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr ""
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr ""
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr ""
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr ""
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr ""
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr ""
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr ""
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr ""
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr ""
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr ""
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr ""
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr ""
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr ""
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr ""
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr ""
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr ""
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr ""
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr ""
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr ""
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr ""
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr ""
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr ""
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr ""
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr ""
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr ""
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr ""
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr ""
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr ""
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr ""
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr ""
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr ""
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr ""
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr ""
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr ""
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr ""
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr ""
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr ""
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr ""
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr ""
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr ""
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr ""
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr ""
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr ""
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr ""
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr ""
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr ""
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr ""
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr ""
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr ""
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr ""
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr ""
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr ""
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr ""
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr ""
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr ""
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr ""
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr ""
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr ""
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr ""
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr ""
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr ""
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr ""
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr ""
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr ""
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr ""
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr ""
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr ""
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr ""
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr ""
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr ""
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr ""
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr ""
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr ""
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr ""
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr ""
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr ""
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr ""
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr ""
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr ""
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr ""
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr ""
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr ""
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
 msgstr ""
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
 "Inspector error -32601 (#4916)"
 msgstr ""
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
 msgstr ""
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
 msgstr ""
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr ""
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr ""
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr ""
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr ""
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr ""
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr ""
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr ""
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr ""
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr ""
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr ""
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr ""
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr ""
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr ""
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr ""
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr ""
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr ""
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr ""
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr ""
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr ""
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr ""
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr ""
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr ""
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr ""
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr ""
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr ""
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr ""
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr ""
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr ""
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr ""
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr ""
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr ""
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr ""
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr ""
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr ""
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr ""
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr ""
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr ""
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr ""
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr ""
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr ""
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr ""
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr ""
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr ""
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr ""
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr ""
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr ""
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr ""
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr ""
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr ""
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr ""
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr ""
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr ""
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr ""
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr ""
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr ""
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr ""
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr ""
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr ""
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr ""
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr ""
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr ""
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr ""
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr ""
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr ""
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr ""
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr ""
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr ""
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr ""
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr ""
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr ""
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr ""
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr ""
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr ""
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr ""
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr ""
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr ""
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr ""
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr ""
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr ""
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr ""
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr ""
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr ""
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr ""
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr ""
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr ""
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr ""
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr ""
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr ""
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr ""
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr ""
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr ""
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr ""
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr ""
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr ""
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr ""
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr ""
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr ""
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr ""
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr ""
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr ""
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr ""
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr ""
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr ""
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr ""
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr ""
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr ""
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr ""
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr ""
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr ""
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr ""
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr ""
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr ""
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr ""
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr ""
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr ""
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr ""
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr ""
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr ""
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr ""
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr ""
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr ""
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr ""
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr ""
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr ""
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr ""
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr ""
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr ""
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr ""
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr ""
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr ""
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr ""
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr ""
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr ""
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr ""
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr ""
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr ""
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr ""
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr ""
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr ""
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr ""
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr ""
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr ""
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr ""
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr ""
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr ""
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr ""
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr ""
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr ""
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr ""
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr ""
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr ""
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr ""
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr ""
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr ""
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr ""
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr ""
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr ""
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr ""
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr ""
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr ""
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr ""
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr ""
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr ""
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr ""
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr ""
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr ""
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr ""
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr ""
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr ""
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr ""
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr ""
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr ""
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr ""
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr ""
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr ""
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr ""
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr ""
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr ""
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr ""
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr ""
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr ""
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr ""
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr ""
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr ""
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr ""
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr ""
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr ""
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr ""
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr ""
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr ""
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr ""
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr ""
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr ""
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr ""
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr ""
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr ""
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr ""
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr ""
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr ""
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr ""
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr ""
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr ""
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr ""
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr ""
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr ""
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr ""
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr ""
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr ""
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr ""
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr ""
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr ""
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr ""
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr ""
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr ""
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr ""
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr ""
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr ""
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr ""
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr ""
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr ""
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr ""
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr ""
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr ""
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr ""
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr ""
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr ""
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr ""
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr ""
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr ""
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr ""
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr ""
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr ""
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr ""
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr ""
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr ""
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr ""
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr ""
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr ""
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr ""
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr ""
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr ""
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr ""
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr ""
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr ""
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr ""
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr ""
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr ""
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr ""
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr ""
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr ""
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr ""
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr ""
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr ""
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr ""
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr ""
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr ""
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr ""
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr ""
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr ""
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr ""
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr ""
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr ""
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr ""
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr ""
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr ""
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr ""
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr ""
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr ""
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr ""
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr ""
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr ""
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr ""
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr ""
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr ""
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr ""
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr ""
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr ""
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr ""
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr ""
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr ""
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr ""
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr ""
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr ""
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr ""
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr ""
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr ""
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr ""
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr ""
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr ""
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr ""
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr ""
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr ""
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr ""
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr ""
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr ""
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr ""
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr ""
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr ""
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr ""
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr ""
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr ""
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr ""
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr ""
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr ""
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr ""
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr ""
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr ""
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr ""
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr ""
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr ""
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr ""
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr ""
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr ""
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr ""
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr ""
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr ""
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr ""
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr ""
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr ""
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr ""
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr ""
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr ""
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr ""
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr ""
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr ""
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr ""
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr ""
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr ""
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr ""
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr ""
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr ""
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr ""
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr ""
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr ""
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr ""
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr ""
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr ""
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr ""
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr ""
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr ""
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr ""
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr ""
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr ""
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr ""
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr ""
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr ""
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr ""
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr ""
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr ""
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr ""
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr ""
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr ""
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr ""
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr ""
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr ""
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr ""
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr ""
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr ""
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr ""
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr ""
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr ""
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr ""
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr ""
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr ""
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr ""
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr ""
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr ""
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr ""
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr ""
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr ""
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr ""
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr ""
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr ""
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr ""
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr ""
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr ""
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr ""
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr ""
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr ""
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr ""
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr ""
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr ""
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr ""
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr ""
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr ""
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr ""
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr ""
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr ""
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr ""
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr ""
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr ""
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr ""
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr ""
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr ""
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr ""
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr ""
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr ""
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr ""
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr ""
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr ""
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr ""
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr ""
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr ""
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr ""
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr ""
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr ""
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr ""
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr ""
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr ""
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr ""
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr ""
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr ""
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr ""
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr ""
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr ""
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr ""
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr ""
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr ""
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr ""
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr ""
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr ""
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr ""
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr ""
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr ""
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr ""
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr ""
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr ""
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr ""
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr ""
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr ""
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr ""
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr ""
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr ""
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr ""
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr ""
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr ""
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr ""
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr ""
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr ""
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr ""
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr ""
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr ""
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr ""
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr ""
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr ""
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr ""
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr ""
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr ""
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr ""
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr ""
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr ""
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr ""
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr ""
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr ""
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr ""
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr ""
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr ""
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr ""
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr ""
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr ""
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr ""
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr ""
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr ""
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr ""
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr ""
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr ""
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr ""
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr ""
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr ""
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr ""
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr ""
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr ""
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr ""
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr ""
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr ""
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr ""
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr ""
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr ""
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr ""
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr ""
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr ""
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr ""
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr ""
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr ""
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr ""
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr ""
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr ""
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr ""
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr ""
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr ""
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr ""
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr ""
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr ""
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr ""
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr ""
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr ""
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr ""
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr ""
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr ""
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr ""
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr ""
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr ""
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr ""
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr ""
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr ""
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr ""
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr ""
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr ""
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr ""
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr ""
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr ""
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr ""
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr ""
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr ""
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr ""
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr ""
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr ""
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr ""
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr ""
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr ""
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr ""
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr ""
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr ""
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr ""
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr ""
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr ""
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr ""
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr ""
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr ""
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr ""
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr ""
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr ""
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr ""
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr ""
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr ""
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr ""
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr ""
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr ""
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr ""
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr ""
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr ""
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr ""
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr ""
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr ""
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr ""
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr ""
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr ""
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr ""
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr ""
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr ""
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr ""
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr ""
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr ""
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr ""
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr ""
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr ""
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr ""
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr ""
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr ""
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr ""
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr ""
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr ""
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr ""
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr ""
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr ""
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr ""
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr ""
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr ""
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr ""
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr ""
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr ""
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr ""
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr ""
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr ""
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr ""
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr ""
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr ""
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr ""
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr ""
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr ""
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr ""
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr ""
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr ""
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr ""
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr ""
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr ""
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr ""
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr ""
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr ""
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr ""
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr ""
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr ""
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr ""
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr ""
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr ""
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr ""
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr ""
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr ""
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr ""
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr ""
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr ""
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr ""
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr ""
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr ""
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr ""
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr ""
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr ""
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr ""
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr ""
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr ""
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr ""
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr ""
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr ""
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr ""
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr ""
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr ""
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr ""
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr ""
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr ""
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr ""
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr ""
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr ""
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr ""
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr ""
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr ""
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr ""
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr ""
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr ""
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr ""
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr ""
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr ""
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr ""
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr ""
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr ""
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr ""
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr ""
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr ""
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr ""
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr ""
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr ""
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr ""
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr ""
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr ""
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr ""
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr ""
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr ""
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr ""
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr ""
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr ""
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr ""
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr ""
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr ""
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr ""
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr ""
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr ""
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr ""
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr ""
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr ""
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr ""
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr ""
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr ""
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr ""
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr ""
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr ""
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr ""
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr ""
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr ""
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr ""
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr ""
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr ""
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr ""
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr ""
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr ""
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr ""
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr ""
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr ""
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr ""
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr ""
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr ""
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr ""
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr ""
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr ""
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr ""
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr ""
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr ""
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr ""
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr ""
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr ""
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr ""
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr ""
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr ""
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr ""
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr ""
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr ""
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr ""
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr ""
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr ""
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr ""
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr ""
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr ""
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr ""
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr ""
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr ""
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr ""
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr ""
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr ""
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr ""
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr ""
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr ""
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr ""
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr ""
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr ""
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr ""
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr ""
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr ""
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr ""
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr ""
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr ""
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr ""
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
 "and a single '+'; no real JS eval loop (#4916)"
 msgstr ""
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr ""
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
 "single '+'; no real JS eval loop (#4916)"
 msgstr ""
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr ""
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr ""
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr ""
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr ""
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr ""
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr ""
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr ""
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr ""
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr ""
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr ""
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr ""
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr ""
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr ""
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr ""
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr ""
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr ""
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr ""
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr ""
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr ""
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr ""
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr ""
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr ""
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr ""
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr ""
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr ""
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr ""
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr ""
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr ""
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr ""
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr ""
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr ""
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr ""
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr ""
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr ""
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr ""
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr ""
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr ""
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr ""
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr ""
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr ""
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr ""
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr ""
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr ""
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr ""
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr ""
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr ""
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr ""
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr ""
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr ""
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr ""
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr ""
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr ""
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr ""
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr ""
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr ""
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr ""
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr ""
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr ""
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr ""
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr ""
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr ""
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr ""
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr ""
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr ""
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr ""
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr ""
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr ""
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr ""
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr ""
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr ""
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr ""
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr ""
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr ""
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr ""
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr ""
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr ""
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr ""
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr ""
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr ""
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr ""
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr ""
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr ""
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr ""
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr ""
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr ""
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr ""
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr ""
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr ""
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr ""
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr ""
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr ""
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr ""
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr ""
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr ""
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr ""
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr ""
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr ""
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr ""
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr ""
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr ""
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr ""
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr ""
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr ""
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr ""
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr ""
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr ""
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr ""
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr ""
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr ""
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr ""
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr ""
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr ""
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr ""
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr ""
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr ""
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr ""
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr ""
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr ""
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr ""
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr ""
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr ""
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr ""
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr ""
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr ""
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr ""
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr ""
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr ""
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr ""
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr ""
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr ""
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr ""
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr ""
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr ""
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr ""
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr ""
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr ""
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr ""
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr ""
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr ""
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr ""
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr ""
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr ""
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr ""
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr ""
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr ""
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr ""
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr ""
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr ""
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr ""
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr ""
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr ""
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr ""
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr ""
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr ""
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr ""
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr ""
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr ""
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr ""
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr ""
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr ""
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr ""
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr ""
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr ""
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr ""
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr ""
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr ""
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr ""
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr ""
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr ""
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr ""
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr ""
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr ""
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr ""
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr ""
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr ""
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr ""
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr ""
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr ""
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr ""
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr ""
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr ""
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr ""
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr ""
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr ""
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr ""
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr ""
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr ""
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr ""
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr ""
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr ""
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr ""
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr ""
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr ""
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr ""
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr ""
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr ""
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr ""
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr ""
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr ""
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr ""
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr ""
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr ""
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr ""
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr ""
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr ""
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr ""
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr ""
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr ""
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr ""
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr ""
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr ""
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr ""
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr ""
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr ""
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr ""
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr ""
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr ""
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr ""
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr ""
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr ""
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr ""
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr ""
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr ""
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr ""
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr ""
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr ""
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr ""
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr ""
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr ""
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr ""
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr ""
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr ""
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr ""
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr ""
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr ""
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr ""
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr ""
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr ""
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr ""
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr ""
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr ""
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr ""
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr ""
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr ""
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr ""
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr ""
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr ""
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr ""
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr ""
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr ""
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr ""
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr ""
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr ""
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr ""
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr ""
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr ""
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr ""
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr ""
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr ""
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr ""
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr ""
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr ""
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr ""
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr ""
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr ""
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr ""
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr ""
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr ""
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr ""
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr ""
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr ""
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr ""
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr ""
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr ""
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr ""
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr ""
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr ""
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr ""
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr ""
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr ""
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr ""
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr ""
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr ""
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr ""
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr ""
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr ""
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr ""
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr ""
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr ""
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr ""
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr ""
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr ""
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr ""
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr ""
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr ""
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr ""
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr ""
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr ""
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr ""
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr ""
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr ""
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr ""
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
 msgstr ""
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr ""
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
 "(#4916)"
 msgstr ""
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -37029,675 +37226,675 @@ msgid ""
 "are 0 (#4916)"
 msgstr ""
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr ""
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr ""
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr ""
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr ""
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr ""
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr ""
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr ""
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr ""
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr ""
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr ""
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr ""
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr ""
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
 msgstr ""
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr ""
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr ""
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr ""
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr ""
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr ""
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr ""
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr ""
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr ""
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr ""
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr ""
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr ""
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr ""
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr ""
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr ""
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr ""
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr ""
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr ""
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr ""
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr ""
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr ""
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr ""
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr ""
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr ""
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr ""
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr ""
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr ""
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr ""
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr ""
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr ""
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr ""
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr ""
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr ""
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr ""
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr ""
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr ""
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr ""
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr ""
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr ""
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr ""
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr ""
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr ""
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr ""
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr ""
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr ""
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr ""
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr ""
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr ""
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr ""
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr ""
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr ""
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr ""
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr ""
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr ""
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr ""
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr ""
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr ""
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr ""
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr ""
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr ""
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr ""
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr ""
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr ""
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr ""
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr ""
 
-#: src/api/reference.md:4106
-msgid "`close` — instance _(class: `Client`)_"
+#: src/api/reference.md:4143
+msgid "`address` — instance"
 msgstr ""
 
-#: src/api/reference.md:4107
-msgid "`closeClient` — module"
-msgstr ""
-
-#: src/api/reference.md:4108
-msgid "`handleUpgrade` — instance"
-msgstr ""
-
-#: src/api/reference.md:4110
-msgid "`on` — instance _(class: `Client`)_"
-msgstr ""
-
-#: src/api/reference.md:4111
-msgid "`readyState` — instance"
-msgstr ""
-
-#: src/api/reference.md:4113
-msgid "`send` — instance _(class: `Client`)_"
-msgstr ""
-
-#: src/api/reference.md:4114
-msgid "`sendToClient` — module"
-msgstr ""
-
-#: src/api/reference.md:4118
-msgid "`CLOSED`"
-msgstr ""
-
-#: src/api/reference.md:4119
-msgid "`CLOSING`"
-msgstr ""
-
-#: src/api/reference.md:4120
-msgid "`CONNECTING`"
-msgstr ""
-
-#: src/api/reference.md:4121
-msgid "`OPEN`"
-msgstr ""
-
-#: src/api/reference.md:4127 src/api/reference.md:4128
-msgid "`BrotliCompress`"
-msgstr ""
-
-#: src/api/reference.md:4129 src/api/reference.md:4130
-msgid "`BrotliDecompress`"
-msgstr ""
-
-#: src/api/reference.md:4131 src/api/reference.md:4132
-msgid "`Deflate`"
-msgstr ""
-
-#: src/api/reference.md:4133 src/api/reference.md:4134
-msgid "`DeflateRaw`"
-msgstr ""
-
-#: src/api/reference.md:4135 src/api/reference.md:4136
-msgid "`Gunzip`"
-msgstr ""
-
-#: src/api/reference.md:4137 src/api/reference.md:4138
-msgid "`Gzip`"
-msgstr ""
-
-#: src/api/reference.md:4139 src/api/reference.md:4140
-msgid "`Inflate`"
-msgstr ""
-
-#: src/api/reference.md:4141 src/api/reference.md:4142
-msgid "`InflateRaw`"
-msgstr ""
-
-#: src/api/reference.md:4143 src/api/reference.md:4144
-msgid "`Unzip`"
-msgstr ""
-
-#: src/api/reference.md:4145
-msgid "`ZstdCompress`"
+#: src/api/reference.md:4144
+msgid "`clients` — instance"
 msgstr ""
 
 #: src/api/reference.md:4146
-msgid "`ZstdDecompress`"
+msgid "`close` — instance _(class: `Client`)_"
 msgstr ""
 
-#: src/api/reference.md:4150
-msgid "`brotliCompress` — module"
+#: src/api/reference.md:4147
+msgid "`closeClient` — module"
+msgstr ""
+
+#: src/api/reference.md:4149
+msgid "`handleUpgrade` — instance"
 msgstr ""
 
 #: src/api/reference.md:4151
-msgid "`brotliCompressSync` — module"
+msgid "`on` — instance _(class: `Client`)_"
 msgstr ""
 
 #: src/api/reference.md:4152
-msgid "`brotliDecompress` — module"
-msgstr ""
-
-#: src/api/reference.md:4153
-msgid "`brotliDecompressSync` — module"
+msgid "`readyState` — instance"
 msgstr ""
 
 #: src/api/reference.md:4154
-msgid "`crc32` — module"
+msgid "`send` — instance _(class: `Client`)_"
 msgstr ""
 
 #: src/api/reference.md:4155
+msgid "`sendToClient` — module"
+msgstr ""
+
+#: src/api/reference.md:4159
+msgid "`CLOSED`"
+msgstr ""
+
+#: src/api/reference.md:4160
+msgid "`CLOSING`"
+msgstr ""
+
+#: src/api/reference.md:4161
+msgid "`CONNECTING`"
+msgstr ""
+
+#: src/api/reference.md:4162
+msgid "`OPEN`"
+msgstr ""
+
+#: src/api/reference.md:4168 src/api/reference.md:4169
+msgid "`BrotliCompress`"
+msgstr ""
+
+#: src/api/reference.md:4170 src/api/reference.md:4171
+msgid "`BrotliDecompress`"
+msgstr ""
+
+#: src/api/reference.md:4172 src/api/reference.md:4173
+msgid "`Deflate`"
+msgstr ""
+
+#: src/api/reference.md:4174 src/api/reference.md:4175
+msgid "`DeflateRaw`"
+msgstr ""
+
+#: src/api/reference.md:4176 src/api/reference.md:4177
+msgid "`Gunzip`"
+msgstr ""
+
+#: src/api/reference.md:4178 src/api/reference.md:4179
+msgid "`Gzip`"
+msgstr ""
+
+#: src/api/reference.md:4180 src/api/reference.md:4181
+msgid "`Inflate`"
+msgstr ""
+
+#: src/api/reference.md:4182 src/api/reference.md:4183
+msgid "`InflateRaw`"
+msgstr ""
+
+#: src/api/reference.md:4184 src/api/reference.md:4185
+msgid "`Unzip`"
+msgstr ""
+
+#: src/api/reference.md:4186
+msgid "`ZstdCompress`"
+msgstr ""
+
+#: src/api/reference.md:4187
+msgid "`ZstdDecompress`"
+msgstr ""
+
+#: src/api/reference.md:4191
+msgid "`brotliCompress` — module"
+msgstr ""
+
+#: src/api/reference.md:4192
+msgid "`brotliCompressSync` — module"
+msgstr ""
+
+#: src/api/reference.md:4193
+msgid "`brotliDecompress` — module"
+msgstr ""
+
+#: src/api/reference.md:4194
+msgid "`brotliDecompressSync` — module"
+msgstr ""
+
+#: src/api/reference.md:4195
+msgid "`crc32` — module"
+msgstr ""
+
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr ""
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr ""
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr ""
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr ""
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
 msgstr ""
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr ""
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr ""
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr ""
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr ""
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr ""
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr ""
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr ""
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr ""
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr ""
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr ""
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr ""
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr ""
 
@@ -38097,7 +38294,7 @@ msgstr ""
 #: src/container/overview.md:185
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 
@@ -38521,7 +38718,7 @@ msgid ""
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 
 #: src/container/containers.md:146
@@ -38614,7 +38811,7 @@ msgstr ""
 #: src/container/containers.md:215
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 
@@ -39130,7 +39327,7 @@ msgstr ""
 #: src/container/compose.md:332
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 
@@ -39379,7 +39576,7 @@ msgstr ""
 
 #: src/container/networking.md:128
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  "
+"The Forgejo example uses this portable pattern (`container_name: "
 "'forgejo-db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 
@@ -39443,7 +39640,7 @@ msgstr ""
 
 #: src/container/networking.md:150
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -39768,7 +39965,7 @@ msgstr ""
 #: src/container/volumes.md:111
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  "
+"created by a different process (e.g. `docker volume create "
 "team-shared-cache` ahead of time):"
 msgstr ""
 
@@ -39783,7 +39980,7 @@ msgstr ""
 
 #: src/container/volumes.md:121
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -39829,15 +40026,15 @@ msgid ""
 msgstr ""
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+msgid "# list app-prefixed volumes\n"
 msgstr ""
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+msgid "# mountpoint, driver, labels\n"
 msgstr ""
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+msgid "# mount + inspect contents\n"
 msgstr ""
 
 #: src/container/volumes.md:160
@@ -39966,7 +40163,7 @@ msgstr ""
 #: src/container/security.md:25
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -40117,7 +40314,7 @@ msgstr ""
 
 #: src/container/security.md:114
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  "
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} "
 "--certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches "
 "pass/fail."
 msgstr ""
@@ -40323,7 +40520,7 @@ msgstr ""
 
 #: src/container/security.md:207
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 
@@ -40432,7 +40629,7 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr ""
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 
 #: src/container/production-patterns.md:42
@@ -40581,7 +40778,7 @@ msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: { "
-"svc: { condition: 'service_healthy'  } }`:"
+"svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 
 #: src/container/production-patterns.md:141
@@ -40688,7 +40885,7 @@ msgid ""
 msgstr ""
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+msgid "# .env\n"
 msgstr ""
 
 #: src/container/production-patterns.md:225
@@ -40701,7 +40898,7 @@ msgid "$(openssl rand -hex 52)"
 msgstr ""
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+msgid "# deploy.sh\n"
 msgstr ""
 
 #: src/container/production-patterns.md:234
@@ -40747,11 +40944,11 @@ msgid ""
 msgstr ""
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+msgid "# preserve volumes\n"
 msgstr ""
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+msgid "# redeploy with new version\n"
 msgstr ""
 
 #: src/container/production-patterns.md:268
@@ -40766,35 +40963,35 @@ msgid "Running it"
 msgstr ""
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+msgid "# Build perry once\n"
 msgstr ""
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+msgid "# Build the example\n"
 msgstr ""
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+msgid "# Deploy\n"
 msgstr ""
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+msgid "# 🔧 Backend: docker\n"
 msgstr ""
 
 #: src/container/production-patterns.md:285
-msgid "# …"
+msgid "# …\n"
 msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr ""
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr ""
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr ""
 
 #: src/container/production-patterns.md:300
@@ -41017,19 +41214,19 @@ msgid ""
 msgstr ""
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+msgid "// tested + emitted as-is\n"
 msgstr ""
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+msgid "// engine emulates host-side\n"
 msgstr ""
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+msgid "// dropped + warning\n"
 msgstr ""
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+msgid "// limited subset; reason documented\n"
 msgstr ""
 
 #: src/container/determinism.md:156
@@ -41153,7 +41350,7 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr ""
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+msgid "// ... arg builders\n"
 msgstr ""
 
 #: src/container/determinism.md:192
@@ -41175,7 +41372,7 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr ""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+msgid "// <-- clean spec\n"
 msgstr ""
 
 #: src/container/determinism.md:212
@@ -41185,15 +41382,15 @@ msgid ""
 msgstr ""
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+msgid "// field removed\n"
 msgstr ""
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+msgid "// mapped to equivalent\n"
 msgstr ""
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+msgid "// engine emulates instead\n"
 msgstr ""
 
 #: src/container/determinism.md:231
@@ -41201,15 +41398,15 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr ""
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+msgid "// default — silent tracing::warn!\n"
 msgstr ""
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+msgid "// surface to TS console.warn\n"
 msgstr ""
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+msgid "// unsupported field → hard up() failure\n"
 msgstr ""
 
 #: src/container/determinism.md:241
@@ -41262,7 +41459,7 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr ""
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+msgid "// Docker shape (NDJSON line)\n"
 msgstr ""
 
 #: src/container/determinism.md:292
@@ -41270,7 +41467,7 @@ msgid "/* docker JSON */"
 msgstr ""
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr ""
 
 #: src/container/determinism.md:294
@@ -41278,7 +41475,7 @@ msgid "/* apple JSON */"
 msgstr ""
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr ""
 
 #: src/container/determinism.md:301
@@ -41537,7 +41734,7 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+msgid "// locales/en.json\n"
 msgstr ""
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -41550,7 +41747,7 @@ msgid "\"Back\""
 msgstr ""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr ""
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -41740,7 +41937,7 @@ msgid "\"Total: {price}\""
 msgstr ""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+msgid "// locales/de.json\n"
 msgstr ""
 
 #: src/i18n/interpolation.md:25
@@ -41849,7 +42046,7 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr ""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr ""
 
 #: src/i18n/interpolation.md:65
@@ -42461,19 +42658,19 @@ msgid "Typical translation workflow:"
 msgstr ""
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+msgid "# 1. Write code with English strings\n"
 msgstr ""
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+msgid "# 2. Extract strings to locale files\n"
 msgstr ""
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr ""
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+msgid "# 4. Build — Perry validates everything\n"
 msgstr ""
 
 #: src/i18n/cli.md:49
@@ -42989,49 +43186,19 @@ msgid ""
 msgstr ""
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr ""
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
-msgstr ""
-
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr ""
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr ""
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr ""
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr ""
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr ""
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-x86_64.tar.gz'"
-msgstr ""
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr ""
 
 #: src/updater/overview.md:231
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 
@@ -44270,7 +44437,7 @@ msgstr ""
 #: src/system/audio_module.md:11
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 
@@ -45092,9 +45259,9 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
-"`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
-"The pump runs on the ArkTS UI thread, so closures fired by "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / `timeUpdate` "
+"/ `error` / `endOfStream` events feed the same callback path. The pump runs "
+"on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
 "Lock-screen integration (`@ohos.multimedia.avsession`) is a follow-up — the "
 "runtime queues now-playing metadata via `drainNowPlaying` but the ArkTS-side "
@@ -45963,23 +46130,23 @@ msgid ""
 msgstr ""
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+msgid "# iOS WidgetKit extension\n"
 msgstr ""
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+msgid "# Android App Widget\n"
 msgstr ""
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+msgid "# watchOS Complication\n"
 msgstr ""
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+msgid "# watchOS Simulator\n"
 msgstr ""
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+msgid "# Wear OS Tile\n"
 msgstr ""
 
 #: src/widgets/overview.md:60
@@ -46617,10 +46784,6 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr ""
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr ""
@@ -47036,11 +47199,11 @@ msgid "Build Commands"
 msgstr ""
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+msgid "# iOS\n"
 msgstr ""
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+msgid "# Android\n"
 msgstr ""
 
 #: src/widgets/configuration.md:141
@@ -47709,19 +47872,19 @@ msgid "Build Instructions"
 msgstr ""
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr ""
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr ""
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr ""
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr ""
 
 #: src/widgets/watchos.md:3
@@ -47870,11 +48033,11 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr ""
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+msgid "# For Apple Watch device\n"
 msgstr ""
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+msgid "# For Apple Watch Simulator\n"
 msgstr ""
 
 #: src/widgets/watchos.md:70
@@ -49024,11 +49187,11 @@ msgid ""
 msgstr ""
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+msgid "// Perry runtime FFI\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:200
@@ -49134,21 +49297,15 @@ msgid ""
 msgstr ""
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+msgid "// build.rs (simplified)\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-msgstr ""
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:248
@@ -49176,7 +49333,7 @@ msgid "Resolve the Perry promise with the result"
 msgstr ""
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+msgid "// Get Activity from PerryBridge\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:266
@@ -49192,7 +49349,7 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr ""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+msgid "// Call platform APIs via JNI...\n"
 msgstr ""
 
 #: src/plugins/native-extensions.md:275
@@ -49687,15 +49844,15 @@ msgid ""
 msgstr ""
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+msgid "# the gate\n"
 msgstr ""
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+msgid "# what is in scope, and what is not\n"
 msgstr ""
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+msgid "# prove the gate can still fail\n"
 msgstr ""
 
 #: src/testing/test-registration.md:18
@@ -49971,31 +50128,31 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+msgid "# 2. Run the app\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+msgid "# List all widgets\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+msgid "# Click button with handle 3\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+msgid "# Capture window screenshot\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:25
@@ -50009,7 +50166,7 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+msgid "# or with perry run:\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:35
@@ -50143,8 +50300,8 @@ msgid "Menu item"
 msgstr ""
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr ""
 
@@ -50156,8 +50313,8 @@ msgstr ""
 msgid "Data table"
 msgstr ""
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr ""
 
@@ -50254,17 +50411,6 @@ msgid ""
 "text as a NaN-boxed string."
 msgstr ""
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr ""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr ""
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr ""
@@ -50281,10 +50427,6 @@ msgstr ""
 
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
-msgstr ""
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:156
@@ -50322,10 +50464,6 @@ msgid ""
 "Directly sets a `State` cell's value, bypassing widget callbacks. This "
 "triggers any reactive bindings attached to the state (bound text labels, "
 "visibility, forEach loops, etc.)."
-msgstr ""
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:186
@@ -50384,10 +50522,6 @@ msgid ""
 "Cmd+N)."
 msgstr ""
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr ""
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -50411,10 +50545,6 @@ msgstr ""
 msgid ""
 "Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
 "points."
-msgstr ""
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:240
@@ -50503,11 +50633,7 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
-msgstr ""
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
+msgid "# Fire random inputs every 200ms\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:285
@@ -50627,11 +50753,13 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:363
@@ -50653,7 +50781,7 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+msgid "# Package into APK and install\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:381
@@ -50661,7 +50789,7 @@ msgid "Install GTK4 development libraries first:"
 msgstr ""
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+msgid "# Ubuntu/Debian\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:402
@@ -50683,15 +50811,15 @@ msgid "A simple end-to-end test using bash:"
 msgstr ""
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+msgid "#!/bin/bash\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+msgid "# Build with geisterhand\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+msgid "# Start the app in background\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:419
@@ -50703,15 +50831,11 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr ""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+msgid "# Wait for the app to be ready\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
-msgstr ""
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
+msgid "# Get widgets\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:430
@@ -50719,16 +50843,19 @@ msgid "\"Registered widgets: $WIDGETS\""
 msgstr ""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+msgid "# Click it\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:436
@@ -50736,7 +50863,7 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr ""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+msgid "# Take a screenshot after interaction\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:441
@@ -50748,7 +50875,7 @@ msgid "Python Test Example"
 msgstr ""
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+msgid "# Start the app\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:450
@@ -50756,11 +50883,11 @@ msgid "\"./testapp\""
 msgstr ""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+msgid "# Wait for startup\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+msgid "# List widgets\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:455
@@ -50768,11 +50895,11 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr ""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+msgid "# Find widgets by label\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+msgid "# Type into the first text field\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:464
@@ -50792,7 +50919,7 @@ msgid "\"test@example.com\""
 msgstr ""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+msgid "# Click the first button\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:470
@@ -50800,7 +50927,7 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr ""
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+msgid "# Capture screenshot for visual regression\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:473
@@ -50816,7 +50943,7 @@ msgid "\"wb\""
 msgstr ""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+msgid "# Assert the app is still healthy\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:478
@@ -50846,39 +50973,11 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+msgid "# Build and launch\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
-msgstr ""
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr ""
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr ""
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr ""
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr ""
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr ""
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr ""
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:518
@@ -50891,11 +50990,11 @@ msgid ""
 msgstr ""
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+msgid "# Initial state\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+msgid "# Interact\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:528
@@ -50903,23 +51002,19 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+msgid "# Capture after interaction\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+msgid "# Compare (using ImageMagick)\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr ""
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr ""
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
+msgid "# GitHub Actions example\njobs"
 msgstr ""
 
 #: src/testing/geisterhand.md:542
@@ -50969,7 +51064,7 @@ msgid "Run UI tests"
 msgstr ""
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+msgid "# Run your test script\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:568
@@ -51068,11 +51163,11 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr ""
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+msgid "# See all interactive widgets\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
+msgid "# [\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:657
@@ -51081,7 +51176,8 @@ msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   "
+"{\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:659
@@ -51089,7 +51185,8 @@ msgid "\"Enter your name\""
 msgstr ""
 
 #: src/testing/geisterhand.md:659
-msgid "#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+msgid ""
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:661
@@ -51097,19 +51194,19 @@ msgid "\"Dark Mode\""
 msgstr ""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
+msgid "# ]\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+msgid "# Click Increment 3 times\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+msgid "# Type a name\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:669
@@ -51117,7 +51214,7 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+msgid "# Set slider to 80%\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:672
@@ -51125,11 +51222,11 @@ msgid "'{\"value\":0.8}'"
 msgstr ""
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+msgid "# Toggle dark mode on\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+msgid "# Screenshot\n"
 msgstr ""
 
 #: src/testing/geisterhand.md:685
@@ -51377,15 +51474,11 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr ""
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+msgid "# Build geisterhand libs for macOS\n"
 msgstr ""
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
-msgstr ""
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
 msgstr ""
 
 #: src/testing/geisterhand.md:824
@@ -51534,15 +51627,15 @@ msgid ""
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+msgid "# a few modules\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+msgid "# only these exports\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+msgid "# combined mod.export form\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:30
@@ -51558,15 +51651,15 @@ msgid "Full sweep and the CI gate"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+msgid "# whole matrix + summary table\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+msgid "# rewrite the committed baseline\n"
 msgstr ""
 
 #: src/testing/node-compat-matrix.md:43
@@ -51776,7 +51869,7 @@ msgid ""
 "`fromJSON(needs.plan.outputs.plan).jobs.<name>`."
 msgstr ""
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr ""
 
@@ -51864,11 +51957,11 @@ msgstr ""
 msgid "pr"
 msgstr ""
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr ""
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr ""
 
@@ -51893,112 +51986,124 @@ msgid "`cargo-test`"
 msgstr ""
 
 #: src/testing/ci-tiers.md:30
-msgid "`gap-suite`"
-msgstr ""
-
-#: src/testing/ci-tiers.md:30
-msgid "6x fast"
-msgstr ""
-
-#: src/testing/ci-tiers.md:30
-msgid "3x fast"
-msgstr ""
-
-#: src/testing/ci-tiers.md:30
-msgid "8x full"
+msgid "`cargo-test-perry`"
 msgstr ""
 
 #: src/testing/ci-tiers.md:31
+msgid "`gap-suite`"
+msgstr ""
+
+#: src/testing/ci-tiers.md:31
+msgid "6x fast"
+msgstr ""
+
+#: src/testing/ci-tiers.md:31
+msgid "3x fast"
+msgstr ""
+
+#: src/testing/ci-tiers.md:31
+msgid "8x full"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr ""
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr ""
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr ""
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr ""
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
 msgstr ""
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
 msgstr ""
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
 msgstr ""
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -52007,18 +52112,18 @@ msgid ""
 "dependency without adding Rust setup to docs-only PRs."
 msgstr ""
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
 "\"everything skipped, therefore green\"."
 msgstr ""
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr ""
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -52026,17 +52131,17 @@ msgid ""
 "PR pushes and ~58 merges a day. That is 1.5–2× total capacity, so:"
 msgstr ""
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
 msgstr ""
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -52044,7 +52149,7 @@ msgid ""
 "bypass** with `lint` and `cargo-test` still queued."
 msgstr ""
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in "
 "[\\#8092](https://github.com/PerryTS/perry/issues/8092). #8087 restored "
@@ -52054,11 +52159,11 @@ msgid ""
 "fan-in described above."
 msgstr ""
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr ""
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the "
@@ -52070,7 +52175,7 @@ msgid ""
 "sees auto-optimize-only link bugs."
 msgstr ""
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -52079,7 +52184,19 @@ msgid ""
 "`cache-warm.yml` is gone: the sweep is the cache-producing build on `main`."
 msgstr ""
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, "
 "`gc-native-roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, "
@@ -52093,75 +52210,75 @@ msgid ""
 "slot."
 msgstr ""
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr ""
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr ""
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr ""
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr ""
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr ""
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr ""
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr ""
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr ""
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr ""
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr ""
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr ""
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr ""
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr ""
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr ""
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr ""
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr ""
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr ""
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with "
 "`cancel-in-progress: false`: GitHub keeps at most one running + one pending "
@@ -52178,11 +52295,20 @@ msgid ""
 "for the six-hourly gates."
 msgstr ""
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr ""
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity "
+"gate](cc-parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -52191,23 +52317,23 @@ msgid ""
 "(`labeled` trigger)."
 msgstr ""
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
 msgstr ""
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
 msgstr ""
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr ""
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -52215,26 +52341,26 @@ msgid ""
 "**from CI**, not from a laptop (the required baseline is Linux, `fast` mode):"
 msgstr ""
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+msgid "# wait for the run, then:\n"
 msgstr ""
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr ""
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
 "(`run_gap_tests.sh` refuses)."
 msgstr ""
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr ""
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -52244,11 +52370,11 @@ msgid ""
 "that result passed or failed."
 msgstr ""
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr ""
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -52256,7 +52382,7 @@ msgid ""
 "same SHA does not count. See [Releasing](../contributing/releasing.md)."
 msgstr ""
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -52264,6 +52390,170 @@ msgid ""
 "design); the threshold minimums and the per-module matrix trend run once in "
 "`parity-aggregate` over the merged report (`scripts/parity_report_merge.py`, "
 "which refuses a missing shard rather than shrinking the suite)."
+msgstr ""
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) "
+"provides more headroom for bundle IR construction than the 7 GB ARM runner. "
+"The job removes unused simulator images and disables Cargo incremental "
+"artifacts to leave disk space for LLVM and the native archives. The issue "
+"estimated 25–40 minutes for bundle compilation; local validation took **57 "
+"minutes 25 seconds** on macOS arm64 with five LLVM workers. The hosted Intel "
+"run with four workers remains to be measured. Allow additional time for "
+"toolchain setup, especially on a cold cache. The job has a 90-minute cap, "
+"compilation a 75-minute cap, and each CLI invocation a 60-second cap. "
+"Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+msgid "What the check proves"
+msgstr ""
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted "
+"`package/cli.js` by both size and SHA-256. Only that regular file is "
+"extracted; no package install hooks run. The compiler is built first, then "
+"the runtime, stdlib, Wasm host, and all native extension archives are built "
+"together with `perry-runtime/wasm-host`. This avoids stale runtime copies in "
+"extension archives (#6303). Compilation uses `--no-auto-optimize --no-cache "
+"--enable-wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) "
+"to use the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, "
+"build/compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+msgid "Run locally on macOS"
+msgstr ""
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+msgid "\"$(command -v node)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and "
+"`logs/node-parity.json`. A deliberate version refresh may fail the old "
+"golden comparison; inspect both command results, require zero exit codes and "
+"no timeout, and review the output changes before copying those two stdout "
+"files into `tests/cc-parity/`. Update their byte counts and SHA-256 values "
+"and the oracle provenance in the manifest. Rerun the Node check, harness "
+"tests, native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
@@ -52372,35 +52662,11 @@ msgid "Reproduce the core of it with:"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:48
@@ -52527,11 +52793,7 @@ msgid "pull_request"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
+msgid "# unchanged — every PR is still measured\n  schedule"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
@@ -52539,11 +52801,7 @@ msgid "cron"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
+msgid "\"7 */6 * * *\"   # staggered; see the table below\n  push"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:125
@@ -52555,11 +52813,7 @@ msgid "\"v*\""
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
-msgstr ""
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
+msgid "# releases stay individually gated\n  workflow_dispatch"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:129
@@ -52783,11 +53037,11 @@ msgid ""
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+msgid "# proves it can still fail\n"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+msgid "# real API, no issue writes\n"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -52810,66 +53064,105 @@ msgid ""
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:218
-msgid "The queue in front of the schedule (#7966)"
+msgid "A completed red gate must create work (#9830)"
 msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
+msgid "The queue in front of the schedule (#7966)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -52879,11 +53172,11 @@ msgid ""
 "scheduling cadence recovers from that; the garbage has to be removed."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -52891,7 +53184,7 @@ msgid ""
 "never appears in this repo's refs."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -52899,13 +53192,13 @@ msgid ""
 "default); the schedule keeps it clear afterwards."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -52913,7 +53206,7 @@ msgid ""
 "incident:"
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -52921,7 +53214,7 @@ msgid ""
 "of them. No gate in the repo ratchets a collection-_kind_ count."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -52929,13 +53222,13 @@ msgid ""
 "never uses."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
 msgstr ""
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -53147,14 +53440,14 @@ msgid "Compile TypeScript to a native executable."
 msgstr ""
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr ""
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr ""
 
@@ -53183,7 +53476,7 @@ msgstr ""
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr ""
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr ""
 
@@ -53191,7 +53484,7 @@ msgstr ""
 msgid "Print HIR intermediate representation"
 msgstr ""
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr ""
 
@@ -53201,7 +53494,7 @@ msgid ""
 "Flags](flags.md))"
 msgstr ""
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr ""
 
@@ -53209,7 +53502,7 @@ msgstr ""
 msgid "Keep `.o` and `.asm` files"
 msgstr ""
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr ""
 
@@ -53217,7 +53510,7 @@ msgstr ""
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr ""
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr ""
 
@@ -53227,8 +53520,8 @@ msgid ""
 "`WebAssembly.*` use)"
 msgstr ""
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr ""
 
@@ -53236,15 +53529,15 @@ msgstr ""
 msgid "Enable type checking via tsgo"
 msgstr ""
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr ""
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr ""
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr ""
 
@@ -53252,7 +53545,7 @@ msgstr ""
 msgid "Bundle ID (required for widget targets)"
 msgstr ""
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr ""
 
@@ -53261,23 +53554,23 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr ""
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+msgid "# Basic compilation\n"
 msgstr ""
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr ""
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+msgid "# Build a plugin\n"
 msgstr ""
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+msgid "# Debug: view intermediate representation\n"
 msgstr ""
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+msgid "# Build an iOS widget\n"
 msgstr ""
 
 #: src/cli/commands.md:82
@@ -53285,23 +53578,23 @@ msgid "Compile and launch your app in one step."
 msgstr ""
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+msgid "# Auto-detect entry file\n"
 msgstr ""
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+msgid "# Run on iOS device/simulator\n"
 msgstr ""
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr ""
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+msgid "# Run on Android device\n"
 msgstr ""
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+msgid "# Forward args to your program\n"
 msgstr ""
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -53426,19 +53719,19 @@ msgid ""
 msgstr ""
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+msgid "# Run a CLI program\n"
 msgstr ""
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+msgid "# Run on a specific simulator\n"
 msgstr ""
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+msgid "# Force remote build\n"
 msgstr ""
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+msgid "# Run web target\n"
 msgstr ""
 
 #: src/cli/commands.md:131
@@ -53452,19 +53745,19 @@ msgid ""
 msgstr ""
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr ""
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+msgid "# forward args to the child\n"
 msgstr ""
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+msgid "# watch an extra directory\n"
 msgstr ""
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+msgid "# override output path\n"
 msgstr ""
 
 #: src/cli/commands.md:144
@@ -53578,7 +53871,7 @@ msgid ""
 "target."
 msgstr ""
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr ""
 
@@ -53643,19 +53936,19 @@ msgid "Include medium-confidence fixes"
 msgstr ""
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+msgid "# Check a single file\n"
 msgstr ""
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+msgid "# Check with dependency analysis\n"
 msgstr ""
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+msgid "# Auto-fix issues\n"
 msgstr ""
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+msgid "# Preview fixes without applying\n"
 msgstr ""
 
 #: src/cli/commands.md:207
@@ -53940,27 +54233,27 @@ msgid ""
 msgstr ""
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+msgid "# Show platform menu\n"
 msgstr ""
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+msgid "# macOS setup (signing credentials)\n"
 msgstr ""
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+msgid "# iOS setup (signing credentials)\n"
 msgstr ""
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+msgid "# visionOS setup (signing credentials)\n"
 msgstr ""
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+msgid "# Android setup (signing credentials)\n"
 msgstr ""
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr ""
 
 #: src/cli/commands.md:318
@@ -53982,19 +54275,19 @@ msgid "update"
 msgstr ""
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+msgid "# Update to latest\n"
 msgstr ""
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+msgid "# Check without installing\n"
 msgstr ""
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+msgid "# Ignore the cached answer\n"
 msgstr ""
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+msgid "# Save how updates should behave, then exit\n"
 msgstr ""
 
 #: src/cli/commands.md:333
@@ -54009,7 +54302,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr ""
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr ""
 
@@ -54106,14 +54399,6 @@ msgstr ""
 
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
-msgstr ""
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr ""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
 msgstr ""
 
 #: src/cli/commands.md:385
@@ -54609,136 +54894,189 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr ""
 
 #: src/cli/flags.md:77
-msgid "`--libc glibc\\|musl`"
+msgid "`--platform node\\|bun`"
 msgstr ""
 
 #: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
+msgid "`--libc glibc\\|musl`"
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
 msgstr ""
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr ""
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr ""
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
 msgstr ""
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr ""
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr ""
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
 msgstr ""
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr ""
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
 msgstr ""
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr ""
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding "
 "environment/config sources for secrets."
 msgstr ""
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr ""
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr ""
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr ""
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr ""
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr ""
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr ""
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+msgid "Bun platform mode"
+msgstr ""
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr ""
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
 msgstr ""
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr ""
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
 "(perry.toml)."
 msgstr ""
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+msgid "`--bunfs-root <dir>`"
+msgstr ""
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr ""
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
 msgstr ""
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr ""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr ""
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr ""
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -54756,7 +55094,7 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -54764,20 +55102,48 @@ msgid ""
 "virtual path or the embed-relative key."
 msgstr ""
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 msgstr ""
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 msgstr ""
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or "
+"`import.meta[\"require\"](\"./chunk.js\")`. Both return the module namespace "
+"immediately and initialize the target once, at its first load. Computed "
+"paths use the existing bounded synchronous `require(expr)` resolver; unknown "
+"targets throw `MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -54786,17 +55152,13 @@ msgid ""
 "checkout."
 msgstr ""
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
 msgstr ""
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr ""
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -54805,7 +55167,7 @@ msgid ""
 "source revision so the generated inputs cannot be stale."
 msgstr ""
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -54813,7 +55175,7 @@ msgid ""
 "digest, and the generating asset module where applicable."
 msgstr ""
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -54822,7 +55184,7 @@ msgid ""
 "explicit `$perryfs/<path>` form when you specifically mean the embedded copy."
 msgstr ""
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -54830,37 +55192,37 @@ msgid ""
 "currently supported."
 msgstr ""
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr ""
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr ""
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr ""
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` "
 "(post-transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), "
 "or `all`"
 msgstr ""
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr ""
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
 "stage is given"
 msgstr ""
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to "
 "`-o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -54869,91 +55231,91 @@ msgid ""
 "object file: <path>`"
 msgstr ""
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr ""
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project "
 "Configuration](../getting-started/project-config.md)"
 msgstr ""
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr ""
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr ""
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr ""
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr ""
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr ""
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr ""
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
 msgstr ""
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr ""
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr ""
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr ""
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "Emit a type-lowering evidence report; implies native-region verification."
 msgstr ""
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr ""
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
 "for tooling. Also settable via `PERRY_OPT_REPORT=1`"
 msgstr ""
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr ""
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited "
 "non-collecting calls omitted, relocations, plain-map fallbacks, and "
@@ -54962,7 +55324,7 @@ msgid ""
 "named are gone)"
 msgstr ""
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -54972,11 +55334,11 @@ msgid ""
 "unchanged modules, leaving the trace dir empty)."
 msgstr ""
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr ""
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection "
@@ -54987,24 +55349,24 @@ msgid ""
 "rule made the call."
 msgstr ""
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr ""
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
 "idiom)."
 msgstr ""
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
 msgstr ""
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -55012,7 +55374,7 @@ msgid ""
 "where one exists)."
 msgstr ""
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -55021,13 +55383,13 @@ msgid ""
 "Neither is a profile — they are static proxies."
 msgstr ""
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
 msgstr ""
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -55036,7 +55398,7 @@ msgid ""
 "a `--format json` payload or your program's piped output."
 msgstr ""
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -55045,15 +55407,15 @@ msgid ""
 "representation silently regressing to zero."
 msgstr ""
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr ""
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr ""
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -55065,54 +55427,54 @@ msgid ""
 "`generic`. Applies to app code and the auto-optimized runtime/stdlib rebuild."
 msgstr ""
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr ""
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for "
 "dead-code elimination."
 msgstr ""
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr ""
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
 msgstr ""
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr ""
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr ""
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr ""
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr ""
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
 msgstr ""
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr ""
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -55120,11 +55482,11 @@ msgid ""
 "auto-optimize):"
 msgstr ""
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr ""
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -55132,21 +55494,21 @@ msgid ""
 "cached independently."
 msgstr ""
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr ""
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
 msgstr ""
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr ""
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -55157,7 +55519,7 @@ msgid ""
 "and `uncaughtException` are unaffected."
 msgstr ""
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -55165,53 +55527,53 @@ msgid ""
 "shrink less, proportionally."
 msgstr ""
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr ""
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr ""
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
 msgstr ""
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr ""
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr ""
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr ""
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
 "without a static reference)"
 msgstr ""
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr ""
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr ""
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -55221,11 +55583,11 @@ msgid ""
 "[Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 msgstr ""
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr ""
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed "
 "(non-resolvable) specifier. By default such a site is compiled to a rejected "
@@ -55238,124 +55600,124 @@ msgid ""
 "[Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 msgstr ""
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr ""
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
 msgstr ""
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr ""
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see "
 "[Lockdown](lockdown.md)."
 msgstr ""
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr ""
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr ""
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr ""
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr ""
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr ""
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr ""
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
 msgstr ""
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr ""
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr ""
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr ""
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr ""
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr ""
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr ""
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr ""
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr ""
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr ""
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr ""
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr ""
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
 msgstr ""
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -55364,15 +55726,15 @@ msgid ""
 "under CLAUDE.md's GC knob kill policy."
 msgstr ""
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr ""
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr ""
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -55414,11 +55776,11 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr ""
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -55431,56 +55793,229 @@ msgid ""
 "```"
 msgstr ""
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+msgid "# Simple CLI program\n"
 msgstr ""
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+msgid "# iOS app for simulator\n"
 msgstr ""
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+msgid "# visionOS app for simulator\n"
 msgstr ""
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr ""
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+msgid "# Plugin shared library\n"
 msgstr ""
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+msgid "# iOS widget with bundle ID\n"
 msgstr ""
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+msgid "# Debug compilation\n"
 msgstr ""
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+msgid "# Verbose compilation\n"
 msgstr ""
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+msgid "# Type-checked compilation\n"
 msgstr ""
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr ""
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr ""
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr ""
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
+msgstr ""
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+msgid "\"schema_version\""
+msgstr ""
+
+#: src/cli/flags.md:503
+msgid "\"compiler\""
+msgstr ""
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr ""
+
+#: src/cli/flags.md:505
+msgid "\"identity\""
+msgstr ""
+
+#: src/cli/flags.md:506
+msgid "\"module\""
+msgstr ""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+msgid "\"source_hash\""
+msgstr ""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+msgid "\"hir_hash\""
+msgstr ""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+msgid "\"lowering_hash\""
+msgstr ""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+msgid "\"target\""
+msgstr ""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+msgid "\"site_id\""
+msgstr ""
+
+#: src/cli/flags.md:514
+msgid "\"function\""
+msgstr ""
+
+#: src/cli/flags.md:514
+msgid "\"perry_fn_app_ts__read\""
+msgstr ""
+
+#: src/cli/flags.md:515
+msgid "\"array_element\""
+msgstr ""
+
+#: src/cli/flags.md:516
+msgid "\"operation\""
+msgstr ""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact "
+"module/compiler/input combination; function, kind and operation must also "
+"match. The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed "
+"schema/compiler/target/source/HIR/options mismatches, unknown modules/sites, "
+"duplicate identities and unsupported observations are ignored for "
+"specialization. Each rejected fact is reported on stderr with its reason. "
+"Accepted and rejected facts also appear in native-rep artifacts "
+"(`PERRY_NATIVE_REPS=1`) and `--explain-lowering`'s typed-path evidence and "
+"reason counts. Replay and catalog builds bypass build/object cache reuse to "
+"produce evidence from this compilation. Artifact filenames and report paths "
+"have run-specific nonces; decisions and lowering are deterministic for "
+"identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit "
+"fallback/materialization record for every claimed profile selection."
 msgstr ""
 
 #: src/cli/cache-dir.md:1
@@ -55655,15 +56190,15 @@ msgid "CLI flag wins over env var, env var wins over package.json:"
 msgstr ""
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+msgid "# 1. Per-build CLI flag\n"
 msgstr ""
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+msgid "# 2. Per-shell environment\n"
 msgstr ""
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr ""
 
 #: src/cli/fast-math.md:35
@@ -55679,17 +56214,17 @@ msgid "Contraction is separate from reassociation:"
 msgstr ""
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+msgid "# Permit FMA contraction only.\n"
 msgstr ""
 
 #: src/cli/fast-math.md:47
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr ""
 
 #: src/cli/fast-math.md:55
@@ -56437,7 +56972,7 @@ msgid "Emit"
 msgstr ""
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+msgid "# → myapp\n"
 msgstr ""
 
 #: src/cli/emit-attest.md:27
@@ -56511,7 +57046,7 @@ msgstr ""
 msgid "\"size\""
 msgstr ""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr ""
 
@@ -57483,10 +58018,6 @@ msgstr ""
 msgid "produces:"
 msgstr ""
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr ""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr ""
@@ -57557,8 +58088,8 @@ msgstr ""
 
 #: src/cli/perry-audit-sbom.md:81
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 
 #: src/cli/perry-audit-sbom.md:84
@@ -59369,7 +59900,7 @@ msgstr ""
 msgid "Setting"
 msgstr ""
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr ""
 
@@ -59449,15 +59980,15 @@ msgid ""
 msgstr ""
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr ""
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr ""
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr ""
 
 #: src/cli/perry-toml.md:605
@@ -59491,7 +60022,7 @@ msgid ""
 msgstr ""
 
 #: src/cli/perry-toml.md:618
-msgid "env"
+msgid "# GitHub Actions example\nenv"
 msgstr ""
 
 #: src/cli/perry-toml.md:620
@@ -60509,142 +61040,146 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
-msgstr ""
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
 
 #: src/cli/telemetry.md:9
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr ""
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
 "Perry version, success/error status, and an anonymous client UUID."
 msgstr ""
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr ""
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 msgstr ""
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr ""
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
 msgstr ""
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr ""
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr ""
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr ""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr ""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr ""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr ""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr ""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr ""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr ""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr ""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr ""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr ""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr ""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr ""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr ""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr ""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr ""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr ""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr ""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr ""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr ""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr ""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr ""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -60654,42 +61189,42 @@ msgid ""
 "capped at 200 chars, with a hard reject if any invariant fails."
 msgstr ""
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
 msgstr ""
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr ""
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+msgid "# shows current mode, sent/queued counts\n"
 msgstr ""
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
-msgstr ""
-
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:62
+msgid "# print redacted payloads queued this run\n"
 msgstr ""
 
 #: src/cli/telemetry.md:63
+msgid "# wipe the 30-day dedup cache\n"
+msgstr ""
+
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr ""
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml "
 "reference](perry-toml.md)."
@@ -60897,15 +61432,15 @@ msgid ""
 msgstr ""
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr ""
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr ""
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+msgid "// total alloc size, used for arena block walking\n"
 msgstr ""
 
 #: src/internals/memory-model.md:69
@@ -61148,7 +61683,7 @@ msgid ""
 "`=on`, and `=true` keep barriers enabled."
 msgstr ""
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr ""
 
@@ -61281,7 +61816,7 @@ msgstr ""
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop "
 "back-edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -61422,192 +61957,206 @@ msgid ""
 msgstr ""
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr ""
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
 msgstr ""
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr ""
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr ""
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr ""
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr ""
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr ""
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr ""
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr ""
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr ""
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr ""
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr ""
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr ""
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr ""
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr ""
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr ""
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr ""
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr ""
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr ""
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr ""
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr ""
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr ""
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr ""
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr ""
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr ""
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr ""
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr ""
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr ""
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr ""
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr ""
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr ""
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr ""
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr ""
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr ""
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -61922,110 +62471,227 @@ msgid ""
 "device/container budget with a 1 MiB floor. Overflow is returned to the "
 "allocator, thread exit drains that thread's pool, and a critical-pressure "
 "drain request is sticky: it survives unsafe/deferred periods and empties the "
-"pool when the owed full collection finishes its arena reclamation."
+"pool when the owed full collection finishes its arena reclamation. A full "
+"cycle's reclaim tail then asks the allocator itself to release what it is "
+"holding — mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, "
+"plus glibc `malloc_trim` or Darwin zone pressure relief for the system "
+"allocator — because a block deallocated into mimalloc's segment cache "
+"otherwise waits for a purge the idle program would never trigger."
 msgstr ""
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
 "of block high-water offsets."
 msgstr ""
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim "
+"(`crates/perry-runtime/src/gc/idle_reclaim.rs`) closes that gap at the event "
+"loop's park site. When the loop is about to sleep — no notify, no microtask, "
+"no timer due — and at least one collection the reducer did not start itself "
+"has completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr ""
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr ""
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr ""
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr ""
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr ""
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr ""
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr ""
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr ""
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr ""
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr ""
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr ""
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr ""
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus "
+"`[gc-trigger]`/`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge "
+"attribution and the per-minor `[gc-survival]` root attribution)"
 msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr ""
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -62034,13 +62700,14 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live "
 "runtime/codegen/compiler parsers and rejects a current document, executable "
@@ -62056,11 +62723,11 @@ msgid ""
 "this page keeps claiming the old thing."
 msgstr ""
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr ""
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -62068,109 +62735,109 @@ msgid ""
 "deliberately:"
 msgstr ""
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr ""
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr ""
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr ""
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
 msgstr ""
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
 msgstr ""
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr ""
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr ""
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr ""
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr ""
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr ""
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr ""
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
 "relevance filters."
 msgstr ""
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr ""
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC "
 "plan](https://github.com/PerryTS/perry/blob/main/docs/generational-gc-plan.md): "
 "original design and phase-by-phase landing log."
 msgstr ""
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC "
 "experiment](https://github.com/PerryTS/perry/blob/main/docs/statepoint-gc-experiment.md): "
@@ -62178,13 +62845,13 @@ msgid ""
 "native-root default."
 msgstr ""
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
 msgstr ""
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -62406,7 +63073,7 @@ msgid ""
 msgstr ""
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+msgid "The six ways it has actually broken"
 msgstr ""
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -62520,40 +63187,81 @@ msgid ""
 msgstr ""
 
 #: src/internals/gc-rooting-invariant.md:132
-msgid "How to check your work"
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
 msgstr ""
 
 #: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
+msgid "How to check your work"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
 "instrument that sees a defect before it crashes, which is why it runs first."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
 "`GcSuppressScope` in the `globalThis` bootstrap."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -62564,14 +63272,14 @@ msgid ""
 "`ALLOC_RE`.**"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the "
 "schedule/quarantine arms below and a _dependency-scale_ workload — #7280 "
 "records 25 curated corpus files passing while 20 lines of stock zod fail."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -62582,37 +63290,23 @@ msgid ""
 "which one you ran:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
 "shadow corpus has zero safepoints, so `--min-statepoints` fails there."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -62620,13 +63314,13 @@ msgid ""
 "collection point\" becomes:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -62635,47 +63329,47 @@ msgid ""
 "they have two different fixes:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -62685,7 +63379,7 @@ msgid ""
 "`llvm.experimental.gc.statepoint.p0`."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -62699,15 +63393,15 @@ msgid ""
 "positive, never a missed bug."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -62717,7 +63411,7 @@ msgid ""
 "without it."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -62730,18 +63424,18 @@ msgid ""
 "no poll anywhere near them."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -62749,7 +63443,7 @@ msgid ""
 "measured:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -62760,12 +63454,12 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -62778,7 +63472,7 @@ msgid ""
 "file already spelled correctly."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -62790,60 +63484,60 @@ msgid ""
 "running every mode (#7616):"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ "
 "`--statepoints`, added in #7663 precisely because the other three were blind "
@@ -62851,7 +63545,7 @@ msgid ""
 "and 8 and leaves the clean arms at 2 and 2."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -62867,14 +63561,14 @@ msgid ""
 "same commit.** Nothing will ask you to."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
 "both alongside `--audit-alloc-re` before the build."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -62889,7 +63583,7 @@ msgid ""
 "deleting it — deleting turns the audit green and leaves the hole."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -62905,25 +63599,21 @@ msgid ""
 "stripped first so a name mentioned in prose cannot become a premise."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -62933,7 +63623,7 @@ msgid ""
 "you run this mode by hand."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -62943,7 +63633,7 @@ msgid ""
 "runtime probe."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -62954,15 +63644,15 @@ msgid ""
 "`alloca_entry` site:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -62971,17 +63661,17 @@ msgid ""
 "when the window you are hunting executes only once — it is far slower."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -62989,13 +63679,13 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. "
 "`scripts/gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints "
 "a reproduce command per failure."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -63004,7 +63694,7 @@ msgid ""
 "only cheap way to explore the space the bug actually lives in."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -63012,7 +63702,7 @@ msgid ""
 "dereferenced. **Use 800.** A clean run at the default depth means nothing."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -63028,7 +63718,7 @@ msgid ""
 "settled."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -63036,7 +63726,7 @@ msgid ""
 "that let it go stale."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -63044,11 +63734,11 @@ msgid ""
 "The static checker catches the _cause_, now."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -63056,71 +63746,71 @@ msgid ""
 "are swapped**."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
 "half"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -63129,41 +63819,41 @@ msgid ""
 "needs a conjunction the program has to supply on its own:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
 "as evidence:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -63172,7 +63862,7 @@ msgid ""
 "verifier only asks about the second one."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -63180,7 +63870,7 @@ msgid ""
 "of the three."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -63188,7 +63878,7 @@ msgid ""
 "object that was never traced."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. "
 "`scripts/check_gc_env_knobs.py` is in `lint` precisely because this drifts: "
@@ -63197,7 +63887,7 @@ msgid ""
 "document is one the gate has confirmed a live parser owns."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -63205,7 +63895,7 @@ msgid ""
 "run\" is a distinguishable event."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -63217,25 +63907,25 @@ msgid ""
 "only thing that said no."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
 "caught:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
 "missing is the #5094 / #7511 family of silent stranding."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -63244,23 +63934,23 @@ msgid ""
 "code is not proof it runs."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
 "discriminating, and the \"optimization\" is measuring nothing."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
 "unknown."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  "
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib "
 "--bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only "
 "the suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -63269,30 +63959,23 @@ msgid ""
 "`index_set_barrier_tests.rs` and `write_pic_barrier_tests.rs` are the shape."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr ""
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -63300,13 +63983,13 @@ msgid ""
 "**new** store site cannot land with the question unanswered."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -63329,7 +64012,7 @@ msgid ""
 "against every stem."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -63344,7 +64027,7 @@ msgid ""
 "that limit."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -63357,17 +64040,17 @@ msgid ""
 "`--self-test` plants fifteen shapes, each of which must be adjudicated."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -63376,51 +64059,51 @@ msgid ""
 "it in one sentence: _25 curated files pass while 20 lines of stock zod fail._"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -63430,17 +64113,17 @@ msgid ""
 "the shapes cannot express them however many files it has."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+msgid "# zod is a package.json devDependency\n"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -63449,7 +64132,7 @@ msgid ""
 "a missing 40-line source would cross."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -63457,11 +64140,11 @@ msgid ""
 "min): its scan is superlinear, and 62 MB is 62 MB."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -63469,28 +64152,28 @@ msgid ""
 "functions."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
 "functions / M modules` so a silently-empty run is visible;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and "
 "`--seeded-violations 40` splices collection points into the **real** corpus "
@@ -63498,7 +64181,7 @@ msgid ""
 "checker silently losing the ability to read perry's output;"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -63508,18 +64191,18 @@ msgid ""
 "`POLL_CAPABLE_RUNTIME`."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in "
 "`scripts/gc_root_dominance_allowlist.json`, one entry each with a "
 "fingerprint, an issue, and a written justification."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -63527,69 +64210,69 @@ msgid ""
 "number by one, and nothing in the diff says what was conceded."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
 "bug cannot leave a tombstone that quietly widens coverage later."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
 "\\#7226);"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
 "0 once `Type::Symbol` stopped being classified as an immediate."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -63598,7 +64281,7 @@ msgid ""
 "the day it becomes required."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -63611,11 +64294,11 @@ msgid ""
 "budget where it is has bought a number, not an invariant."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -63624,26 +64307,26 @@ msgid ""
 "lowering's own emitted `js_object_set_field_by_name` calls."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
 "one rooted."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
 msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -63821,6 +64504,175 @@ msgstr ""
 
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism "
+"index](https://github.com/PerryTS/perry/blob/main/scripts/codegen_mechanisms.json) "
+"starts with the per-site concat cache from "
+"[\\#9514](https://github.com/PerryTS/perry/pull/9514), following the "
+"correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/9824#issuecomment-5554137476). "
+"It is an evidence index, not a complete inventory or a new CI gate. Missing "
+"entries mean unrecorded. Each entry names its lowering, runtime helper, "
+"admission conditions, workload expectations, observations, and existing "
+"regression tests. Refresh observations when the compiler, bundle, flags, or "
+"proof changes; a historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The "
+"[lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-codegen/src/concat_site_cache.rs) "
+"requires a string literal on the left in HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+msgid "Compile-time integer"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and "
+"integer-constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in "
+"[`bench_object_property.ts`](https://github.com/PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) "
+"is admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation "
+"with the codegen at `d36a1af0c` produced three tables and three fill call "
+"sites; disabling the cache produced none. Both builds retained the ordinary "
+"helper. This confirms applicability; it does not add a timing measurement to "
+"#9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+msgid "Recheck a workload"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid "Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler "
+"tests](https://github.com/PerryTS/perry/blob/main/crates/perry/tests/concat_site_cache.rs) "
+"pin positive and negative admission, the disable switch, and Node parity "
+"under evacuation. The [runtime lifecycle "
+"test](https://github.com/PerryTS/perry/blob/main/crates/perry-runtime/src/gc/tests/concat_site.rs) "
+"checks that collection rewrites a filled slot. These cover the public "
+"admitted shape even when the application bundle legitimately has no eligible "
+"sites."
 msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
@@ -64164,7 +65016,7 @@ msgid "\"js_object_alloc\""
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -64195,29 +65047,26 @@ msgid "Three types and one rule."
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
-msgstr ""
-
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:75
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:80
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
-msgstr ""
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:87
@@ -64227,20 +65076,23 @@ msgid ""
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:92
-msgid "/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+msgid ""
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:95
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:100
-msgid "/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+msgid ""
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -64255,23 +65107,19 @@ msgid ""
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+msgid "// Raw<'_>, borrows e\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+msgid "// needs &mut e\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr ""
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr ""
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
@@ -64280,7 +65128,7 @@ msgid ""
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+msgid "// re-read, correct\n"
 msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -64765,7 +65613,7 @@ msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:308
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -65927,10 +66775,27 @@ msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -65940,7 +66805,7 @@ msgid ""
 "attributes from untrusted downloaded binaries at runtime."
 msgstr ""
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -65951,41 +66816,41 @@ msgid ""
 "target artifact."
 msgstr ""
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr ""
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
 msgstr ""
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr ""
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr ""
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr ""
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr ""
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr ""
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr ""
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -65994,11 +66859,11 @@ msgid ""
 "object files are unchanged."
 msgstr ""
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr ""
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's "
 "[`js_native_api.h`](https://github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) "
@@ -66010,22 +66875,15 @@ msgid ""
 "resolution, but it deterministically reports the stated unsupported facility."
 msgstr ""
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr ""
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr ""
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -66033,610 +66891,617 @@ msgstr ""
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr ""
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr ""
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr ""
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr ""
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr ""
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 msgstr ""
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr ""
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 msgstr ""
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr ""
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr ""
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr ""
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr ""
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr ""
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr ""
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 msgstr ""
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr ""
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 msgstr ""
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr ""
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 msgstr ""
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr ""
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr ""
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr ""
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 msgstr ""
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr ""
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 msgstr ""
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr ""
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 msgstr ""
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr ""
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr ""
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr ""
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr ""
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr ""
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr ""
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr ""
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr ""
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr ""
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 msgstr ""
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr ""
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 msgstr ""
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr ""
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 msgstr ""
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr ""
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 msgstr ""
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr ""
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr ""
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr ""
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 msgstr ""
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr ""
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr ""
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr ""
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr ""
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr ""
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr ""
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 msgstr ""
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr ""
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr ""
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr ""
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
 msgstr ""
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr ""
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr ""
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr ""
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr ""
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr ""
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr ""
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr ""
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr ""
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 msgstr ""
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr ""
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 msgstr ""
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr ""
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr ""
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr ""
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr ""
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
 msgstr ""
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr ""
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr ""
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr ""
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr ""
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr ""
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr ""
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr ""
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr ""
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr ""
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 msgstr ""
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr ""
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr ""
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 msgstr ""
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr ""
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 msgstr ""
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr ""
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr ""
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr ""
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr ""
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr ""
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 msgstr ""
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr ""
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr ""
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr ""
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr ""
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr ""
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr ""
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 msgstr ""
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr ""
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 msgstr ""
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr ""
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr ""
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
 msgstr ""
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr ""
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 msgstr ""
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr ""
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr ""
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr ""
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 msgstr ""
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr ""
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 msgstr ""
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr ""
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr ""
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr ""
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr ""
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr ""
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr ""
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr ""
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
 "exports."
 msgstr ""
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr ""
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -66644,21 +67509,21 @@ msgid ""
 "audit scripts are clean."
 msgstr ""
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
 "addon asserts that no unwind entered its frames."
 msgstr ""
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
 "executable. The smoke call count must be greater than zero."
 msgstr ""
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -66666,33 +67531,33 @@ msgid ""
 "exact diagnostics."
 msgstr ""
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
 "both sides assert that their native implementation actually ran."
 msgstr ""
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a "
 "read-only location and load successfully; deletion or mutation of a sidecar "
 "fails the manifest hash check."
 msgstr ""
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
 msgstr ""
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
 msgstr ""
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -67172,27 +68037,11 @@ msgid "Use explicit commands for broader scopes:"
 msgstr ""
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+msgid "# Product feedback loop\n"
 msgstr ""
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
-msgstr ""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr ""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr ""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr ""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr ""
 
 #: src/contributing/crate-policy.md:104
@@ -67304,7 +68153,7 @@ msgid ""
 msgstr ""
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+msgid "# Build the default product and its dependency closure\n"
 msgstr ""
 
 #: src/contributing/building.md:37
@@ -67408,7 +68257,7 @@ msgid ""
 msgstr ""
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+msgid "# Slim, optimized developer CLI\n"
 msgstr ""
 
 #: src/contributing/building.md:80
@@ -67432,22 +68281,23 @@ msgid "Build Specific Crates"
 msgstr ""
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr ""
 
 #: src/contributing/building.md:95
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 
 #: src/contributing/building.md:97
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+msgid "# Codegen only\n"
 msgstr ""
 
 #: src/contributing/building.md:106
@@ -67482,15 +68332,15 @@ msgid "Run Tests"
 msgstr ""
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+msgid "# Product unit targets\n"
 msgstr ""
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+msgid "# Specific crate\n"
 msgstr ""
 
 #: src/contributing/building.md:137
@@ -67498,11 +68348,11 @@ msgid "Compile and Run TypeScript"
 msgstr ""
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+msgid "# Compile a TypeScript file\n"
 msgstr ""
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+msgid "# Debug: print HIR\n"
 msgstr ""
 
 #: src/contributing/building.md:148
@@ -67557,19 +68407,19 @@ msgid ""
 msgstr ""
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr ""
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+msgid "# must print 0\n"
 msgstr ""
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+msgid "# must print nothing\n"
 msgstr ""
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+msgid "# Fast policy and script checks.\n"
 msgstr ""
 
 #: src/contributing/releasing.md:23
@@ -67577,7 +68427,7 @@ msgid "origin/main"
 msgstr ""
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+msgid "# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 
 #: src/contributing/releasing.md:38
@@ -67593,7 +68443,7 @@ msgid ""
 msgstr ""
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr ""
 
 #: src/contributing/releasing.md:48
@@ -67613,7 +68463,7 @@ msgid "'[0-9]*.md'"
 msgstr ""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr ""
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -67695,7 +68545,7 @@ msgstr ""
 #: src/contributing/releasing.md:101
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -67716,20 +68566,14 @@ msgid ""
 msgstr ""
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr ""
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
-msgstr ""
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr ""
 
 #: src/contributing/releasing.md:128
@@ -67915,11 +68759,11 @@ msgid ""
 msgstr ""
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+msgid "# Compile for the simulator\n"
 msgstr ""
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr ""
 
 #: src/contributing/releasing.md:178
@@ -67927,19 +68771,7 @@ msgid "\"iPhone 15\""
 msgstr ""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
-msgstr ""
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr ""
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr ""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+msgid "# Install + launch with test mode\n"
 msgstr ""
 
 #: src/contributing/releasing.md:191
@@ -68145,6 +68977,10 @@ msgid "patch distance"
 msgstr ""
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr ""
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -68170,15 +69006,15 @@ msgid ""
 msgstr ""
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+msgid "# proves it can fail\n"
 msgstr ""
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+msgid "# offline\n"
 msgstr ""
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+msgid "# real registry, no issue writes\n"
 msgstr ""
 
 #: src/contributing/releasing.md:289

--- a/docs/po/th.po
+++ b/docs/po/th.po
@@ -214,7 +214,7 @@ msgstr "Hooks"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "ตัวอย่าง"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "ระดับ CI (ตรวจสอบ PR / sweep / ชุดทดสอบเต็ม)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "การจัดกำหนดการตรวจสอบ CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "อ้างอิง CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "คำสั่ง"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "แฟล็กของคอมไพเลอร์"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "ไดเรกทอรีแคช"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dynamic Stdlib Dispatch"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS Runtime Opt-In"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar การรับรองไบนารี)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Egress Allowlist (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "ความสามารถรายแพ็คเกจ (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Host Allowlist (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "อ้างอิง perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "การตรวจสอบอัปเดตในแอปของคุณ"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "ความเป็นส่วนตัวและเทเลเมตร"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Internals"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Memory Model"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "ตัวเก็บขยะ"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "การจัดการหน่วยความจำแบบชัดแจ้ง"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "อินวาเรียนต์การรูทของ GC (การสร้างโค้ด)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "หลักฐานชนิดสำหรับไบนดิงภายใน"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "ขอบเขตของขั้นตอน GC แบบเพิ่มหน่วย"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: การรูทโดยโครงสร้าง"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "การมีส่วนร่วม"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "สถาปัตยกรรม"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "นโยบาย crate"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "การคอมไพล์จากซอร์สโค้ด"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "การเผยแพร่ Perry"
 
@@ -927,7 +935,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# เปิดหน้าต่าง macOS/Windows/Linux เป็นพื้นเมือง"
 
 #: src/introduction.md:79
@@ -960,11 +969,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -973,9 +982,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -985,7 +994,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "ขั้นตอนถัดไป"
@@ -1056,27 +1065,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux Linker toolchain โดยการกระจาย"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS สตรีม"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# อัลปิน / มูสล"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# ไม่มีผล Linux"
 
 #: src/getting-started/installation.md:41
@@ -1115,15 +1130,18 @@ msgstr ""
 "(macOS arm64/x64, Linux x64/arm64 glibc + musl, Windows x64) ด้วยคําสั่งเดียว:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# โครงการ-ท้องถิ่น (สตาร์ท Perry's รุ่นข้าง deps ของคุณ)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# ไม่ติดตั้งอะไรเลย ยิงครั้งเดียว"
 
 #: src/getting-started/installation.md:66
@@ -1316,7 +1334,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "ไฟล์ไบนารีอยู่ที่ `target/release/perry` เพิ่มลงใน PATH ของคุณ:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# เพิ่ม ~/.zshrc หรือ ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1447,16 +1466,14 @@ msgstr ""
 "platform อื่นไม่จำเป็นต้องใช้)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2127,24 +2144,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "โค้ดเดียวกันรันได้บนทั้ง 6 แพลตฟอร์ม:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (ปกติ)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOS ซิมูเลอร์"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# เว็บ (สะกดเป็น WebAssembly + DOM bridge ในไฟล์ HTML ที่ครอบคลุมตัวเอง)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# ชื่อเล่น: --target"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# สนามอื่นๆ"
 
 #: src/getting-started/first-app.md:138
@@ -2383,7 +2405,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2401,7 +2423,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2615,7 +2637,8 @@ msgstr ""
 "โดย script สำหรับ generate มีดังนี้:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2647,7 +2670,8 @@ msgid "\"port\""
 msgstr "\"ท่าเรือ\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// แหล่งที่อยู่ลําพัง"
 
 #: src/getting-started/project-config.md:122
@@ -2891,19 +2915,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "ฟิลด์"
 
@@ -2918,9 +2943,9 @@ msgstr "ฟิลด์"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3038,11 +3063,13 @@ msgid ""
 msgstr "Perry รองรับแพ็กเกจ npm ยอดนิยมหลายตัวอย่างเป็นธรรมชาติโดยไม่ต้องกำหนดค่าใดๆ:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3097,7 +3124,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3105,7 +3132,7 @@ msgstr ""
 "แพ็กเกจเหล่านี้ถูกคอมไพล์เป็นโค้ดเนทีฟโดยใช้การติดตั้งภายในของ Perry ดูรายการทั้งหมดได้ที่ "
 "[Standard Library](../stdlib/overview.md)"
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3113,44 +3140,47 @@ msgstr ""
 "สำหรับแพ็กเกจที่ไม่ได้รับการสนับสนุนแบบเนทีฟ ให้ใช้ `compilePackages` สำหรับแพ็กเกจ TS/JS "
 "ล้วน หรือใช้ JavaScript runtime สำรองสำหรับแพ็กเกจที่ซับซ้อน"
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "โครงสร้างโปรเจกต์"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry มีความยืดหยุ่นเกี่ยวกับโครงสร้างโปรเจกต์ รูปแบบที่พบบ่อย:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "สำหรับแอป UI:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "การคอมไพล์"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# รวมไฟล์"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# รวบรวมกับเป้าหมายเฉพาะ"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Debug: พิมพ์การแสดงระยะกลาง"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "ดูตัวเลือกทั้งหมดได้ที่ [CLI Commands](../cli/commands.md)"
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr "[CLI Commands](../cli/commands.md) — คำสั่งและแฟล็กของคอมไพเลอร์ทั้งหมด"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3158,7 +3188,7 @@ msgstr ""
 "[Supported Features](../language/supported-features.md) — ฟีเจอร์ TypeScript "
 "ที่ใช้งานได้"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Standard Library](../stdlib/overview.md) — แพ็กเกจ npm ที่รองรับ"
 
@@ -3295,32 +3325,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "คลาส"
 
@@ -5314,6 +5345,7 @@ msgstr ""
 "และรองรับสองเส้นทาง:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5323,7 +5355,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**class decorator, method decorator, property decorator, constructor "
 "parameter decorator และ method parameter decorator แบบ legacy** สำหรับ Nest-"
@@ -5335,7 +5371,7 @@ msgstr ""
 "emit `design:paramtypes` สำหรับ class/method ที่มี decorator และ `design:type` "
 "สำหรับ property ที่มี decorator"
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5347,15 +5383,15 @@ msgstr ""
 "ที่พิมพ์ข้อมูล entry/exit ณ compile time โดยไม่มี decorator machinery ณ runtime ใดๆ "
 "ดู `crates/perry-hir/src/decorator_log.rs` สำหรับรายละเอียดการ implement"
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "สิ่งที่ใช้งานไม่ได้"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "accessor decorator และการแทนที่ descriptor"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5370,15 +5406,15 @@ msgstr ""
 "wrapper ที่ return class ที่ถูก wrap ต้องการการ port ให้รองรับ Perry เนื่องจาก class "
 "ที่ถูก lower ถูกตรึงไว้ใน IR และไม่สามารถแทนที่ได้ ณ runtime"
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr "การเรียก helper `Reflect.metadata(...)` ทั่วไปนอก syntax decorator"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` ในฐานะคีย์ metadata"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5386,7 +5422,7 @@ msgstr ""
 "`emitDecoratorMetadata` นอกเหนือจาก `design:paramtypes` ของ class/method และ "
 "`design:type` ของ property"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5396,12 +5432,12 @@ msgstr ""
 "class-constructor แบบจำกัด (`tsyringe`, พฤติกรรม NestJS injector แบบเต็มรูปแบบ, "
 "root injector ของ Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "การไหลของ metadata ในขณะรันไทม์ของ `class-validator`, `type-graphql`, `TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5411,11 +5447,11 @@ msgstr ""
 "หรือ AOT transform เฉพาะทาง ไม่ใช่การพึ่งพา legacy TypeScript decorator runtime "
 "แบบเต็มรูปแบบ"
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "รูปแบบที่แนะนำ: การสร้างแบบชัดเจน"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5427,7 +5463,7 @@ msgstr ""
 "และเป็นวิธีที่เฟรมเวิร์ก TS ที่ไม่ใช้ decorator (Hono, เซิร์ฟเวอร์ tRPC, แอป Drizzle) "
 "ทำงานอยู่แล้ว"
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5443,7 +5479,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5452,11 +5488,11 @@ msgstr ""
 "ไม่มี container ไม่มี `@Injectable` ไม่มี `providedIn: 'root'` — ลำดับการสร้าง _คือ_ "
 "กราฟการอ้างอิง และถูกตรวจสอบโดยคอมไพเลอร์ TypeScript"
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "สูตรการย้าย: บริการ Angular"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5465,25 +5501,25 @@ msgstr ""
 "ตัวอย่างด้านล่างเป็นบริการจริงจาก sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 บรรทัด) แสดงในรูปแบบ Angular ดั้งเดิมและพอร์ตมาเป็น Perry"
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "ก่อน — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "หลัง — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "การเปลี่ยนแปลงเชิงกลสามอย่าง:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
 msgstr "**ลบ `@Injectable` ออก** มันไม่ได้นำข้อมูลที่รูปร่างของคลาสไม่ได้นำอยู่แล้วมา"
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5493,7 +5529,7 @@ msgstr ""
 "Observables-from-HTTP ส่วนใหญ่เป็นค่าเดี่ยวและทำงานเหมือน Promises "
 "(สำหรับสตรีมแบบหลายค่า ให้ใช้ `AsyncIterable`)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5504,11 +5540,11 @@ msgstr ""
 "ด้วยการประกาศฟิลด์อย่างชัดเจน Perry รองรับ parameter properties "
 "แต่ฟิลด์ที่ประกาศชัดเจนอ่านได้เข้าใจง่ายกว่าเมื่อคลาสถูกสร้างอินสแตนซ์ด้วยมือแทนที่จะใช้ container"
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "การเชื่อมต่อ"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5528,7 +5564,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5546,7 +5582,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5556,11 +5592,11 @@ msgstr ""
 "container โดยปริยาย — ทั้งหมดยุบลงเหลือเพียงบรรทัด `new RatingService(api)` "
 "หนึ่งบรรทัดใน `services.ts`"
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "แล้ว Angular components, NestJS controllers, TypeORM entities ล่ะ?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5581,11 +5617,11 @@ msgstr ""
 "ปล่อยการตกแต่งเมื่อเป็นไปได้, เขียนการสร้างที่ชัดเจนเทียบเท่า, "
 "บันทึกเส้นทางหรือสเก็มะเป็นการเรียกฟังก์ชันธรรมดา / เงื่อนไขระดับโมดูล"
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "ทิศทางในอนาคต"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6260,12 +6296,13 @@ msgstr ""
 "ใช้พื้นผิวที่สวยงามด้านบนและไม่ต้องการอะไรในเวลาเชื่อมต่อ"
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**การเรียกสแตติก** (`WebAssembly.instantiate(bytes)` เขียนต่อต้านโลก) ต่ําลงไปยัง "
@@ -7786,52 +7823,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "การเขียน binding — ทัวร์ใน 60 วินาที"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF rendering bindings\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr "# แก้ไข src/lib.rs  เพิ่มฟังก์ชัน `js_*` ของคุณ, ใช้ทั้งหมดเพียง"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# แก้ไข src/index.ts  ประกาศการนําเข้ารหัสผู้ใช้บนพื้นที่ TS"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# แก้ไข package.json  รายการทุกการส่ง js_* ใน"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ รายงานการใช้งานตรงกับ staticlib"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# release.yml ที่ติดกระเบื้อง"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr "                                    # สร้างเครื่องมือสําหรับเป้าหมายทั้งหมด"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # และจะผูกมันไว้กับการปล่อย"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8209,7 +8207,7 @@ msgstr "สถานะปัจจุบัน"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8229,7 +8227,7 @@ msgstr "รวม; คาดว่าจะถอน"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8281,7 +8279,7 @@ msgstr "แบนด์; การอพยพรอคอย"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8341,7 +8339,7 @@ msgstr "รวมแหล่งแพคเกจด้านบน"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8349,7 +8347,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8357,7 +8355,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8365,7 +8363,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8397,7 +8395,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8405,7 +8403,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8413,7 +8411,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8445,7 +8443,7 @@ msgstr "ผสมผสาน"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8453,7 +8451,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8485,7 +8483,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8493,7 +8491,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8501,7 +8499,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8509,7 +8507,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8525,7 +8523,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8533,7 +8531,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8541,7 +8539,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8549,7 +8547,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8573,7 +8571,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8581,7 +8579,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8589,7 +8587,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8597,7 +8595,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8605,7 +8603,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8613,7 +8611,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8621,7 +8619,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8629,7 +8627,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8637,7 +8635,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8645,7 +8643,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8653,7 +8651,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8661,7 +8659,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8714,14 +8712,6 @@ msgstr "บัญชี GitHub หากคุณต้องการให้�
 msgid "1. Scaffold"
 msgstr "1. สร้างโครง"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"การผูกพันธนาการพื้นเมืองสําหรับ <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "สิ่งนี้สร้าง:"
@@ -8753,26 +8743,14 @@ msgstr ""
 "โดยใช้ **เฉพาะ** ชนิดข้อมูลจาก `perry_ffi`:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  สกัดข้อความจากพัฟเฟอร์ PDF"
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # ความปลอดภัย"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
-msgstr "/// `buf_ptr` ต้องเป็น null หรือใช้ได้สําหรับ `buf_len` ไบท์ Perry ผ่าน"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// คู่นี้มาจากพารามีเตอร์ `buffer+len`"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
+msgstr ""
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -8905,7 +8883,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"ใจดี\""
 
@@ -9140,7 +9118,8 @@ msgid "In a separate directory:"
 msgstr "ในไดเรกทอรีแยกต่างหาก:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# หรือเส้นทางใด ๆ ที่เครื่องมือของคุณรองรับ"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9525,7 +9504,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Event listeners (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// การปิดตัวชี้วัด, ถูกรักษามีชีวิตโดย GC สแกนเนอร์ด้านล่าง"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -9945,7 +9925,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ...อ่านไฟล์, กําหนดสภาพแวดล้อม, กลับ 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10243,8 +10224,8 @@ msgstr "จำเป็น"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "หมายเหตุ"
 
@@ -10302,14 +10283,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -11988,28 +11969,35 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "เครื่องมือ  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr "# การจัดสรรหรือบัมป์ pin หนึ่งไปยังเวอร์ชั่นเฉพาะเจาะจง (แบบตั้งค่า: ล่าสุดคง)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# การจัดสรรทุกการผูกพันที่ไม่ติดต่อกันในขณะนี้ที่คงที่ล่าสุดของมัน"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr "# ประตูออฟไลน์ (CI): ปินมีอยู่, ปิดล็อค, กล่องมีอยู่ ทางออกที่ 1"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr "# แนะนํา: นอกจากนี้ปิ้นธงที่มีการปล่อยที่มั่นคงใหม่ขึ้นไป"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr "# วัตถุประกอบ repo ด้านบนที่ ref ปิงใน gitignored ด้านบน/<name>"
 
 #: src/native-libraries/upstream-pins.md:71
@@ -12228,15 +12216,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "สําหรับ CI ที่ไม่ควรแทนการบรรจุบางส่วน ตั้ง:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12386,7 +12374,7 @@ msgstr "ความเป็นจริง"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12403,7 +12391,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14350,19 +14338,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "เปรียบเทียบกับ Node.js worker_threads"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~ 15 เส้น, ต้องการไฟล์แยก"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14382,12 +14370,11 @@ msgid "/* handle */"
 msgstr "/* มือถือ */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// ── Perry: 1 เส้น"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const result = wait spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14601,13 +14588,14 @@ msgid "Mental Model"
 msgstr "แบบจำลองความคิด"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "UI ของ Perry ใช้แบบจำลองเดียวกับ SwiftUI และ Flutter: "
 "คุณประกอบวิดเจ็ตเนทีฟโดยใช้คอนเทนเนอร์เลย์เอาต์แบบ stack (`VStack`, `HStack`, "
@@ -14691,7 +14679,7 @@ msgstr "`App({})` รับอ็อบเจ็กต์การกำหน�
 msgid "Property"
 msgstr "คุณสมบัติ"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15132,7 +15120,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15154,7 +15142,7 @@ msgid ""
 "Platform-specific behavior is noted on each widget's documentation page."
 msgstr "พฤติกรรมเฉพาะแพลตฟอร์มถูกระบุไว้ในหน้าเอกสารของแต่ละวิดเจ็ต"
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -16755,7 +16743,8 @@ msgid "Double-click handler"
 msgstr "ตัวจัดการการดับเบิลคลิก"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -16814,12 +16803,13 @@ msgstr ""
 "examples/ui/layout/snippets.ts) — CI จะคอมไพล์และรันในทุก PR"
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "ผู้ช่วยการวางแผนเป็นฟังก์ชันฟรี: `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17288,7 +17278,7 @@ msgstr "ผลลัพธ์"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17301,7 +17291,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "ลูก ๆ จัดแนวให้ชิดขอบนำหน้า (ซ้าย)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17314,7 +17304,7 @@ msgid "Children centered horizontally"
 msgstr "ลูก ๆ จัดให้อยู่กึ่งกลางตามแนวนอน"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17335,7 +17325,7 @@ msgstr "**การจัดแนวของ HStack** (แกนตัดข�
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17362,8 +17352,8 @@ msgstr "ลูก ๆ จัดให้อยู่กึ่งกลางต�
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17415,9 +17405,9 @@ msgstr "พฤติกรรม"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17440,11 +17430,11 @@ msgstr "ลูกทุกตัวได้ขนาดเท่ากัน"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -17632,9 +17622,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stack ที่มี Padding ในตัว"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "สร้าง stack พร้อม padding ในการเรียกครั้งเดียว ลำดับคือ **top, left, bottom, right** "
 "(สไตล์ shorthand แบบ CSS) ไม่ใช่ top/right/bottom/left:"
@@ -17658,11 +17649,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` คือคู่หูในแนวนอน "
 "เทียบเท่ากับการสร้าง stack แล้วเรียก `widgetSetEdgeInsets` แต่กระชับกว่า ลูก ๆ "
@@ -17946,8 +17938,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18328,6 +18321,7 @@ msgstr ""
 "ที่แสดงที่นี่จะเป็น API ที่คอมไพเลอร์ยอมรับเสมอ"
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18339,7 +18333,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18367,11 +18360,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "สี"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18387,11 +18380,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "ฟอนต์"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18407,15 +18400,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "ใช้ `\"monospaced\"` สำหรับฟอนต์ monospaced ของระบบ"
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Corner Radius"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18427,21 +18420,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "ขอบ"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding และ Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18451,11 +18444,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "การกำหนดขนาด"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18471,11 +18472,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "ความทึบ"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18487,11 +18488,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Gradient พื้นหลัง"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18513,11 +18514,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "ขนาดของ Control"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18529,17 +18530,17 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
 msgstr "**macOS**: แมปไปยัง `NSControl.ControlSize` แพลตฟอร์มอื่นอาจตีความต่างกัน"
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltip"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18551,7 +18552,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18559,11 +18560,11 @@ msgstr ""
 "**macOS/Windows/Linux**: tooltip เนทีฟ **iOS/Android**: ไม่รองรับ tooltip "
 "**Web**: แอตทริบิวต์ HTML `title`"
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "เปิด/ปิดใช้งาน"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -18575,11 +18576,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "ตัวอย่าง Imperative แบบสมบูรณ์"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -18599,7 +18601,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -18627,10 +18629,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -18703,15 +18705,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "การประกอบสไตล์ (ฟังก์ชันช่วยเหลือแบบ imperative)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "ลดการเขียนซ้ำซ้อนด้วยการสร้างฟังก์ชันช่วยเหลือ:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -18720,11 +18722,11 @@ msgstr ""
 "สำหรับแอปขนาดใหญ่ ให้ใช้แพ็กเกจ `perry-styling` เพื่อกำหนด design tokens ใน JSON "
 "และสร้างไฟล์ธีมที่มีการกำหนดประเภท ดู [Theming](theming.md) สำหรับเวิร์กโฟลว์ฉบับเต็ม"
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "การรองรับแพลตฟอร์ม"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -18734,7 +18736,7 @@ msgstr ""
 "matrix.md) — ถูกสร้างอัตโนมัติจาก `crates/perry-ui/src/styling_matrix.rs` และ CI "
 "ตรวจสอบกับ exports ของ `lib.rs` ของแต่ละ backend ในทุก PR"
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -18752,15 +18754,15 @@ msgstr ""
 "github.com/PerryTS/perry/issues/210) อย่าสําเนาการนับไปในตารางที่รักษาด้วยมืออื่น; "
 "ดูเมทริกซ์เพื่อให้เอกสารไม่สามารถหลุดออกจากรายการรายการด้านหลัง."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — คอนเทนเนอร์เลย์เอาต์"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — แอนิเมตการเปลี่ยนแปลงสไตล์"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — Design tokens ผ่านแพ็กเกจ `perry-styling`"
 
@@ -20082,8 +20084,8 @@ msgstr "การ Implement"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "สถานะ"
 
@@ -23547,7 +23549,7 @@ msgstr "ล้าง cookie / localStorage / IndexedDB สำหรับ data s
 msgid "Options"
 msgstr "Options"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25088,7 +25090,7 @@ msgstr "ความเทียบเท่ากับ ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -25805,15 +25807,18 @@ msgid "Cross-Compilation"
 msgstr "การคอมไพล์ข้ามแพลตฟอร์ม"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# ปกติ: รวมให้กับแพลตฟอร์มปัจจุบัน"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# รวมสําหรับเป้าหมายเฉพาะ"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  Android บนนาฬิกา"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26024,7 +26029,8 @@ msgid "Building"
 msgstr "การบิลด์"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS เป็นเป้าหมายโดยซ้ํา"
 
 #: src/platforms/macos.md:18
@@ -26125,7 +26131,8 @@ msgid "App Store Distribution"
 msgstr "การแจกจ่ายบน App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# สมัครด้วยใบรับรอง App Store"
 
 #: src/platforms/macos.md:60
@@ -26133,7 +26140,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -26262,15 +26270,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "วิธีที่ง่ายที่สุดในการบิลด์และรันบน iOS คือ `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# อัตโนมัติตรวจพบ device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# การถ่ายทอดสด stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# ใช้ Perry ฮับ สร้างเซอร์เวอร์"
 
 #: src/platforms/ios.md:40
@@ -26895,7 +26906,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "คำสั่งนี้สร้างไบนารี ARM64 สำหรับฮาร์ดแวร์ Apple TV จริง"
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# การตรวจจับอัตโนมัติ Apple TV simulator booted"
 
 #: src/platforms/tvos.md:39
@@ -27369,11 +27381,13 @@ msgstr ""
 "กลางคืน (ดู [การ สร้าง เครื่อง](#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# เครื่องจําลอง (ระดับ 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -27480,20 +27494,14 @@ msgstr ""
 "renderer) จากแหล่งหนึ่งครั้ง, แล้วชี้ `PERRY_RUNTIME_DIR` ไปยังพวกเขา:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (ซีรีส์ 9+ / watchOS 26+)  เป้าหมายอุปกรณ์แบบตั้งค่า"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (ชุด 4-8 / SE) เลือกใช้ PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -27509,7 +27517,7 @@ msgid "Build environment variables"
 msgstr "สร้างแปรแวดล้อม"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "ตัวแปร"
@@ -27623,7 +27631,8 @@ msgstr ""
 "และการบังคับค่า `TypeError` ที่เกิดขึ้นทําให้การปิดเป็นวัตถุ."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# เครื่องจําลองนาฬิกาที่เปิดด้วยระบบตรวจจับอัตโนมัติ"
 
 #: src/platforms/watchos.md:126
@@ -28194,36 +28203,13 @@ msgstr ""
 "เท่านั้น ดังนั้นสไลส์จึงเป็นเครื่องสําอางค์) แล้ว `lipo` รวมมันเข้าด้วยกัน:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 ตัดที่เป้าหมายการใช้งานร่วม (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 slice (เป้าหมายของอุปกรณ์โดยกําหนด)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. สะดวกเหลี่ยม + ฟิวส์"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -28338,19 +28324,8 @@ msgstr ""
 "ดังนั้นแอพที่ใช้แค่การดู **บันทึกแอพใหม่ของตัวเอง** ใน App Store Connect"
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"การจําหน่ายของแอปเปิล: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -28363,6 +28338,10 @@ msgid ""
 msgstr ""
 "`altool` ไม่สามารถอัพโหลดแอปพลิเคชั่นการเฝ้า (\"ไม่สามารถกําหนดแพลตฟอร์ม\") ใช้ "
 "Transporter:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -28698,18 +28677,21 @@ msgid "One-time setup (macOS example)"
 msgstr "การตั้งค่าครั้งเดียว (ตัวอย่าง macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` อาจเป็น 9.x  pin 8.x หากเช่นนั้น)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# หรือ Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr "# 2. ชี้ env ที่ SDK / NDK / JDK 17 (เพิ่มไปยังโปรไฟล์ shell ของคุณ)"
 
 #: src/platforms/wearos.md:40
@@ -28717,7 +28699,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -28729,32 +28712,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. แพ็คเกจ SDK + ภาพ Wear OS arm64"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"เครื่องมือแพลตฟอร์ม\" \"เอมูเลอร์\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "แพลตฟอร์ม แอนดรอยด์-35 เครื่องมือสร้าง 35.0.0"
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"ภาพระบบ แอนดรอยด์-34 แอนดรอยด์ใส่ แอร์ม64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. เป้าหมายข้าม Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. สร้าง + เบ็ตเอมูเลอเตอร์ Wear OS (ชมรอบ)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -28779,7 +28743,8 @@ msgstr ""
 "(ด้านล่าง)"
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# การตรวจพบนาฬิกาที่เชื่อมต่อ / เครื่องจําลอง Wear booted โดยอัตโนมัติ"
 
 #: src/platforms/wearos.md:82
@@ -30695,7 +30660,8 @@ msgstr ""
 "`GskRenderer` สำหรับการจับภาพที่แม่นยำระดับพิกเซล"
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# ในเทอร์มินอลอีกแห่ง"
 
 #: src/platforms/linux.md:82
@@ -30713,7 +30679,8 @@ msgstr ""
 "widget"
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# ออกแบบเดียวกันกับ --target wasm"
 
 #: src/platforms/web.md:10
@@ -30787,15 +30754,18 @@ msgstr ""
 "การ import FFI และการทำเธรดผ่าน Web Worker แบบ \"ฟรี\""
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML ที่ครอบคลุมตัวเอง (แบบปกติ)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# เหมือนกัน"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# รู .wasm ไบนารี (ไม่มี HTML wrapper)"
 
 #: src/platforms/wasm.md:21
@@ -31109,11 +31079,13 @@ msgid "Provide them when instantiating:"
 msgstr "ระบุฟังก์ชันเหล่านี้ตอนสร้างอินสแตนซ์:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// ผ่าน __ffiImports ทั่วโลก (ตั้งก่อนการเริ่มต้น)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// หรือผ่าน bootPerryWasm อาร์กัมเมนต์ที่สอง"
 
 #: src/platforms/wasm.md:95
@@ -31645,7 +31617,7 @@ msgstr "stdlib ครบทั้งหมด"
 msgid "The compiler links only the required runtime components."
 msgstr "คอมไพเลอร์จะลิงก์เฉพาะส่วนประกอบรันไทม์ที่จำเป็นเท่านั้น"
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "ไบดิ้งเนทีฟภายนอก"
 
@@ -31757,7 +31729,7 @@ msgstr "[ระบบไฟล์](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP และเครือข่าย](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[ฐานข้อมูล](database.md)"
 
@@ -31976,8 +31948,8 @@ msgid ""
 "Pass file paths across thread boundaries and reopen files inside the worker."
 msgstr "ส่ง path ของไฟล์ข้ามขอบเขต thread และเปิดไฟล์ใหม่ภายใน worker"
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[ภาพรวม](overview.md) — โมดูล stdlib ทั้งหมด"
 
@@ -32074,10 +32046,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "รองรับใน `IncomingMessage`: `.method`, `.url`, `.headers`, `.rawHeaders`, "
@@ -32086,10 +32059,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`"
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -32682,10 +32656,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / ที่เก็บอ็อบเจกต์ที่เข้ากันได้กับ S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -32700,11 +32700,11 @@ msgstr ""
 "คอมไพล์เนทีฟภายใต้ `perry.compilePackages` โดยไม่ต้องแพตช์ใดๆ — ตรวจสอบแล้วว่า SigV4 "
 "presigned-URL ตรงกันแบบ byte-for-byte กับ `bun` (issue #551)"
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -32778,76 +32778,76 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr "โค้ดเดียวกันทำงานกับบริการที่เข้ากันได้กับ S3 ใดก็ได้ — เปลี่ยนเฉพาะ `endPoint`:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "บริการ"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (สำหรับทดสอบ)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -32863,7 +32863,7 @@ msgstr ""
 "ได้รับการตรวจสอบว่าเหมือนกัน byte-for-byte กับ `bun` เทียบกับ test vectors ที่ pinned "
 "ไว้ และจะยืนยันตัวตนกับ S3 จริงได้"
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -32874,7 +32874,7 @@ msgstr ""
 "chunk) ใช้พื้นผิวเพิ่มเติม — การสืบทอด `WritableStream` / `TransformStream` ตาม #562 "
 "— เส้นทางนั้นคอมไพล์ได้แต่ยังไม่ได้รับการตรวจสอบอิสระเทียบกับ pinned vectors ที่นี่"
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -33510,9 +33510,10 @@ msgstr ""
 "`mean`, `sumBy`, `meanBy`, `max`, `min`, `maxBy`, `minBy` และ `inRange`"
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "ใช้การนําเข้าที่มีชื่อ: แบบฟอร์มตัวรับการนําเข้าแบบบังคับ (`import _ from \"lodash\";  "
@@ -33722,19 +33723,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"แพ็กเกจ npm เพิ่มเติมและ API ของ Node.js ที่ Perry รองรับ "
-"ทั้งหมดที่ระบุไว้ที่นี่เชื่อมต่อผ่านรีจิสตรี native bindings ของ Perry (#466) "
-"และคอมไพล์เป็นโค้ดเนทีฟโดยไม่มีรันไทม์ JavaScript เข้ามาเกี่ยวข้อง"
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (การประมวลผลภาพ)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -33742,7 +33739,7 @@ msgstr ""
 "Native bindings ผ่าน `perry-ext-sharp` (v0.5.551) การปรับขนาด การแปลงรูปแบบ "
 "และการส่งออกเป็น buffer/ไฟล์ ทำงานได้ทั้งหมด"
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -33792,15 +33789,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (การแยกวิเคราะห์ HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Native bindings ผ่าน `perry-ext-cheerio` (v0.5.550)"
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -33818,11 +33815,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (อีเมล)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -33862,15 +33859,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (การบีบอัด)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Native bindings ผ่าน `perry-ext-zlib` (v0.5.541)"
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -33888,11 +33885,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (การกำหนดเวลางาน)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -33900,7 +33897,7 @@ msgstr ""
 "Native bindings ผ่าน `perry-ext-cron` (v0.5.564) ชื่อแพ็กเกจ `cron` และ `node-"
 "cron` ทั้งสองอย่าง route ไปยังแบ็กเอนด์เดียวกัน"
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -33920,11 +33917,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -33934,7 +33931,7 @@ msgstr ""
 "สไตล์ [`ethers-rs`](https://github.com/gakonst/ethers-rs) ผ่านส่วนต่อประสาน "
 "BigInt + Buffer ของ `perry-ffi`"
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -33952,11 +33949,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -33964,7 +33961,7 @@ msgstr ""
 "Native bindings ผ่าน `perry-ext-events` (v0.5.546) รูปแบบของ `EventEmitter` "
 "ตรงกับ Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`"
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -33982,15 +33979,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (ตรรกะการลองใหม่)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Native bindings ผ่าน `perry-ext-exponential-backoff` (v0.5.542)"
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -34012,11 +34009,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (ความแม่นยำตามต้องการ)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -34024,7 +34021,7 @@ msgstr ""
 "Native bindings ผ่าน `perry-ext-decimal` (v0.5.547) ชื่อแพ็กเกจทั้งสองส่งไปยัง "
 "backend เดียวกัน — เปิดใช้ทั้ง `Decimal` และ `BigNumber`"
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -34060,11 +34057,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (การจัดการวันที่)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -34072,7 +34069,7 @@ msgstr ""
 "Native bindings ผ่าน `perry-ext-dayjs` (v0.5.548) ชื่อแพ็กเกจทั้งสองส่งไปยัง Rust "
 "backend เดียวกัน — มีส่วนต่อประสาน parse/format/diff เหมือนกัน"
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -34090,11 +34087,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (วันที่แบบเดิม)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -34104,7 +34101,7 @@ msgstr ""
 "อยู่ในโหมดบำรุงรักษาที่ต้นทาง — แนะนำให้ใช้ `dayjs` สำหรับโค้ดใหม่ แต่ Perry "
 "รองรับทั้งสองตัวสำหรับโค้ดเบสที่มีอยู่"
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -34120,11 +34117,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -34133,7 +34130,7 @@ msgstr ""
 "ตัวจำกัดอัตราในหน่วยความจำได้รับการเชื่อมต่อแล้ว ส่วน Redis / cluster backing stores "
 "จะตามมาในภายหลัง"
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -34157,11 +34154,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -34179,7 +34176,7 @@ msgstr ""
 "`parallelFilter` / `spawn` จาก `perry/thread` ยังคงเป็นอินเตอร์เฟซที่เรียบง่าย (ดู "
 "[Threading](../threading/overview.md))"
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -34217,12 +34214,12 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr "URL โมดูล Web Worker ถูกค้นพบเทียบกับไฟล์แหล่งการนําเข้า:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -34255,10 +34252,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (การ Parse CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -34300,11 +34470,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -34325,7 +34495,7 @@ msgstr ""
 "`sizeCalculation`, `dispose`, `fetch`, `allowStale` และพื้นผิว iterator "
 "ยังไม่ได้นําไปใช้"
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -34355,11 +34525,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -34409,11 +34579,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -34427,7 +34597,7 @@ msgstr ""
 "POSIX เพียงในขณะนี้ (macOS + Linux); ในเจ้าภาพอื่น ๆ `spawn` โยง, "
 "ซึ่งกระตุ้นเส้นทางกลับที่ไม่ว่างเปล่าของผู้บริโภค."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -34438,7 +34608,7 @@ msgstr ""
 "`{ exitCode, signal }` ด้วยสัญญาณจํานวนสําหรับการตายของสัญญาณและ `undefined` "
 "ไม่เช่นนั้น; `kill()` เป็นตัวตั้งค่าเป็น `SIGHUP` เช่น node-pty `TERM` ในเด็กมาจาก `name`"
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -34484,11 +34654,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -34503,7 +34673,7 @@ msgstr ""
 "ที่ขึ้นอยู่กับเป้าหมายของมันถูกพับเข้ากับหน้าผาพื้นเมืองในเวลาคอมพิล พฤติกรรมถูกตรวจสอบกับ "
 "`@parcel/watcher` 2.5.1"
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -34522,7 +34692,7 @@ msgstr ""
 "สําหรับเส้นทางเก่าบวกกับ `create` สําหรับเส้นทางใหม่. ข่าวสาร overflow/rescan ของ "
 "Backend จะกระตุ้นการถ่ายภาพต้นไม้ใหม่ และส่ง Diff ของมันออกมา"
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -34539,7 +34709,7 @@ msgstr ""
 "การสมัครสมาชิกแบบสด ทําให้วงจรกิจกรรมทํางาน `writeSnapshot` และ `getEventsSince` "
 "ใช้สมานติกความแตกต่างของฉบับฉับพลันเดียวกันกับการฟื้นฟู overflow"
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -34549,7 +34719,7 @@ msgstr ""
 "ได้ด้วย `bun add` เหมือนแพ็กเกจ npm ทั่วไป แต่รองรับโดย Rust และคอมไพล์เป็น native ผ่าน "
 "`perry-ffi`:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -34557,7 +34727,7 @@ msgstr ""
 "**`@perryts/tursodb`** — ไคลเอนต์ฐานข้อมูล Turso (libSQL fork) ดู [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)"
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -34565,11 +34735,11 @@ msgstr ""
 "**`@perryts/iroh`** — เครือข่าย peer-to-peer Iroh ดู [PerryTS/iroh-bindings]"
 "(https://github.com/PerryTS/iroh-bindings)"
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "ไดรเวอร์ TypeScript ล้วนที่คอมไพล์ผ่าน `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -34579,7 +34749,7 @@ msgstr ""
 "**`@perryts/redis`** — client ระดับ wire-protocol ที่รองรับการทำงานบน Node.js "
 "และ Bun ได้โดยไม่ต้องแก้ไข"
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -34587,11 +34757,11 @@ msgstr ""
 "ดู [Native Bindings — ภาพรวม](../native-libraries/overview.md) "
 "สำหรับสัญญาที่แพ็กเกจภายนอกเหล่านี้ปฏิบัติตาม"
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[ระบบไฟล์](fs.md) — API ของ fs และ path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[Native Bindings](../native-libraries/overview.md) — การเขียนของคุณเอง"
 
@@ -34614,7 +34784,8 @@ msgstr ""
 "ในเวลารันบนเป้าหมายที่เลือก"
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "ทั้งหมด: 3019 รายการใน 138 โมดูล"
 
 #: src/api/reference.md:9
@@ -34711,4831 +34882,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "เมธอด"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — โมดูล"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "คุณสมบัติ"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount`  โมดูล"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince`  โมดูล"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — โมดูล"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — โมดูล"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot`  โมดูล"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — module"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — module"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — module"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — module"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — module"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — instance"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — instance"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — instance"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — instance"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — instance"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — instance"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — instance"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — โมดูล"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — โมดูล"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — module"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — module"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — โมดูล"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — module"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — module"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — module"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — module"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — module"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — module"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — module"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — module"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — module"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — module"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — module"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — module"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — module"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — module"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — module"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — module"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — module"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — module _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — module _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — module"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — อินสแตนซ์"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — instance _(class: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — อินสแตนซ์"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — module"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — โมดูล"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — อินสแตนซ์"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — อินสแตนซ์"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — อินสแตนซ์"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — โมดูล _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — โมดูล"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — โมดูล"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — โมดูล"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — โมดูล"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — โมดูล"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — โมดูล"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — โมดูล"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — โมดูล"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — โมดูล"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — โมดูล"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — โมดูล"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — โมดูล"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — อินสแตนซ์"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — อินสแตนซ์"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — instance"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — อินสแตนซ์"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — อินสแตนซ์"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — instance"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — instance"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — instance"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — อินสแตนซ์"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — instance"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — instance"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — โมดูล"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — โมดูล"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — โมดูล"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — โมดูล"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — โมดูล"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — โมดูล"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "การถ่ายโอน"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob`  โมดูล"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — โมดูล"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — โมดูล"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — โมดูล"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — โมดูล"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — โมดูล"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — module"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file`  โมดูล"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — โมดูล"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — module"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — โมดูล"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — โมดูล"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — โมดูล"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — instance _(class: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(class: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — โมดูล"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth`  โมดูล"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — module"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(class: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction`  ตัวอย่าง _ ((ประเภท: `Database`) _"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported`  โมดูล"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — module"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — โมดูล"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — module"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — module"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — module"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction`  โมดูล"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString`  โมดูล"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback`  โมดูล"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — module"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols`  โมดูล"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr`  โมดูล"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer`  โมดูล"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer`  โมดูล"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource`  โมดูล"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — โมดูล"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database`  โมดูล"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction`  ตัวอย่าง _ ((ประเภท: `Database`) _"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values`  ตัวอย่าง _ ((ประเภท: `Statement`) _"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — อินสแตนซ์"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — อินสแตนซ์"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — อินสแตนซ์"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — อินสแตนซ์"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — อินสแตนซ์"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — อินสแตนซ์"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — อินสแตนซ์"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — อินสแตนซ์"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — อินสแตนซ์"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — โมดูล"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — อินสแตนซ์"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — อินสแตนซ์"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — อินสแตนซ์"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — โมดูล"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — โมดูล"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — โมดูล"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — โมดูล"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — โมดูล"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — โมดูล"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — โมดูล"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — โมดูล"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — โมดูล"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — โมดูล"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — อินสแตนซ์"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  ตัวอย่าง"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  ตัวอย่าง"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — อินสแตนซ์"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — อินสแตนซ์"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — อินสแตนซ์"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — อินสแตนซ์"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — อินสแตนซ์"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — อินสแตนซ์"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — อินสแตนซ์"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — อินสแตนซ์"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — โมดูล"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — โมดูล"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — โมดูล"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — โมดูล"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — โมดูล"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — โมดูล"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — โมดูล"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — โมดูล"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — โมดูล"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — โมดูล"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — โมดูล"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — โมดูล"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — โมดูล"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — โมดูล"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — โมดูล"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — โมดูล"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — โมดูล"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — โมดูล"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — โมดูล"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — โมดูล"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — โมดูล"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — โมดูล"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — โมดูล"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — โมดูล"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — โมดูล"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — อินสแตนซ์"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — อินสแตนซ์"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — โมดูล"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — อินสแตนซ์"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — อินสแตนซ์"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — โมดูล"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — โมดูล"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — โมดูล"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — โมดูล"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — โมดูล"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — โมดูล"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — โมดูล"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — โมดูล"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — โมดูล"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — โมดูล"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — โมดูล"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — โมดูล"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — โมดูล"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — โมดูล"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — โมดูล"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — โมดูล"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — โมดูล"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — โมดูล"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — โมดูล"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — โมดูล"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — โมดูล"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — โมดูล"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — โมดูล"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — โมดูล"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — โมดูล"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — โมดูล"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — โมดูล"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — โมดูล"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — โมดูล"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — โมดูล"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — โมดูล"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — โมดูล"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — โมดูล"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — โมดูล"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — โมดูล"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — โมดูล"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — โมดูล"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — โมดูล"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — โมดูล"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — โมดูล"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — โมดูล"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — โมดูล"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — โมดูล"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — โมดูล"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — โมดูล"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — โมดูล"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — โมดูล"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — โมดูล"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — โมดูล"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — โมดูล"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — โมดูล"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — โมดูล"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — โมดูล"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — โมดูล"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — โมดูล"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — โมดูล"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — โมดูล"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — โมดูล"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — โมดูล"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — โมดูล"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — โมดูล"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — โมดูล"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — โมดูล"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — โมดูล"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — โมดูล"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — โมดูล"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — โมดูล"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — โมดูล"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — อินสแตนซ์"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — อินสแตนซ์"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — อินสแตนซ์"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — อินสแตนซ์"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — โมดูล"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — อินสแตนซ์"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — อินสแตนซ์"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — อินสแตนซ์"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — อินสแตนซ์"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — อินสแตนซ์"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — อินสแตนซ์"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — อินสแตนซ์"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — อินสแตนซ์"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — อินสแตนซ์"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — อินสแตนซ์"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — อินสแตนซ์"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — อินสแตนซ์"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — อินสแตนซ์"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — อินสแตนซ์"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — อินสแตนซ์"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — อินสแตนซ์"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — อินสแตนซ์"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — อินสแตนซ์"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — อินสแตนซ์"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — อินสแตนซ์"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — อินสแตนซ์"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — อินสแตนซ์"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — อินสแตนซ์"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — อินสแตนซ์"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — อินสแตนซ์"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — อินสแตนซ์"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — อินสแตนซ์"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — อินสแตนซ์"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — อินสแตนซ์"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — อินสแตนซ์"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — อินสแตนซ์"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — อินสแตนซ์"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — อินสแตนซ์"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — อินสแตนซ์"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — อินสแตนซ์"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — อินสแตนซ์"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — อินสแตนซ์"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — อินสแตนซ์"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — อินสแตนซ์"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — อินสแตนซ์"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — อินสแตนซ์"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — โมดูล"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — โมดูล"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — โมดูล"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — โมดูล"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — โมดูล"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — โมดูล"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — โมดูล"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — โมดูล"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — โมดูล"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — โมดูล"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — โมดูล"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — โมดูล"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — โมดูล"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — โมดูล"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — โมดูล"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — โมดูล"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — โมดูล"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — โมดูล"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — โมดูล"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — โมดูล"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — โมดูล"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — โมดูล"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — โมดูล"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — โมดูล"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — โมดูล"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — โมดูล"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — โมดูล"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — โมดูล"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — โมดูล"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — instance"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — instance"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — โมดูล"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — อินสแตนซ์"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — instance"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — instance"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — อินสแตนซ์"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — instance"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — โมดูล"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — โมดูล"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — โมดูล _(คลาส: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — โมดูล"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — โมดูล"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — โมดูล"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — โมดูล"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — โมดูล"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — โมดูล"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — โมดูล"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — โมดูล"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — instance"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — instance"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — โมดูล"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — instance"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — module"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — module"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — instance"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — module"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — instance"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — instance"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — module"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — instance"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — module"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — instance"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — instance"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — instance"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — อินสแตนซ์"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — อินสแตนซ์"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — instance"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — module"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — โมดูล"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — อินสแตนซ์"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — อินสแตนซ์"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — อินสแตนซ์"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — อินสแตนซ์"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — อินสแตนซ์"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — อินสแตนซ์"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — อินสแตนซ์"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — อินสแตนซ์"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — อินสแตนซ์"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — อินสแตนซ์"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — อินสแตนซ์"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — อินสแตนซ์"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — อินสแตนซ์"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — อินสแตนซ์"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — อินสแตนซ์"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — อินสแตนซ์"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — อินสแตนซ์"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — อินสแตนซ์"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — อินสแตนซ์"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — อินสแตนซ์"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — อินสแตนซ์"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — อินสแตนซ์"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — instance"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — อินสแตนซ์"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — อินสแตนซ์"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — instance"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — อินสแตนซ์"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — อินสแตนซ์"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer`  โมดูล"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString`  โมดูล"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — module"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — module"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — โมดูล"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — โมดูล"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — โมดูล"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — module"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — โมดูล"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — module"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — module"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — module"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — module"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — module"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — โมดูล"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — module"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — module"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — โมดูล"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — โมดูล"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — module"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — โมดูล"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — module"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — module"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — module"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — module"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — module"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — module"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — module"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — module"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — module"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — module"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — module"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — module"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — module"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — module"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — module"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — module"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — module"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — module"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — module"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — module"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — module"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — module"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — module"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — โมดูล"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — module"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — module"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — โมดูล"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — โมดูล"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — module"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — module"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — โมดูล"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — โมดูล"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — module"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — module"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — module"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — module"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — module"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — โมดูล"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — โมดูล"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — module"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — โมดูล"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — โมดูล"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — module"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — module"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — module"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — module"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — module"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — โมดูล"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — module"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — โมดูล"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — โมดูล"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — โมดูล"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — module"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — โมดูล"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — โมดูล"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — โมดูล"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — module"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — module"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — module"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — module"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — module"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — module"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — โมดูล"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — โมดูล"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — โมดูล"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — module"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — module"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — module"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — โมดูล"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — โมดูล"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — โมดูล"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — module"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — module"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — module"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — module"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — module"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — โมดูล"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening`  ตัวอย่าง _ ((ประเภท: `HttpServer`) _"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — module"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — โมดูล"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -39543,103 +39861,103 @@ msgstr ""
 "`keepSocketAlive`  ตัวอย่าง _ ((ประเภท: `Agent`) _ **สตับ** reqwest "
 "เป็นเจ้าของสระว่ายน้ํารักษาชีวิต; โฮกต่อซ็อค็อตคือ no-ops, เตือนครั้งเดียว (# 4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening`  ตัวอย่าง _ ((ประเภท: `HttpServer`) _"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once`  ตัวอย่าง _ ((ประเภท: `ClientRequest`) _"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref`  ตัวอย่าง _ ((ประเภท: `HttpServer`) _"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -39647,375 +39965,369 @@ msgstr ""
 "`reuseSocket`  ตัวอย่าง _ ((ประเภท: `Agent`) _ **สตับ** reqwest "
 "เป็นเจ้าของสระว่ายน้ํารักษาชีวิต; โฮกต่อซ็อค็อตคือ no-ops, เตือนครั้งเดียว (# 4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — module"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — module"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket`  ตัวอย่าง _ ((ประเภท: `IncomingMessage`) _"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref`  ตัวอย่าง _ ((ประเภท: `HttpServer`) _"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — module"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — module"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — โมดูล"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — module"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — module"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — module"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — module"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — module"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening`  ตัวอย่าง _ ((ประเภท: `HttpsServer`) _"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening`  ตัวอย่าง _ ((ประเภท: `HttpsServer`) _"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref`  ตัวอย่าง _ ((ประเภท: `HttpsServer`) _"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref`  ตัวอย่าง _ ((ประเภท: `HttpsServer`) _"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — module"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  โมดูล _ ((ประเภท: `console`) _"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  โมดูล _ ((ประเภท: `console`) _"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  โมดูล _ ((ประเภท: `console`) _"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  โมดูล _ ((ประเภท: `console`) _"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -40023,7 +40335,7 @@ msgstr ""
 "`open`  โมดูล **สตับ** ยอมรับ port/host แต่ไม่ผูกกับจุดปลายผู้ตรวจสอบ WebSocket จริงๆ; "
 "การประชุมเป็นการปลอมแปลงในกระบวนการ (# 4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -40033,14 +40345,14 @@ msgstr ""
 "Runtime.evaluate สับเซตกระป๋อง; วิธีโปรโตคอลอื่น ๆ ทุก throws ตรวจสอบความผิดพลาด "
 "-32601 (# 4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
 msgstr ""
 "`url`  โมดูล **สตับ** มักไม่นิยาม: Perry ไม่เคยเปิดเผยจุดปลายผู้ตรวจสอบจริง (# 4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -40048,3285 +40360,3276 @@ msgstr ""
 "`waitForDebugger`  โมดูล **สตับ** กลับมาทันทีหลังจาก open ((); ไม่มีเครื่องแก้ปัญหาการรอ "
 "(# 4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  โมดูล _ ((ประเภท: `console`) _"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — อินสแตนซ์"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — โมดูล"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — อินสแตนซ์"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — อินสแตนซ์"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — instance"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — อินสแตนซ์"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — อินสแตนซ์"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — อินสแตนซ์"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — อินสแตนซ์"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — อินสแตนซ์"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — อินสแตนซ์"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — อินสแตนซ์"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — โมดูล"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — อินสแตนซ์"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — อินสแตนซ์"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — อินสแตนซ์"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — อินสแตนซ์"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — อินสแตนซ์"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — อินสแตนซ์"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — โมดูล"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — โมดูล"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — โมดูล"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — โมดูล"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — โมดูล"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — โมดูล"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — โมดูล"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — โมดูล"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — module"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — โมดูล"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — โมดูล"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — module"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — module"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — module"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — module"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — module"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — module"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — module"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — โมดูล"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — โมดูล"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — โมดูล"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — module"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — module"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — module"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — โมดูล"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — โมดูล"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — โมดูล"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — อินสแตนซ์"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — อินสแตนซ์"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  ตัวอย่าง"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — อินสแตนซ์"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — module"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — module"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — module"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — module"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — module"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — module"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — module"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — module"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — module"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — module"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — module"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — module"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — module"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — module"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — module"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — module"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — module"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — module"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — module"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — module"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — module"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — module"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — module"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  ตัวอย่าง"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  ตัวอย่าง"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — โมดูล"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  ตัวอย่าง"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — อินสแตนซ์"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — อินสแตนซ์"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — อินสแตนซ์"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — อินสแตนซ์"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — อินสแตนซ์"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — อินสแตนซ์"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — อินสแตนซ์"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — อินสแตนซ์"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — อินสแตนซ์"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — อินสแตนซ์"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — อินสแตนซ์"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — อินสแตนซ์"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — โมดูล"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — โมดูล"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — อินสแตนซ์ _(คลาส: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — อินสแตนซ์"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — อินสแตนซ์ _(คลาส: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — อินสแตนซ์ _(คลาส: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — อินสแตนซ์"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — อินสแตนซ์"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — อินสแตนซ์ _(คลาส: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — อินสแตนซ์ _(คลาส: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — อินสแตนซ์"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — อินสแตนซ์"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — โมดูล"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — module"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — module"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — module"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — module"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — module"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — module _(class: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — module"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — module"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — module"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — module _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert`  ตัวอย่าง _ ((ประเภท: `Socket`) _"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — อินสแตนซ์ _(คลาส: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem`  โมดูล"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem`  โมดูล"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate`  โมดูล"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem`  โมดูล"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem`  โมดูล"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem`  โมดูล"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions`  ตัวอย่าง _ ((ประเภท: `Certificate`) _"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer`  ตัวอย่าง _ ((ประเภท: `Certificate`) _"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject`  ตัวอย่าง _ ((ประเภท: `Certificate`) _"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign`  ตัวอย่าง _ ((ประเภท: `Certificate`) _"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — โมดูล"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — อินสแตนซ์"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — อินสแตนซ์"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — โมดูล"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — module"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — โมดูล"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — module"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — โมดูล"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — module"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — โมดูล"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — โมดูล"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — module"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — module"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — โมดูล"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — โมดูล"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — โมดูล"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — module"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — โมดูล"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — โมดูล"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — โมดูล"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — โมดูล"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — โมดูล"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — module"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — module"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — โมดูล"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — โมดูล"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — โมดูล"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — โมดูล"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — โมดูล"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — module"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — โมดูล"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — โมดูล"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — module"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — โมดูล"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization`  โมดูล"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — โมดูล"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — โมดูล"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles`  โมดูล"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded`  โมดูล"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — โมดูล"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — โมดูล"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — โมดูล"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — โมดูล"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent`  โมดูล"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — โมดูล"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — โมดูล"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — โมดูล"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — โมดูล"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — โมดูล"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — โมดูล"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — โมดูล"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — โมดูล"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — โมดูล"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — โมดูล"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — โมดูล"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — โมดูล"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — โมดูล"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — โมดูล"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — โมดูล"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — โมดูล"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — โมดูล"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — โมดูล"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — โมดูล"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — โมดูล"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — โมดูล"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — โมดูล"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — โมดูล"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — โมดูล"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — โมดูล"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — โมดูล"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — โมดูล"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — โมดูล"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — โมดูล"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — โมดูล"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — โมดูล"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — โมดูล"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — โมดูล"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — โมดูล"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — โมดูล"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — โมดูล"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — โมดูล"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — โมดูล"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — โมดูล"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — โมดูล"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — โมดูล"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — โมดูล"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — โมดูล"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — โมดูล"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — โมดูล"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — โมดูล"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — โมดูล"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — โมดูล"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — โมดูล"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — โมดูล"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — โมดูล"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — โมดูล"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect`  โมดูล"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint`  โมดูล"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor`  โมดูล"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — โมดูล"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — โมดูล"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — โมดูล"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — โมดูล"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — โมดูล"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — โมดูล"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — โมดูล"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — โมดูล"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession`  โมดูล"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession`  โมดูล"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability`  โมดูล"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment`  โมดูล"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange`  โมดูล"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange`  โมดูล"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond`  โมดูล"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — โมดูล"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — โมดูล"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — โมดูล"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — โมดูล"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — โมดูล"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — โมดูล"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — โมดูล"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — โมดูล"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  โมดูล _ ((ภายใน) _"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32`  โมดูล"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64`  โมดูล"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16`  โมดูล"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32`  โมดูล"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64`  โมดูล"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8`  โมดูล"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize`  โมดูล"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  โมดูล _ ((ภายใน) _"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  โมดูล _ ((ภายใน) _"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16`  โมดูล"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32`  โมดูล"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64`  โมดูล"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8`  โมดูล"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize`  โมดูล"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — โมดูล"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — โมดูล"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — โมดูล"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — โมดูล"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — โมดูล"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — โมดูล"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — โมดูล"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — โมดูล"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — โมดูล"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — โมดูล"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — โมดูล"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — โมดูล"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — โมดูล"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — โมดูล"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — โมดูล"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — โมดูล"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — โมดูล"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — โมดูล"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — โมดูล"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — โมดูล"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — โมดูล"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — โมดูล"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — โมดูล"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — โมดูล"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — โมดูล"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — โมดูล"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — โมดูล"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — โมดูล"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — โมดูล"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — โมดูล"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — โมดูล"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — โมดูล"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — โมดูล"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — โมดูล"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — โมดูล"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — โมดูล"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — โมดูล"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — โมดูล"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — โมดูล"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — โมดูล"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay`  โมดูล"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — โมดูล"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — โมดูล"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — โมดูล"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — โมดูล"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — โมดูล"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — โมดูล"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — โมดูล"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — โมดูล"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — โมดูล"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — โมดูล"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — โมดูล"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — โมดูล"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — โมดูล"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — โมดูล"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — โมดูล"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — โมดูล"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — โมดูล"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — โมดูล"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — โมดูล"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — โมดูล"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — โมดูล"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — โมดูล"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — โมดูล"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — โมดูล"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — โมดูล"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — โมดูล"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — โมดูล"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — โมดูล"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — โมดูล"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — โมดูล"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — โมดูล"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — โมดูล"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — โมดูล"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — โมดูล"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — โมดูล"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — โมดูล"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — โมดูล"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — โมดูล"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — โมดูล"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — โมดูล"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — โมดูล"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — โมดูล"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — โมดูล"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — โมดูล"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — โมดูล"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — โมดูล"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — โมดูล"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — โมดูล"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — โมดูล"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — โมดูล"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — โมดูล"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — โมดูล"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — instance _(class: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — โมดูล"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — โมดูล"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — โมดูล"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — อินสแตนซ์ _(คลาส: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — instance _(class: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — โมดูล"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — อินสแตนซ์ _(คลาส: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — instance _(class: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — โมดูล"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — โมดูล"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — โมดูล"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — โมดูล"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — โมดูล"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — โมดูล"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — โมดูล"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — โมดูล"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — โมดูล"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — โมดูล"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — โมดูล"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — โมดูล"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — โมดูล"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — instance _(class: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — โมดูล"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — โมดูล"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView`  โมดูล"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — โมดูล"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — โมดูล"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — โมดูล"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — โมดูล"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — โมดูล"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — โมดูล"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — โมดูล"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — โมดูล"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — โมดูล"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — โมดูล"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — โมดูล"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — โมดูล"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — โมดูล"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — โมดูล"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — โมดูล"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — โมดูล"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — โมดูล"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — โมดูล"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — โมดูล"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — โมดูล"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — โมดูล"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — โมดูล"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — โมดูล"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — โมดูล"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — โมดูล"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — โมดูล"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — โมดูล"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — โมดูล"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker`  โมดูล"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — โมดูล"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — โมดูล"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — โมดูล"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — โมดูล"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — โมดูล"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy`  โมดูล"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — โมดูล"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — โมดูล"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — โมดูล"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — โมดูล"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — โมดูล"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd`  โมดูล"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle`  โมดูล"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — โมดูล"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — โมดูล"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — โมดูล"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — โมดูล"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — โมดูล"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — โมดูล"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — โมดูล"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — โมดูล"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — โมดูล"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — โมดูล"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — โมดูล"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — โมดูล"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — โมดูล"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — โมดูล"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — โมดูล"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — โมดูล"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — โมดูล"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — โมดูล"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — โมดูล"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — โมดูล"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — โมดูล"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — โมดูล"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — โมดูล"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — โมดูล"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — โมดูล"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — โมดูล"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — โมดูล"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — โมดูล"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — โมดูล"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — โมดูล"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — โมดูล"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — โมดูล"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — โมดูล"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — โมดูล"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — โมดูล"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — โมดูล"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — โมดูล"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — โมดูล"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — โมดูล"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — โมดูล"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — โมดูล"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — โมดูล"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — โมดูล"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — โมดูล"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — โมดูล"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — โมดูล"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — โมดูล"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — โมดูล"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — โมดูล"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — โมดูล"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — โมดูล"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — โมดูล"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — โมดูล"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — โมดูล"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — โมดูล"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — โมดูล"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — โมดูล"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — โมดูล"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — โมดูล"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — โมดูล"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — โมดูล"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — โมดูล"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — โมดูล"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — โมดูล"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — โมดูล"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — โมดูล"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — โมดูล"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — โมดูล"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — module"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — module"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — module"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem`  โมดูล"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected`  โมดูล"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected`  โมดูล"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — โมดูล"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — โมดูล"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — โมดูล"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders`  โมดูล"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl`  โมดูล"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue`  โมดูล"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — โมดูล"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig`  โมดูล"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — โมดูล"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — โมดูล"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — โมดูล"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — โมดูล"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — โมดูล"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse`  โมดูล"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — โมดูล"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — โมดูล"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — โมดูล"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — โมดูล"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — โมดูล"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — โมดูล"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — module"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — module"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — module"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — module"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout`  โมดูล"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount`  โมดูล"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed`  โมดูล"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge`  โมดูล"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild`  โมดูล"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree`  โมดูล"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew`  โมดูล"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild`  โมดูล"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge`  โมดูล"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum`  โมดูล"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap`  โมดูล"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc`  โมดูล"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber`  โมดูล"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc`  โมดูล"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — โมดูล"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — อินสแตนซ์ _(คลาส: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — module"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — module"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — module"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — module"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — module"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — module"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — module"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — module"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — module"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — module"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — module"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — module"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — module"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — module"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — module"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — module"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — module"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — module"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — module"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — module"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — module"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — module"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — module"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — module"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — module"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — module"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — module"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — module"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — module"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — module"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — module"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — module"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — module"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — module"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — module"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — module"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — module"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — module"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — module"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — module"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — module"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — module"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — module"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — module"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — module"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — module"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — module"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — module"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — module"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — module"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — module"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — module"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  ตัวอย่าง"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  ตัวอย่าง"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  ตัวอย่าง"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  ตัวอย่าง"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — module"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — module"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — โมดูล"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — module"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — module"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — instance"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — instance"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — instance"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — instance"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — module"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — instance"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — instance"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — อินสแตนซ์"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — instance"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — instance"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — instance"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — instance"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -43336,43 +43639,43 @@ msgstr ""
 "และ .write() ประเมินแค่ตัวเลขตัวจริง, การค้นหาเนื้อหา, และ '+' เดียว; ไม่มี JS eval "
 "loop จริง (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — module"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -43382,1459 +43685,1459 @@ msgstr ""
 "และ .write() ประเมินแค่ตัวเลขตัวจริง, การค้นหาเนื้อหา, และ '+' เดียว; ไม่มี JS eval "
 "loop จริง (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — module"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — module"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — module"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — module"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — module"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  ตัวอย่าง"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  ตัวอย่าง"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — อินสแตนซ์"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  ตัวอย่าง"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  ตัวอย่าง"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  ตัวอย่าง"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — อินสแตนซ์"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — อินสแตนซ์"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — อินสแตนซ์"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — อินสแตนซ์"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — อินสแตนซ์"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — อินสแตนซ์"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — อินสแตนซ์"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — อินสแตนซ์"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — อินสแตนซ์"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — โมดูล"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  ตัวอย่าง"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — อินสแตนซ์"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — อินสแตนซ์"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  ตัวอย่าง"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — อินสแตนซ์"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — อินสแตนซ์"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — instance"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — module"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — module"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — instance"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — instance"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — module"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — instance"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — instance"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  ตัวอย่าง"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — instance"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — instance"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — instance"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — instance"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — instance"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — instance"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — instance"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — instance"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — instance"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  ตัวอย่าง"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — instance"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — instance"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — instance"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — instance"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — instance"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — module"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — module"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — module"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — module"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — instance"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — instance"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — module"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — instance"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — instance"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — instance"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — module"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — instance"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — โมดูล"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — module"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — module"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — module"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — module"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — instance"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — module"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — module"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — instance"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — โมดูล"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — instance"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — instance"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — instance"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — instance"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — instance"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — instance"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — instance"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — instance"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — instance"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — instance"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — instance"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — module"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — instance"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — instance"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — instance"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — instance"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — instance"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — instance"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — instance"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — instance"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — instance"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — instance"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — instance"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — instance"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — module"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — module"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — module"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — module"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — module"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — module"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — instance _(class: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — instance _(class: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — module"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — module"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — module"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — module"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — module"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — module"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — โมดูล"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — module"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — module"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — โมดูล"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — module"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — module"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — module"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — module"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — module"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — module"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — โมดูล"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — module"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — โมดูล"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — module"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — module"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — โมดูล"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — module"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — module"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — module"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — module"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — module"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — module"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — module"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — module"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — module"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — module"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — module _(class: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — module"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — module"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — module"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — module _(class: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — module _(class: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — module _(class: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — module"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — module"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — module"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — module _(class: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — module"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — module"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — module"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — module"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — module"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — module"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — module"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — module"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — module"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — module"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — module"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — โมดูล"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — โมดูล"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — โมดูล"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — โมดูล"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols`  โมดูล"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — โมดูล"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — โมดูล"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms`  โมดูล"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — โมดูล"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — โมดูล"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — โมดูล"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — โมดูล"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — instance _(class: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — อินสแตนซ์"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — อินสแตนซ์"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — อินสแตนซ์"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — อินสแตนซ์"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — อินสแตนซ์"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText`  โมดูล"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule`  โมดูล"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent`  โมดูล"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close`  ตัวอย่าง _ ((ประเภท: `ProxyAgent`) _"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy`  ตัวอย่าง _ ((ประเภท: `ProxyAgent`) _"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch`  โมดูล"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher`  โมดูล"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher`  โมดูล"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — โมดูล"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — โมดูล"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — โมดูล"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — instance _(class: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — โมดูล"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — โมดูล"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — instance _(class: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — โมดูล"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — โมดูล"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — โมดูล"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — โมดูล"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — โมดูล"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — โมดูล"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — โมดูล"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — โมดูล"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — โมดูล"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — โมดูล"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — โมดูล"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — โมดูล"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — โมดูล"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — โมดูล"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — โมดูล"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — โมดูล"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — โมดูล"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — โมดูล"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — โมดูล"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — โมดูล"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — โมดูล"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — โมดูล"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — โมดูล"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — โมดูล"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — โมดูล"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — โมดูล"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — โมดูล"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — โมดูล"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — โมดูล"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — โมดูล"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — โมดูล"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — โมดูล"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — โมดูล"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — โมดูล"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — โมดูล"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — โมดูล"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — โมดูล"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — โมดูล"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — โมดูล"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — โมดูล"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — โมดูล"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — โมดูล"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — โมดูล"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — โมดูล"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — โมดูล"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3`  โมดูล"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — โมดูล"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5`  โมดูล"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — โมดูล"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — โมดูล"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — โมดูล"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — โมดูล"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -44842,11 +45145,11 @@ msgstr ""
 "`getHeapCodeStatistics`  โมดูล **สตับ** สนามทั้งหมด 0; Perry รวม AOT ไม่มี JIT "
 "code heap (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — โมดูล"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -44855,7 +45158,7 @@ msgstr ""
 "`getHeapSpaceStatistics`  โมดูล **สตับ** ชื่อสเปซของ Node "
 "ด้วยการใช้งานสดทั้งหมดที่อ้างถึง old_space จากสนาม Perry; สเปซอื่นรายงาน 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -44868,87 +45171,87 @@ msgstr ""
 "total_physical_size=RSS, heap_size_limit แก้ไข ~ 2GB (ไม่บังคับ); \\*\\_ "
 "executable, external_memory, global-handles และ Zap สนามคือ 0 (# 4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — โมดูล"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — โมดูล"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — โมดูล"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — โมดูล"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — โมดูล"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — instance _(class: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — โมดูล"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -44956,459 +45259,469 @@ msgstr ""
 "`stop`  ตัวอย่าง _ ((ประเภท: `GCProfiler`) _ **สตับ** รายงานมีรูปร่าง Node แต่ "
 "array สถิติจะว่างเสมอ (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — โมดูล"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — โมดูล"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — โมดูล"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — โมดูล"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — โมดูล"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — โมดูล"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — โมดูล"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — โมดูล"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — โมดูล"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — instance"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — โมดูล"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — โมดูล"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — instance"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — instance"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — instance"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — instance"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — instance"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — instance"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — instance"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — โมดูล"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — instance"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — instance"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — โมดูล"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — instance"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — instance"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — โมดูล"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — โมดูล"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — โมดูล"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — instance"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — module"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — module"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — module"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  ตัวอย่าง"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — module"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — module"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — module"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — module"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — module"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — module"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — module"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload`  ตัวอย่าง _ ((ประเภท: `Worker`) _"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  ตัวอย่าง"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — module"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — โมดูล"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — อินสแตนซ์"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — instance"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — โมดูล"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — instance"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  ตัวอย่าง"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — โมดูล"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — module"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — module"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — module"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — module"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — module"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45416,7 +45729,7 @@ msgstr ""
 "`createBrotliCompress`  โมดูล **สตับ** params/quality ตัวเลือกยอมรับ แต่ไม่สนใจ, "
 "เตือนครั้งหนึ่ง (# 4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -45424,7 +45737,7 @@ msgstr ""
 "`createBrotliDecompress`  โมดูล **สตับ** params/quality ตัวเลือกยอมรับ แต่ไม่สนใจ, "
 "เตือนครั้งหนึ่ง (# 4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45432,7 +45745,7 @@ msgstr ""
 "`createDeflate`  โมดูล **สตับ** ระดับได้รับเกียรติ; strategy/memLevel ได้รับการยืนยัน "
 "แต่ไม่ได้ใช้ (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45440,11 +45753,11 @@ msgstr ""
 "`createDeflateRaw`  โมดูล **สตับ** ระดับได้รับเกียรติ; strategy/memLevel "
 "ได้รับการยืนยัน แต่ไม่ได้ใช้ (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — module"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -45452,19 +45765,19 @@ msgstr ""
 "`createGzip`  โมดูล **สตับ** ระดับได้รับเกียรติ; strategy/memLevel ได้รับการยืนยัน "
 "แต่ไม่ได้ใช้ (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — module"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — module"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — module"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45472,7 +45785,7 @@ msgstr ""
 "`createZstdCompress`  โมดูล **สตับ** params/quality ตัวเลือกยอมรับ แต่ไม่สนใจ, "
 "เตือนครั้งหนึ่ง (# 4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -45480,79 +45793,71 @@ msgstr ""
 "`createZstdDecompress`  โมดูล **สตับ** params/quality ตัวเลือกยอมรับ แต่ไม่สนใจ, "
 "เตือนครั้งหนึ่ง (# 4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — module"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — module"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — module"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — โมดูล"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — โมดูล"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — โมดูล"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — โมดูล"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — โมดูล"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — module"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — module"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — module"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — โมดูล"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — module"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — module"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — module"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — module"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — module"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — module"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -46071,9 +46376,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "คุณจะใช้ไฟล์ `docker-compose.yaml` แทน"
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "ทั้งสองโมดูลมีเวลาทํางานร่วมกัน; คุณสามารถผสมผสานมันในโปรแกรมเดียวกันถ้าคุณ e.g. ใช้ "
@@ -46595,12 +46901,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` คือ `docker rm -f`"
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**หมายเหตุเกี่ยวกับรูปการคืน `logs` และ `exec`:** วันนี้ FFI จะคืนตัวจับ Registry-id เป็น "
 "`Vec<ContainerLogs>` แทนที่จะเป็น JS object รักษาค่าที่กลับมาเป็นไม่โปร่งใส  งาน "
@@ -46726,9 +47033,10 @@ msgstr ""
 "cache จาก `OnceLock` และคืนผลทันที"
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` เป็น async และคืน JSON array ของผู้สมัครที่ตรวจสอบทุกรายการด้วย "
@@ -47473,9 +47781,10 @@ msgstr ""
 "_พร้อมใช้งาน_ หากต้องการบล็อกจนกว่า stack จะให้บริการได้:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**ใช้บล็อก `healthcheck` ในบริการ** (ภายใน, runtime จัดการมัน) รวมกับ `depends_on: "
@@ -47844,8 +48153,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "ตัวอย่าง Forgejo ใช้รูปแบบพกพานี้ (`container_name:  'forgejo-db'` + "
@@ -47916,8 +48226,9 @@ msgid "Single-network shorthand"
 msgstr "shorthand แบบ single-network"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -48324,9 +48635,10 @@ msgid "External volumes"
 msgstr "External volumes"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "กําหนดวอลเล็ม `external: true` "
@@ -48348,8 +48660,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -48416,15 +48729,18 @@ msgstr ""
 "JS ในตอนนี้ — สำหรับการตรวจสอบให้ใช้ CLI ของ runtime โดยตรง:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# รายการปริมาตรที่ตั้งอยู่เบื้องหน้าแอพ"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# จุดติดตั้ง, คนขับ, แผ่น"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# การติดตั้ง + ตรวจสอบสาร"
 
 #: src/container/volumes.md:160
@@ -48585,9 +48901,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -48768,8 +49085,9 @@ msgstr ""
 "เดิมจะไม่มีค่าใช้จ่าย"
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -49030,8 +49348,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**รันในฐานะผู้ใช้ที่ไม่ใช่ root** (`user: \"nobody\"` หรือ UID แบบตัวเลข)"
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**ลดความสามารถทั้งหมด เพิ่มความสามารถเฉพาะอย่างยิ่ง** (`cap_drop:  [\"ALL\"]` + "
@@ -49177,7 +49496,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "แสดง banner สำหรับผู้ดูแลระบบพร้อม URL + \"วิธีการ teardown\""
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr "ทางออก 0 คอนเทนเนอร์ยังคงทํางานด้วย `restart:  unless-stopped`"
 
 #: src/container/production-patterns.md:42
@@ -49394,11 +49714,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "การเริ่มต้น dependency แบบ gate ด้วย Healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres ใช้เวลา ~510 วินาทีในการเริ่มต้นในการทํางานครั้งแรก (initdb + listener bind) "
 "ถ้าไม่มีเกตเจอร์ โฟร์จีโอจะเริ่มต้นทันที ไม่สามารถเชื่อมต่อได้ และเผาธงบประมาณการทดลองใหม่ "
@@ -49564,7 +49885,8 @@ msgstr ""
 "manager:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -49577,7 +49899,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -49634,11 +49957,13 @@ msgstr ""
 "ให้ทำ `--down` อย่างชัดเจนก่อน:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# จํานวนการรักษา"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# redploy กับเวอร์ชั่นใหม่"
 
 #: src/container/production-patterns.md:268
@@ -49655,35 +49980,42 @@ msgid "Running it"
 msgstr "การรัน"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# สร้างเพอรี่ครั้งเดียว"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# สร้างตัวอย่าง"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Backend: โดเกอร์"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# ค้นหา http://localhost:3000/ ในบราว์เซอร์"
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# หยุดการทำงาน (เก็บวอลุ่มไว้สำหรับนำไปใช้อีกครั้ง):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# ลดลง + ลดปริมาณ (DESTROYS DATA):"
 
 #: src/container/production-patterns.md:300
@@ -49986,19 +50318,23 @@ msgstr ""
 "ชื่อสนามคงที่ข้ามแบ็คเอ็นด์  ค่าต่างกัน"
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// ทดสอบ + ออกเป็น-เป็น"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// เครื่องยนต์เลียนแบบฝั่งเจ้าภาพ"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// ลด + เตือน"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// กลุ่มย่อยจํากัด; เหตุผลบันทึกไว้"
 
 #: src/container/determinism.md:156
@@ -50122,7 +50458,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "ทุกโปรโตคอลคืนค่าคงที่จากวิธี `capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... สร้างอาร์ก"
 
 #: src/container/determinism.md:192
@@ -50148,7 +50485,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"สนามรายละเอียด dropped/translated สําหรับ Backend\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- สเปคสะอาด"
 
 #: src/container/determinism.md:212
@@ -50160,15 +50498,18 @@ msgstr ""
 "มันผลิต `Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// สนามถอนออก"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// แมปป์เป็นเทียบเท่า"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// เครื่องยนต์เลียนแบบแทน"
 
 #: src/container/determinism.md:231
@@ -50176,15 +50517,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. รูปแบบการบังคับใช้  เลือกวิธีการแจ้งเตือน"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// ปกติ  การติดตามเงียบ:: เตือน!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// พื้นที่ไปยัง TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// สนามที่ไม่สนับสนุน → การล้มเหลวของ hard up()"
 
 #: src/container/determinism.md:241
@@ -50246,7 +50590,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "การปรับประจําผลิต  รูปแบบเดียวกัน ไม่ว่าจะเป็นแบคเอ็นด์"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker shape (NDJSON line)"
 
 #: src/container/determinism.md:292
@@ -50254,7 +50599,8 @@ msgid "/* docker JSON */"
 msgstr "/* docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// รูปแบบแอปเปิ้ล ( JSON array ของ `configuration`-wrapped วัตถุ)"
 
 #: src/container/determinism.md:294
@@ -50262,7 +50608,8 @@ msgid "/* apple JSON */"
 msgstr "/* apple JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// ทั้งคู่ผลิต ContainerInfo ด้วยความหมายสนามเดียวกัน:"
 
 #: src/container/determinism.md:301
@@ -50588,7 +50935,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -50601,7 +50949,8 @@ msgid "\"Back\""
 msgstr "\"กลับ\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (ค่าว่าง = ความต้องการการแปล)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -50825,7 +51174,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -50939,7 +51289,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json"
 
 #: src/i18n/interpolation.md:65
@@ -51693,19 +52044,23 @@ msgid "Typical translation workflow:"
 msgstr "กระบวนการแปลโดยทั่วไป:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. เขียนรหัสด้วยเชิงอังกฤษ"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. ส่ง string ไปยังไฟล์สถานที่"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr "# 3. ส่ง locales/de.json ให้ผู้แปล (ค่าว่างต้องเต็ม)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. สร้าง  Perry ยืนยันทุกอย่าง"
 
 #: src/i18n/cli.md:49
@@ -52365,52 +52720,22 @@ msgstr ""
 "ลงนามการแสดงตัวจริงที่ใช้โดย `perry update`"
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) การสร้างคู่คีย์ครั้งเดียว เก็บ kp.json ด้วยโหมด 0600 และ"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) การลงนามตามฉบับ การออก JSON envelope มีทุก"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 3) ตรวจสอบความสุขภาพของลายเซ็นในท้องถิ่น ก่อนอัพโหลดรายการ"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    ที่นี่คาดการณ์การตรวจสอบผ่านลูกค้า"
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr "# 4) ปล่อย CI ลงนาม CLI manifest, การผูกพัน URL อาร์คิฟ์, พลาตฟอร์ม,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "สร้างรายการสุดท้ายโดยการนําผลิต `sign` ผ่าน `jq` สําหรับสรรพสินทรัพย์แต่ละอัน "
@@ -54012,9 +54337,10 @@ msgstr ""
 "เสียงเดินหลายครั้ง)"
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** กลุ่มผสมผสาน เสียงทางผ่าน Bus เสียงทางผ่านบัส (Default: master) หนึ่ง "
@@ -55006,6 +55332,7 @@ msgstr ""
 "dispatch แต่ละครั้ง ถูก throttle ที่ 100 ms โดยการเปรียบเทียบ wall-clock"
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -55015,7 +55342,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -56176,23 +56503,28 @@ msgstr ""
 "ไม่ต้องมีความรู้ภาษาเฉพาะแพลตฟอร์ม"
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# ขยาย iOS WidgetKit"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android แอปพลิเคชั่น วิดเจ็ต"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS ความซับซ้อน"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOS ซิมูเลอร์"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS ไทล์"
 
 #: src/widgets/overview.md:60
@@ -57088,10 +57420,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -57676,11 +58004,13 @@ msgid "Build Commands"
 msgstr "คำสั่ง Build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -58541,19 +58871,23 @@ msgid "Build Instructions"
 msgstr "คำแนะนำในการ Build"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# สําเนาไฟล์ .kt ไปยัง app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# การรวม AndroidManifest_snippet.xml ลงใน AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# สําเนาไฟล์ .kt ไปยังโมดูล Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# การรวม AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -58738,11 +59072,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "การ refresh แบบ background ใช้ framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# สําหรับอุปกรณ์ Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# สําหรับ Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -60311,11 +60647,13 @@ msgstr ""
 "`#[no_mangle] pub extern \"C\"`:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry เวลาทํางาน FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ...เรียก API ของแพลตฟอร์ม, แก้ไขสัญญาเมื่อทํา ..."
 
 #: src/plugins/native-extensions.md:200
@@ -60444,23 +60782,17 @@ msgstr ""
 "พร้อมระบุเป้าหมายเป็น SDK ของแพลตฟอร์มที่ถูกต้อง:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (เรียบง่าย)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr "//ตรวจจับเป้าหมาย: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// รวม: swiftc -emit-library -static -target ... -sdk ... -framework StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// ลิงค์: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -60487,7 +60819,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Resolve Perry promise ด้วยผลลัพธ์"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// รับกิจกรรมจาก PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -60503,7 +60836,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "//เรียก API ของแพลตฟอร์มผ่าน JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -61098,15 +61432,18 @@ msgstr ""
 "pull request ใช้เวลาประมาณ 1/5 ของวินาที"
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# ประตู"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# สิ่งที่อยู่ในขอบเขต และสิ่งที่ไม่อยู่ในขอบเขต"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# พิสูจน์ว่าประตูยังคงล้มเหลวได้"
 
 #: src/testing/test-registration.md:18
@@ -61437,31 +61774,38 @@ msgstr ""
 "enable-geisterhand`"
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr "# 1. รวมด้วย geisterhand เอนกประสงค์ (libs สร้างอัตโนมัติเมื่อใช้ครั้งแรก)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. วิ่งแอพ"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. ในเทอร์มินอลอื่น  ติดต่อกับแอพ"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# รายการวิดเจ็ตทั้งหมด"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# คลิกปุ่มด้วยมือ 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# ถ่ายภาพหน้าจอของหน้าต่าง"
 
 #: src/testing/geisterhand.md:25
@@ -61477,7 +61821,8 @@ msgstr ""
 "geisterhand` ในตัว ดังนั้นคุณไม่ต้องใช้ทั้งสองแฟล็ก):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# หรือมีเพอรี่รัน:"
 
 #: src/testing/geisterhand.md:35
@@ -61620,8 +61965,8 @@ msgid "Menu item"
 msgstr "รายการเมนู"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -61633,8 +61978,8 @@ msgstr "คีย์ลัดบนแป้นพิมพ์"
 msgid "Data table"
 msgstr "ตารางข้อมูล"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -61748,17 +62093,6 @@ msgstr ""
 "ตั้งค่าเนื้อหาของ text field และเรียก callback `onChange` พร้อมส่งข้อความใหม่เป็น "
 "string แบบ NaN-boxed"
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"ชนิดเนื้อหา: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "{\"ข้อความ\":\"hello world\"}'"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "ขยับ Slider"
@@ -61782,10 +62116,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "ตั้งตำแหน่งของ slider และเรียก `onChange` พร้อมส่งค่าตัวเลข"
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"ค่า\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -61835,10 +62165,6 @@ msgid ""
 msgstr ""
 "ตั้งค่าของ cell `State` โดยตรง โดยข้าม callback ของ widget สิ่งนี้จะกระตุ้น reactive "
 "binding ใด ๆ ที่ผูกกับ state นั้น (ป้ายข้อความที่ผูกไว้ การแสดง/ซ่อน ลูป forEach ฯลฯ)"
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "'{\"ค่า\":42}'"
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -61915,10 +62241,6 @@ msgstr ""
 "ที่ไม่สนใจตัวพิมพ์ใหญ่/เล็ก และจะตรงกับ key string ที่ส่งให้กับ `menuAddItem` (เช่น `\"s\"` "
 "สำหรับ Cmd+S, `\"S\"` สำหรับ Cmd+Shift+S, `\"n\"` สำหรับ Cmd+N)"
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "{\"ทางลัด\":\"s\"}"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -61949,10 +62271,6 @@ msgid ""
 "Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
 "points."
 msgstr "ตั้งค่า scroll offset ของ widget ScrollView ทั้ง `x` และ `y` มีหน่วยเป็น point"
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -62050,12 +62368,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# ไฟเข้าแบบสุ่มทุก 200 มิลลิเมตร"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -62193,12 +62508,16 @@ msgstr ""
 "`iproxy` จาก `libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# ติดตั้งและเปิดผ่าน Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP ของ:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -62225,7 +62544,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# แพ็คเกจเข้า APK และติดตั้ง"
 
 #: src/testing/geisterhand.md:381
@@ -62233,7 +62553,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "ติดตั้งไลบรารีสำหรับการพัฒนา GTK4 ก่อน:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -62257,15 +62578,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "การทดสอบ end-to-end อย่างง่ายโดยใช้ bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# สร้างด้วยมือผี"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# เปิดแอพในพื้นหลัง"
 
 #: src/testing/geisterhand.md:419
@@ -62277,33 +62601,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"ฆ่า $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# รอให้แอพพร้อม"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# รับวิดเจ็ท"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# ค้นหาปุ่มที่ติดป้ายว่า \"ส่ง\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# คลิกมัน"
 
 #: src/testing/geisterhand.md:436
@@ -62311,7 +62639,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# ถ่ายภาพหน้าจอหลังจากการปฏิสัมพันธ์"
 
 #: src/testing/geisterhand.md:441
@@ -62323,7 +62652,8 @@ msgid "Python Test Example"
 msgstr "ตัวอย่างการทดสอบด้วย Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# เปิดแอพ"
 
 #: src/testing/geisterhand.md:450
@@ -62331,11 +62661,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# รอการเริ่มต้น"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# วิดเจ็ตรายการ"
 
 #: src/testing/geisterhand.md:455
@@ -62343,11 +62675,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# ค้นหาวิดเจ็ทตามสัญลักษณ์"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# กรอกในสนามข้อความแรก"
 
 #: src/testing/geisterhand.md:464
@@ -62367,7 +62701,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# คลิกปุ่มแรก"
 
 #: src/testing/geisterhand.md:470
@@ -62375,7 +62710,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# ถ่ายภาพจอสําหรับการลดลงทางสายตา"
 
 #: src/testing/geisterhand.md:473
@@ -62391,7 +62727,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# การยืนยันว่าแอพยังคงใช้ได้"
 
 #: src/testing/geisterhand.md:478
@@ -62422,40 +62759,14 @@ msgstr ""
 "เรียกใช้งาน chaos mode กับแอปของคุณเพื่อค้นหาการ crash, การค้าง, หรือสถานะที่ไม่คาดคิด:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# สร้างและเปิดตัว"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# เริ่มการก่อความวุ่นวาย (ทุก 50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# ปล่อยให้มันทํางาน 30 วินาที"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# ตรวจสอบสถิติ"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"ทํางาน\": true, \"events_fired\": 600, \"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# ถ่ายฉากหน้าจอเพื่อดูสภาพสุดท้าย"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# หยุดความวุ่นวาย"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# ตรวจสอบว่าแอพยังใช้อยู่"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -62467,11 +62778,13 @@ msgid ""
 msgstr "จับภาพหน้าจอที่จุดสำคัญในการโต้ตอบและเปรียบเทียบกับภาพอ้างอิง:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# สภาพเริ่มต้น"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -62479,24 +62792,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# การจับหลังจากปฏิสัมพันธ์"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# เปรียบเทียบ (ใช้ ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "การผสานเข้ากับ CI Pipeline"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# ตัวอย่างการกระทํา GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# ตัวอย่าง GitHub Actions\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -62545,7 +62860,8 @@ msgid "Run UI tests"
 msgstr "เรียกใช้การทดสอบ UI"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# วิ่งสคริปต์ทดสอบของคุณ"
 
 #: src/testing/geisterhand.md:568
@@ -62723,20 +63039,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "หลังจากคอมไพล์ด้วย `--enable-geisterhand` และเรียกใช้งาน:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# ดูวิดเจ็ทอินเตอร์เอ็กซ์ทั้งหมด"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr "#   {\"มือ\":4,\"widget_type\":0,\"callback_kind\":0,\"ฉลาก\":\"รีเซ็ต\"}"
 
 #: src/testing/geisterhand.md:659
@@ -62744,8 +63063,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"แฮนด์\": 6, \"widget_type\" 2, \"callback_kind\" 1, \"เล็บเบิ้ล\":\"\"}"
 
@@ -62754,19 +63074,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# คลิกเพิ่ม 3 ครั้ง"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# ป้ายคอนเตอร์แสดงให้เห็นว่า \"นับ: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# กรอกชื่อ"
 
 #: src/testing/geisterhand.md:669
@@ -62774,7 +63097,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# กําหนดสไลเดอร์ให้ 80%"
 
 #: src/testing/geisterhand.md:672
@@ -62782,11 +63106,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# เปิดโหมดมืด"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -63085,16 +63411,13 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr "หาก auto-build ล้มเหลว หรือคุณต้องการ cross-compile ด้วยตนเอง:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# สร้าง Geisterhand libs สําหรับ macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# สร้างสําหรับ iOS (แครสคอมพิล)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -63271,15 +63594,18 @@ msgstr ""
 "run สะดวกต่อ:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# แมดูเลอร์ไม่กี่ตัว"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# เพียงการส่งออกเหล่านี้"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# แบบรวม mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -63299,15 +63625,18 @@ msgid "Full sweep and the CI gate"
 msgstr "ตรวจสอบเต็มที่ และประตู CI"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# แมตริกซ์ทั้งตัว + ตารางสรุป"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# ทางออกที่ 1 ในการลดลงเทียบกับเส้นเบอร์ลีน"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# เขียนใหม่เส้นเบสลีนที่ผูกพัน"
 
 #: src/testing/node-compat-matrix.md:43
@@ -63574,7 +63903,7 @@ msgstr ""
 "`scripts/ci_plan.py` ในงานแรกของกระบวนการทํางาน (`plan`) ทุกงานอื่นๆคือ `needs: "
 "plan` และมีเกตที่ `fromJSON(needs.plan.outputs.plan).jobs.<name>`"
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -63669,11 +63998,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -63698,94 +64027,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "รวดเร็ว 6 เท่า"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "เร็ว 3 เท่า"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x เต็ม"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "เพียง deps"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "ใน **pr** tier the changed-file list ลดความหมายของแผนลงอีก"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -63793,7 +64135,7 @@ msgstr ""
 "**เพียง docs** (เพียง `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, ...  ดู `NON_CORE_GLOBS` ใน `ci_plan.py`) → ใช้เพียง `lint`"
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -63801,7 +64143,7 @@ msgstr ""
 "**หัว** (อะไรก็ตามที่สามารถเปลี่ยนแปลงตัวประกอบ, เวลาทํางาน, หรือผลการทดสอบ) → ชั้น PR "
 "ทั้งหมด"
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -63809,7 +64151,7 @@ msgstr ""
 "**กรุงเทพ** (ไฟล์ล็อค, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, ...) → นอกจากนี้กระบวนการทํางาน `security-audit` สามารถนําไปใช้ใหม่ได้"
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -63822,7 +64164,7 @@ msgstr ""
 "หลักจะวิ่งอีกครั้งทุกการทดสอบที่ถูกยกเว้นและล้มเหลวถ้ามันไม่ล้มเหลวอีกต่อไป นี้จับการแก้ไขที่ทําใน "
 "HIR, แปลง, หรือความพึ่งพาอื่น ๆ โดยไม่ต้องเพิ่มการตั้ง Rust ไปยัง PRs docs เท่านั้น"
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -63831,11 +64173,11 @@ msgstr ""
 "รายการไฟล์ที่ว่างเปล่าหรือล้มเหลวจะถูกพิจารณาว่า **หัว** และงาน `plan` "
 "ที่ล้มเหลวล้มเหลวประตูโดยสิ้นเชิง"
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "ทําไมมันจึงดูเหมือนอย่างนี้ (วัด 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -63847,11 +64189,11 @@ msgstr ""
 "งาน / ~ 650 นาที**, และ `main` เห็น ~ 66 PR push และ ~ 58 การรวมต่อวัน นั่นก็คือ "
 "1.52× ความจุทั้งหมด, ดังนั้น:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr "การรอคอยในคิวงานอยู่ที่ 37 ชั่วโมง (ฉีก `conformance-smoke`: กลาง 4 ชั่วโมง)"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -63859,7 +64201,7 @@ msgstr ""
 "**0 จาก 66** การทํางาน PR ของกระแสทํางาน `Tests` ได้เสร็จสิ้นในหน้าต่างตัวอย่าง  8 "
 "ประเด็นล้มเหลว 56 ประเด็นถูกยกเลิกโดยการผลักดันต่อไป"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -63871,7 +64213,7 @@ msgstr ""
 "**การรวมทั้งหมด 12 ครั้งที่ผ่านมา เป็นการเลี่ยงทางผู้บริหาร** โดย `lint` และ `cargo-test` "
 "ยังคงรอคอย"
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -63885,11 +64227,11 @@ msgstr ""
 "และ # 8187 ได้แทนรายการสภาพแวดล้อมที่จําเป็นที่แตกแยกลงด้วยแฟนอิน `pr-gate` "
 "เดียวที่อธิบายข้างต้น"
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "ค่าใช้จ่ายเฉพาะอย่างยิ่งสองรายการ:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -63908,7 +64250,7 @@ msgstr ""
 "1.5 s แต่ละตัว; นั่นคือ รูปแบบช่องว่าง `fast` ที่ระดับ PR และ sweep ใช้ รูปแบบอัตโนมัติ 8-"
 "shard ถูกเก็บไว้ในระดับเต็ม เพราะมันเป็นแขนเดียวที่เห็นข้อผิดพลาดของลิงค์ที่อัตโนมัติ-อัตโนมัติเท่านั้น"
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -63922,7 +64264,19 @@ msgstr ""
 "line run; PRs ฟื้นฟู blob main-line ใหม่ที่สุด `cache-warm.yml` หายไป: การ sweep "
 "เป็นการสร้าง cache บน `main`"
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -63943,75 +64297,75 @@ msgstr ""
 "tests` กับ PR และใช้กับมัน ร่วมกับระดับ `full` ของ `test.yml` "
 "งานประชาสัมพันธ์ที่ไม่ได้ติดป้าย ยังได้รับเงินทุกๆ  กับทุกๆงานที่หลีกเลี่ยง ซึ่งไม่ต้องเสียค่าใช้จ่าย"
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "งานประจํา"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "นาทีวิ่งเฉพาะ"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "นาฬิกากําแพงเป้าหมาย"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (แกน)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 ชิ้นส่วนช่องว่าง)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 นาทีเมื่อติดคิว"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (docs-only)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 นาที"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "ไม่ใช่เป้าหมาย  มันรวมกัน"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "ไม่ใช่เป้าหมาย"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -64038,11 +64392,20 @@ msgstr ""
 "จะไม่ได้ใช้สล็อตทุกคนในขณะที่การผสมผสานลง การกําหนดความล้มเหลวในการ sweep "
 "เป็นโดยหน้าต่าง (`previous sweep SHA .. this sweep SHA`) เหมือนกับประตู 6 ชั่วโมง"
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "เลือก PR เป็นมากกว่า"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -64055,7 +64418,7 @@ msgstr ""
 "ที่ควรวัดก่อนการรวม, และสําหรับอะไรก็ตามที่สัมผัสกับชุดระดับเต็มเท่านั้น "
 "การใช้สัญลักษณ์จะเริ่มการทํางานใหม่ (`labeled` trigger)"
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -64063,7 +64426,7 @@ msgstr ""
 "**ตรา `skip-changelog`** ละเว้นขั้นตอนการตั้งค่าการเปลี่ยนแปลงใน `lint` "
 "(การเปลี่ยนแปลง `crates/` ไม่เช่นนั้นต้องเพิ่ม `changelog.d/<PR>-<slug>.md` กระบวน)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -64071,11 +64434,11 @@ msgstr ""
 "**`workflow_dispatch`** ในสาขาใด ๆ: `tier` (`pr` / `sweep` / `full`) และ "
 "`update_gap_snapshot`"
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "การปรับพื้นฐานของช่องว่าง"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -64087,15 +64450,17 @@ msgstr ""
 "(การเลื่อนย้อนที่ที่ระบุลําดับ, การเปลี่ยนแปลง Oracle), กลับมัน **จาก CI**, "
 "ไม่ใช่จากคอมพิวเตอร์แล็ปท็อป (แนวพื้นฐานที่จําเป็นคือ Linux, `fast` mode):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# รอการขับขี่ แล้ว:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# กรอก `issue` / `reason` สําหรับรายการใหม่ทุกรายการ, แล้ว commit"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -64104,11 +64469,11 @@ msgstr ""
 "รายการใหม่ลงใน `category: untriaged`; ให้แต่ละรายการมีประเด็นและเหตุผลก่อนการรวม "
 "การชนอาจไม่ถูกจอดในฉาก (`run_gap_tests.sh` ไม่ยอม)"
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "การปกป้องสาขา"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -64123,11 +64488,11 @@ msgstr ""
 "ตรวจสอบว่าการกวาดเส้นหลักแต่ละเส้นผลิตผลที่ _ จบ_ ภายในงบประมาณของมัน; "
 "การดําเนินการของประตูเองจะดําเนินการไม่ว่าผลที่ผ่านหรือล้มเหลว."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -64139,7 +64504,7 @@ msgstr ""
 "succeeded  การใช้ green sweep หรือ PR-tier บน SHA เดียวกันไม่นับ ดู [Releasing](../"
 "contributing/releasing.md)"
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -64153,6 +64518,173 @@ msgstr ""
 "`parity_known_failures.py` วิ่งภายในแต่ละชิ้น (โดยการออกแบบมันปลอดภัยจากชิ้น); "
 "ขั้นต่ําขั้นต่ําและแนวโน้มเมทริกซ์ต่อโมดูล วิ่งครั้งเดียวใน `parity-aggregate` ผ่านรายงานรวม "
 "(`scripts/parity_report_merge.py`, ซึ่งปฏิเสธชิ้นที่หายไปแทนที่จะลดชุด)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "ช็อคส่งอะไร"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "ใช้มันในท้องถิ่นด้วย:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"คําสั่ง\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -64269,36 +64801,13 @@ msgid "Reproduce the core of it with:"
 msgstr "พันธุ์เนื้อหาของมันด้วย:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# สิ่งที่เกิดขึ้นจริง ๆ ในระดับงาน"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "งาน | select(.status==\"in_progress\") | (ตรา|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# ความลึกของคิว และสระว่ายน้ําไหน"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "งาน | select(.status==\"queued\") | (ตรา|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -64470,24 +64979,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# ไม่เปลี่ยนแปลง  ทุก PR ยังคงวัด"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # กระแส; ดูตารางด้านล่าง"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -64498,12 +65005,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# ปล่อยไว้เป็นส่วนตัว"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -64764,11 +65270,13 @@ msgstr ""
 "ผู้โทรที่ล้มเหลวในงานที่ไม่เกี่ยวข้อง ก็ยังเป็นหลักฐานใหม่ จากการตรวจสอบความปลอดภัย"
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# พิสูจน์ว่ามันยังล้มเหลวได้"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# API ของจริง ไม่มีประเด็นเขียน"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -64798,10 +65306,49 @@ msgstr ""
 "หมายความว่าตัวตรวจจับทํางาน ไม่ใช่ว่าไม่มีอะไรพยายาม"
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "คิวหน้าตารางการทํางาน (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -64809,57 +65356,57 @@ msgstr ""
 "การ sweep ทุกๆ 6 ชั่วโมง จะช่วยได้ ถ้าคิวหมดเร็วกว่า 6 ชั่วโมง เมื่อวันที่ 12 สิงหาคม 2026 "
 "มันไม่ได้ และสาเหตุไม่ใช่ประตู"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "การเดินคิว"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "การดําเนินงานพร้อมกันที่สังเกต"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "คอยตามเหตุการณ์"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "สาขาหัวที่แตกต่างกันระหว่างการเดิน PR ในคิว"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**สาขาที่ยังมีอยู่**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -64875,11 +65422,12 @@ msgstr ""
 "ที่ไม่ได้เสร็จใน 32+ ชั่วโมง ไม่มีการกําหนดช่วงเวลาที่สามารถฟื้นฟูได้ จากการกําหนดช่วงเวลานั้น "
 "ขยะต้องถูกกําจัด"
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -64894,7 +65442,7 @@ msgstr ""
 "PRs เปิดมากกว่าการมีสาขา ซึ่งเป็นสิ่งที่ทําให้ PRs ของฟอร์คปลอดภัย  "
 "สาขาหัวของฟอร์คไม่เคยปรากฏในรีฟของ repo นี้"
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -64906,13 +65454,13 @@ msgstr ""
 "reap_stale_ci_runs.py --apply` แบบมือ (การทํางานแบบแห้งเป็นแบบตั้งค่า) "
 "โปรแกรมจะทําให้มันว่างหลังจากนั้น"
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr "ทําไม \"ประตูมืด\" ไม่เหมือนกับ \"ประตูจะจับมันได้\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -64923,7 +65471,7 @@ msgstr ""
 "คําสรุปที่น่าดึงดูด  ประตูมืดปล่อยให้มันผ่าน  ไม่รอดการตรวจสอบ "
 "และบันทึกว่าทําไมจึงสําคัญมากกว่าเหตุการณ์:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -64934,7 +65482,7 @@ msgstr ""
 "**ไม่มีการสกัดลวดลายเต็มหรือการนับวงจรหลัก**, และตัวนับที่พบ \\#7965 (`collection_kind: "
 "\"full\"` เป็น 0 → 2) ไม่ใช่หนึ่งในนั้น ไม่มีเกตใน repo ราเช็ตการนับ collection-_kind_"
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -64945,7 +65493,7 @@ msgstr ""
 "profile CI รัน โดยมีเหตุผลบันทึกไว้ใน `tolerances.json` พวกเขายังใช้รหัส "
 "`pinned_host` เท่านั้น ซึ่ง CI ไม่เคยใช้"
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -64953,7 +65501,7 @@ msgstr ""
 "ค่าทํางานที่แสดงมัน (`retain`, `deeplist`, ...) เป็น gc-handoff corpus ไม่ใช่ `gc-"
 "ratchet` ที่ตั้ง 14 probes"
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -65173,14 +65721,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "คอมไพล์ TypeScript เป็น executable แบบ native"
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# หรือการสั้น (Auto-detects compile)"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Flag"
 
@@ -65209,7 +65758,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (ค่าเริ่มต้น) หรือ `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -65217,7 +65766,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "พิมพ์การแสดงผลกลาง HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -65229,7 +65778,7 @@ msgstr ""
 "ผลิตวัตถุ file ((s) เท่านั้น, เลิกเชื่อม; เขียนไปยัง `-o` (ดู [ฟันธงของคอมพิลเลอร์]"
 "(flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -65237,7 +65786,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "เก็บไฟล์ `.o` และ `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -65245,7 +65794,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "เปิดใช้งาน V8 JavaScript runtime fallback"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -65256,8 +65805,8 @@ msgid ""
 msgstr ""
 "บังคับ link wasmi WebAssembly host runtime (ตรวจพบอัตโนมัติเมื่อใช้ `WebAssembly.*`)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -65265,15 +65814,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "เปิดใช้งานการตรวจสอบ type ผ่าน tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "Minify และ obfuscate output (เปิดใช้อัตโนมัติสำหรับ `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -65281,7 +65830,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (จำเป็นสำหรับ target ของ widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -65290,23 +65839,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "รวม TypeScript extension จาก directory"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# การประกอบพื้นฐาน"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# การจัดสรรข้ามสําหรับ iOS Simulator"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# สร้างโปรแกรม"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: ดูการแสดงระยะกลาง"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# สร้างวิดเจ็ท iOS"
 
 #: src/cli/commands.md:82
@@ -65314,23 +65868,28 @@ msgid "Compile and launch your app in one step."
 msgstr "คอมไพล์และเปิดแอปของคุณในขั้นตอนเดียว"
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# ไฟล์การตรวจสอบการเข้าโดยอัตโนมัติ"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# ใช้ iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# ใช้ Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# วิ่งบนเครื่อง Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# ส่งอาร์ก์ฟอร์มไปยังโปรแกรมของคุณ"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -65462,19 +66021,23 @@ msgstr ""
 "รองรับ target นั้น ใช้ `--local` หรือ `--remote` เพื่อบังคับเส้นทางใดเส้นทางหนึ่ง"
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# วิ่งโปรแกรม CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# วิ่งบนเครื่องจําลองเฉพาะ"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# พยายามก่อสร้างทางไกล"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# วิ่งเป้าหมายเว็บ"
 
 #: src/cli/commands.md:131
@@ -65488,19 +66051,23 @@ msgid ""
 msgstr "เฝ้าดู source tree ของ TypeScript และคอมไพล์ + เปิดใหม่อัตโนมัติทุกครั้งที่บันทึก"
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# ดู + สร้างใหม่ + เริ่มใหม่"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# ด้านหน้าอาร์ก์กับเด็ก"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# ดูรายการเพิ่มเติม"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# override ทางออก"
 
 #: src/cli/commands.md:144
@@ -65631,7 +66198,7 @@ msgstr ""
 "การรักษา state ข้าม rebuild / HMR — \"fast restart\" "
 "คือเป้าหมายที่ตั้งไว้อย่างตรงไปตรงมา"
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -65696,19 +66263,23 @@ msgid "Include medium-confidence fixes"
 msgstr "รวมการแก้ไขที่มีความเชื่อมั่นระดับกลาง"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# ตรวจสอบไฟล์เดียว"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# ตรวจสอบกับการวิเคราะห์ความพึ่งพา"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# ปัญหาการแก้ไขอัตโนมัติ"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# ปรับปรุงแบบรีวิวโดยไม่ใช้"
 
 #: src/cli/commands.md:207
@@ -66000,27 +66571,33 @@ msgstr ""
 "สำหรับ Windows"
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# แสดงเมนู"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# การตั้งค่า macOS (ข้อมูลการลงนาม)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# การตั้งค่า iOS (ข้อมูลการลงนาม)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# การตั้งค่า visionOS (ข้อมูลการลงนาม)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# การตั้งค่า Android (ข้อมูลการลงนาม)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows toolchain (ดาวน์โหลด MS CRT + Windows SDK ผ่าน xwin)"
 
 #: src/cli/commands.md:318
@@ -66048,19 +66625,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# อัพเดทเป็นล่าสุด"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# ตรวจสอบโดยไม่ติดตั้ง"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# ไม่สนใจคําตอบที่แคช"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# เก็บวิธีการอัพเดทและออก"
 
 #: src/cli/commands.md:333
@@ -66077,7 +66658,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` เขียน `[update] mode` ไปยัง `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -66186,14 +66767,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "สร้างโครงร่างแพ็กเกจ native-bindings ใหม่:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"การผูกพันธนาการพื้นเมืองสําหรับ libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -66722,10 +67295,21 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr "Output executable, bundle, shared library, archive หรือเส้นทางของวัตถุ"
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -66733,90 +67317,123 @@ msgstr ""
 "เลือก Linux libc/linkage; `musl` อัพเกรดเป้าหมาย Linux "
 "ที่ตรงกันไปยังการสร้างที่ไม่มีหัวแบบสแตตติกเต็ม"
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "ตัวระบุพัสดุที่ต้องการโดยเป้าหมายของวิดเจ็ตหน้าจอหลัก"
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "ค้นพบและรวมแพคเกจการขยายพื้นเมืองจากดาราโดยสแตติก"
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
 msgstr "วิ่งเครื่องตรวจสอบ TypeScript (`@typescript/native-preview`) ก่อน codegen"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr "กําหนดพื้นความสอดคล้อง Windows PE; ไม่สนใจสําหรับเป้าหมายที่ไม่ใช่ Windows"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
 msgstr "เลือกระบบย่อย Windows PE แทนที่จะพึ่งพาการตรวจจับอัตโนมัติที่ใช้การนําเข้า"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
 msgstr ""
 "สําหรับเป้าหมายของวิดเจ็ต Apple ให้ส่งแหล่ง SwiftUI และเมทาข้อมูลโดยไม่เรียก `swiftc`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
 msgstr "เลือก HarmonyOS วัสดุเซ็น HAP เลือกแหล่ง environment/config ที่ตรงกับความลับ"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS การใช้งานเชือกรับรอง"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS โปรไฟล์การจัดหาที่ลงนาม"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS keystore alias; ปกติเป็น `debugKey`"
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — โมดูล"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "การฝังทรัพย์สิน"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -66824,11 +67441,11 @@ msgstr ""
 "เก็บไฟล์สแตติก (SPA `dist/`, ภาพ, JSON, แฟนท์, ...) "
 "ลงในไฟล์ที่สามารถดําเนินการได้อย่างอิสระเพื่อให้มันทํางานโดยไม่ต้องมีไฟล์ภายนอกบนดิสก์ (# 5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -66837,11 +67454,23 @@ msgstr ""
 "การแทงไฟล์, แดรคทอรี่, หรือ `*`/`**` glob (เทียบกับรากของโครงการ) Repeatable. "
 "ผสมผสานกับ `perry.embed` (package.json) และ `[compile] embed` (perry.toml)"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -66849,19 +67478,20 @@ msgstr ""
 "สร้างโมดูลเสมือน ซึ่งการส่งออกแบบบังคับใช้งาน แผนที่ทุกไฟล์ที่อยู่ภายใต้ `dir` ไปยัง `$perryfs` "
 "ที่มั่นคง สามารถซ้ําได้ แผนที่แหล่งไม่ได้"
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# ให้บริการ dist/ จากความจํา  ไม่จําเป็นต้อง dist/ โฟลเดอร์"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "ไฟล์ที่ฝังไว้สามารถเข้าถึงได้ในเวลาทํางานได้ใน 3 วิธี:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -66893,7 +67523,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -66904,7 +67534,7 @@ msgstr ""
 "เพื่อให้วิธีการเรียงส่งผลของมัน `readEmbedded(path)` และ `node:fs` ยอมรับเส้นทางเสมือน "
 "`$perryfs/<path>` หรือกุญแจสัมพันธ์การฝัง"
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -66912,7 +67542,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -66922,7 +67552,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -66935,7 +67593,7 @@ msgstr ""
 "รักษาทุกขอบ `{ type: \"file\" }`, "
 "และเก็บแหล่งที่สร้างขึ้นในแคชของมันแทนที่จะปรับเปลี่ยนการตรวจสอบ."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -66943,11 +67601,7 @@ msgstr ""
 "สําหรับกราฟแหล่ง OpenCode ที่ติดไว้, สร้าง UI เว็บด้านบนก่อน, จากนั้นรวมจากรากแพคเกจของ "
 "`packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -66960,7 +67614,7 @@ msgstr ""
 "หรือการนําเข้าที่หายไปจะล้มเหลวด้วยข้อความแก้ไขแทนที่จะกลายเป็นเตือนการนําเข้าที่ยังไม่แก้ไข "
 "ให้ทํางานคําสั่งการเตรียมสําหรับการแก้ไขแหล่งทุกครั้ง เพื่อให้ข้อมูลที่สร้างขึ้น ไม่อาจเก่า"
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -66972,7 +67626,7 @@ msgstr ""
 "โครงการที่เกี่ยวข้องกับแหล่งต้นกําเนิด, ขนาด byte, SHA-256 ภาพรวม, "
 "และโมดูลทรัพย์สินการผลิตเมื่อมี."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -66986,7 +67640,7 @@ msgstr ""
 "อ่านไฟล์บนดิสก์จริงโดยเส้นทางที่สมบูรณ์แบบ และใช้รูปแบบ `$perryfs/<path>` "
 "โดยชัดเจนเมื่อคุณหมายถึงสําเนาที่ฝังไว้"
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -66997,19 +67651,19 @@ msgstr ""
 "เพื่อส่งวัตถุการลงทะเบียน COFF; กําหนด `PERRY_LLVM_CLANG` เมื่อ clang "
 "ที่ตรงกันไม่ได้เป็นครั้งแรกใน `PATH` การฝังเป้าหมายข้ามไม่ได้สนับสนุนในขณะนี้"
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Flag สำหรับ Debug"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "พิมพ์ HIR (intermediate representation) ออกทาง stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -67017,11 +67671,11 @@ msgstr ""
 "dump IR ที่หนึ่งหรือหลาย pipeline stage คั่นด้วยจุลภาค: `hir` (HIR หลัง transform), "
 "`llvm` (ต่อ module `.ll` ลงใน `.perry-trace/llvm/`) หรือ `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -67030,7 +67684,7 @@ msgstr ""
 "จำกัด `--trace hir` ให้แสดงเฉพาะ function/method/class ที่ชื่อมี `NAME` โดยซ่อน "
 "import/export/init noise หากไม่ระบุ stage จะ implies `--trace hir`"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -67043,11 +67697,11 @@ msgstr ""
 "เนื่องจาก `-o` หนึ่งไม่สามารถตั้งชื่อหลายไฟล์. ถ้าไม่มี `-o` พวกมันจะลงในดาราปัจจุบัน "
 "เส้นทางแต่ละเส้นถูกพิมพ์เป็น `Wrote object file: <path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -67057,70 +67711,70 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`) ดู [Project Configuration](../getting-started/project-"
 "config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "เก็บไฟล์ตัวกลาง `.o` และ `.asm` ไว้"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr "รักษา symbols/DWARF (และปล่อย Windows PDB) แทนที่จะถอดผล"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr "ปิดการใช้งานแคชของวัตถุต่อโมดูลสําหรับการสร้างนี้; นอกจากนี้ `PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr "ปรับเปลี่ยนรูทแคชในเครื่อง; ดู [ไดเรกทอรีแคช](cache-dir.md)"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
 msgstr "วิ่งตัวแทนพื้นเมืองลดตัวจํากัด และบังคับ codegen แทนการใช้แคชอีกครั้ง"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr "ปิดการลด Buffer/Uint8Array load/store ของพื้นเมืองเพื่อวินิจฉัย A/B"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr "ออกรายงานหลักฐานการลดประเภท; หมายความว่าการตรวจสอบในภูมิภาคพื้นเมือง"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -67130,11 +67784,11 @@ msgstr ""
 "ข้อความโดยซ่อนข้าง; `--opt-report=json` ออกแบบสภาพคงสําหรับเครื่องมือ "
 "สามารถตั้งค่าได้ด้วย `PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -67146,7 +67800,7 @@ msgstr ""
 "และความกว้างของรากที่ใช้อยู่ เพียงการวิจัยเท่านั้น; ต้องการ `PERRY_RS4GC=1`, "
 "แบ็คเอ็นด์รากพื้นเมืองเดียว (รูปแบบแผนที่สเตคธรรมดาและรูปแบบพานชัดเจนที่ยังมีชื่อหายไป)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -67162,11 +67816,11 @@ msgstr ""
 "เต็มรูปแบบ (object cache จะข้าม codegen สำหรับ module ที่ไม่เปลี่ยน ทำให้ trace dir "
 "ว่างเปล่า)"
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  ทําไมค่าจึงถูกกรองไว้"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -67182,11 +67836,11 @@ msgstr ""
 "และเส้นทางที่รวดเร็วอย่างเงียบไม่ยิง `--opt-report` เป็นตัวแทนตัวแทนการเลือกของ LLVM's `-"
 "Rpass-missed` หมายเหตุ: มันพิมพ์สิ่งที่พิสูจน์, สิ่งที่ไม่ได้, และกฎที่ทําการเรียก."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "ทุกค่าที่ปฏิเสธมี:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -67195,13 +67849,13 @@ msgstr ""
 "**ตําแหน่ง** `local`, `param`, `return`, `field`, หรือ `alloc-site` "
 "(ตัวอักษรที่เป็นตัวอักษรที่ไม่เคยถูกผูกพันกับภาษาท้องถิ่น, ภาษา `.map(x => ({...}))`)"
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
 msgstr "**กฎที่ปฏิเสธมัน**, ในตัวเลขของผู้สะสมเอง, เพื่อให้คุณสามารถเช็คมันกับไฟล์แหล่งที่มีชื่อ"
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -67212,7 +67866,7 @@ msgstr ""
 "อย่าจับมันในการปิด), _Inherently polymorphic_ (ถูกต้องกล่อง  ไม่มีการกระทํา), หรือ _ "
 "Perry จํากัด_ (ไม่ใช่รหัสของคุณ; ชื่อปัญหาการติดตามที่มีอยู่)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -67225,13 +67879,13 @@ msgstr ""
 "`map`/`sort`/`reduce` ไม่มีลุปของตัวเอง แต่ทํางานครั้งละองค์ประกอบ "
 "ดังนั้นความลึกของลุปคนเดียวจะจัดอันดับสุดท้าย ไม่เป็นโปรไฟล์  พวกเขาเป็นตัวแทนสแตติก"
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
 msgstr "การชนะถูกรายงานพร้อมกับการพลาด ดังนั้นอัตราส่วนจึงเห็นได้มากกว่าการร้องเรียนเท่านั้น"
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -67245,7 +67899,7 @@ msgstr ""
 "และไม่มีอะไรที่จะรายงาน รายงานว่า **สตเดอร์**, ดังนั้นมันจะไม่ผสมกับภาระ `--format json` "
 "หรือผลิตของโปรแกรมของคุณ"
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -67258,15 +67912,15 @@ msgstr ""
 "การแตกต่างของ JSON ของสอง build เป็นการตรวจสอบ CI "
 "ราคาถูกต่อการแสดงที่ลดลงเป็นศูนย์โดยเงียบ"
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "การ optimize ผลลัพธ์"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -67286,21 +67940,21 @@ msgstr ""
 "`[build] march`; `[build] native_tuning = false` เป็นตัวสั้นของ `generic` "
 "ใช้กับรหัสแอพและการสร้างใหม่ runtime/stdlib ที่อัตโนมัติ"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
 msgstr "กําหนดค่าคงที่ `__feature_NAME__` ที่แยกกันด้วยคอมมา เพื่อกําจัดรหัสตาย"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -67308,24 +67962,24 @@ msgstr ""
 "ใช้ runtime/stdlib เต็มแบบที่สร้างขึ้นล่วงหน้า "
 "แทนที่จะสร้างใหม่ชุดคุณสมบัติที่สามารถเข้าถึงได้ขนาดเล็กที่สุด"
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr "ขออนุญาตการผสมผสานตัวอักษรระยองใหม่; ดู [Fast-math](fast-math.md)"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "การควบคุมอัตราต่อเนื่องต่อเนื่องต่อเนื่อง"
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -67333,11 +67987,11 @@ msgstr ""
 "การ minify จะลบคอมเมนต์ ยุบ whitespace และเปลี่ยนชื่อตัวแปร local/พารามิเตอร์/"
 "ฟังก์ชันที่ไม่ได้ export เพื่อให้ผลลัพธ์เล็กลง"
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "การสร้างที่ปรับปรุงขนาด"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -67348,11 +68002,11 @@ msgstr ""
 "ที่อัตโนมัติปรับปรุงให้ดีขึ้น โดยปรับขนาดแทนความเร็ว (มันต้องการการตรวจสอบพื้นที่ทํางาน Perry "
 "เช่นส่วนที่เหลือของอัตโนมัติปรับปรุง):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -67364,11 +68018,11 @@ msgstr ""
 "(คํานวณหนักในวงกลมสามารถทํางาน ~ 2-3 × ช้าขึ้น) "
 "อาร์คิฟที่ปรับปรุงขนาดและอาร์คิฟปกติถูกแคชเป็นอิสระ"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -67376,11 +68030,11 @@ msgstr ""
 "นอกจากนี้ยังใช้ LTO ไขมันในอาร์คิฟทั้งหมดบนอาร์คิฟที่สร้างใหม่ (การสร้างใหม่ช้าลง, "
 "ไบนารีขนาดเล็กขึ้น) มีความหมายเพียงกับ `PERRY_SIZE_OPT`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -67398,7 +68052,7 @@ msgstr ""
 "จากนั้นจะหยุดการทํางานโดยไม่มีการสัญลักษณ์ย้อนหลัง  JS `throw`/`catch`, `finally`, "
 "เซียนความผิดพลาด และ `uncaughtException` ไม่ถูกกระทบ"
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -67409,15 +68063,15 @@ msgstr ""
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB เพิ่ม `PERRY_SIZE_PANIC=abort-"
 "immediate` โปรแกรมที่ใช้เวลาทํางานมากกว่า จะลดตัวน้อยลง"
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Flag สำหรับการทดสอบ"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -67425,25 +68079,25 @@ msgstr ""
 "ฝัง HTTP server [Geisterhand](../testing/geisterhand.md) สำหรับการทดสอบ UI แบบ "
 "programmatic (พอร์ตเริ่มต้น 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "กำหนดพอร์ตเองสำหรับ Geisterhand server (เปิดใช้ `--enable-geisterhand` โดยอัตโนมัติ)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Flag สำหรับ Runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "เปิดใช้ runtime V8 JavaScript สำหรับแพ็กเกจ npm ที่ไม่รองรับ"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -67452,15 +68106,15 @@ msgstr ""
 "บังคับ link wasmi WebAssembly host runtime (ตรวจพบอัตโนมัติเมื่อ `WebAssembly.*` "
 "ถูกอ้างอิง; จำเป็นเฉพาะเมื่อโหลดผ่าน dlopen / FFI โดยไม่มี static reference)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "เปิดใช้การตรวจสอบ type ผ่าน tsgo IPC"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -67477,11 +68131,11 @@ msgstr ""
 "`PERRY_ALLOW_EVAL=1` ทําให้มันปิด ดู [Limitations](../language/limitations.md#no-"
 "eval-or-dynamic-code)"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -67502,11 +68156,11 @@ msgstr ""
 "template literals over const locals, finite union-type params, glob) "
 "ไม่ถูกกระทบ ดู [Limitations](../language/limitations.md#no-eval-or-dynamic-code)"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -67514,50 +68168,50 @@ msgstr ""
 "ล้มเหลวในเวลาคอมพิล เมื่อการอ้างอิง API Node/stdlib ที่ได้รับการยอมรับ "
 "แต่ไม่ได้นําไปใช้แทนที่จะปล่อยความผิดพลาดการทํางานที่เลื่อนออกไป"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr "ออก `<binary>.attest.json`; ดู [การรับรองแบบสองแบบ](emit-attest.md)"
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr "ออกรถข้าง sandbox ระบบ; ดู [โปรไฟล์ทรายกล่อง](emit-sandbox.md)"
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
 msgstr "ปฏิเสธพื้นผิวที่สามารถเข้าถึงการดําเนินการรหัสแบบสุ่ม; ดู [Lockdown](lockdown.md)"
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "ตัวแปรสภาพแวดล้อม"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "license key ของ Perry Hub สำหรับ `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "รหัสผ่านสำหรับใบรับรอง .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -67565,60 +68219,60 @@ msgstr ""
 "ระเบียบพื้นฐานของ CPU สําหรับรหัสเครื่องที่ผลิต (มูลค่าเดียวกันกับ `--march`; ฟันธงและ "
 "perry.toml `[build] march` ชนะเหนือสิ่งแวดล้อม)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "ปิดการตรวจสอบอัปเดตอัตโนมัติ"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "เหมือนกัน โดยใช้การสะกดคําทั่วระบบนิเวศ"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` สําหรับการทํางานครั้งเดียว ดู [Updates](updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL ของ update server ที่กำหนดเอง"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr "ข้ามการตรวจสอบอัปเดตอัตโนมัติ (ระบบ CI ส่วนใหญ่ตั้งค่านี้ให้)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "ระดับการ log สำหรับ debug (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -67626,7 +68280,7 @@ msgstr ""
 "`1`/`text` หรือ `json`  เหมือนกับ `--opt-report[=json]` "
 "สําหรับการขับรายงานจากสภาพแวดล้อมที่การเพิ่มฟล็อกเป็นเรื่องที่ไม่สะดวก"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -67639,15 +68293,15 @@ msgstr ""
 "ตัวแปรถูกตั้งโดยผู้ขับรถที่จะนําเสนอธงที่พนักงาน codegen และไม่ได้อ่านเป็นการใส่ของผู้ใช้ "
 "CLAUDE.mdนโยบายการฆ่าก๊อกจีซี"
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "ไฟล์การตั้งค่า"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (โปรเจกต์)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -67727,11 +68381,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (global)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -67753,57 +68407,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# โปรแกรม CLI ง่าย"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# แอพ iOS สําหรับเครื่องจําลอง"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# แอพ visionOS สําหรับเครื่องจําลอง"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# แอพเว็บ (WASM กับ DOM bridge  ชื่อเล่น: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# พล็อกไพร์คที่ใช้ร่วมกัน"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# วิดเจ็ต iOS กับบันด์ ID"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# การรวบรวม Debug"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# การรวบรวมคําพูด"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# การรวบรวมแบบตรวจสอบ"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# WASM ไบนารีสด (ไม่มี HTML wrapper)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# การออกเว็บที่ลดขนาด (ยับยับ JS bridge ที่ฝังไว้)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Commands](commands.md) — คำสั่ง CLI ทั้งหมด"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[Platform Overview](../platforms/overview.md) — เป้าหมายแพลตฟอร์ม"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"โมดูล\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "อัตลักษณ์ของแคช"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"โมดูล\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"แหล่ง\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "โลดาช"
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"เป้าหมาย\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"ฟังก์ชัน\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"คําบรรยาย\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -68038,15 +68888,18 @@ msgstr ""
 "CLI flag มีลำดับความสำคัญเหนือ env var, env var มีลำดับความสำคัญเหนือ package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. ฟันธง CLI ต่อการสร้าง"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. สภาพแวดล้อมในแต่ละ shell"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. ต่อโครงการ package.json (บ่อยที่สุด)"
 
 #: src/cli/fast-math.md:35
@@ -68062,17 +68915,20 @@ msgid "Contraction is separate from reassociation:"
 msgstr "การหดรวมแยกออกจาก reassociation:"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# ขออนุญาต FMA การหดตัวเท่านั้น"
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr "# ปล่อยให้หน้าเครื่องทํางานอย่างรุนแรงที่สุด โดยไม่ต้องผูกพันใหม่"
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# รักษาการเชื่อมต่อใหม่จาก --fast-math แต่หยุดการหดตัวของ FMA"
 
 #: src/cli/fast-math.md:55
@@ -69029,7 +69885,8 @@ msgid "Emit"
 msgstr "การ emit"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -69112,7 +69969,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"ขนาด\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -70300,10 +71157,6 @@ msgstr ""
 msgid "produces:"
 msgstr "จะสร้างผลลัพธ์:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"โมดูล\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -70385,9 +71238,10 @@ msgstr ""
 "`<host source>`"
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "ส่งกลับความผิดพลาดที่ชัดเจน หาก manifest ยังไม่มีอยู่  `perry  compile` หรือ `perry run` "
 "เขียนมันในทุก build ที่ประสบความสําเร็จ"
@@ -72502,7 +73356,7 @@ msgstr "Perry อ่านการตั้งค่าจากทั้งส
 msgid "Setting"
 msgstr "การตั้งค่า"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "ไฟล์"
 
@@ -72585,15 +73439,18 @@ msgstr ""
 "แบบโต้ตอบและเขียนกลับไปยังทั้ง `perry.toml` และ `~/.perry/config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# ปรับแต่งการลงนาม iOS (ใบรับรอง, รูปแบบการจัดหา)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# การตั้งค่าการลงนาม Android (keystore, key Play Store)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# การตั้งค่าการจําหน่าย macOS (แอพสตอร์, การรับรอง)"
 
 #: src/cli/perry-toml.md:605
@@ -72628,8 +73485,11 @@ msgstr ""
 "สำหรับสภาพแวดล้อม CI ให้ใช้ตัวแปรสภาพแวดล้อมแทนการเก็บ credentials ใน `perry.toml`:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# ตัวอย่างการกระทํา GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -73812,19 +74672,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Perry เรือ **2 ช่องทางการเลือกอิสระ** สําหรับการส่งข้อมูลกลับบ้าน  "
-"ไม่มีอะไรออกจากเครื่องของคุณโดยไม่มี `enabled = true` หรือ `on` ใน `~/.perry/"
-"config.toml` ทั้งสองคํานวณ `PERRY_NO_TELEMETRY=1` และ `CI=true`"
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. การวิเคราะห์การใช้งานทั่วไป  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. การวิเคราะห์การใช้งานทั่วไป  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -73834,14 +74695,16 @@ msgstr ""
 "ส่ง: ชื่อคําสั่ง, พลาตฟอร์ม (`darwin`/`linux`/...), เวอร์ชั่น Perry, สถานะ success/"
 "error, และ UUID คลิกันด์ที่ไม่ชื่อเสียง"
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. รายงานความสอดคล้อง  `telemetry.compatibility_reports` (# 849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -73851,15 +74714,15 @@ msgstr ""
 "`UnsupportedExpression`, `UnsupportedStatement`, `DynamicPropertyAccess`, "
 "`ImplicitCoercion`, `UnresolvedImport`, `NoOpStub`"
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "3 รูปแบบ"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr "`off` ไม่เคยส่ง สระว่ายน้ํายังไม่ได้ติดตั้งเลย ไม่มีค่าใช้จ่าย"
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -73867,99 +74730,99 @@ msgstr ""
 "`ask` (แบบตั้งค่า)  เมื่อการวินิจฉัยที่เหมาะสมถูกออกเสียง สอบถามครั้งละครั้ง: `[y] just this "
 "once / [a] always / [n] not this time / [N] never`"
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  ส่งเสมอ (หลังจากถอน + การแก้ไข) ไม่มีคําเตือน"
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**สิ่งที่ถูกส่ง (แผนการแบ่งของภาระทั้งหมด):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"UID\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"รหัส\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"ประเภท\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"ช่องว่างประเภท\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"เวที\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"ล่างกว่า\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"นักตกแต่ง\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"nodes:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"ออส\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"ดาร์วิน-อาร์ม 64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -73974,7 +74837,7 @@ msgstr ""
 "ตัวระบุ (ยกเว้นที่สร้างขึ้นในเช่น `console`, `Math`, `Promise`) → `<id1>`, `<id2>`, "
 "ปิด 200 ตัวอักษร, โดยการปฏิเสธอย่างแข็งแรงถ้ามีตัวจํากัดใดล้มเหลว"
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -73982,32 +74845,36 @@ msgstr ""
 "แคชถอดถอนที่ใช้ในพื้นที่ 30 วันที่ `~/.perry/.report-cache` ป้องกันการส่ง `snippet_hash` "
 "เดียวกันใหม่ทุกครั้ง"
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "ตรวจสอบและบริหาร"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# แสดงโหมดปัจจุบัน, sent/queued นับ"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# พิมพ์ค่าใช้จ่ายที่ถูกตัดออกในคิวในการทํางานนี้"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# สะอาดแคช 30 วัน"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "เพื่อเลือกออกในระดับไฟล์, แก้ไข `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -74016,7 +74883,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -74257,15 +75124,18 @@ msgstr ""
 "types.rs`) ขนาด 8 ไบท:"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// ตรา | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// ขนาดการจัดสรรทั้งหมด, ใช้สําหรับการเดินบล็อกสนาม"
 
 #: src/internals/memory-model.md:69
@@ -74582,7 +75452,7 @@ msgstr ""
 "helper barrier ในช่วง runtime สำหรับการ bisection ด้านประสิทธิภาพ/debug "
 "ค่าที่ไม่ได้กำหนด, `=1`, `=on`, และ `=true` จะคง barrier ไว้ให้ทำงาน"
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -74757,10 +75627,11 @@ msgstr ""
 "protect] retired_set=#N` ใน `PERRY_GC_DIAG=1`"
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -74972,10 +75843,24 @@ msgstr ""
 "ดังนั้นตัวเลขหัวข้อ RSS จะแสดงให้เห็นมากเกินไปว่ากระบวนการจะยึดไว้ในความกดดัน."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Source map"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -74983,183 +75868,183 @@ msgstr ""
 "เส้นทาง ไม่ใช่หมายเลขแถว: ตัวเลขแถวคือคําเรียกร้อง ไม่มีอะไรนํามาใหม่ และทุกแถวของตารางนี้ "
 "เคยชี้ไปยัง `gc.rs` ที่ไม่มีอยู่อีกต่อไป"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "หัวข้อ"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "สัญลักษณ์ที่จะมองหา"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "แท็ก NaN-boxing"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, type/flag constants"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "รอบเงา (ลดรากหลุด)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Registered root scanner"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "สําเนาเล็กน้อย"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "โปรโมชั่นในพื้นที่ทั้งบล็อก"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "นโยบายส่งเสริม"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "ขั้นต่ําการดําเนินงานที่ปรับปรุง"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "เขียนข้อจํากัด"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "การติดตั้งอย่างชัดเจน"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "พิเดคิตปินอนุรักษ์"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "เครื่องกระตุ้นการเก็บและการกําหนดเวลา"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "หน้าการดําเนินงานปัจจุบัน"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "แผนการออกแบบ (ประวัติศาสตร์)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -75562,12 +76447,18 @@ msgstr ""
 "gc/heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "ในกระบวนการ desktop/server ที่ไม่มีข้อจํากัด ซึ่งปรับขนาดเป็นหนึ่งในแปดของงบประมาณ device/"
 "container โดยมีพื้นที่ 1 MiB การไหลเวียนกลับไปที่ตัวจัดสรร, "
@@ -75575,7 +76466,7 @@ msgstr ""
 "มันรอดชีวิต unsafe/deferred "
 "ระยะเวลาและว่างสระเมื่อการรวบรวมเต็มที่ต้องเสร็จสิ้นการฟื้นฟูสนามของมัน."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -75585,100 +76476,214 @@ msgstr ""
 "คือการใช้งานหลังการเก็บข้อมูล **การนับชําร่วยชีวิต** บวก delta เพิ่มเติม "
 "ไม่ใช่ยอดของบล็อคการชําระน้ําสูง"
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "การควบคุมที่ได้รับการสนับสนุน"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr "นี่คือการควบคุมการปฏิบัติงานที่มีประโยชน์มากที่สุดภายนอกการพัฒนาตัวเก็บ:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "การหลุดจากส่วนแยกเป็นจุดหมายเต็ม"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime ปกป้องการแยกแยก; ยังบังคับการครบเครื่องหมาย sweep"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "ยกเลิกการเก็บของโดยตรงสําหรับการเปรียบเทียบระยะเวลา"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "กลับการส่งเสริมทั้งบล็อค เป็นการถอนตัวของแต่ละตัว"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "กําหนดหมวกพื้นที่เด็ก"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "override งบประมาณกระบวนการ heap ใน MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "เลือกรากเงาบนเป้าหมายที่สามารถใช้รากพื้นบ้าน"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "การวินิจฉัยการสแกนสเตคพื้นเมืองเต็ม; ปิดการสําเนา"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "ออกบันทึกการติดตามในแต่ละวงจร"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "ส่งสัญญาณการวินิจฉัยที่สามารถอ่านได้โดยมนุษย์"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -75687,10 +76692,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "ความเครียดการรูตใช้ `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -75704,7 +76710,7 @@ msgstr ""
 "`PERRY_GC_SAFEPOINT_ONLY`, และ `PERRY_STACKMAP_WALKER` ถูกยอมรับ "
 "แต่ไม่ใช่รูปแบบการเก็บข้อมูลที่สนับสนุนเพิ่มเติม"
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -75730,11 +76736,11 @@ msgstr ""
 "และการเปลี่ยนแปลงพฤติกรรมจะล้มเหลว `cargo-test`; ไม่สามารถเงียบไปเลย "
 "ขณะที่หน้านี้ยังคงอ้างอิงเรื่องเก่า"
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "หน่วยงานรับรองและ CI"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -75745,92 +76751,92 @@ msgstr ""
 "แฟนอินของระดับ PR ของ `test.yml` (ดู `docs/src/testing/ci-tiers.md`; "
 "นโยบายระดับคือ `scripts/ci_plan.py`) การครอบคลุมเฉพาะ GC ถูกแบ่งแยกโดยเจตนา:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "ที่มันวิ่ง"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "สถานะที่ต้องการ"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr "การดูแลตัวถือราก, การเคลื่อนไหว GC-knob, และข้อเรียกร้อง path/number ของหน้านี้"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "ใช่ (ผ่าน `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr "ชุดหน่วยเวลาทํางานและเมทริกซ์ 4 รูปแบบ `run_memory_stability_tests.sh`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
 msgstr "ใช่ (ผ่าน `pr-gate`; ระดับ PR มีความแตกต่าง, ระดับ sweep/full ใช้พื้นที่ทํางาน)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
 msgstr "GC × แมตริกซ์การเลือกแสดง ตัวเครื่องมือ Rooting-bug ความตึงเครียดการเขียน"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "ใช่ (ผ่าน `pr-gate`; PR กลุ่มย่อยบน PRs, แมตริกซ์เต็มในการ sweep)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "ความเด่นของรากที่ปล่อยออกมา รวมถึง IR ของจุดสถานะพื้นเมือง"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
 msgstr ""
 "ไม่จําเป็นต้องมีสาขา; PR arm opt-in ผ่าน `run-extended-tests` ทุก 6 ชั่วโมงบน `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "คอลเลคเตอร์ที่ติดกับสตาร์ท counters/RSS/wall แมตริกซ์"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "งบประมาณ mechanism/policy ท้องถิ่น"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "คําสั่งที่ใช้ได้ก่อนการบิน"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -75840,11 +76846,11 @@ msgstr ""
 "ที่มอบหมายมีความต้องการของคอมพิลเลอร์และโฮสต์ที่กว้างกว่า; "
 "ไฟล์กระบวนการทํางานของพวกเขาเป็นหน่วยงานสําหรับคําสั่งที่แม่นยําและกรองความเกี่ยวข้อง"
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "หลักฐานทางประวัติศาสตร์"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -75852,7 +76858,7 @@ msgstr ""
 "[แผน GC ระดับรุ่น](https://github.com/PerryTS/perry/blob/main/docs/generational-"
 "gc-plan.md): การออกแบบเดิมและบันทึกการลงจอดระยะต่อระยะ"
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -75862,7 +76868,7 @@ msgstr ""
 "statepoint-gc-experiment.md): "
 "การวัดและการแก้ไขแบบต้นแบบตามวาระที่นําไปสู่การตั้งค่าพื้นฐานของราก"
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -75871,7 +76877,7 @@ msgstr ""
 "กติกาความแข็งแรงของโคเดเจนปัจจุบัน, รูปแบบการตรวจสอบ, จุดตาบอดที่รู้จัก, "
 "และเครื่องมือแก้ไขปัญหา"
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -76176,7 +77182,8 @@ msgid ""
 msgstr "สี่ตัวอย่างถูกส่งไปในวันเดียว ความช้าในการตรวจจับ ไม่ใช่การแก้ไข เป็นค่าใช้จ่ายทุกครั้ง"
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "5 วิธีที่มันแตก"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -76323,14 +77330,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` ใน `gc/mod.rs` ใน commit เดียวกัน"
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "วิธีการตรวจสอบงานของคุณ"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. เครื่องตรวจสอบสแตติก  วิ่งอันนี้"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -76339,13 +77387,13 @@ msgstr ""
 "**สาขาใช้งาน: เพียงอันตรายจากการก่อรากของ LLVM ที่ปล่อยออก** ลงทะเบียนเก่า หรือ alloca "
 "ที่ไม่ได้ถูกก่อตั้งในรหัสที่สร้างขึ้น ภายในวงกว้างนั้น มันเป็นเครื่องมือเดียวที่เห็นความบกพร่อง ก่อนที่จะชน"
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
 msgstr "**มันตาบอดกับสามประเภท ทั้งหมดพบทางที่ยากลําบาก รายงานที่ไม่ผิดก็ไม่ได้เป็นหลักฐาน**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -76353,7 +77401,7 @@ msgstr ""
 "**ตารางการทํางานและแคชการทํางาน** (#7231)  มันอ่าน IR ที่ปล่อยออกมา "
 "และไม่สามารถเห็นเซลล์เวลาทํางานได้ บอก: พลาด 10/10 แทนที่จะหยุดพัก"
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -76363,7 +77411,7 @@ msgstr ""
 "ทั้งสองด้านของบั๊กจริง ที่แก้ไขได้เป็น `GcSuppressScope` หนึ่งบรรทัดใน `globalThis` "
 "bootstrap"
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -76379,7 +77427,7 @@ msgstr ""
 "ทรัพย์สินได้รับ `MOVING: no`, และ 31 การใช้งานที่เก่าแก่ถูกทิ้งโดย `--moving-only`. "
 "**ตรวจสอบชุดเหล่านี้ให้ตรงกับสิ่งที่ codegen ส่งออกจริง เหมือนที่ #7227 ตรวจสอบ `ALLOC_RE`**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -76388,7 +77436,7 @@ msgstr ""
 "สําหรับประเภทด้านบน อุปกรณ์ที่จับพวกเขาคือแขน schedule/quarantine ด้านล่าง และภาระงาน "
 "_dependence-scale_ #7280 บันทึก 25 ไฟล์คอร์ปัสที่ผ่านไปในขณะที่ 20 เส้นของสต็อคโซดล้มเหลว"
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -76404,26 +77452,13 @@ msgstr ""
 "dominance` สีเขียวเป็นคําแถลงเกี่ยวกับการลดที่ไม่ได้เป็นแบบตั้งค่าบนเป้าหมายที่สามารถเดินได้ตั้งแต่ "
 "# 7370 **วิ่งทั้งคู่**และรู้ว่าคุณวิ่งไปไหน"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# SHADOW (PERRY_RS4GC=0): ยังคงลดลงบน arm64_32 watchOS และ ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# NATIVE (PERRY_RS4GC=1): เป็นตัวกําหนดตามปกติทุกที่อื่น แอนเกอร์ติด"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr "# `ptr addrspace(1)` แผนกรานและ LLVM ใส่ safepoints ภายหลัง"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -76433,11 +77468,11 @@ msgstr ""
 "คอร์ปัสพื้นเมืองมีศูนย์ที่เก็บราก ดังนั้น `--min-binds` จะล้มเหลวในนั้น "
 "และคอร์ปัสเงามีศูนย์จุดปลอดภัย ดังนั้น `--min-statepoints` จะล้มเหลวในนั้น"
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "สิ่งที่ `--statepoints` ตรวจสอบ และวิธีการที่มันแตกต่างกัน"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -76448,13 +77483,13 @@ msgstr ""
 "live\"` แบนด์ล็อก และตัวตนของมันที่อยู่ใต้จุดปลอดภัยคือ `gc.relocate` ผล. ดังนั้น "
 "\"ที่เก็บรากต้องมีอํานาจเหนือจุดรวบรวมทุกครั้ง\" จะกลายเป็น:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
 msgstr "ไม่มีบันทึกที่ตั้งชื่อของวัตถุ GC สามารถใช้ได้ ต่ํากว่าจุดปลอดภัย เว้นแต่มันเป็นค่าที่ย้ายไป"
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -76467,23 +77502,23 @@ msgstr ""
 "กล่อง NaN ดังนั้น JSValue ใช้เวลาส่วนใหญ่ของชีวิตของมันเป็น `double` "
 "สองประเภทของคําพิพากษา เพราะมีวิธีแก้ไขที่แตกต่างกัน"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -76491,25 +77526,25 @@ msgstr ""
 "ไม่มีค่า `ptr addrspace(1)` ในโซ่การโยงของทะเบียนอยู่ในพัสดุสดของ safepoint "
 "ไม่มีอะไรหมายหรือเขียนใหม่ของวัตถุ"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "รากมัน"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
 msgstr "วัตถุ IS ในพัสดุและถูกย้ายไป แต่สําเนาแท้ของที่อยู่ก่อนการย้ายถูกใช้ต่อไปนี้"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "ค้นหาใหม่จากค่าที่ถูกย้าย (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -76524,7 +77559,7 @@ msgstr ""
 "**ชื่อของลูกหอยที่ห่อ**, ดังนั้น `--moving-only` จะจัดหมวดตามสัญลักษณ์จริง แทน "
 "`llvm.experimental.gc.statepoint.p0`"
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -76545,15 +77580,15 @@ msgstr ""
 "มันมีลักษณะเฉพาะทาง: การเรียกที่ไม่ยอมรับ จะนับเป็นการเรียกเก็บ ดังนั้นช่องว่างในรุ่นของมัน "
 "จะมีค่าเป็นบวกเท็จ ไม่เคยพลาดบวก"
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "สําหรับไฟล์เดียวที่คุณกําลังทบทวน:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "ปุ่มแวดล้อมทั้งคู่มีความสําคัญ เพราะเหตุผลต่างกัน"
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -76568,7 +77603,7 @@ msgstr ""
 "ดังนั้นแมลงที่ต้องการการสะสมระหว่างสองจุดของหลุมลุปที่อ่อนแอโดยอื่น "
 "ไม่สามารถปรากฏในคอร์ปัสโดยไม่มีมัน"
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -76589,7 +77624,7 @@ msgstr ""
 "`js_object_set_field_by_name`, `js_object_get_field_ic_miss` และ "
 "`js_closure_call1` พวกนั้นเคลื่อนที่โดยไม่มีการสํารวจ ใกล้ๆพวกเขา"
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -76597,12 +77632,12 @@ msgstr ""
 "ดังนั้น: เปิดปุ่ม เพราะมันขยายสิ่งที่คอร์ปัสสามารถแสดงออกได้ "
 "แต่อย่าอ่านฟังก์ชันที่ไม่มีการสํารวจว่าปลอดภัย"
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr "`POLL_CAPABLE_RUNTIME` เป็นสัญลักษณ์ที่ออกมาจาก EXACT และมันได้กัดสองครั้ง"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -76613,7 +77648,8 @@ msgstr ""
 "codegen จะไม่ได้ปล่อยอะไรไปตลอดไป และดูเหมือนการครอบคลุมในขณะที่ทํามัน "
 "ปัจจุบันมีการวัดสองรอบของสิ่งนี้"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -76624,7 +77660,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -76639,7 +77675,7 @@ msgstr ""
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` ที่ `clone` ของ zod. "
 "ผู้ปกป้องและผู้ตรวจสอบไม่เห็นด้วย; ผู้ตรวจสอบผิด"
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -76659,7 +77695,7 @@ msgstr ""
 "ดังนั้นการประกอบการเดียวที่ชัดเจนที่สุดในภาษาถูกครอบคลุมศูนย์ครั้ง; จุดเข้าจริงคือ "
 "`js_closure_callN` ซึ่ง `RECEIVER_SINKS` ในไฟล์เดียวกันได้สะกดถูกแล้ว"
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -76678,60 +77714,60 @@ msgstr ""
 "และหยุดรายการหนึ่งที่สั้น ดังนั้นรูปไม่เคยสามารถจับได้ภายใต้การทํางานแบบ CI. "
 "การปลูกรหัสใหม่และทํางานทุกโหมด (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (การมีอํานาจ)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (การลดที่ส่ง)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (ไม่กรอง)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (ไม่กรอง)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -76741,7 +77777,7 @@ msgstr ""
 "ทุกแขนปิดประตู ทั้งสองแขนไม่กรอง ไม่รวม `--statepoints` เพิ่มใน # 7663 การเพิ่มชื่อหนึ่ง "
 "จะทําให้แขนที่ถูกทําลายเป็น 13 และ 8 และเหลือแขนที่สะอาดเป็น 2 และ 2"
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -76767,7 +77803,7 @@ msgstr ""
 "หรือจัดสรรผ่านเส้นทางที่สามารถ, เพิ่มมันไปยัง `POLL_CAPABLE_RUNTIME` ใน commit "
 "เดียวกัน** ไม่มีอะไรจะขอให้คุณ"
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -76777,7 +77813,7 @@ msgstr ""
 "คือประตูสําหรับรอบ 3 รอบ 4 ไม่มีประตู `gc-root-dominance.yml` วิ่งพร้อมกับ `--audit-"
 "alloc-re` ก่อนการสร้าง"
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -76801,7 +77837,7 @@ msgstr ""
 "\"C\" fn js_*` ที่ถูกส่งออก เมื่อมันกลายเป็นสีแดง **แทน** ภาพลวงที่มีสัญลักษณ์ codegen "
 "ที่จริงส่งออก แทนที่จะลบมัน  การลบเปลี่ยนการตรวจสอบสีเขียวและออกจากช่อง"
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -76828,19 +77864,15 @@ msgstr ""
 "และความคิดเห็นและ string literals ถูกถอดออกก่อน "
 "ดังนั้นชื่อที่กล่าวในบทประพันธ์จึงไม่สามารถกลายเป็นข้อเสนอ"
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr "การตรวจสอบชื่อที่น่าเชื่อถือไม่เพียงพอ ยืนยันกับ IR ที่ปล่อย:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -76848,7 +77880,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` ทําให้ทุกรหัสที่รุนแรง รหัสเรียก `js_shadow_slot_bind` "
 "ช่องเช็คเกอร์ติดต่อ"
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -76862,7 +77894,7 @@ msgstr ""
 "**คําสั่งประตูด้านบนไม่ผ่านมัน**: การสแกนที่เชื่อมโยงเป็นแขนที่ถูกกําหนดฐานโดยรายการอนุญาต "
 "ดังนั้นกรณี 3 และ 4 จะปรากฏขึ้นเมื่อคุณทํางานโหมดนี้ด้วยมือ"
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -76877,7 +77909,7 @@ msgstr ""
 "มันพบตัวแสดงตัวใน `lower_call/new.rs` `this_slot` "
 "โดยอิสระจากเครื่องตรวจสอบเวลาทํางานใด ๆ"
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -76893,15 +77925,15 @@ msgstr ""
 "pointer_locals.rs` ประเภท `Type::Symbol` เป็นทันที, ดังนั้น `Symbol` "
 "ท้องถิ่นไม่ได้มีช่องเงาเลย. ใช้ด้วยมือเมื่อคุณสัมผัสเว็บ `alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. อุปกรณ์เวลาทํางาน  วินาที, และใส่ใจความลึก"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "จาก #7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -76914,7 +77946,7 @@ msgstr ""
 "4) ของวัสดุพืชใหม่ ช้าๆ ละเอียด เพิ่ม `PERRY_GC_SCHEDULE_ALLOC_KB=0` "
 "สําหรับโหมดการสํารวจทุกครั้ง เมื่อหน้าต่างที่คุณกําลังตามหาจะดําเนินการเพียงครั้งเดียว"
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -76922,11 +77954,12 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1`  `mprotect` จากอวกาศหลังจากการอพยพ "
 "ดังนั้นการอ่านความผิดพลาดเก่าทันทีแทนการอ่านขยะที่น่าเชื่อถือได้"
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT`  ตอนนี้จะทํางานจริง"
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -76934,7 +77967,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -76948,7 +77981,7 @@ msgstr ""
 "60\" เป็นสิ่งที่คุณสามารถตัดออกเป็นสอง `scripts/gc_schedule_fuzz.sh <binary> [seed-"
 "count]` สกัดเมล็ดและพิมพ์คําสั่งการผลิตต่อความล้มเหลว"
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -76961,7 +77994,7 @@ msgstr ""
 "ในอัตราจริงคือ ~ `3/N` เท่านั้น ดังนั้นการทํางานที่สะอาด 120 ครั้งจํากัดกับ 1.7% บั๊กที่ 2.5%  "
 "ไม่มีหลักฐานเลย การเปลี่ยนไฟคือวิธีที่ถูกเดียว ที่จะสํารวจพื้นที่ ที่แมลงอยู่จริง"
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -76972,7 +78005,7 @@ msgstr ""
 "สี่ระดับที่เก็บไว้จากพื้นที่ ไม่เพียงพอที่จะยังคงถือบล็อกที่ตัวชี้วัดเก่าของคุณอยู่ในขณะที่มันถูกตัดความหมาย "
 "**ใช้ 800** การทํางานที่สะอาดในความลึกแบบปกติ ไม่ได้หมายความว่าอะไร"
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -76996,7 +78029,7 @@ msgstr ""
 "ไม่เคยเป็นเหตุผลที่จะสงสัยตัวป้องกัน เมื่อมันไม่เห็นด้วยกับตัวตรวจสอบสแตติก ลองดูตัวตรวจสอบก่อน "
 "นั่นเป็นวิธีการที่การไม่เห็นด้วยกับ zod `clone` ได้ถูกแก้ไข"
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -77006,7 +78039,7 @@ msgstr ""
 "และเมื่อความผิดพลาดเกิดขึ้น **เดินขึ้นไปบนค้อน**. ผู้รายงานตั้งชื่อกรอบที่ DEREFERENCE ค่าเก่า "
 "ซึ่งมักไม่ใช่กรอบที่เป็นเจ้าของทะเบียน  ค่ามักมาเป็นข้อโต้แย้งจากผู้เรียกที่ปล่อยให้มันเก่า"
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -77017,11 +78050,11 @@ msgstr ""
 "ไม่มีอะไรในขณะนั้นสําหรับการตรวจสอบเวลาทํางานใด ๆ ที่จะสังเกต อุปกรณ์เหล่านี้จับผลต่อมา "
 "ภายหลัง เครื่องตรวจสอบสแตติกจับสาเหตุได้ ตอนนี้"
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "ภาพกระจก: ป้องกันการเขียนที่หายไป (# 8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -77032,43 +78065,43 @@ msgstr ""
 "ป้องกันการเขียนคือเกี่ยวกับขอบที่คอลเลคเตอร์ไม่เคย **บอกเกี่ยวกับ**. ทั้งสองเป็นคู่กัน "
 "และนี่คือส่วนที่จับคนอยู่ **เครื่องตรวจจับของพวกมันถูกเปลี่ยน**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "แมลงราก"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted ป้องกันการเขียน"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "สิ่งที่ผิดพลาด"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "ค่าที่ใช้อยู่ไม่เห็นได้จากการสแกนราก"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "a old→young edge ไม่มีในชุดที่จํา"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "เมื่อมันผิดพลาด"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "ที่การเก็บเงิน เงียบๆ"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "ไม่ใช่ที่ร้านเลย; ในบางครั้ง"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "เครื่องตรวจจับ"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -77077,28 +78110,28 @@ msgstr ""
 "อุปกรณ์ในเวลาทํางาน (`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_PROTECT_FROMSPACE`) "
 "บวกเครื่องตรวจสอบสแตติกสําหรับครึ่งที่มองเห็น IR"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **การยืนยัน IR สแตติก**ไม่มีอะไรเลย"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "จุดตาย"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr "ผู้ตรวจสอบสแตติกไม่สามารถเห็นแคชด้านการทํางานของตัวชี้ heap ได้ (ดู §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**ทุกซอนด์เวลาทํางานที่เรามี**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "ทําไมไม่มีเครื่องสํารวจเวลาทํางานจะเห็นมัน"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -77110,16 +78143,16 @@ msgstr ""
 "กราฟของวัตถุถูกต้อง สิ่งที่เกิดขึ้นคือการบันทึกในเซตที่จดจําไม่ได้ จึงเป็นเซตที่ไม่สมบูรณ์ "
 "การเปลี่ยนมันให้เป็นความล้มเหลวที่สังเกตได้ ต้องการการเชื่อมโยงที่โปรแกรมต้องให้ด้วยตัวเอง"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr "ผู้ปกครองต้องอยู่รอดจนแก่ (หรือเป็นเจ้าหน้าที่จ้าง) **ก่อน** ร้านค้า"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "เด็กต้องยังอยู่ในห้องเด็ก **ในช่วงเวลาเล็ก ๆ ต่อไป**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -77127,14 +78160,14 @@ msgstr ""
 "a **ขั้นต่ํา** การรวบรวม  ไม่ครบเครื่องหมาย- sweep, ซึ่ง retraces "
 "ทุกอย่างและเอกสารในชั้นเรียนทั้งหมด  ต้องลงในหน้าต่างที่; และ"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
 msgstr ""
 "ขอบนั้นต้องเป็นเส้นทางเดียวไปยังเด็ก, หรือว่ารากอื่นๆ จะหามันเจอ และการรวบรวมจะสะอาด"
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -77142,7 +78175,7 @@ msgstr ""
 "ผิดพลาดอะไรสักอย่าง และเด็กจะเก็บข้อมูลถูกต้อง โปรแกรมจะพิมพ์คําตอบที่ถูกต้อง "
 "และเครื่องตรวจสอบจะรายงานความสําเร็จ ไม่มีอะไรพยายาม"
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -77151,7 +78184,7 @@ msgstr ""
 "ปุ่มแต่ละตัวมันแย่กว่าแค่ไม่รู้สึก  สามตัวของมันมีคุณสมบัติที่แตกต่างกันไปโดยสิ้นเชิง "
 "และมันง่ายที่จะอ่านสีเขียวของพวกเขาเป็นหลักฐาน"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -77164,7 +78197,7 @@ msgstr ""
 "ไม่ใช่สล็อตที่เขาพลาดการเขียนใหม่ การจดจําและการเขียนใหม่ เป็นคุณสมบัติที่แตกต่างกัน "
 "และผู้ตรวจสอบถามเพียงเรื่องที่สองเท่านั้น"
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -77175,7 +78208,7 @@ msgstr ""
 "มันทําให้แมลงไม่สามารถเข้าถึงได้ การวิ่งสีเขียวตรงนี้ "
 "เป็นหลักฐานที่ดูแข็งแกร่งและว่างเปล่าที่สุดของทั้งสามตัว"
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -77186,7 +78219,7 @@ msgstr ""
 "object_  สภาพที่เคลื่อนไหว (4)'s ภายหลัง, บนด้านการกิ่งของความเป็นสอง. "
 "พวกเขาผิดพลาดกับตัวชี้จากอวกาศ ไม่ใช่กับวัตถุมีชีวิตที่ไม่เคยถูกตามหา"
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -77199,7 +78232,7 @@ msgstr ""
 "DEFAULT และรายงานความสําเร็จ  ความเสี่ยง 4 อีกครั้ง, ระดับหนึ่งขึ้น "
 "ชื่อทุกตัวในเอกสารนี้คือชื่อที่ประตูยืนยันว่ามีตัวพาร์เซอร์อยู่"
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -77210,7 +78243,7 @@ msgstr ""
 "**การไม่มีอุปสรรคไม่สามารถสังเกตได้ โดยการทํางานโปรแกรม** ไม่มีการประหารชีวิตที่ "
 "\"ขั้วไม่วิ่ง\" เป็นเหตุการณ์ที่แตกต่างกัน"
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -77228,11 +78261,11 @@ msgstr ""
 "และการเก็บบังคับด้วยการป้องกันจากอวกาศในความลึก 400 **การออกแบบแบบ byte-identical, "
 "exit 0**, ทั้งในช่องว่างที่ติดตั้งและที่ใหญ่ การทดสอบสแตติก IR เป็นสิ่งเดียวที่บอกว่าไม่"
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "อะไรที่ PR ที่เพิ่มหรือย้ายร้านบนสล็อต GC ต้อง"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -77241,7 +78274,7 @@ msgstr ""
 "หลักฐานที่ป้องกันมันคือ **การยืนยัน IR สแตติก**ไม่ใช่การทดสอบพฤติกรรม มันต้องจับสี่อย่าง "
 "แต่ละอย่าง เพราะการวางระเบิดที่ข้ามมันไม่ได้ถูกจับ"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -77250,7 +78283,7 @@ msgstr ""
 "**การบัญชีมีอยู่** ในแขนที่สามารถมีตัวชี้วัดได้  ป้องกันการเขียน, ข้อตกลงการวางแผน, และ "
 "string addref ถ้ามีคนหายตัวไป 3 คน จะเป็นครอบครัว #5094 / #7511 ที่เงียบสงบ"
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -77262,7 +78295,7 @@ msgstr ""
 "8183 ของ sabotage ที่สาม **IR ตาย** ว่าทุกข้อเสนอความเห็นในเนื้อหาอย่างมีความสุขตรวจสอบ "
 "และเริ่มต้นผ่าน การมีรหัสไม่ได้เป็นหลักฐานว่ามันทํางาน"
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -77271,7 +78304,7 @@ msgstr ""
 "**แขนลบจะอยู่สะอาด** แขนที่ไม่มีตัวชี้ต้องไม่มีบัญชี การหลุดเข้าไปในอุปกรณ์นี้ "
 "หมายความว่าตัวแบ่งแยกหยุดแบ่งแยก และ \"การปรับปรุง\" ก็ไม่ได้วัดอะไรเลย"
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -77280,9 +78313,10 @@ msgstr ""
 "**รายงานว่ามีการลุกลอบทําลาย** ลบแต่ละธาตุตามลําดับ และบันทึกว่าการทดสอบเปลี่ยนเป็นสีแดง "
 "การทดสอบที่ไม่เคยล้มเหลว คือการทดสอบที่มีรูปแบบล้มเหลวที่ไม่รู้จัก"
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -77297,30 +78331,23 @@ msgstr ""
 "codegen/src/expr/class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` "
 "และ `write_pic_barrier_tests.rs` เป็นรูป"
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "เครื่องหมาย `GC_STORE_AUDIT` และสิ่งที่มันทําและไม่พิสูจน์"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr "ทุกเว็บไซต์ของร้านค้าที่เกี่ยวข้องกับ GC มีเครื่องหมายใกล้เคียงที่ระบุคําตัดสินของมัน"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "// GC_STORE_AUDIT(BARRIERED): การเขียนสล็อตเป็นไร้เงื่อนไข"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
+msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr "// ด้านล่างถูกคุ้มกันเพียงด้วยการทดสอบที่ใช้จริงที่บิตที่เก็บไว้ไม่มี heap"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "//ตัวชี้ ซึ่งเป็นการทดสอบครั้งแรกของอุปสรรคเอง"
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -77332,7 +78359,7 @@ msgstr ""
 "สแกนเว็บไซต์ร้านค้าของฝ่ายแรกและล้มเหลวเมื่อไม่มีเครื่องหมาย **ใหม่** "
 "เว็บไซต์ร้านค้าไม่สามารถลงพื้นที่ กับคําถามที่ไม่ได้รับคําตอบ"
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -77340,7 +78367,7 @@ msgstr ""
 "เนื่องจาก #8185 ได้ลงพื้นที่ครึ่งที่สองของมัน, บันทึกยืนยัน **การร้องขอ**, ไม่ใช่แค่คําสังเกต, "
 "สําหรับสองประเภทที่คําอ้างเท็จเป็นเส้นของวัตถุ:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -77376,7 +78403,7 @@ msgstr ""
 "และเช่นกันก็มีอุปสรรคที่ข้ามไปในคลอนเฉพาะหนึ่ง แต่ไม่เสียหายในอีกหนึ่ง. การผ่าตัด IR 4 ครั้ง "
 "(ลบสายโทรศัพท์ ผ่าตัดประตู โอนสายโทรศัพท์ออกจากบล็อค และเลี่ยงประตู)"
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -77400,7 +78427,7 @@ msgstr ""
 "จะทําให้ตัวหมายเลขที่สอดแน่นอยู่บนตัวมันเป็นสีแดง Granularity คือฟังก์ชันที่ปิด "
 "(สองร้านค้าที่มีความกีดขวางและการเรียกกีดขวางหนึ่งในฟังก์ชันเดียวกันยังผ่าน) และสคริปต์พิมพ์ที่จํากัด"
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -77421,11 +78448,11 @@ msgstr ""
 "**2** แทนที่จะอ่านเป็นการผ่านว่างสะอาด (วินัย `gc_rekeyed_key_tables.py`) และ `--"
 "self-test` ของมันพืช 15 รูปแบบ, แต่ละอย่างที่ต้องตัดสิน."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "ปัญหาของ corpus และสอง corpus (# 7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -77433,7 +78460,7 @@ msgstr ""
 "**คอร์ปัสที่เขียนด้วยมือ ไม่สามารถแสดงความผิดพลาดประเภทนี้ ในระดับความพึ่งพาได้ "
 "และสําหรับเวลาหนึ่ง ไม่มีใครสามารถบอกได้ เพราะมันสีเขียว**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -77447,7 +78474,7 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. # 7280 วางมันในประโยคเดียว: _25 "
 "กําหนดไฟล์ผ่านในขณะที่ 20 เส้นของสต็อค zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -77455,41 +78482,41 @@ msgstr ""
 "นั่นไม่ใช่ปัญหาเรื่องขนาด ทั้งสองตัวถูกวัดบนเครื่องประกอบเดียวกันด้วย `--stale-registers --"
 "moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "การใช้งานเก่า"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "อะไรเป็นหลัก"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "คัดเลือก 124 แหล่ง / 144 โมดูล"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr ""
 "properties-GET helper windows, `js_number_coerce`, `js_closure_callN` "
 "รายละเอียดของรายละเอียดที่เกี่ยวข้อง"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "ระดับความพึ่งพา, 81 โมดูล / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -77497,7 +78524,7 @@ msgstr ""
 "`js_object_assign_one` (สเปรดของวัตถุ) 137 `js_new_function_construct` 102 "
 "`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -77513,7 +78540,7 @@ msgstr ""
 "**ความเสี่ยงของการก่อรากอยู่ในรูปร่าง**, ดังนั้น corpus ที่ไม่มีรูปร่างนั้นไม่สามารถแสดงออกได้ "
 "แม้ว่ามันจะมีไฟล์จํานวนมากแค่ไหน"
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -77521,11 +78548,12 @@ msgstr ""
 "ดังนั้นจึงมี corpus อันที่สอง, สร้างขึ้นจากความพึ่งพา npm ที่จริง "
 "แทนที่จะมาจากอะไรที่เขียนไว้สําหรับโอกาส:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod คือ package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -77538,7 +78566,7 @@ msgstr ""
 "ซึ่งเป็นการตรวจสอบขนาดพื้นที่ไม่สามารถเป็น, เนื่องจาก ~ 90 โมดูลของ `zod` ทุ่งใด ๆ "
 "นับที่ขาดแหล่ง 40 เส้นจะข้าม."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -77550,11 +78578,11 @@ msgstr ""
 "registers` เป็นงบประมาณที่แพงที่สุด (~ 5 นาที): การสแกนของมันเป็นแบบเหนือเส้นตรง, และ "
 "62 MB คือ 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "ประตู CI"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -77565,16 +78593,16 @@ msgstr ""
 "งานทั้งหมดใช้เวลาไม่กี่นาทีบวกกับการสร้างคอมพิลเลอร์; "
 "การตรวจสอบสองเกตเกตใช้เวลาประมาณสามวินาทีแต่ละครั้งมากกว่า ~ 2000 และ ~ 12900 ฟังก์ชัน"
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr "มันถูกสร้างขึ้นเพื่อที่จะสามารถล้มเหลว, ต่อต้านทั้งหมดสี่อันตรายใน CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr "สถานะการออกของผู้ตรวจสอบคืองาน  ไม่มี `continue-on-error` ไม่มีท่อ"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -77582,7 +78610,7 @@ msgstr ""
 "`concurrency` ยกเลิกการใช้งาน pull-request เท่านั้น ดังนั้นการใช้งาน `main` "
 "จะไม่มีการขาดอาหาร"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -77592,7 +78620,7 @@ msgstr ""
 "corpus ที่บางเกินไปที่จะใช้อะไร และการทํางานพิมพ์ `checked N functions / M modules` "
 "ดังนั้นการทํางานที่เงียบเปล่าจะเห็นได้"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -77603,7 +78631,7 @@ msgstr ""
 "**จริง** corpus IR และต้องการให้รายงานทั้งหมด 40  "
 "นั่นคือแขนที่จับการตรวจสอบเงียบเสียความสามารถในการอ่านผลิตของ Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -77618,11 +78646,11 @@ msgstr ""
 "เพราะทั้งคู่เป็นสแตติกและทันที และทั้งคู่ส่งรายการที่ตายไป: เก้าใน `ALLOC_RE` ผ่านสองรอบ,สิบใน "
 "`POLL_CAPABLE_RUNTIME`"
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "รายการอนุญาต และทําไมมันไม่เป็นจํานวน"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -77631,7 +78659,7 @@ msgstr ""
 "การละเมิดที่ยังคงมีอยู่ใน `scripts/gc_root_dominance_allowlist.json` "
 "มีแต่ละรายการมีลายนิ้วมือ มีประเด็น และข้ออ้างอิงที่เขียนไว้"
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -77642,11 +78670,11 @@ msgstr ""
 "และยอดรวมไม่เปลี่ยนแปลงและประตูยังคงเป็นสีเขียว ที่เลวร้ายยิ่งกว่านั้น ภายใต้กําหนดเวลา "
 "ช่องทางที่ถูกที่สุดที่จะเปลี่ยนสีแดงเป็นสีเขียว ก็คือการเพิ่มจํานวนไปอีกหนึ่งตัว"
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "ดังนั้นตัวตรวจสอบจะบังคับใช้คุณสมบัติสามประการ:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -77656,7 +78684,7 @@ msgstr ""
 "เดียวกัน นั่นเป็นจุดสําคัญ และนั่นคือเหตุผลที่ว่าทําไมแมลงที่ติดตั้ง ไม่สามารถทิ้งศพที่เงียบๆ "
 "จะขยายการครอบคลุมในภายหลังได้"
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -77664,12 +78692,12 @@ msgstr ""
 "**ข้อความใดอย่างหนึ่งยกเลิก `count` มากที่สุด** "
 "การละเมิดครั้งที่สองของรูปร่างเดียวกันในหน้าที่เดียวกัน เป็นเรื่องใหม่ และล้มเหลว"
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr "**การละเมิดโดยไม่มีการเข้า**ไม่ว่าจะมีรายการกี่รายการ"
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -77677,11 +78705,11 @@ msgstr ""
 "การเพิ่มรายการคือการตรวจสอบรหัส การบุก `count` เพื่อให้การสร้างเป็นสีเขียว "
 "คือสิ่งที่ไฟล์นี้มีอยู่เพื่อป้องกัน"
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "โปรโมชั่นประตูนี้"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -77689,11 +78717,11 @@ msgstr ""
 "**ณ เวลาที่เขียน งานนี้ยังไม่อยู่ในรายการตรวจสอบที่บังคับใช้โดยการป้องกัน branch** "
 "ซึ่งหมายความว่างานนี้ไม่สามารถทำให้การ merge ล้มเหลวได้ — ความเสี่ยง 2"
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "ทั้งสองเงื่อนไขที่ #7198 ที่ระบุตอนนี้ได้รับการตอบสนอง:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -77702,7 +78730,7 @@ msgstr ""
 "การตรวจสอบความเด่นที่เชื่อมโยงเป็นสีเขียวบน `main` **เงินเปล่า** allowlist (รายการ "
 "#7211 ถูกลบเมื่อคําเสนอนั้นถูกแก้ไขใน \\#7226)"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -77712,7 +78740,7 @@ msgstr ""
 "นั่นเป็นอันที่โดดเด่น: มันคือ 98 ก่อน #7235, 2 หลังจาก, และ 0 เมื่อ `Type::Symbol` "
 "หยุดการจัดอันดับเป็นทันที."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -77720,7 +78748,7 @@ msgstr ""
 "ดังนั้นขั้นตอนที่เหลือคือ **admin repo** เพิ่ม `gc-root-dominance` "
 "ไปยังกรอบที่ต้องการในการป้องกันสาขา:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -77733,7 +78761,7 @@ msgstr ""
 "การดําเนินงานครั้งแรกของงานบน `main` กับขั้นตอน `--unrooted-allocas` รวมถึง  "
 "ประตูที่ไม่เคยเป็นสีเขียวในรูปแบบปัจจุบันของมัน ยับยั้งทุก PR ที่เปิดในวันที่มันจําเป็น"
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -77754,11 +78782,11 @@ msgstr ""
 "ส่วนที่เหลือถูกนับตามรูปร่างใน # 7664. ลดมันลงเมื่อประชากรคงที่ "
 "โปรโมชั่นที่ทําให้งบประมาณเย็นลงในที่มันอยู่"
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "กติกาหลัก"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -77772,7 +78800,7 @@ msgstr ""
 "ทดลองว่าและถามเพียงเกี่ยวกับผู้เขียนที่ให้บริการ initialisers "
 "ไม่เคยเกี่ยวกับการลดลงของตัวเองออกเสียง `js_object_set_field_by_name` การเรียก"
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -77780,7 +78808,7 @@ msgstr ""
 "**อ่านรากใหม่หลังจากจุดเก็บทุกครั้ง** ไม่เคยแคชชาร์จโหลดจากสล็อตรากระหว่างการเรียก "
 "`rooted_handle_get` มีไว้สําหรับเรื่องนี้"
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -77789,7 +78817,7 @@ msgstr ""
 "**การประเมินแล้วจัดสรรคือความเสี่ยง** การลดต่ําใด ๆ "
 "ที่มีออเพรนด์สองตัวหรือมากกว่าหนึ่งที่หนึ่งในนั้นมีตัวตนก่อนที่อีกตัวหนึ่งจะลดต่ํา ต้องให้ออเพรนด์แรกมีราก"
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -77797,7 +78825,7 @@ msgstr ""
 "**`--trace llvm` และอ่านมัน** สามวินาทีของเช็คเกอร์ ชนะวันของการตัด `not a function` "
 "เป็นสองห้ารอบ"
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -78036,6 +79064,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "ใช้มันในท้องถิ่นด้วย:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "การตรวจสอบในเวลาคอมไพล์"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "ผู้ใช้เลือกแบคเอนด์ตามภาระงาน"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -78464,7 +79661,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: สตริง -- ชื่อทะเบียน, e.g \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -78501,31 +79699,31 @@ msgid "Three types and one rule."
 msgstr "สามประเภทและกฎเดียว"
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr "/// เรจิสเตอร์ที่ถือค่าที่จัดการโดย GC ที่ไม่เป็นรูท"
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// ยืมตัวเครื่องออกเสียงโดยไม่เปลี่ยนแปลง ไม่คลอน ไม่คอปี้"
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr "/// รากเงา อายุเกินจุดเก็บ; ไม่สามารถอ่านตรงได้"
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// เพียงได้รับจาก ShadowFrame:: alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr "/// เลขทะเบียนที่เก็บสิ่งที่ GC ไม่จัดการ: i32, double, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr "/// ดัชนีสล็อต สามารถลอกแบบได้โดยอิสระ ไม่มีอายุการใช้งาน ไม่มีการยืมตัวของตัวปล่อย"
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -78534,22 +79732,27 @@ msgid ""
 msgstr "การออกแบบทั้งหมดนั้นขึ้นอยู่กับ **การแบ่งวิธีการของผู้ปล่อยออกโดยว่าพวกเขาสามารถเก็บ**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr "/// ไม่สามารถเก็บได้ ใช้ &self, ดังนั้นการจัดการ `Raw` ที่เด่นจะยังคงเป็นจริง"
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr "/// สามารถเก็บเงินได้ ใช้ &mut เอง, ซึ่งสิ้นสุดทุกการกู้ `Raw` ที่เหลือ"
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr "/// อ่านช่องใหม่ Raw ที่ได้รับการส่งกลับนั้นมีอายุจนถึง &mut ที่ออกต่อไป"
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr "/// ใช้ทะเบียนนี้เป็นราก วิธีเดียวที่จะสร้าง Rooted"
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -78566,24 +79769,22 @@ msgstr ""
 "**`Raw` ไม่สามารถใช้ได้ในจุดเก็บ** เครื่องคอมพิลเลอร์ปฏิเสธ"
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_> ยืม e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// ความต้องการ"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "// ERROR: obj ยืม e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// ซึ่งเป็น mutable"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// ยืมจากด้านบน"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -78591,7 +79792,8 @@ msgid ""
 msgstr "การแก้ไขคือรหัสที่ถูกต้อง และมันเป็นเส้นทางที่สั้นที่สุดออกจากความผิดพลาด"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// อ่านใหม่ ถูกต้อง"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -79183,8 +80385,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**ช่องหนี**ตราบใดที่ผู้โทรศัพท์ใช้มัน"
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -80702,17 +81905,35 @@ msgstr ""
 "`node_modules` ของเครื่องสร้าง"
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "รุ่น sidecar นี้ไม่มีการเขียนในการทํางานครั้งแรก ดังนั้นการติดตั้งตําแหน่งที่อ่านเท่านั้นจะรองรับ "
 "การย้าย exe ต้องย้าย `.perry-native` พี่น้องของมัน ไฟล์ที่หายไปหรือ hash-mismatched "
 "พลาดก่อน `dlopen` ด้วยความผิดพลาดในการบรรจุ"
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -80727,7 +81948,7 @@ msgstr ""
 "ปล่อยเครื่องมือหมายแต่ละ sidecar ก่อน executable และส่งพวกเขาในอาร์คิฟหนึ่ง. Perry "
 "ไม่ถอดลักษณะการกักกันจากไบนารีที่ดาวน์โหลดไม่น่าเชื่อถือในเวลาทํางาน"
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -80744,11 +81965,11 @@ msgstr ""
 "วิธีนี้จะรักษาข้อมูลการสมัครและการแก้ไขความขึ้นอยู่กับในผู้จัดการแพคเกจในขณะที่ป้องกันไฟล์ `.node` "
 "ที่เป็นโฮสต์จากการใส่ศิลปะเป้าหมาย"
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "อัตลักษณ์ของแคช"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -80756,31 +81977,31 @@ msgstr ""
 "แมนนิเฟสอัพเดทตอนการประกอบถูกจัดลําดับอย่างกําหนด "
 "และมีส่วนร่วมต่อไปนี้ในการสร้างและลิงค์ความเป็นตัวของแคช"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "เวอร์ชั่นสกéma แนวทาง และเวอร์ชั่น Node-API ที่ประกาศ"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "หมายเป้า tuple และ list ทะเบียน"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "พัสดุที่เลือก name/version และเส้นทางการเข้าที่เกี่ยวข้อง"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 และขนาดของแต่ละไฟล์ภาระประโยชน์ของรถข้าง"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "รายการของสัญลักษณ์ที่ถูกสั่งส่งออก"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "รูปแบบการส่ง (`sidecar-v1`)"
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -80793,11 +82014,11 @@ msgstr ""
 "เส้นทางการสร้างที่สมบูรณ์แบบ ไม่เข้าสู่คีย์หรือวัตถุที่ผลิต การเปลี่ยนแปลงแฮชของ sidecar "
 "ต้องพลาดการสร้างแคชระดับบน แม้ว่าไฟล์ TypeScript และไฟล์ของอัตถุทั้งหมดจะไม่เปลี่ยนแปลง"
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -80815,22 +82036,15 @@ msgstr ""
 "ส่งสัญลักษณ์เวอร์ชั่น-8 เมื่อจําเป็นสําหรับความละเอียดไบนารี "
 "แต่มันรายงานโดยกําหนดความสามารถที่ไม่ได้รับการสนับสนุน"
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: คอร์จนถึงเวอร์ชั่น 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "จุดเข้า"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -80838,49 +82052,56 @@ msgstr "จุดเข้า"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "การเก็บรักษาที่มั่นคงต่อสภาพแวดล้อม"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "ค่า Singleton รับการจัดการแบบปกติ"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Perry object/array เครื่องจัดสรร"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -80888,11 +82109,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN-box การแปลง"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -80900,37 +82121,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "จํากัดความยาว; รองรับ `NAPI_AUTO_LENGTH`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "การเรียกกลับพื้นบ้านใช้บันทึกโฮสต์"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` ถูกติดตั้งเมื่อนํามา"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "รวมถึงการแยกแยกฟังก์ชัน, นอก, สัญลักษณ์, และ bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -80938,11 +82159,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "ตรวจสอบพฤติกรรม type/status"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -80950,11 +82171,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "รวมซามานติกความยาวของคําถามและ NUL-termination"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -80962,19 +82183,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "รหัสผู้ใช้งานถูกจับกุมด้วยข้อจํากัด"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "สัญลักษณ์ของวัตถุทั่วไป"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -80982,11 +82203,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "สตริง สัญลักษณ์ และคีย์เลข"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -80994,11 +82215,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "ชื่อ UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -81006,43 +82227,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "แอเรย์และวัตถุที่มีดัชนีแปลก"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "ข้อมูล, วิธี, และตัวอธิบายของ Accessory"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "ไม่มีทางลัดการระบุตัวชี้"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "เอกลักษณ์ทั่วไป Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "Callback-info ตลอดชีวิตคือการเรียกพื้นเมือง"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -81050,11 +82271,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "ตารางเมทาข้อมูลของวัตถุพื้นเมือง"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -81062,11 +82283,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "การออกแบบที่แข็งแรงและอ่อนแอ"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -81076,11 +82297,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "การรับรองการตั้งรังและการสร้างรุ่นอย่างเข้มงวด"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -81088,19 +82309,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "รูปแบบสล็อตที่รออยู่"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "สามารถใช้ได้ในขณะที่รอ"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -81108,37 +82329,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "ตัวชี้วัดที่มั่นคง"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "ทั้งหมดสิบเอ็ดประเภทที่ประกอบด้วย arrays"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "ความเป็นตัวตนของการสนับสนุนและการชําระเงินที่รักษาไว้"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "กลับ 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -81146,19 +82367,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "การบันทึกที่เลื่อนออกไปคือรากที่เป็นของสิ่งแวดล้อม"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -81166,40 +82387,40 @@ msgstr ""
 "ส่งกลับ `napi_generic_failure`; "
 "การดําเนินงานแหล่งเวลาทํางานที่สุ่มจะละเมิดรุ่นไม่มีเครื่องยนต์เวลาทํางาน"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "การบัญชีความดันของเครื่องเก็บ"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: เวอร์ชั่น 5 ถึง 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "คอยต่อการเสร็จสิ้นหลังการตรวจสอบ"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -81207,11 +82428,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "ความแม่นยําแบบสุ่ม"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -81219,69 +82440,69 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "`lossless` ที่ถูกต้องและพฤติกรรมการนับคํา"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "รูปแบบการรวบรวม, ฟิลเตอร์, และการแปลงกุญแจได้รับเกียรติ"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
 msgstr ""
 "รายการหนึ่งรายการต่อสภาพแวดล้อม; การเปลี่ยนเขียนเกินโดยไม่ต้องเรียก Finaliser ก่อนหน้า"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "การกระจายพันธุ์จากการแยกตัว"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "แท็ก 128 บิตในเมตาข้อมูลของวัตถุ"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "เครื่องอธิบาย Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: เวอร์ชั่น 9, เวอร์ชั่น 10 และทดลอง"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -81289,16 +82510,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "ลงโฆษณาเพียงกับหน้าผิวแบบเต็ม 9"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -81306,11 +82527,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "จําเป็นต้องทํางาน lifetime/accounting สตริงภายนอก"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -81318,29 +82539,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "เวอร์ชั่น 10 ชื่อเล่นทางเร็ว"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "ไม่เป็นส่วนหนึ่งของ ABI ที่มั่นคงที่ประกาศ"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -81348,33 +82569,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "การจดทะเบียนที่ผ่านมาและเส้นทางการยกเลิก"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "การบูรณาการ async-hooks ที่มีอยู่"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -81382,11 +82603,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` ตัวตนและไบท์ที่มั่นคง"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -81394,30 +82615,30 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "เครื่องรัฐที่ชัดเจนด้านบน"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
 msgstr ""
 "คืนยันส่วนประกอบ semver ของ Perry ด้วยเชือกปล่อย `perry`; มันไม่เรียกร้องการปล่อย Node"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr "ส่งกลับ `napi_generic_failure` และลุป null; Perry ไม่มี libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -81425,19 +82646,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "ระยะชีวิตของเส้นใยหลัก"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "สถานะที่ไม่สมองกันและการจัดห่ออย่างเครียด"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -81445,11 +82666,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN ที่ได้รับการสนับสนุนจากปั๊มเหตุการณ์"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -81457,35 +82678,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "จํานวนเส้นและการรักษาวงจรเหตุการณ์"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "การปิดรอให้เสร็จสิ้น"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "สิ่งแวดล้อมบันทึกค่าในอนาคต"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "โฆษณาด้วยเวอร์ชั่น 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -81494,16 +82715,16 @@ msgstr ""
 "เครื่องเริ่มต้นด้านตัวเพิ่มส่งออก `node_api_module_get_api_version_v1` และ "
 "`napi_register_module_v1`; เหล่านี้ถูกค้นหาในตัวเพิ่มเติมและไม่ใช่การส่งออกโฮสต์"
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "ประตูที่จําเป็น"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr "การดําเนินการไม่ได้เสร็จสิ้นจนกว่าประตูด้านล่างจะล้มเหลวได้อย่างอิสระ:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -81515,7 +82736,7 @@ msgstr ""
 "แฮนด์เลอร์เก่าล้มเหลวในการรับรองการสร้าง; สคริปต์ตรวจสอบ root-holder และ rekey-table "
 "นั้นสะอาด"
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -81525,7 +82746,7 @@ msgstr ""
 "callback ทั้งหมดกลับผ่าน C ก่อนที่ Perry จะยก; addon ที่มีเครื่องมือยืนยันว่าไม่มี unwind "
 "เข้าไปในเฟรมของมัน"
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -81534,7 +82755,7 @@ msgstr ""
 "**ประตู Loader/export:** แอดดอนตัวจริงบันทึกที่อยู่ของฟังก์ชันที่เรียกว่า `napi_*` "
 "และการทดสอบพิสูจน์ว่าที่อยู่เป็นของ Perry จํานวนเสียงควันต้องมากกว่าศูนย์"
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -81546,7 +82767,7 @@ msgstr ""
 "buffers เวอร์ชั่น NAPI ที่ไม่สนับสนุน เครื่องติดตั้ง NAN/V8 และ `uv_*` "
 "ยืนยันการวินิจฉัยที่แม่นยําของพวกเขา"
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -81556,7 +82777,7 @@ msgstr ""
 "ตรวจสอบต้นไม้ไฟฟักเดียวกันและปล่อยกระแสที่รวมกันเหมือนกัน; "
 "ทั้งคู่ยืนยันว่าการดําเนินงานพื้นบ้านของพวกเขาทํางานจริง"
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -81566,7 +82787,7 @@ msgstr ""
 "และล็อดได้สําเร็จ; การลบหรือการกลายพันธุ์ของ sidecar จะล้มเหลวในการตรวจสอบ hash "
 "manifest"
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -81574,7 +82795,7 @@ msgstr ""
 "**ประตูแคช:** การเปลี่ยนเพียงแอดดอนไบท์หรือนโยบายจะพลาดคาช์การสร้าง; "
 "การสร้างใหม่ข้อมูลที่ไม่ได้เปลี่ยนแปลงจะกระทบมัน"
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -81582,7 +82803,7 @@ msgstr ""
 "**ขนาดประตู:** ผลิต hello-world ที่เหมือนกันกับ byte ด้วยกราฟ addon ที่ว่างเปล่า; รายงาน "
 "delta สําหรับโฮสต์เท่านั้นสําหรับ build addon และบังคับใช้งบ 0.6 MB"
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -82118,28 +83339,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "ใช้คําสั่งที่ชัดเจนสําหรับขอบเขตที่กว้างกว่า"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# สินค้า feedback ลุป"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# ทุกสมาชิกพื้นที่ทํางานที่เข้ากันได้กับโฮสต์ (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$package\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# ตรวจสอบหรือรับรองสถาปัตยกรรมพื้นที่ทํางาน"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -82282,7 +83489,8 @@ msgstr ""
 "หรือเมื่อสร้างด้วย `--no-default-features` เพื่อแยก text-IR backend เป็นสอง"
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# สร้างผลิตภัณฑ์โดยกําหนดเองและการปิดความพึ่งพาของมัน"
 
 #: src/contributing/building.md:37
@@ -82401,7 +83609,8 @@ msgstr ""
 "อุปกรณ์ `sccache` ในแวดล้อมผู้ใช้งานของคุณ, แล้วทํางาน Cargo ผ่าน wrapper:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# CLI สําหรับผู้พัฒนาที่ผอมและดีที่สุด"
 
 #: src/contributing/building.md:80
@@ -82432,22 +83641,27 @@ msgid "Build Specific Crates"
 msgstr "Build crate เฉพาะ"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# เวลาทํางานเท่านั้น (ต้องสร้าง stdlib อีกด้วย!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr "# อาร์คิฟสแตติก .a ออกจากกล่องบรรจุที่แยกแยก (# 5422)"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr "# โดยชัดเจนเมื่อคุณต้องการ libperry_runtime.a / libperry_stdlib.a (e.g"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# เพียง Codegen"
 
 #: src/contributing/building.md:106
@@ -82492,15 +83706,19 @@ msgid "Run Tests"
 msgstr "รัน Tests"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# เป้าหมายหน่วยสินค้า"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr "# ตรวจสอบขอบเขตการทดสอบ CI รายคืน (ทุกตู้ทดสอบที่เข้ากันได้กับ Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# กล่องเฉพาะ"
 
 #: src/contributing/building.md:137
@@ -82508,11 +83726,13 @@ msgid "Compile and Run TypeScript"
 msgstr "คอมไพล์และรัน TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# รวมไฟล์ TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# การแก้ไข: พิมพ์ HIR"
 
 #: src/contributing/building.md:148
@@ -82576,19 +83796,23 @@ msgstr ""
 "shasum ต่างกัน."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# ยืนยันว่าการเช็คออท เป็นของใหม่และสะอาด"
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# ต้องพิมพ์ 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# ไม่ต้องพิมพ์อะไร"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# การตรวจสอบนโยบายและบทความอย่างรวดเร็ว"
 
 #: src/contributing/releasing.md:23
@@ -82596,7 +83820,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr "# การตรวจสอบพฤติกรรมที่สามารถทํางานได้ ซึ่งช่วยให้การตอบสนองเพิ่มขึ้น แต่ไม่"
 
 #: src/contributing/releasing.md:38
@@ -82617,7 +83843,8 @@ msgstr ""
 "หากเวอร์ชั่นนั้นถูกติดป้ายแล้ว, แลนด์เวอร์ชั่นใหม่ผ่านกระบวนการรวมแบบปกติก่อน"
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# เปลี่ยนให้เป็นเวอร์ชั่นที่มีอยู่ใน Cargo.toml"
 
 #: src/contributing/releasing.md:48
@@ -82637,7 +83864,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # ไม่ต้องพิมพ์อะไร"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -82735,9 +83963,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "การกระทําที่อนุญาต: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -82766,20 +83995,15 @@ msgstr ""
 "Trusted Publisher บน. ไพปลายการปลดปล่อยโดยเจตนาปฏิเสธชุดบางส่วน"
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# แพ็คเกจการปล่อยหนึ่งครั้ง: exact-SHA gates/builds"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
-msgstr "                            # พิมพ์ + ยืนยันทั้งหมด 9 ผ่าน OIDC แล้วสร้าง"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub การปล่อยครั้งสุดท้าย"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
+msgstr ""
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# ตรวจสอบใบเสร็จรับ commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -82992,11 +84216,13 @@ msgstr ""
 "ที่ทํางานโดยไม่ต้องใช้มนุษย์:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# รวมข้อมูลสําหรับเครื่องจําลอง"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# เริ่มต้นอุปกรณ์ (ครั้งเดียว; ใช้ยูดีดีใหม่ตลอดการทํางาน)"
 
 #: src/contributing/releasing.md:178
@@ -83004,20 +84230,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# อุปกรณ์ติดตั้ง + เริ่มต้นด้วยโหมดทดสอบ"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr "# แอพออก 0 หลังจากการเรนเดอร์; ภาพจอลงที่ counter-ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -83275,6 +84490,10 @@ msgid "patch distance"
 msgstr "ระยะทางติด"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -83307,15 +84526,18 @@ msgstr ""
 "การใช้งานที่ล้มเหลวส่งข้อมูลเรื่องหนึ่งและอัพเดทมันในที่; มันปิดตัวเองเมื่อทะเบียนได้ติดตาม"
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# พิสูจน์ว่ามันอาจล้มเหลว"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# ลงทะเบียนจริง ไม่มีประเด็นเขียน"
 
 #: src/contributing/releasing.md:289
@@ -83369,6 +84591,350 @@ msgstr ""
 "**โฮกการกระจายสติ๊กอัพล้มเหลว**: ทําการทํางานที่ล้มเหลวอีกครั้ง "
 "เพื่อทดลองใหม่ขากระจายพัสดุการปล่อยเดิม, ส่งมันไปกับ `existing_tag=vX.Y.Z`; เพิ่ม "
 "`publish_npm=true` เพียงเมื่อขา npm ที่ไม่สมบูรณ์แบบด้วยตนเองยังต้องการการทดลองใหม่"
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr "# แก้ไข src/lib.rs  เพิ่มฟังก์ชัน `js_*` ของคุณ, ใช้ทั้งหมดเพียง"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# แก้ไข src/index.ts  ประกาศการนําเข้ารหัสผู้ใช้บนพื้นที่ TS"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# แก้ไข package.json  รายการทุกการส่ง js_* ใน"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ รายงานการใช้งานตรงกับ staticlib"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# release.yml ที่ติดกระเบื้อง"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr "                                    # สร้างเครื่องมือสําหรับเป้าหมายทั้งหมด"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # และจะผูกมันไว้กับการปล่อย"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"การผูกพันธนาการพื้นเมืองสําหรับ <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  สกัดข้อความจากพัฟเฟอร์ PDF"
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # ความปลอดภัย"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr "/// `buf_ptr` ต้องเป็น null หรือใช้ได้สําหรับ `buf_len` ไบท์ Perry ผ่าน"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// คู่นี้มาจากพารามีเตอร์ `buffer+len`"
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const result = wait spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding และ Insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 slice (เป้าหมายของอุปกรณ์โดยกําหนด)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. สะดวกเหลี่ยม + ฟิวส์"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "แพลตฟอร์ม แอนดรอยด์-35 เครื่องมือสร้าง 35.0.0"
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"ภาพระบบ แอนดรอยด์-34 แอนดรอยด์ใส่ แอร์ม64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. เป้าหมายข้าม Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. สร้าง + เบ็ตเอมูเลอเตอร์ Wear OS (ชมรอบ)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "แพ็กเกจ npm เพิ่มเติมและ API ของ Node.js ที่ Perry รองรับ "
+#~ "ทั้งหมดที่ระบุไว้ที่นี่เชื่อมต่อผ่านรีจิสตรี native bindings ของ Perry (#466) "
+#~ "และคอมไพล์เป็นโค้ดเนทีฟโดยไม่มีรันไทม์ JavaScript เข้ามาเกี่ยวข้อง"
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr "# 3) ตรวจสอบความสุขภาพของลายเซ็นในท้องถิ่น ก่อนอัพโหลดรายการ"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    ที่นี่คาดการณ์การตรวจสอบผ่านลูกค้า"
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr "# 4) ปล่อย CI ลงนาม CLI manifest, การผูกพัน URL อาร์คิฟ์, พลาตฟอร์ม,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "//ตรวจจับเป้าหมาย: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// รวม: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// ลิงค์: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"ชนิดเนื้อหา: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "{\"ข้อความ\":\"hello world\"}'"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"ค่า\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "'{\"ค่า\":42}'"
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "{\"ทางลัด\":\"s\"}"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP ของ:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# ปล่อยให้มันทํางาน 30 วินาที"
+
+#~ msgid "# Check stats"
+#~ msgstr "# ตรวจสอบสถิติ"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"ทํางาน\": true, \"events_fired\": 600, \"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# ถ่ายฉากหน้าจอเพื่อดูสภาพสุดท้าย"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# หยุดความวุ่นวาย"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# ตรวจสอบว่าแอพยังใช้อยู่"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# สร้างสําหรับ iOS (แครสคอมพิล)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr "งาน | select(.status==\"in_progress\") | (ตรา|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# ความลึกของคิว และสระว่ายน้ําไหน"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "งาน | select(.status==\"queued\") | (ตรา|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"การผูกพันธนาการพื้นเมืองสําหรับ libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Perry เรือ **2 ช่องทางการเลือกอิสระ** สําหรับการส่งข้อมูลกลับบ้าน  "
+#~ "ไม่มีอะไรออกจากเครื่องของคุณโดยไม่มี `enabled = true` หรือ `on` ใน `~/.perry/"
+#~ "config.toml` ทั้งสองคํานวณ `PERRY_NO_TELEMETRY=1` และ `CI=true`"
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "ส่งสัญญาณการวินิจฉัยที่สามารถอ่านได้โดยมนุษย์"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# NATIVE (PERRY_RS4GC=1): เป็นตัวกําหนดตามปกติทุกที่อื่น แอนเกอร์ติด"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr "# `ptr addrspace(1)` แผนกรานและ LLVM ใส่ safepoints ภายหลัง"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr "// GC_STORE_AUDIT(BARRIERED): การเขียนสล็อตเป็นไร้เงื่อนไข"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr "// ด้านล่างถูกคุ้มกันเพียงด้วยการทดสอบที่ใช้จริงที่บิตที่เก็บไว้ไม่มี heap"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "//ตัวชี้ ซึ่งเป็นการทดสอบครั้งแรกของอุปสรรคเอง"
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// ยืมตัวเครื่องออกเสียงโดยไม่เปลี่ยนแปลง ไม่คลอน ไม่คอปี้"
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// ดัชนีสล็อต สามารถลอกแบบได้โดยอิสระ ไม่มีอายุการใช้งาน ไม่มีการยืมตัวของตัวปล่อย"
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "// ERROR: obj ยืม e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// ซึ่งเป็น mutable"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// ยืมจากด้านบน"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$package\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# ตรวจสอบหรือรับรองสถาปัตยกรรมพื้นที่ทํางาน"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# แพ็คเกจการปล่อยหนึ่งครั้ง: exact-SHA gates/builds"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr "                            # พิมพ์ + ยืนยันทั้งหมด 9 ผ่าน OIDC แล้วสร้าง"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub การปล่อยครั้งสุดท้าย"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr "# แอพออก 0 หลังจากการเรนเดอร์; ภาพจอลงที่ counter-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -84366,9 +85932,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "ตัวแปร env `LANG` / `LC_ALL` / `LC_MESSAGES`"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "การตรวจสอบในเวลาคอมไพล์"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr "Perry ตรวจสอบพารามิเตอร์ทั่วทุก locale ในระหว่างการคอมไพล์:"
 
@@ -84465,13 +86028,6 @@ msgstr ""
 
 #~ msgid "`SKStoreReviewController.requestReview()`"
 #~ msgstr "`SKStoreReviewController.requestReview()`"
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# ตัวอย่าง GitHub Actions\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "สร้างเฉพาะไฟล์ object โดยข้ามการ link"

--- a/docs/po/vi.po
+++ b/docs/po/vi.po
@@ -214,7 +214,7 @@ msgstr "Hook"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "Ví dụ"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "Các cấp CI (kiểm tra PR / quét / bộ đầy đủ)"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "Lập lịch kiểm tra CI"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "Tham khảo CLI"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "Lệnh"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "Cờ trình biên dịch"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "Thư mục bộ nhớ đệm"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math (`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "Dynamic Stdlib Dispatch"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS Runtime Opt-In"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest` (sidecar chứng thực nhị phân)"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "Danh sách cho phép Egress (`allowedHosts`)"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "Quyền theo gói (`perry.permissions`)"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "Danh sách cho phép Host (nativeLibrary, compilePackages)"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "Tham khảo perry.toml"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "Kiểm tra bản cập nhật trong ứng dụng"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "Quyền riêng tư & Telemetry"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "Nội tại"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "Mô hình bộ nhớ"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "Bộ thu gom rác"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "Quản lý bộ nhớ tường minh"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "Bất biến giữ gốc GC (sinh mã)"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "Bằng chứng kiểu cho binding cục bộ"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "Giới hạn bước GC tăng dần"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC: giữ gốc theo cấu trúc"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "Đóng góp"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "Kiến trúc"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "Chính sách crate"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "Build từ mã nguồn"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "Phát hành Perry"
 
@@ -934,7 +942,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# Mở cửa sổ macOS/Windows/Linux gốc"
 
 #: src/introduction.md:79
@@ -967,11 +976,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -980,9 +989,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -992,7 +1001,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "Các bước tiếp theo"
@@ -1065,27 +1074,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "Linux chuỗi công cụ liên kết theo phân phối:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# Debian / Ubuntu / Pop!_OS / Mint"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# Fedora / RHEL / CentOS Stream"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# Dựa trên núi Alpine / musl"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# Không hiệu lực Linux"
 
 #: src/getting-started/installation.md:41
@@ -1127,15 +1142,18 @@ msgstr ""
 "x64) với một lệnh duy nhất:"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# Dự án địa phương (pin phiên bản Perry bên cạnh deps của bạn)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# Không cài đặt, một lần bắn"
 
 #: src/getting-started/installation.md:66
@@ -1331,7 +1349,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "Tệp nhị phân nằm tại `target/release/perry`. Thêm nó vào PATH của bạn:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# Thêm vào ~/.zshrc hoặc ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1469,16 +1488,14 @@ msgstr ""
 "thuần túy / cross-compile sang các nền tảng khác không yêu cầu chúng.)"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# Ubuntu / Debian"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2162,25 +2179,30 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "Cùng một đoạn mã chạy trên cả 6 nền tảng:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (bên định)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# iOS Simulator"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr ""
 "# Web (đóng tập thành WebAssembly + DOM bridge trong một tệp HTML tự chứa)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# Alias: --target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# Các nền tảng khác"
 
 #: src/getting-started/first-app.md:138
@@ -2424,7 +2446,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2442,7 +2464,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2665,7 +2687,8 @@ msgstr ""
 "dạng source thuần túy. Script tạo code:"
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2697,7 +2720,8 @@ msgid "\"port\""
 msgstr "\"cảng\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// nguồn độc lập"
 
 #: src/getting-started/project-config.md:122
@@ -2943,19 +2967,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "Trường"
 
@@ -2970,9 +2995,9 @@ msgstr "Trường"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3094,11 +3119,13 @@ msgstr ""
 "nào:"
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3153,7 +3180,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3162,7 +3189,7 @@ msgstr ""
 "của Perry. Xem [Thư viện chuẩn](../stdlib/overview.md) để biết danh sách đầy "
 "đủ."
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3171,45 +3198,48 @@ msgstr ""
 "cho các gói TS/JS thuần, hoặc dùng phương án dự phòng runtime JavaScript cho "
 "các gói phức tạp."
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "Cấu trúc dự án"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry linh hoạt về cấu trúc dự án. Các mẫu phổ biến:"
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "Đối với ứng dụng giao diện người dùng:"
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "Biên dịch"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# Tóm lại một tệp"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# biên dịch với mục tiêu cụ thể"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# Trình gỡ lỗi: đại diện trung gian in"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "Xem [Lệnh CLI](../cli/commands.md) để biết tất cả các tùy chọn."
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr ""
 "[Lệnh CLI](../cli/commands.md) — Tất cả các lệnh và cờ của trình biên dịch"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3217,7 +3247,7 @@ msgstr ""
 "[Tính năng được hỗ trợ](../language/supported-features.md) — Những tính năng "
 "TypeScript nào hoạt động"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Thư viện chuẩn](../stdlib/overview.md) — Các gói npm được hỗ trợ"
 
@@ -3357,32 +3387,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "Lớp"
 
@@ -5415,6 +5446,7 @@ msgstr ""
 "hai đường dẫn:"
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5424,7 +5456,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**Decorator class legacy, decorator method, decorator property, decorator "
 "tham số constructor, và decorator tham số method** cho DI theo phong cách "
@@ -5436,7 +5472,7 @@ msgstr ""
 "các class/method được trang trí và `design:type` cho các property được trang "
 "trí."
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5448,15 +5484,15 @@ msgstr ""
 "entry/exit tại thời điểm biên dịch, không có bất kỳ cơ chế decorator runtime "
 "nào. Xem `crates/perry-hir/src/decorator_log.rs` để biết cách triển khai."
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "Những gì không hoạt động"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "Decorator accessor và thay thế descriptor"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5472,16 +5508,16 @@ msgstr ""
 "Perry — class đã hạ thấp được cố định trong IR và không thể thay thế tại "
 "runtime."
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr ""
 "Các lời gọi helper `Reflect.metadata(...)` chung ngoài cú pháp decorator"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "`Symbol(...)` làm khóa metadata"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5489,7 +5525,7 @@ msgstr ""
 "`emitDecoratorMetadata` ngoài `design:paramtypes` cho class/method và "
 "`design:type` cho property"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5499,12 +5535,12 @@ msgstr ""
 "constructor rút gọn (`tsyringe`, hành vi injector NestJS đầy đủ, injector "
 "gốc của Angular)"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr ""
 "Các luồng metadata runtime của `class-validator`, `type-graphql`, `TypeORM`"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5514,11 +5550,11 @@ msgstr ""
 "vẫn là kết nối tường minh hoặc một transform AOT chuyên dụng, không dựa vào "
 "runtime decorator TypeScript legacy đầy đủ."
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "Mẫu khuyến nghị: khởi tạo tường minh"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5531,7 +5567,7 @@ msgstr ""
 "không dùng decorator (Hono, các server tRPC, các ứng dụng Drizzle) đã hoạt "
 "động."
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5547,7 +5583,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5557,11 +5593,11 @@ msgstr ""
 "thứ tự khởi tạo _chính là_ đồ thị phụ thuộc, và được kiểm tra bởi trình biên "
 "dịch TypeScript."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "Công thức chuyển đổi: một Angular service"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5571,19 +5607,19 @@ msgstr ""
 "rating.service.ts`, ~80 dòng), được hiển thị ở dạng Angular nguyên bản và đã "
 "được chuyển sang Perry."
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "Trước — Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "Sau — Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "Ba thay đổi mang tính cơ học:"
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
@@ -5591,7 +5627,7 @@ msgstr ""
 "**Bỏ `@Injectable`.** Nó không mang thông tin gì mà cấu trúc của class chưa "
 "mang sẵn."
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5601,7 +5637,7 @@ msgstr ""
 "các Observable từ HTTP của Angular đều có giá trị đơn và hoạt động giống như "
 "Promise. (Đối với luồng đa giá trị, hãy sử dụng `AsyncIterable`.)"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5613,11 +5649,11 @@ msgstr ""
 "các trường tường minh dễ đọc hơn khi class được khởi tạo thủ công thay vì "
 "bằng container."
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "Kết nối"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5637,7 +5673,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5655,7 +5691,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5665,11 +5701,11 @@ msgstr ""
 "`providedIn: 'root'`, việc tra cứu container ngầm — tất cả đều được rút gọn "
 "thành một dòng `new RatingService(api)` trong `services.ts`."
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "Còn Angular components, NestJS controllers, TypeORM entities thì sao?"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5690,11 +5726,11 @@ msgstr ""
 "decorator khi có thể, viết cấu trúc rõ ràng tương đương, đăng ký tuyến đường "
 "hoặc sơ đồ như các cuộc gọi hàm đơn giản / hằng số cấp module."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "Định hướng tương lai"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6397,12 +6433,13 @@ msgstr ""
 "vào thời điểm liên kết."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**Các cuộc gọi tĩnh theo nghĩa đen** (`WebAssembly.instantiate(bytes)` được "
@@ -7965,55 +8002,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "Tạo một binding — tour 60 giây"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"Bindings render PDF\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\"'"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr ""
-"# chỉnh sửa src/lib.rs  thêm các chức năng `js_*` của bạn, tất cả chỉ sử dụng"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# chỉnh sửa src/index.ts  khai báo mã người dùng bề mặt TS nhập khẩu"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# Chỉnh sửa package.json  liệt kê tất cả các xuất js_* trong"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅ trình bày phù hợp với staticlib"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# release.yml được dựng lên"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr ""
-"                                    # xây dựng các mục tiêu trước cho tất cả "
-"các mục tiêu"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # và gắn chúng vào sự giải phóng"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8401,7 +8396,7 @@ msgstr "Tình trạng hiện tại"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8421,7 +8416,7 @@ msgstr "Được đóng gói; đang chờ di chuyển"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8473,7 +8468,7 @@ msgstr "Được đóng gói; đang chờ di cư"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8533,7 +8528,7 @@ msgstr "Bộ sưu tập nguồn gói phía trên"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8541,7 +8536,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8549,7 +8544,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8557,7 +8552,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8589,7 +8584,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8597,7 +8592,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8605,7 +8600,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8637,7 +8632,7 @@ msgstr "Được đóng gói; giữ lại"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8645,7 +8640,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8677,7 +8672,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8685,7 +8680,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8693,7 +8688,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8701,7 +8696,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8717,7 +8712,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8725,7 +8720,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8733,7 +8728,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8741,7 +8736,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8765,7 +8760,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8773,7 +8768,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8781,7 +8776,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8789,7 +8784,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8797,7 +8792,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8805,7 +8800,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8813,7 +8808,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8821,7 +8816,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8829,7 +8824,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8837,7 +8832,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8845,7 +8840,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8853,7 +8848,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8908,14 +8903,6 @@ msgstr ""
 msgid "1. Scaffold"
 msgstr "1. Tạo khung"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"Native bindings for <upstream crate>\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "Lệnh này tạo ra:"
@@ -8947,27 +8934,14 @@ msgstr ""
 "hiển thị với TypeScript, **chỉ** sử dụng các kiểu từ `perry_ffi`:"
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string`  trích xuất văn bản từ bộ đệm PDF."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "/// # An toàn"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
 msgstr ""
-"/// `buf_ptr` phải là không hoặc hợp lệ cho `buf_len` bytes. Perry vượt qua"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "/// cặp này từ một tham số biểu hiện `buffer+len`."
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -9101,7 +9075,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"Lòng tốt\""
 
@@ -9339,7 +9313,8 @@ msgid "In a separate directory:"
 msgstr "Trong một thư mục riêng:"
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# hoặc bất kỳ đường dẫn công cụ của bạn hỗ trợ"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9730,7 +9705,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "Event listeners (`.on(event, cb)`)"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// dấu chấm kết thúc, được giữ sống bởi máy quét GC bên dưới"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -10168,7 +10144,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ... đọc tập tin, đặt môi trường, trả về 1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10472,8 +10449,8 @@ msgstr "Bắt buộc"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "Ghi chú"
 
@@ -10531,14 +10508,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -12259,33 +12236,40 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "Công cụ  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr ""
 "# Cung cấp hoặc đẩy một chân đến một phiên bản cụ thể (bên mặc định: ổn định "
 "mới nhất)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# Cung cấp mỗi liên kết hiện tại unpined tại ổn định mới nhất của nó"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr ""
 "# Cổng không hoạt động (CI): có chân, khóa, có thùng. Cổng 1 trên bất kỳ"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr ""
 "# Tư vấn: thêm các chân cờ có nguồn phía trên có một giải phóng ổn định mới "
 "hơn"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr ""
 "# Thực hiện các repo phía trên tại ref gắn vào gitignored phía trên/<name>"
 
@@ -12518,15 +12502,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "Đối với CI không bao giờ được thay thế một bao bì một phần, đặt:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12680,7 +12664,7 @@ msgstr "Thực tế"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12697,7 +12681,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14678,19 +14662,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "So sánh với Node.js worker_threads"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~ 15 dòng, cần một tập tin riêng biệt ───────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14710,12 +14694,11 @@ msgid "/* handle */"
 msgstr "/* tay cầm */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr "// ── Perry: 1 dòng ────────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const kết quả = chờ spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14929,13 +14912,14 @@ msgid "Mental Model"
 msgstr "Mô hình Tư duy"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "UI của Perry tuân theo cùng mô hình như SwiftUI và Flutter: bạn kết hợp các "
 "widget gốc bằng cách sử dụng các container bố cục dạng stack (`VStack`, "
@@ -15020,7 +15004,7 @@ msgstr "`App({})` chấp nhận một đối tượng cấu hình với các thu
 msgid "Property"
 msgstr "Thuộc tính"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -15467,7 +15451,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -15491,7 +15475,7 @@ msgstr ""
 "Hành vi đặc thù của từng nền tảng được ghi chú trên trang tài liệu của mỗi "
 "widget."
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -17109,7 +17093,8 @@ msgid "Double-click handler"
 msgstr "Hàm xử lý nhấp đúp"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -17171,12 +17156,13 @@ msgstr ""
 "chạy nó trên mỗi PR."
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "Trợ lý bố cục là các chức năng miễn phí: `widgetAddChild(parent, child)`, "
 "`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
@@ -17655,7 +17641,7 @@ msgstr "Hiệu ứng"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -17668,7 +17654,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "Các phần tử con căn theo cạnh leading (trái)"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17681,7 +17667,7 @@ msgid "Children centered horizontally"
 msgstr "Các phần tử con được căn giữa theo chiều ngang"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17702,7 +17688,7 @@ msgstr "**Căn chỉnh HStack** (trục ngang = dọc):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17729,8 +17715,8 @@ msgstr "Các phần tử con được căn giữa theo chiều dọc"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17784,9 +17770,9 @@ msgstr "Hành vi"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17811,11 +17797,11 @@ msgstr "Tất cả các phần tử con có kích thước bằng nhau"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -18013,9 +17999,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "Stack với Padding tích hợp"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "Tạo một stack với padding trong một lệnh gọi duy nhất. Thứ tự là **top, "
 "left, bottom, right** (kiểu CSS-shorthand), không phải top/right/bottom/left:"
@@ -18039,11 +18026,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` là phiên bản theo "
 "chiều ngang. Tương đương với việc tạo một stack rồi gọi "
@@ -18332,8 +18320,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18717,6 +18706,7 @@ msgstr ""
 "nhận."
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18728,7 +18718,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18756,11 +18745,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "Màu sắc"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18776,11 +18765,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "Phông chữ"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18796,15 +18785,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "Sử dụng `\"monospaced\"` cho phông chữ monospaced của hệ thống."
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "Bo góc"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18816,21 +18805,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "Viền"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding và Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "Padding"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18840,11 +18829,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "Kích thước"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18860,11 +18857,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "Độ trong suốt"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18876,11 +18873,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "Gradient nền"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18902,11 +18899,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "Kích thước Control"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18918,7 +18915,7 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
@@ -18926,11 +18923,11 @@ msgstr ""
 "**macOS**: Ánh xạ tới `NSControl.ControlSize`. Các nền tảng khác có thể diễn "
 "giải khác đi."
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "Tooltips"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18942,7 +18939,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18950,11 +18947,11 @@ msgstr ""
 "**macOS/Windows/Linux**: Tooltip native. **iOS/Android**: Không hỗ trợ "
 "tooltip. **Web**: thuộc tính HTML `title`."
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "Bật/Tắt"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -18966,11 +18963,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "Ví dụ Mệnh lệnh Hoàn chỉnh"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -18990,7 +18988,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -19018,10 +19016,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -19094,15 +19092,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "Kết hợp Style (các hàm trợ giúp mệnh lệnh)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "Giảm sự lặp lại bằng cách tạo các hàm trợ giúp:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -19112,11 +19110,11 @@ msgstr ""
 "các design token trong JSON và tạo ra file theme có kiểu. Xem [Theming]"
 "(theming.md) để biết quy trình đầy đủ."
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "Hỗ trợ nền tảng"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -19127,7 +19125,7 @@ msgstr ""
 "styling_matrix.rs` và được CI kiểm tra dựa trên các export `lib.rs` của mỗi "
 "backend trên mọi PR."
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -19147,15 +19145,15 @@ msgstr ""
 "tay; tham khảo ma trận để tài liệu không thể trôi qua khỏi danh mục tồn kho "
 "phía sau."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — Các container bố cục"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — Hoạt hóa các thay đổi style"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — Các design token thông qua gói `perry-styling`"
 
@@ -20484,8 +20482,8 @@ msgstr "Cài đặt"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "Trạng thái"
 
@@ -24001,7 +23999,7 @@ msgstr "Xóa cookie / localStorage / IndexedDB của data store WebView này."
 msgid "Options"
 msgstr "Tùy chọn"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -25580,7 +25578,7 @@ msgstr "Tương đương với ink"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -26302,15 +26300,18 @@ msgid "Cross-Compilation"
 msgstr "Biên dịch chéo"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# mặc định: biên dịch cho nền tảng hiện tại"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# biên dịch cho một mục tiêu cụ thể"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# Wear OS  Android trên đồng hồ"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -26526,7 +26527,8 @@ msgid "Building"
 msgstr "Biên dịch"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS là mục tiêu mặc định"
 
 #: src/platforms/macos.md:18
@@ -26627,7 +26629,8 @@ msgid "App Store Distribution"
 msgstr "Phân phối qua App Store"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# Đăng ký bằng chứng chỉ App Store"
 
 #: src/platforms/macos.md:60
@@ -26635,7 +26638,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -26764,15 +26768,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "Cách dễ nhất để biên dịch và chạy trên iOS là `perry run`:"
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# Tự động phát hiện device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# Truyền trực tiếp stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# Sử dụng máy chủ xây dựng Perry"
 
 #: src/platforms/ios.md:40
@@ -27420,7 +27427,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "Lệnh này tạo ra một binary ARM64 cho phần cứng Apple TV vật lý."
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# Tự động phát hiện mô phỏng Apple TV khởi động"
 
 #: src/platforms/tvos.md:39
@@ -27906,11 +27914,13 @@ msgstr ""
 "bị](#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# Máy mô phỏng (mức 2)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -28021,20 +28031,14 @@ msgstr ""
 "đó trỏ `PERRY_RUNTIME_DIR` vào chúng:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (Series 9+ / watchOS 26+)  mục tiêu thiết bị mặc định"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (Dòng 4-8 / SE)  chọn với PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -28051,7 +28055,7 @@ msgid "Build environment variables"
 msgstr "Xây dựng các biến môi trường"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "Biến"
@@ -28171,7 +28175,8 @@ msgstr ""
 "quả đã loại bỏ sự đóng cửa như một đối tượng."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# Khám phá tự động mô phỏng đồng hồ khởi động"
 
 #: src/platforms/watchos.md:126
@@ -28770,36 +28775,13 @@ msgstr ""
 "đó `lipo` chúng cùng nhau:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. arm64_32 cắt ở mục tiêu triển khai chung (e.g. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64 slice (mục tiêu thiết bị mặc định)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. điều chỉnh minos + bộ an toàn"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -28918,19 +28900,8 @@ msgstr ""
 "trong App Store Connect."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"Apple phân phối: <Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -28943,6 +28914,10 @@ msgid ""
 msgstr ""
 "`altool` không thể tải ứng dụng xem (\"không thể xác định nền tảng\"). Sử "
 "dụng Transporter:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -29296,19 +29271,22 @@ msgid "One-time setup (macOS example)"
 msgstr "Thiết lập một lần (ví dụ macOS)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (`gradle` của Homebrew có thể là 9.x  pin 8.x nếu "
 "có)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# hoặc bất kỳ Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr "# 2. Chỉ env tại SDK / NDK / JDK 17 (thêm vào hồ sơ shell của bạn)"
 
 #: src/platforms/wearos.md:40
@@ -29316,7 +29294,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr "\"$ANDROID_HOME/ndk/<installed-version>\" # e.g 28.2.13676358"
 
 #: src/platforms/wearos.md:42
@@ -29328,32 +29307,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. Các gói SDK + một hình ảnh Wear OS arm64"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"các công cụ nền tảng\" \"các trình giả lập\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"nền tảng;android-35\" \"công cụ xây dựng;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"hình ảnh hệ thống;Android-34;Android-wear;arm64-v8a\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. Mục tiêu chéo Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. Tạo + khởi động một trình giả lập Wear OS (xem vòng)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -29379,7 +29339,8 @@ msgstr ""
 "vào APK đồng hồ xảy ra tại thời gian chạy (dưới đây)."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# Tự động phát hiện đồng hồ được kết nối / booted Wear emulator"
 
 #: src/platforms/wearos.md:82
@@ -31358,7 +31319,8 @@ msgstr ""
 "sử dụng `WidgetPaintable` + `GskRenderer` để chụp chính xác từng pixel."
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# Trong một nhà ga khác:"
 
 #: src/platforms/linux.md:82
@@ -31377,7 +31339,8 @@ msgstr ""
 "JavaScript cho các widget DOM."
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# cùng đầu ra như --target wasm"
 
 #: src/platforms/web.md:10
@@ -31454,15 +31417,18 @@ msgstr ""
 "Worker \"miễn phí\"."
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# HTML độc lập (bên mặc định)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# Tương tự"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# Raw .wasm nhị phân (không có HTML wrapper)"
 
 #: src/platforms/wasm.md:21
@@ -31777,11 +31743,13 @@ msgid "Provide them when instantiating:"
 msgstr "Cung cấp chúng khi khởi tạo:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// Thông qua __ffiImports toàn cầu (được đặt trước khi khởi động)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// Hoặc thông qua bootPerryWasm đối số thứ hai"
 
 #: src/platforms/wasm.md:95
@@ -32329,7 +32297,7 @@ msgstr "Toàn bộ stdlib"
 msgid "The compiler links only the required runtime components."
 msgstr "Trình biên dịch chỉ liên kết các thành phần runtime cần thiết."
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "Các binding native bên ngoài"
 
@@ -32445,7 +32413,7 @@ msgstr "[Hệ thống tập tin](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP & Mạng](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[Cơ sở dữ liệu](database.md)"
 
@@ -32668,8 +32636,8 @@ msgstr ""
 "Hãy truyền đường dẫn file qua ranh giới luồng và mở lại file bên trong "
 "worker."
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[Tổng quan](overview.md) — Tất cả các module stdlib"
 
@@ -32767,10 +32735,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "Được hỗ trợ trên `IncomingMessage`: `.method`, `.url`, `.headers`, "
@@ -32779,10 +32748,11 @@ msgstr ""
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -33380,10 +33350,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / Lưu trữ đối tượng tương thích S3"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -33399,11 +33395,11 @@ msgstr ""
 "vá — đã được xác minh khớp byte-for-byte presigned-URL SigV4 với `bun` "
 "(issue #551)."
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -33477,78 +33473,78 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr ""
 "Cùng một đoạn mã hoạt động với bất kỳ dịch vụ tương thích S3 nào — chỉ "
 "`endPoint` thay đổi:"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "Dịch vụ"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack (kiểm thử)"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -33564,7 +33560,7 @@ msgstr ""
 "giống byte-for-byte với `bun` so với các vector kiểm thử cố định và sẽ xác "
 "thực thành công với S3 thật."
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -33576,7 +33572,7 @@ msgstr ""
 "#562 — đường dẫn đó biên dịch được nhưng chưa được xác minh độc lập với các "
 "vector cố định ở đây."
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -34217,9 +34213,10 @@ msgstr ""
 "`mean`, `sumBy`, `meanBy`, `max`, `min`, `maxBy`, `minBy`, và `inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "Sử dụng nhập khẩu có tên: biểu mẫu nhận nhập khẩu mặc định (`import _ from "
@@ -34430,19 +34427,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Các gói npm và API Node.js bổ sung được Perry hỗ trợ. Tất cả được liệt kê ở "
-"đây đều được nối qua registry binding native well-known của Perry (#466) và "
-"biên dịch thành mã native mà không cần đến runtime JavaScript."
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp (Xử lý ảnh)"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -34450,7 +34443,7 @@ msgstr ""
 "Binding native qua `perry-ext-sharp` (v0.5.551). Thay đổi kích thước, chuyển "
 "đổi định dạng và xuất ra buffer/tập tin đều hoạt động."
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -34500,15 +34493,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio (Phân tích HTML)"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "Binding native qua `perry-ext-cheerio` (v0.5.550)."
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -34526,11 +34519,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer (Email)"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -34570,15 +34563,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib (Nén)"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "Binding native qua `perry-ext-zlib` (v0.5.541)."
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -34596,11 +34589,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron (Lập lịch tác vụ)"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -34608,7 +34601,7 @@ msgstr ""
 "Binding native qua `perry-ext-cron` (v0.5.564). Cả tên gói `cron` và `node-"
 "cron` đều định tuyến đến cùng một backend."
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -34628,11 +34621,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers (Ethereum)"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -34642,7 +34635,7 @@ msgstr ""
 "ABI kiểu [`ethers-rs`](https://github.com/gakonst/ethers-rs)\\ thông qua các "
 "bề mặt BigInt + Buffer của `perry-ffi`."
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -34660,11 +34653,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events (EventEmitter)"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -34672,7 +34665,7 @@ msgstr ""
 "Liên kết native qua `perry-ext-events` (v0.5.546). Hình dáng `EventEmitter` "
 "khớp với Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -34690,15 +34683,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff (Logic Thử lại)"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "Liên kết native qua `perry-ext-exponential-backoff` (v0.5.542)."
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -34720,11 +34713,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js (Độ chính xác Tùy ý)"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -34732,7 +34725,7 @@ msgstr ""
 "Liên kết native qua `perry-ext-decimal` (v0.5.547). Cả hai tên gói đều định "
 "tuyến đến cùng một backend — cả `Decimal` và `BigNumber` đều được phơi bày."
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -34768,11 +34761,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns (Thao tác Ngày tháng)"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -34780,7 +34773,7 @@ msgstr ""
 "Liên kết native qua `perry-ext-dayjs` (v0.5.548). Cả hai tên gói đều định "
 "tuyến đến cùng một backend Rust — cùng bề mặt parse/format/diff."
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -34798,11 +34791,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment (Ngày tháng Kế thừa)"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -34812,7 +34805,7 @@ msgstr ""
 "bảo trì ở thượng nguồn — ưu tiên `dayjs` cho mã mới, nhưng Perry hỗ trợ cả "
 "hai cho các codebase hiện có."
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -34828,11 +34821,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -34841,7 +34834,7 @@ msgstr ""
 "nhớ đã được kết nối; các kho lưu trữ hỗ trợ Redis / cluster là phần tiếp "
 "theo."
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -34865,11 +34858,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -34887,7 +34880,7 @@ msgstr ""
 "đóng, `parallelMap` / `parallelFilter` / `spawn` từ `perry/thread` vẫn là "
 "giao diện đơn giản hơn (xem [Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -34925,14 +34918,14 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr ""
 "Các URL của mô-đun Web Worker được phát hiện liên quan đến tệp nguồn nhập "
 "khẩu:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -34965,10 +34958,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander (Phân tích CLI)"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -35010,11 +35176,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -35036,7 +35202,7 @@ msgstr ""
 "`sizeCalculation`, `dispose`, `fetch`, `allowStale` và bề mặt lặp chưa được "
 "thực hiện."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -35066,11 +35232,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -35120,11 +35286,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -35138,7 +35304,7 @@ msgstr ""
 "chỉ cho bây giờ (macOS + Linux); trên các máy chủ khác `spawn` ném, kích "
 "hoạt các con đường phục hồi không trống của người tiêu dùng."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -35150,7 +35316,7 @@ msgstr ""
 "số cho tín hiệu chết và `undefined` nếu không; `kill()` mặc định là `SIGHUP` "
 "như node-pty. `TERM` ở đứa trẻ xuất phát từ `name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -35196,11 +35362,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -35216,7 +35382,7 @@ msgstr ""
 "tiền gốc tại thời điểm biên dịch. Hành vi đã được kiểm tra với `@parcel/"
 "watcher` 2.5.1."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -35236,7 +35402,7 @@ msgstr ""
 "`create` cho đường dẫn mới. Thông báo overflow/rescan của backend kích hoạt "
 "một ảnh chụp cây mới và phát ra sự khác biệt của nó."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -35254,7 +35420,7 @@ msgstr ""
 "sau đó. Đăng ký trực tiếp giữ vòng lặp sự kiện hoạt động. `writeSnapshot` và "
 "`getEventsSince` sử dụng cùng một ngữ nghĩa khác nhau như phục hồi tràn."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -35264,7 +35430,7 @@ msgstr ""
 "được import bằng `bun add` như bất kỳ gói npm nào, nhưng được hỗ trợ bằng "
 "Rust và biên dịch native qua `perry-ffi`:"
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -35272,7 +35438,7 @@ msgstr ""
 "**`@perryts/tursodb`** — Client cơ sở dữ liệu Turso (nhánh libSQL). Xem "
 "[PerryTS/tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -35280,12 +35446,12 @@ msgstr ""
 "**`@perryts/iroh`** — Mạng ngang hàng Iroh. Xem [PerryTS/iroh-bindings]"
 "(https://github.com/PerryTS/iroh-bindings)."
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr ""
 "Các trình điều khiển TypeScript thuần được biên dịch qua `compilePackages`:"
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -35295,7 +35461,7 @@ msgstr ""
 "**`@perryts/redis`** — các client theo wire-protocol, cũng chạy được trên "
 "Node.js và Bun mà không cần thay đổi."
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -35303,11 +35469,11 @@ msgstr ""
 "Xem [Liên kết Native — Tổng quan](../native-libraries/overview.md) về hợp "
 "đồng mà các gói bên ngoài này tuân theo."
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[Hệ thống Tệp](fs.md) — các API fs và path"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr ""
 "[Liên kết Native](../native-libraries/overview.md) — Tự viết liên kết của bạn"
@@ -35332,7 +35498,8 @@ msgstr ""
 "target đã chọn."
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "Tổng cộng: 3019 mục trên 138 mô-đun."
 
 #: src/api/reference.md:9
@@ -35429,4833 +35596,4980 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "Phương thức"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — module"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "Thuộc tính"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "`__nativeEventCount`  module"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "`getEventsSince`  module"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — module"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — module"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "`writeSnapshot`  module"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — module"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — module"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — module"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — module"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — module"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — instance"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — instance"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — instance"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — instance"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — instance"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — instance"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — instance"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — module"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — module"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — module"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — module"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — module"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — module"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — module"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — module"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — module"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — module"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — module"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — module"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — module"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — module"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — module"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — module"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — module"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — module"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — module"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — module"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — module"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — module"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — module _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — module _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — module"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — instance"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — instance _(class: `AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — instance"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — module"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — module"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — instance"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — instance"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — instance"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — module"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — module"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — module"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — module"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — module"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — module"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — module"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — module"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — module"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — module"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — module"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — module"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — instance"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — instance"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — instance"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — instance"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — instance"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — instance"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — instance"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — instance"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — instance"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — instance"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — instance"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — module"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — module"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — module"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — module"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — module"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — module"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "Truyền"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "`Glob`  module"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — module"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — module"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — module"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — module"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — module"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — module"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "`file`  module"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — module"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — module"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — module"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — module"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — module"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — instance _(class: `Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(class: `GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — module"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "`stringWidth`  module"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — module"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — instance _(class: `GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction`  trường hợp _ ((thể loại: `Database`) _"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "`unsupported`  module"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — module"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — module"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — module"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — module"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — module"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "`CFunction`  module"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "`CString`  module"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "`JSCallback`  module"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — module"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "`linkSymbols`  module"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "`ptr`  module"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "`toArrayBuffer`  module"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "`toBuffer`  module"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "`viewSource`  module"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — module"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "`Database`  module"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction`  trường hợp _ ((thể loại: `Database`) _"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values`  trường hợp _ ((thể loại: `Statement`) _"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — instance"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — instance"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — instance"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — instance"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — instance"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — instance"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — instance"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — instance"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — instance"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — module"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — instance"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — instance"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — instance"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — module"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — module"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — module"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — module"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — module"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — module"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — module"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — module"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — module"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — module"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — instance"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args`  instance"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument`  instance"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — instance"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — instance"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — instance"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — instance"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — instance"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — instance"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — instance"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — instance"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — module"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — module"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — module"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — module"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — module"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — module"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — module"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — module"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — module"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — module"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — module"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — module"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — module"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — module"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — module"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — module"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — module"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — module"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — module"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — module"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — module"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — module"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — module"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — module"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — module"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — instance"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — instance"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — module"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — instance"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — instance"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — module"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash`  module"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac`  module"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign`  module"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify`  module"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2`  module"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync`  module"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime`  module"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync`  module"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv`  module"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv`  module"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman`  module"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup`  module"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH`  module"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — module"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — module"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey`  module"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey`  module"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey`  module"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign`  module"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify`  module"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate`  module"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman`  module"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — module"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — module"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — module"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — module"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — module"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — module"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — module"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — module"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — module"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — module"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — module"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — module"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — module"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — module"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — module"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — module"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — module"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — module"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — module"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — module"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — module"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — module"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — module"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — module"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — module"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — module"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — module"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — module"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — module"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — module"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — module"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — module"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — module"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — module"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — module"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — module"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — module"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — module"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — module"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — module"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — module"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — module"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — module"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — module"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — module"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — instance"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — instance"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — instance"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — instance"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — module"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — instance"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — instance"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — instance"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — instance"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — instance"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — instance"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — instance"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — instance"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — instance"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — instance"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — instance"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — instance"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — instance"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — instance"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — instance"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — instance"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — instance"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — instance"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — instance"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — instance"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — instance"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — instance"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — instance"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — instance"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — instance"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — instance"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — instance"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — instance"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — instance"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — instance"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — instance"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — instance"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — instance"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — instance"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — instance"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — instance"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — instance"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — instance"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — instance"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — instance"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — instance"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — module"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — module"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — module"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — module"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — module"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — module"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — module"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — module"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — module"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — module"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — module"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — module"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — module"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — module"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — module"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — module"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — module"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — module"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — module"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — module"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — module"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — module"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — module"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — module"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — module"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — module"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — module"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — module"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — instance _(class: `Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — module"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — instance"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — instance"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — module"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — instance"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — instance"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — instance"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — instance"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — instance"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — module"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — module"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — module _(class: `Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — module"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — module"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — module"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — module"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — module"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — module"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — module"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — module"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — instance"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — instance"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — module"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — instance"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — module"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — module"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — instance"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — module"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — instance"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — instance"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — module"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — instance"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — module"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — instance"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — instance"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — instance"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — instance"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — instance"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — instance"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — module"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — module"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — instance"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — instance"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — instance"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — instance"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — instance"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — instance"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — instance"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — instance"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — instance"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — instance"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — instance"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — instance"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — instance"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — instance"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — instance"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — instance"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — instance"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — instance"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — instance"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — instance"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — instance"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — instance"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — instance"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — instance"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — instance"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — instance"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — instance"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — instance"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "`getRawPointer`  module"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "`toString`  module"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — module"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — module"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — module"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — module"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — module"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — module"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — module"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — module"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — module"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — module"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — module"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — module"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — module"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — module"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — module"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — module"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — module"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — module"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — module"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — module"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — module"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — module"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — module"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — module"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — module"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — module"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — module"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — module"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — module"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — module"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — module"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — module"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — module"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — module"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — module"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — module"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — module"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — module"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — module"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — module"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — module"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — module"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — module"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — module"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — module"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — module"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — module"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — module"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — module"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — module"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — module"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — module"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — module"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — module"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — module"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — module"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — module"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — module"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — module"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — module"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — module"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — module"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — module"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — module"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — module"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — module"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — module"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — module"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — module"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — module"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — module"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — module"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — module"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — module"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — module"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — module"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — module"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — module"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — module"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — module"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — module"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — module"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — module"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — module"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — module"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — module"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — module"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — module"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — module"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — module"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — module"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — module"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — module"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — module"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — instance _(class: `FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — module"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — module"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMajor`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr ""
 "`__get_httpVersionMinor`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening`  trường hợp _ ((thể loại: `HttpServer`) _"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — module"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — module"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40263,103 +40577,103 @@ msgstr ""
 "`keepSocketAlive`  trường hợp _ ((thể loại: `Agent`) _ **stub** Reqwest sở "
 "hữu hồ bơi giữ cho sống; mỗi ổ cắm móc không có op, cảnh báo một lần (# 4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening`  trường hợp _ ((thể loại: `HttpServer`) _"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once`  trường hợp _ ((thể loại: `ClientRequest`) _"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref`  trường hợp _ ((thể loại: `HttpServer`) _"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -40367,375 +40681,369 @@ msgstr ""
 "`reuseSocket`  trường hợp _ ((thể loại: `Agent`) _ **stub** Reqwest sở hữu "
 "hồ bơi giữ cho sống; mỗi ổ cắm móc không có op, cảnh báo một lần (# 4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — module"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — module"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket`  trường hợp _ ((thể loại: `IncomingMessage`) _"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — instance _(class: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — instance _(class: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — instance _(class: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref`  trường hợp _ ((thể loại: `HttpServer`) _"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — instance _(class: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — module"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — module"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — instance _(class: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — module"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — module"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — module"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — module"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — module"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — module"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening`  trường hợp _ ((thể loại: `HttpsServer`) _"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening`  trường hợp _ ((thể loại: `HttpsServer`) _"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref`  trường hợp _ ((thể loại: `HttpsServer`) _"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — instance _(class: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref`  trường hợp _ ((thể loại: `HttpsServer`) _"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — module"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug`  mô-đun _ ((lớp: `console`) _"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error`  mô-đun _ ((lớp: `console`) _"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info`  mô-đun _ ((lớp: `console`) _"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log`  mô-đun _ ((lớp: `console`) _"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -40743,7 +41051,7 @@ msgstr ""
 "`open`  module **stub** chấp nhận port/host nhưng không ràng buộc điểm cuối "
 "thanh tra WebSocket thực sự; các phiên là giả mạo trong quá trình (# 4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -40753,7 +41061,7 @@ msgstr ""
 "và một tập con Runtime.evaluate đóng hộp trả lời; mọi phương pháp giao thức "
 "khác ném lỗi thanh tra -32601 (# 4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -40761,7 +41069,7 @@ msgstr ""
 "`url`  module **stub** luôn không xác định: Perry không bao giờ lộ một điểm "
 "cuối kiểm tra thực sự (# 4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
@@ -40769,3285 +41077,3276 @@ msgstr ""
 "`waitForDebugger`  module **stub** trả về ngay sau khi open ((); không có "
 "trình gỡ lỗi để chờ đợi (# 4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn`  mô-đun _ ((lớp: `console`) _"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — instance _(class: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — instance"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — module"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — instance"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — instance"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — instance"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — instance"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — instance"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — instance"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — instance"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — instance"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — instance"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — instance"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — module"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — instance"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — instance"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — instance"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — instance"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — instance"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — instance"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — module"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — module"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — module"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — module"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — module"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — module"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — module"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — module"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — module"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — module"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — module"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — module"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — module"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — module"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — module"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — module"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — module"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — module"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — module"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — module"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — module"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — module"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — module"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — module"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — module"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — module"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — module"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — instance"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — instance"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek`  instance"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — instance"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — module"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — module"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — module"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — module"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — module"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — module"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — module"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — module"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — module"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — module"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — module"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — module"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — module"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — module"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — module"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — module"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — module"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — module"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — module"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — module"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — module"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — module"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — module"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow`  instance"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween`  instance"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — module"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate`  instance"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — instance"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — instance"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — instance"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — instance"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — instance"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — instance"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — instance"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — instance"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — instance"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — instance"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — instance"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — instance"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — module"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — module"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — instance _(class: `Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — instance"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — instance _(class: `Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — instance _(class: `PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — instance"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — instance"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — instance _(class: `Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — instance _(class: `PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — instance"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — instance"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — module"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — module"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — module"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — module"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — module"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — module"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — module _(class: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — module"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — module"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — module"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — module _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — instance _(class: `SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — module"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert`  trường hợp _ ((thể loại: `Socket`) _"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — instance _(class: `BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — instance _(class: `Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "`certificateFromPem`  module"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "`certificateToPem`  module"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "`createCertificate`  module"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "`privateKeyFromPem`  module"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "`privateKeyToPem`  module"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "`publicKeyToPem`  module"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions`  trường hợp _ ((thể loại: `Certificate`) _"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer`  trường hợp _ ((thể loại: `Certificate`) _"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject`  trường hợp _ ((thể loại: `Certificate`) _"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign`  trường hợp _ ((thể loại: `Certificate`) _"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — module"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — instance"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — instance"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — module"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — module"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — module"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — module"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — module"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — module"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — module"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — module"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — module"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — module"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — module"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — module"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — module"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — module"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — module"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — module"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — module"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — module"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — module"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — module"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — module"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — module"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — module"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — module"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — module"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — module"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — module"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — module"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — module"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — module"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — module"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "`eventLoopUtilization`  module"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — module"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — module"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "`embeddedFiles`  module"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "`readEmbedded`  module"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — module"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — module"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — module"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — module"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "`js_ads_request_consent`  module"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — module"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — module"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — module"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — module"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — module"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — module"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — module"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — module"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — module"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — module"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — module"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — module"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — module"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — module"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — module"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — module"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — module"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — module"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — module"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — module"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — module"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — module"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — module"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — module"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — module"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — module"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — module"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — module"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — module"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — module"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — module"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — module"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — module"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — module"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — module"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — module"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — module"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — module"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — module"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — module"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — module"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — module"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — module"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — module"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — module"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — module"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — module"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — module"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — module"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — module"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — module"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — module"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "`collect`  module"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "`idleHint`  module"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "`minor`  module"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — module"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — module"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — module"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — module"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — module"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — module"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — module"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — module"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "`createLanguageModelSession`  module"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "`destroyLanguageModelSession`  module"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "`foundationModelAvailability`  module"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "`getLayoutEnvironment`  module"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "`offLayoutChange`  module"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "`onLayoutChange`  module"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "`respond`  module"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — module"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — module"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — module"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — module"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — module"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — module"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — module"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — module"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof`  mô-đun _ ((trên bản) _"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "`f32`  module"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "`f64`  module"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "`i16`  module"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "`i32`  module"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "`i64`  module"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "`i8`  module"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "`isize`  module"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof`  mô-đun _ ((trên bản) _"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof`  mô-đun _ ((trên bản) _"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "`u16`  module"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "`u32`  module"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "`u64`  module"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "`u8`  module"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "`usize`  module"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — module"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — module"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — module"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — module"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — module"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — module"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — module"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — module"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — module"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — module"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — module"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — module"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — module"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — module"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — module"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — module"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — module"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — module"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — module"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — module"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — module"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — module"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — module"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — module"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — module"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — module"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — module"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — module"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — module"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — module"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — module"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — module"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — module"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — module"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — module"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — module"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — module"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — module"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — module"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — module"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "`hapticPlay`  module"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — module"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — module"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — module"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — module"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — module"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — module"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — module"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — module"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — module"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — module"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — module"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — module"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — module"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — module"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — module"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — module"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — module"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — module"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — module"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — module"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — module"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — module"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — module"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — module"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — module"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — module"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — module"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — module"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — module"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — module"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — module"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — module"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — module"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — module"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — module"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — module"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — module"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — module"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — module"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — module"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — module"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — module"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — module"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — module"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — module"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — module"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — module"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — module"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — module"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — module"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — module"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — module"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — instance _(class: `TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — module"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — module"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — module"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — instance _(class: `FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — instance _(class: `State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — instance _(class: `RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — module"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — instance _(class: `State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — instance _(class: `RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — module"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — module"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — module"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — module"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — module"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — module"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — module"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — module"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — module"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — module"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — module"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — module"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — module"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — instance _(class: `TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — instance _(class: `TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — module"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — module"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "`BloomView`  module"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — module"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — module"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — module"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — module"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — module"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — module"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — module"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — module"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — module"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — module"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — module"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — module"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — module"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — module"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — module"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — module"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — module"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — module"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — module"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — module"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — module"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — module"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — module"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — module"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — module"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — module"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — module"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — module"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "`WheelPicker`  module"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — module"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — module"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — module"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — module"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — module"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "`appSetActivationPolicy`  module"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — module"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — module"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — module"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — module"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — module"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "`bloomViewGetHwnd`  module"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "`bloomViewGetNativeHandle`  module"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — module"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — module"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — module"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — module"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — module"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — module"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — module"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — module"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — module"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — module"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — module"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — module"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — module"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — module"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — module"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — module"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — module"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — module"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — module"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — module"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — module"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — module"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — module"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — module"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — module"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — module"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — module"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — module"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — module"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — module"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — module"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — module"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — module"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — module"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — module"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — module"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — module"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — module"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — module"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — module"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — module"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — module"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — module"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — module"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — module"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — module"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — module"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — module"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — module"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — module"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — module"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — module"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — module"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — module"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — module"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — module"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — module"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — module"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — module"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — module"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — module"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — module"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — module"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — module"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — module"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — module"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — module"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — module"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — module"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "`wheelPickerAddItem`  module"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "`wheelPickerGetSelected`  module"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "`wheelPickerSetSelected`  module"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — module"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — module"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — module"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "`embeddedCheckHeaders`  module"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "`embeddedCheckUrl`  module"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "`embeddedRefreshDue`  module"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — module"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "`getEmbeddedConfig`  module"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — module"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — module"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — module"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — module"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — module"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "`recordEmbeddedResponse`  module"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — module"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — module"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — module"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — module"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — module"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — module"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — module"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — module"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — module"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — module"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "`calculateLayout`  module"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "`childCount`  module"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "`getComputed`  module"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "`getComputedEdge`  module"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "`insertChild`  module"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "`nodeFree`  module"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "`nodeNew`  module"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "`removeChild`  module"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "`setEdge`  module"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "`setEnum`  module"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "`setGap`  module"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "`setMeasureFunc`  module"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "`setNumber`  module"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "`unsetMeasureFunc`  module"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — module"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — module"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — module"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — module"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — module"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — module"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — module"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — module"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — module"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — module"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — module"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — module"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — module"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — module"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — module"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — module"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — module"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — module"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — module"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — module"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — module"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — module"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — module"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — module"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — module"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — module"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — module"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — module"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — module"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — module"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — module"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — module"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — module"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — module"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — module"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — module"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — module"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — module"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — module"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — module"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — module"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — module"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — module"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — module"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — module"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — module"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — module"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — module"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — module"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — module"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — module"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — module"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — module"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — module"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — module"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block`  instance"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume`  instance"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty`  instance"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward`  instance"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — module"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — module"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — module"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — module"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — module"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — instance"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — instance"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — instance"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — instance"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — module"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — instance"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — instance"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — instance"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — instance"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — instance"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — instance"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — instance"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -44057,43 +44356,43 @@ msgstr ""
 "luồng đầu vào, và .write() chỉ đánh giá chữ số, tìm kiếm ngữ cảnh và một '+' "
 "duy nhất; không có vòng lặp eval JS thực sự (# 4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — module"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -44103,1459 +44402,1459 @@ msgstr ""
 "luồng đầu vào, và .write() chỉ đánh giá chữ số, tìm kiếm ngữ cảnh và một '+' "
 "duy nhất; không có vòng lặp eval JS thực sự (# 4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — instance _(class: `REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — module"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — module"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — module"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — module"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — module"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient`  instance"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif`  instance"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — instance"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite`  instance"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend`  instance"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract`  instance"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — instance"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — instance"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — instance"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — instance"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — instance"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — instance"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — instance"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — instance"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — instance"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — module"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen`  instance"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — instance"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — instance"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim`  instance"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — instance"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — instance"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — instance"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — module"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — module"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — instance"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — instance"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — module"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — instance"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — instance"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — instance _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — instance _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize`  instance"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — thực thể _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — thực thể"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — thực thể"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — thực thể _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — thực thể _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — thực thể"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — thực thể"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — thực thể _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — thực thể"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — thực thể"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — thực thể"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — thực thể"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — thực thể"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — thực thể _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize`  instance"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — thực thể"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — thực thể"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — thực thể _(class: `DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — thực thể"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — thực thể"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — thực thể _(class: `SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — thực thể"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — mô-đun"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — mô-đun"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — mô-đun"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — mô-đun"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — thực thể"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — thực thể"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — mô-đun"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — thực thể"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — thực thể"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — thực thể"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — mô-đun"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — thực thể"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — module"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — mô-đun"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — mô-đun"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — mô-đun"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — mô-đun"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — thực thể"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — mô-đun"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — mô-đun"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — thực thể"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — module"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — thực thể"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — thực thể"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — thực thể"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — thực thể"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — thực thể"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — thực thể"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — thực thể"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — thực thể"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — thực thể"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — thực thể"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — thực thể"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — mô-đun"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — thực thể"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — thực thể"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — thực thể"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — thực thể"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — thực thể"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — thực thể"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — thực thể"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — thực thể"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — thực thể"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — thực thể"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — thực thể"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — thực thể"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — mô-đun"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — mô-đun"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — mô-đun"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — mô-đun"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — mô-đun"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — mô-đun"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — thực thể _(class: `StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — thực thể _(class: `StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — mô-đun"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — mô-đun"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — mô-đun"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — mô-đun"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — mô-đun"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — mô-đun"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — module"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — mô-đun"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — mô-đun"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — module"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — mô-đun"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — mô-đun"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — mô-đun"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — mô-đun"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — mô-đun"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — mô-đun"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — module"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — mô-đun"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — module"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — mô-đun"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — mô-đun"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — module"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — mô-đun"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — mô-đun"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — mô-đun"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — mô-đun"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — mô-đun"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — mô-đun"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — mô-đun"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — mô-đun"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — mô-đun"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — mô-đun"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — mô-đun _(class: `timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — mô-đun"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — mô-đun"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — mô-đun"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — mô-đun _(class: `timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — mô-đun _(class: `snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — mô-đun _(class: `snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — mô-đun _(class: `timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — mô-đun _(class: `mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — mô-đun"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — mô-đun"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — mô-đun"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — mô-đun _(class: `timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — mô-đun"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — mô-đun"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — mô-đun"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — mô-đun"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — mô-đun"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — mô-đun"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — mô-đun"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — mô-đun"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — mô-đun"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — mô-đun"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — mô-đun"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — module"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — module"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — module"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — module"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "`convertALPNProtocols`  module"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — module"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — module"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "`getCertificateCompressionAlgorithms`  module"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — module"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — instance _(class: `Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — module"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — module"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — module"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — instance _(class: `WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — instance _(class: `ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — instance"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — instance"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — instance"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — instance"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — instance"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "`flattenDiagnosticMessageText`  module"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "`transpileModule`  module"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "`ProxyAgent`  module"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close`  trường hợp _ ((thể loại: `ProxyAgent`) _"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy`  trường hợp _ ((thể loại: `ProxyAgent`) _"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "`fetch`  module"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "`getGlobalDispatcher`  module"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "`setGlobalDispatcher`  module"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — module"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — module"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — module"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — instance _(class: `URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — module"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — module"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — instance _(class: `URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — module"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — module"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — module"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — module"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — module"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — module"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — module"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — module"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — module"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — module"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — module"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — module"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — module"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — module"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — module"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — module"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — module"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — module"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — module"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — module"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — module"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — module"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — module"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — module"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — module"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — module"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — module"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — module"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — module"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — module"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — module"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — module"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — module"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — module"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — module"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — module"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — module"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — module"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — module"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — module"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — module"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — module"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — module"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — module"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — module"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "`v3`  module"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — module"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "`v5`  module"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — module"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — module"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — module"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — module"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -45563,11 +45862,11 @@ msgstr ""
 "`getHeapCodeStatistics`  module **stub** tất cả các trường 0; Perry biên "
 "dịch AOT, không có tập mã JIT (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — module"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -45577,7 +45876,7 @@ msgstr ""
 "sử dụng trực tiếp được gán cho old_space từ các đấu trường Perry; các không "
 "gian khác báo cáo 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -45591,87 +45890,87 @@ msgstr ""
 "(không được thực thi); \\*\\_ thực thi, external_memory, các trường xử lý "
 "toàn cầu và zap là 0 (# 4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — module"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — instance _(class: `promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — module"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — instance _(class: `Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — module"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — module"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — module"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — instance _(class: `GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — module"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -45679,459 +45978,469 @@ msgstr ""
 "`stop`  trường hợp _ ((thể loại: `GCProfiler`) _ **stub** báo cáo có hình "
 "dạng Node nhưng mảng thống kê luôn trống (# 4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — module"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — module"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — module"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — instance _(class: `Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — module"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — module"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — module"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — module"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — module"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — module"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — instance"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — module"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — module"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — instance"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — instance"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — instance"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — instance"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — instance"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — instance"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — instance"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — module"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — instance"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — instance"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — module"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — instance"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — instance"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — module"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — module"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — module"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — instance"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — module"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — instance _(class: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — module"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — module"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener`  instance"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — module"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — module"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — module"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — module"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — module"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — module"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — module"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload`  trường hợp _ ((thể loại: `Worker`) _"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener`  instance"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — module"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — instance _(class: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — module"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — instance"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — thực thể"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — module"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — instance"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState`  instance"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — instance _(class: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — module"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — module"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — module"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — module"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — module"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — module"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46139,7 +46448,7 @@ msgstr ""
 "`createBrotliCompress`  module **stub** Các tùy chọn params/quality được "
 "chấp nhận nhưng bị bỏ qua, cảnh báo một lần (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -46147,7 +46456,7 @@ msgstr ""
 "`createBrotliDecompress`  module **stub** Các tùy chọn params/quality được "
 "chấp nhận nhưng bị bỏ qua, cảnh báo một lần (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46155,7 +46464,7 @@ msgstr ""
 "`createDeflate`  module **stub** cấp độ được tôn trọng; strategy/memLevel "
 "được xác nhận nhưng không được áp dụng (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46163,11 +46472,11 @@ msgstr ""
 "`createDeflateRaw`  module **stub** cấp độ được tôn trọng; strategy/memLevel "
 "được xác nhận nhưng không được áp dụng (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — module"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -46175,19 +46484,19 @@ msgstr ""
 "`createGzip`  module **stub** cấp độ được tôn trọng; strategy/memLevel được "
 "xác nhận nhưng không được áp dụng (#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — module"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — module"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — module"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46195,7 +46504,7 @@ msgstr ""
 "`createZstdCompress`  module **stub** Các tùy chọn params/quality được chấp "
 "nhận nhưng bị bỏ qua, cảnh báo một lần (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -46203,79 +46512,71 @@ msgstr ""
 "`createZstdDecompress`  module **stub** Các tùy chọn params/quality được "
 "chấp nhận nhưng bị bỏ qua, cảnh báo một lần (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — module"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — module"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — module"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — module"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — module"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — module"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — module"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — module"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — module"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — module"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — module"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — module"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — module"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — module"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — module"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — module"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — module"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — module"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -46805,9 +47106,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "Bạn vốn sẽ dùng file `docker-compose.yaml`."
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "Hai mô-đun chia sẻ thời gian chạy; bạn có thể trộn chúng trong cùng một "
@@ -47337,12 +47639,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` tương đương với `docker rm -f`."
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**Ghi chú về hình dạng trả về `logs` và `exec`:** ngày nay FFI trả về một xử "
 "lý đăng ký-id vào một `Vec<ContainerLogs>` thay vì một đối tượng JS. Đối xử "
@@ -47470,9 +47773,10 @@ msgstr ""
 "các lần gọi sau sẽ truy cập `OnceLock` đã được cache và trả về ngay lập tức."
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()` là không đồng bộ và trả về một mảng JSON của _every_ ứng "
@@ -48227,9 +48531,10 @@ msgstr ""
 "mỗi service _sẵn sàng_. Để chặn cho đến khi stack đang phục vụ:"
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**Sử dụng khối `healthcheck` trên dịch vụ** (được xây dựng trong, thời gian "
@@ -48607,8 +48912,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "Ví dụ Forgejo sử dụng mẫu di động này (`container_name:  'forgejo-db'` + "
@@ -48679,8 +48985,9 @@ msgid "Single-network shorthand"
 msgstr "Shorthand cho single-network"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -49091,9 +49398,10 @@ msgid "External volumes"
 msgstr "External volumes"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "Nhãn một khối lượng `external: true` để chia sẻ nó qua các ngăn xếp hoặc sử "
@@ -49115,8 +49423,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -49184,15 +49493,18 @@ msgstr ""
 "`inspectVolume()` — tạm thời, hãy kiểm tra bằng CLI runtime bên dưới:"
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# Danh sách các khối lượng được đặt trước ứng dụng"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# điểm gắn, trình điều khiển, nhãn"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# gắn + kiểm tra nội dung"
 
 #: src/container/volumes.md:160
@@ -49360,9 +49672,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -49545,8 +49858,9 @@ msgstr ""
 "đối với cùng digest sẽ không tốn chi phí."
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -49811,8 +50125,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**Chạy với tư cách non-root** (`user: \"nobody\"` hoặc UID số)."
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**Bỏ tất cả các khả năng, thêm những khả năng cụ thể trở lại** (`cap_drop:  "
@@ -49961,7 +50276,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "In banner dành cho operator với URL + \"cách teardown\"."
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr ""
 "Lối ra số 0. Các container tiếp tục chạy nhờ `restart:  unless-stopped`."
 
@@ -50180,11 +50496,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "Khởi động dependency có kiểm soát bằng healthcheck"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "postgres mất ~ 510 giây để khởi động trong lần chạy đầu tiên (initdb + "
 "listener bind). Không có Getting, Forgejo bắt đầu ngay lập tức, không thể "
@@ -50355,7 +50672,8 @@ msgstr ""
 "file `.env` hoặc một secrets manager:"
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# .env"
 
 #: src/container/production-patterns.md:225
@@ -50368,7 +50686,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -50428,11 +50747,13 @@ msgstr ""
 "cầu recreate), hãy thực hiện `--down` trước:"
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# giữ khối lượng"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# tái triển khai với phiên bản mới"
 
 #: src/container/production-patterns.md:268
@@ -50450,35 +50771,42 @@ msgid "Running it"
 msgstr "Chạy ứng dụng"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# Xây dựng Perry một lần"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# Xây dựng ví dụ"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# Backend: Docker"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# Truy cập http://localhost:3000/ trong trình duyệt."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# Dừng (giữ lại các volume để triển khai lại):"
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# Rút xuống + giảm khối lượng (DISTROYS DATA):"
 
 #: src/container/production-patterns.md:300
@@ -50785,19 +51113,23 @@ msgstr ""
 "khác nhau."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// thử nghiệm + phát ra như-là"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// động cơ mô phỏng bên máy chủ"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// giảm + cảnh báo"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// tập hợp con hạn chế; lý do được ghi chép"
 
 #: src/container/determinism.md:156
@@ -50921,7 +51253,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "Mỗi giao thức trả về hằng số của nó từ phương thức `capabilities()`:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... các nhà xây dựng"
 
 #: src/container/determinism.md:192
@@ -50949,7 +51282,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"specic field dropped/translated cho backend\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- thông số kỹ thuật"
 
 #: src/container/determinism.md:212
@@ -50961,15 +51295,18 @@ msgstr ""
 "cho cùng một kết quả. Nó tạo ra một `Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// xóa trường"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// được gán cho tương đương"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// động cơ bắt chước thay vào đó"
 
 #: src/container/determinism.md:231
@@ -50977,15 +51314,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. Chế độ thực thi  chọn cách cảnh báo xuất hiện"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// mặc định  âm thầm:"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// bề mặt đến TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// không hỗ trợ trường → khó up() thất bại"
 
 #: src/container/determinism.md:241
@@ -51047,7 +51387,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "Tiêu chuẩn hóa đầu ra  cùng hình dạng bất kể backend"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker hình dạng (dòng NDJSON)"
 
 #: src/container/determinism.md:292
@@ -51055,7 +51396,8 @@ msgid "/* docker JSON */"
 msgstr "/* Docker JSON */"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "// Apple hình dạng (JSON mảng của `configuration`-wrapped đối tượng)"
 
 #: src/container/determinism.md:294
@@ -51063,7 +51405,8 @@ msgid "/* apple JSON */"
 msgstr "/* apple JSON */"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// Cả hai sản xuất ContainerInfo với cùng một ngữ nghĩa trường:"
 
 #: src/container/determinism.md:301
@@ -51397,7 +51740,8 @@ msgstr ""
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -51410,7 +51754,8 @@ msgid "\"Back\""
 msgstr "\"Trở lại\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (giá trống = cần dịch)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -51639,7 +51984,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -51760,7 +52106,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json"
 
 #: src/i18n/interpolation.md:65
@@ -52533,19 +52880,23 @@ msgid "Typical translation workflow:"
 msgstr "Quy trình dịch điển hình:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. Viết mã bằng chuỗi tiếng Anh"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. Tạo chuỗi vào tệp địa phương"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr "# 3. Gửi locales/de.json cho người dịch (cần điền các giá trị trống)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. Build  Perry xác nhận mọi thứ"
 
 #: src/i18n/cli.md:49
@@ -53223,54 +53574,22 @@ msgstr ""
 "sử dụng bởi `perry update`."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) Sản xuất cặp phím một lần. Lưu kp.json với chế độ 0600 và"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) Chữ ký mỗi bản phát hành. Các bản bìa JSON đầu ra chứa tất cả các"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr ""
-"# 3) Kiểm tra sức khỏe tâm lý chữ ký tại địa phương trước khi tải lên bản "
-"trình bày"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    ở đây dự đoán một xác minh vượt qua trên khách hàng."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr "# 4) Giới thiệu CI ký biểu thức CLI, ràng buộc URL lưu trữ, nền tảng,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "Soạn một bản trình bày cuối cùng bằng cách dẫn đầu ra `sign` qua `jq` cho "
@@ -54902,9 +55221,10 @@ msgstr ""
 "lên nhau (ví dụ: nhiều tiếng súng, nhiều tiếng bước chân)."
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** một nhóm hỗn hợp. Âm thanh đi qua một Bus, Bus đi qua cha mẹ của "
@@ -55908,6 +56228,7 @@ msgstr ""
 "mỗi dispatch, throttle xuống 100 ms bằng so sánh thời gian thực."
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -55917,7 +56238,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -57109,23 +57430,28 @@ msgstr ""
 "tảng — không yêu cầu kiến thức ngôn ngữ riêng của nền tảng."
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS WidgetKit mở rộng"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android App Widget"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS Sự phức tạp"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# watchOS Simulator"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS Tile"
 
 #: src/widgets/overview.md:60
@@ -58035,10 +58361,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "Padding"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -58636,11 +58958,13 @@ msgid "Build Commands"
 msgstr "Lệnh Build"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -59524,19 +59848,23 @@ msgid "Build Instructions"
 msgstr "Hướng dẫn build"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# Sao chép tệp .kt vào app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# Kết hợp AndroidManifest_snippet.xml vào AndroidManifest.xml"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# Sao chép tệp .kt vào mô-đun Wear OS"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# Kết hợp AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -59724,11 +60052,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "Làm mới nền sử dụng framework `BackgroundTask`"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# Đối với thiết bị Apple Watch"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# Đối với Apple Watch Simulator"
 
 #: src/widgets/watchos.md:70
@@ -61322,11 +61652,13 @@ msgstr ""
 "báo bằng `#[no_mangle] pub extern \"C\"`:"
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// Perry thời gian chạy FFI"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ... gọi nền tảng API, giải quyết lời hứa khi hoàn thành ..."
 
 #: src/plugins/native-extensions.md:200
@@ -61455,25 +61787,17 @@ msgstr ""
 "`swiftc`, nhắm tới SDK nền tảng phù hợp:"
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (đơn giản)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr ""
-"// phát hiện mục tiêu: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"// biên dịch: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "// Liên kết: cargo:rustc-link-lib=static=review_bridge"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -61500,7 +61824,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "Resolve Perry promise với kết quả"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// Nhận hoạt động từ PerryBridge"
 
 #: src/plugins/native-extensions.md:266
@@ -61516,7 +61841,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "// Gọi nền tảng API qua JNI..."
 
 #: src/plugins/native-extensions.md:275
@@ -62132,15 +62458,18 @@ msgstr ""
 "không cần trình biên dịch, không có nút và không xây dựng."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# cổng"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# những gì trong phạm vi, và những gì không"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# chứng minh cổng vẫn có thể thất bại"
 
 #: src/testing/test-registration.md:18
@@ -62491,33 +62820,40 @@ msgstr ""
 "bạn biên dịch với `--enable-geisterhand`."
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr ""
 "# 1. biên dịch với geisterhand được bật (libs tự động xây dựng khi sử dụng "
 "lần đầu tiên)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. Chạy ứng dụng"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. Trong một thiết bị đầu cuối khác  tương tác với ứng dụng"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# Danh sách tất cả các tiện ích"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# Nhấp nút với tay cầm 3"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# Chụp ảnh màn hình cửa sổ"
 
 #: src/testing/geisterhand.md:25
@@ -62533,7 +62869,8 @@ msgstr ""
 "ý `--enable-geisterhand`, nên bạn không cần cả hai cờ):"
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# hoặc với Perry Run:"
 
 #: src/testing/geisterhand.md:35
@@ -62677,8 +63014,8 @@ msgid "Menu item"
 msgstr "Mục menu"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -62690,8 +63027,8 @@ msgstr "Phím tắt bàn phím"
 msgid "Data table"
 msgstr "Bảng dữ liệu"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -62805,17 +63142,6 @@ msgstr ""
 "Đặt nội dung của ô văn bản và kích hoạt callback `onChange` của nó với văn "
 "bản mới dưới dạng chuỗi NaN-boxed."
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"Công thức: application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "'{\"text\":\"hello world\"}'"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "Di chuyển thanh trượt"
@@ -62839,10 +63165,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "Đặt vị trí thanh trượt và kích hoạt `onChange` với giá trị số."
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"value\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -62893,10 +63215,6 @@ msgstr ""
 "Đặt trực tiếp giá trị của một ô `State`, bỏ qua các callback widget. Điều "
 "này kích hoạt mọi binding phản ứng được gắn với state (nhãn văn bản được "
 "bind, hiển thị, vòng lặp forEach, v.v.)."
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "\"{\"giá trị\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -62974,10 +63292,6 @@ msgstr ""
 "vào `menuAddItem` (ví dụ: `\"s\"` cho Cmd+S, `\"S\"` cho Cmd+Shift+S, "
 "`\"n\"` cho Cmd+N)."
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "'{\"chọn tắt\":\"s\"}'"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -63011,10 +63325,6 @@ msgid ""
 msgstr ""
 "Đặt offset cuộn của một widget ScrollView. Cả `x` và `y` đều tính theo điểm "
 "(points)."
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -63115,12 +63425,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# Bắn vào ngẫu nhiên mỗi 200ms"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -63260,12 +63567,16 @@ msgstr ""
 "Wi-Fi) hoặc dùng `iproxy` từ `libimobiledevice`:"
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# Cài đặt và khởi động qua Xcode/devicectl"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "IP của:"
+#, fuzzy
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -63292,7 +63603,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# Gói vào APK và cài đặt"
 
 #: src/testing/geisterhand.md:381
@@ -63300,7 +63612,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "Cài đặt các thư viện phát triển GTK4 trước:"
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -63324,15 +63637,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "Một kiểm thử end-to-end đơn giản dùng bash:"
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# Xây dựng bằng tay linh hồn"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# Khởi động ứng dụng trong nền"
 
 #: src/testing/geisterhand.md:419
@@ -63344,33 +63660,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"tử $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# Chờ cho ứng dụng sẵn sàng"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# Nhận widget"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# Tìm nút ghi \"Submit\""
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr ""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# Nhấp vào nó"
 
 #: src/testing/geisterhand.md:436
@@ -63378,7 +63698,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# Chụp ảnh màn hình sau khi tương tác"
 
 #: src/testing/geisterhand.md:441
@@ -63390,7 +63711,8 @@ msgid "Python Test Example"
 msgstr "Ví dụ kiểm thử bằng Python"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# Khởi động ứng dụng"
 
 #: src/testing/geisterhand.md:450
@@ -63398,11 +63720,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# Chờ khởi động"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# Các tiện ích danh sách"
 
 #: src/testing/geisterhand.md:455
@@ -63410,11 +63734,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# Tìm widget theo nhãn"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# Nhập vào trường văn bản đầu"
 
 #: src/testing/geisterhand.md:464
@@ -63434,7 +63760,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# Nhấp vào nút đầu tiên"
 
 #: src/testing/geisterhand.md:470
@@ -63442,7 +63769,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# Chụp ảnh màn hình để khôi phục hình ảnh"
 
 #: src/testing/geisterhand.md:473
@@ -63458,7 +63786,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# Đảm bảo ứng dụng vẫn còn hoạt động"
 
 #: src/testing/geisterhand.md:478
@@ -63490,40 +63819,14 @@ msgstr ""
 "bất thường:"
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# Xây dựng và phóng"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# Bắt đầu hỗn loạn hung hăng (mỗi 50ms)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# Để nó chạy trong 30 giây"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# Kiểm tra số liệu thống kê"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# {\"running\":true, \"events_fired\":600, \"uptime_secs\":30}"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# Chụp ảnh màn hình để xem trạng thái cuối cùng"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# Ngừng hỗn loạn"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# Kiểm tra ứng dụng vẫn còn hoạt động"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -63536,11 +63839,13 @@ msgstr ""
 "Chụp ảnh màn hình tại các điểm tương tác then chốt và so sánh với baseline:"
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# Trạng thái ban đầu"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -63548,24 +63853,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# Lấy sau khi tương tác"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# So sánh (sử dụng ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "Tích hợp pipeline CI"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# Ví dụ về hành động GitHub"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# Ví dụ GitHub Actions\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -63614,7 +63921,8 @@ msgid "Run UI tests"
 msgstr "Chạy kiểm thử UI"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# Chạy kịch bản thử nghiệm của bạn"
 
 #: src/testing/geisterhand.md:568
@@ -63792,20 +64100,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "Sau khi biên dịch với `--enable-geisterhand` và chạy:"
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# Xem tất cả các widget tương tác"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   {\"đàm\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
 
@@ -63814,8 +64125,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   {\"đàm\": 6,\"widget_type\" 2,\"callback_kind\" 1,\"đánh dấu\":\"\"},"
 
@@ -63824,19 +64136,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# Nhấp vào Increment 3 lần"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# Nhãn trên mặt đếm hiện hiển thị \"Đếm: 3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# Nhập tên"
 
 #: src/testing/geisterhand.md:669
@@ -63844,7 +64159,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# Đặt thanh trượt lên 80%"
 
 #: src/testing/geisterhand.md:672
@@ -63852,11 +64168,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# Bật chế độ tối"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -64164,16 +64482,13 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr "Nếu auto-build thất bại hoặc bạn muốn cross-compile thủ công:"
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# Xây dựng Geisterhand libs cho macOS"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# Xây dựng cho iOS (cross compile)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -64362,15 +64677,18 @@ msgstr ""
 "+ run. Hẹp thêm:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# một vài module"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# chỉ xuất khẩu này"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# Mẫu kết hợp mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -64390,15 +64708,18 @@ msgid "Full sweep and the CI gate"
 msgstr "Quét toàn bộ và cổng CI"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# Toàn bộ ma trận + bảng tóm tắt"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# Điểm ra số 1 về hồi quy so với đường cơ bản"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# viết lại đường cơ sở cam kết"
 
 #: src/testing/node-compat-matrix.md:43
@@ -64682,7 +65003,7 @@ msgstr ""
 "`needs: plan` và được kiểm soát bởi `fromJSON(needs.plan.outputs.plan).jobs."
 "<name>`."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -64778,11 +65099,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -64807,94 +65128,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6 lần nhanh hơn"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "3 lần nhanh"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8x đầy đủ"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "Chỉ có deps"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "Trong **v** cấp danh sách thay đổi tập tin thu hẹp kế hoạch thêm:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -64903,7 +65237,7 @@ msgstr ""
 "`packaging/`, `.claude/`, ...  xem `NON_CORE_GLOBS` trong `ci_plan.py`) → "
 "chỉ chạy `lint`."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
@@ -64911,7 +65245,7 @@ msgstr ""
 "**lõi** (bất cứ điều gì có thể thay đổi trình biên dịch, thời gian chạy, "
 "hoặc kết quả kiểm tra) → toàn bộ tầng PR."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -64920,7 +65254,7 @@ msgstr ""
 "`skills/`, ...) → thêm vào đó là luồng công việc tái sử dụng `security-"
 "audit`."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -64935,7 +65269,7 @@ msgstr ""
 "hiện trong HIR, biến đổi hoặc phụ thuộc khác mà không cần thêm thiết lập "
 "Rust vào PR chỉ docs."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -64945,11 +65279,11 @@ msgstr ""
 "`plan` thất bại thất bại cổng hoàn toàn  một kế hoạch bị hỏng không bao giờ "
 "phải biến thành \"mọi thứ bỏ qua, do đó xanh lá cây\"."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "Tại sao nó trông như thế này (đánh giá 2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -64962,13 +65296,13 @@ msgstr ""
 "chạy**, và `main` thấy ~ 66 PR đẩy và ~ 58 hợp nhất một ngày. Đó là 1.52 × "
 "tổng công suất, vì vậy:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr ""
 "Thời gian chờ đợi trong hàng đợi công việc là 37h (`conformance-smoke` "
 "shards: median 4h);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -64976,7 +65310,7 @@ msgstr ""
 "**0 trong số 66** PR chạy của luồng công việc `Tests` đạt đến kết luận trong "
 "cửa sổ mẫu  8 thất bại, 56 đã bị hủy bởi lần đẩy tiếp theo;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -64988,7 +65322,7 @@ msgstr ""
 "đỏ trên `main` trong nhiều ngày, vì vậy **mỗi một trong 12 lần sáp nhập cuối "
 "cùng là một bypass quản trị** với `lint` và `cargo-test` vẫn đang xếp hàng."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -65003,11 +65337,11 @@ msgstr ""
 "sách ngữ cảnh yêu cầu phân mảnh bằng fan-in `pr-gate` duy nhất được mô tả ở "
 "trên."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "Hai chi phí cụ thể chiếm ưu thế:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -65028,7 +65362,7 @@ msgstr ""
 "8 phần được giữ ở cấp đầy đủ bởi vì nó là cánh tay duy nhất nhìn thấy lỗi "
 "liên kết tối ưu hóa tự động."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -65043,7 +65377,19 @@ msgstr ""
 "chính mới nhất. `cache-warm.yml` đã biến mất: việc quét là xây dựng sản xuất "
 "bộ nhớ cache trên `main`."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -65066,75 +65412,75 @@ msgstr ""
 "nhãn vẫn nhận được một run của mỗi  với mỗi công việc bỏ qua, mà không có "
 "chi phí chỗ chạy."
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "Công việc điển hình"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "phút chạy điển hình"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "đồng hồ tường mục tiêu"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "pr (core)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6 mảnh vỡ)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "≤ 30 phút khi xếp hàng"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "pr (chỉ cho tài liệu)"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 phút"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "không phải mục tiêu  nó hợp nhất"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "Không phải mục tiêu"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -65163,11 +65509,20 @@ msgstr ""
 "gán lỗi quét là theo cửa sổ (`previous sweep SHA .. this sweep SHA`), chính "
 "xác như các cổng sáu giờ."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "Chọn một PR vào nhiều hơn"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -65181,7 +65536,7 @@ msgstr ""
 "đến một bộ cấp đầy đủ. Áp dụng nhãn sẽ khởi động lại các chạy (`labeled` "
 "kích hoạt)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -65189,7 +65544,7 @@ msgstr ""
 "**`skip-changelog` nhãn** bỏ qua bước thay đổi trong `lint` (một thay đổi "
 "`crates/` phải thêm một mảnh `changelog.d/<PR>-<slug>.md`)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -65197,11 +65552,11 @@ msgstr ""
 "**`workflow_dispatch`** trên bất kỳ chi nhánh nào: `tier` (`pr` / `sweep` / "
 "`full`) và `update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "Đặt lại cơ sở của khoảng cách"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -65214,15 +65569,17 @@ msgstr ""
 "loại, một thay đổi Oracle), tái tạo nó **từ CI**, không phải từ máy tính "
 "xách tay (đường chuẩn bắt buộc là chế độ Linux, `fast`):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# chờ đến khi chạy, sau đó:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# điền vào `issue` / `reason` cho mỗi mục mới, sau đó commit"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -65232,11 +65589,11 @@ msgstr ""
 "lý do trước khi sáp nhập. Một vụ tai nạn không bao giờ được đỗ trong ảnh "
 "chụp tức thời (`run_gap_tests.sh` từ chối)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "Bảo vệ nhánh"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -65252,11 +65609,11 @@ msgstr ""
 "ra kết quả _ hoàn thành_ trong ngân sách của nó; việc chạy của cổng tự nó "
 "mang theo cho dù kết quả đó đã vượt qua hoặc thất bại."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -65268,7 +65625,7 @@ msgstr ""
 "gate`** job succeeded  một green sweep hoặc PR-tier run trên cùng một SHA "
 "không được tính. Xem [Releasing](../contributing/releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -65284,6 +65641,173 @@ msgstr ""
 "trận mỗi mô-đun chạy một lần trong `parity-aggregate` trên báo cáo hợp nhất "
 "(`scripts/parity_report_merge.py`, từ chối một mảnh bị thiếu thay vì thu hẹp "
 "bộ)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "Một tấm séc gửi đi"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "Chạy nó tại địa phương với:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"định lệnh\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -65406,37 +65930,13 @@ msgid "Reproduce the core of it with:"
 msgstr "Tái tạo lõi của nó với:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# Những gì thực sự đang chạy, repo-wide, ở cấp độ công việc:"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr ""
-"\"công việc\" | select(.status==\"in_progress\") | (tick)|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# Đường đợi sâu như thế nào, và trên những hồ bơi nào:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "\"công việc\" | select(.status==\"queued\") | (tick)|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -65624,24 +66124,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# không thay đổi  mỗi PR vẫn được đo"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # lắc lư; xem bảng dưới đây"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -65652,12 +66150,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# phát hành giữ riêng biệt"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -65934,11 +66431,13 @@ msgstr ""
 "gọi mà bỏ qua thậm chí một trong năm không phải là."
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# chứng minh nó vẫn có thể thất bại"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# API thực sự, không có vấn đề viết"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -65973,10 +66472,49 @@ msgstr ""
 "gì được thử."
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "Hàng đợi trước lịch trình (# 7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
@@ -65984,57 +66522,57 @@ msgstr ""
 "Một cuộc quét sáu giờ một lần chỉ giúp ích nếu hàng đợi bị cạn kiệt nhanh "
 "hơn sáu giờ. Vào ngày 12/8/2026, nó đã không, và lý do không phải là cổng:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "chạy xếp hàng"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "Các hoạt động đồng thời được quan sát"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "xếp hàng theo sự kiện"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "các nhánh đầu khác nhau giữa các lần chạy PR xếp hàng"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**nhánh vẫn tồn tại**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -66050,11 +66588,12 @@ msgstr ""
 "trước mười cổng `main` không hoàn thành trong 32 + giờ. Không có một lượng "
 "lịch trình nào phục hồi từ đó; rác thải phải được loại bỏ."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -66070,7 +66609,7 @@ msgstr ""
 "nhánh, đó là những gì giữ cho fork PR an toàn  nhánh đầu của fork không bao "
 "giờ xuất hiện trong các ref của repo này."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -66082,13 +66621,13 @@ msgstr ""
 "tiên là một `python3 scripts/reap_stale_ci_runs.py --apply` thủ công (đi "
 "chạy khô là mặc định); lịch trình giữ cho nó rõ ràng sau đó."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr "Tại sao \"cổng đã tối\" không giống như \"cổng sẽ bắt nó\""
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -66099,7 +66638,7 @@ msgstr ""
 "khi `gc-ratchet` tối. Kết luận hấp dẫn  cổng đen cho nó đi qua  không tồn "
 "tại kiểm tra, và ghi lại lý do tại sao quan trọng hơn sự cố:"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -66111,7 +66650,7 @@ msgstr ""
 "tìm thấy \\#7965 (`collection_kind: \"full\"` đi 0 → 2) không phải là một "
 "trong số đó. Không có cổng trong repo ratchets một collection-_kind_ count."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -66122,7 +66661,7 @@ msgstr ""
 "ràng trong các chạy CI hồ sơ `shared_ci`, với lý do được ghi lại trong "
 "`tolerances.json`. Chúng chỉ dùng `pinned_host` mà CI không bao giờ dùng."
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -66130,7 +66669,7 @@ msgstr ""
 "Các khối lượng công việc cho thấy nó (`retain`, `deeplist`, ...) là tập thể "
 "trao đổi gc, chứ không phải 14 đầu dò cố định của `gc-ratchet`."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -66352,14 +66891,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "Biên dịch TypeScript thành executable native."
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# Hoặc viết tắt:"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "Cờ"
 
@@ -66388,7 +66928,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable` (mặc định) hoặc `dylib` (plugin)"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -66396,7 +66936,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "In biểu diễn trung gian HIR"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -66408,7 +66948,7 @@ msgstr ""
 "Chỉ tạo đối tượng file (s), bỏ qua liên kết; viết vào `-o` (xem [Cờ trình "
 "biên dịch](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -66416,7 +66956,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "Giữ lại các file `.o` và `.asm`"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -66424,7 +66964,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "Bật fallback runtime V8 JavaScript"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -66436,8 +66976,8 @@ msgstr ""
 "Bắt buộc liên kết runtime WebAssembly wasmi (tự động phát hiện khi sử dụng "
 "`WebAssembly.*`)"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -66445,15 +66985,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "Bật kiểm tra kiểu thông qua tsgo"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "Minify và obfuscate output (tự động bật cho `--target web`)"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -66461,7 +67001,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID (bắt buộc cho các target widget)"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -66470,23 +67010,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "Bundle các extension TypeScript từ thư mục"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# Bộ sưu tập cơ bản"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# Cross-compile cho iOS Simulator"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# Xây dựng plugin"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# Debug: xem đại diện trung gian"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# Xây dựng một tiện ích iOS"
 
 #: src/cli/commands.md:82
@@ -66494,23 +67039,28 @@ msgid "Compile and launch your app in one step."
 msgstr "Biên dịch và khởi chạy ứng dụng của bạn trong một bước."
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# Tự động phát hiện tệp nhập"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# Chạy trên iOS device/simulator"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# Chạy trên Apple Vision Pro simulator/device"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# Chạy trên thiết bị Android"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# Chuyển tiếp args đến chương trình của bạn"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -66644,19 +67194,23 @@ msgstr ""
 "đi theo một trong hai đường."
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# Chạy một chương trình CLI"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# Chạy trên một trình mô phỏng cụ thể"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# Lực lượng từ xa tạo"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# Chạy mục tiêu web"
 
 #: src/cli/commands.md:131
@@ -66672,19 +67226,23 @@ msgstr ""
 "lại sau mỗi lần lưu."
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# xem + xây dựng lại + khởi động lại trên lưu"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# Args phía trước cho đứa trẻ"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# xem một thư mục bổ sung"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# đường dẫn đầu ra"
 
 #: src/cli/commands.md:144
@@ -66826,7 +67384,7 @@ msgstr ""
 "Bảo toàn state giữa các lần build lại / HMR — \"khởi động lại nhanh\" là mục "
 "tiêu trung thực."
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -66892,19 +67450,23 @@ msgid "Include medium-confidence fixes"
 msgstr "Bao gồm các bản sửa lỗi có độ tin cậy trung bình"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# Kiểm tra một tệp duy nhất"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# Kiểm tra với phân tích phụ thuộc"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# Các vấn đề tự động sửa chữa"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# Chọn sửa trước mà không áp dụng"
 
 #: src/cli/commands.md:207
@@ -67198,27 +67760,33 @@ msgstr ""
 "với thiết lập toolchain cho Windows."
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# Hiển thị menu nền tảng"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# macOS thiết lập (đăng ký thông tin)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# iOS thiết lập (đăng ký thông tin)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# visionOS thiết lập (đăng ký thông tin)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# Android thiết lập (đăng ký thông tin)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows toolchain (tải xuống MS CRT + Windows SDK thông qua xwin)"
 
 #: src/cli/commands.md:318
@@ -67248,19 +67816,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# Cập nhật đến mới nhất"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# Kiểm tra mà không cài đặt"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# Bỏ qua câu trả lời được lưu trữ"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# Lưu cách cập nhật nên cư xử, sau đó thoát"
 
 #: src/cli/commands.md:333
@@ -67278,7 +67850,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` viết `[update] mode` vào `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -67390,14 +67962,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "Tạo khung cho một package native-bindings mới:"
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"Native bindings cho libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\"'"
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -67934,10 +68498,21 @@ msgstr ""
 "đối tượng."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
@@ -67945,16 +68520,16 @@ msgstr ""
 "Chọn Linux libc/linkage; `musl` nâng cấp mục tiêu Linux tương ứng thành một "
 "bản xây dựng không đầu hoàn toàn tĩnh."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "Nhãn số cụm được yêu cầu bởi các mục tiêu widget màn hình chính."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "Khám phá và liên kết các gói mở rộng gốc từ thư mục."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
@@ -67962,22 +68537,22 @@ msgstr ""
 "Chạy trình kiểm tra TypeScript gốc (`@typescript/native-preview`) trước "
 "codegen."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr ""
 "Thiết lập tầng tương thích Windows PE; bỏ qua đối với các mục tiêu không "
 "phải Windows."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
@@ -67985,11 +68560,11 @@ msgstr ""
 "Chọn hệ thống con Windows PE thay vì dựa vào phát hiện tự động dựa trên nhập "
 "khẩu."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
@@ -67997,11 +68572,11 @@ msgstr ""
 "Đối với các mục tiêu widget Apple, phát ra nguồn và siêu dữ liệu SwiftUI mà "
 "không gọi `swiftc`."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
@@ -68009,35 +68584,68 @@ msgstr ""
 "Chọn HarmonyOS HAP ký tài liệu. Ưu tiên các nguồn environment/config tương "
 "ứng cho bí mật."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS chuỗi chứng chỉ ứng dụng."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "HarmonyOS đã ký hồ sơ cung cấp."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS keystore alias; mặc định là `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — module"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "Tích hợp tài sản"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -68046,11 +68654,11 @@ msgstr ""
 "trình thực thi độc lập để nó chạy mà không có tệp bên ngoài trên đĩa (# "
 "5731)."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -68060,11 +68668,23 @@ msgstr ""
 "Repeatable. Kết hợp với `perry.embed` (package.json) và `[compile] embed` "
 "(perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -68072,19 +68692,20 @@ msgstr ""
 "Tạo một mô-đun ảo mà mặc định xuất bản bản đồ mỗi tệp dưới `dir` đến một xử "
 "lý `$perryfs` ổn định. Có thể lặp lại; các bản đồ nguồn được loại trừ."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# phục vụ dist/ từ bộ nhớ  không cần dist/ thư mục"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "Các tệp nhúng có thể truy cập vào thời gian chạy theo ba cách:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -68116,7 +68737,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -68128,7 +68749,7 @@ msgstr ""
 "`readEmbedded(path)` và `node:fs` chấp nhận đường dẫn ảo `$perryfs/<path>` "
 "hoặc khóa tương đối nhúng."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -68136,7 +68757,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -68146,7 +68767,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -68159,7 +68808,7 @@ msgstr ""
 "xếp hành trình thư mục, bảo tồn mỗi cạnh `{ type: \"file\" }` và giữ nguồn "
 "được tạo trong bộ nhớ cache của nó thay vì sửa đổi thanh toán."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -68167,11 +68816,7 @@ msgstr ""
 "Đối với biểu đồ nguồn OpenCode được gắn, hãy xây dựng giao diện người dùng "
 "web phía trên trước, sau đó biên dịch từ nguồn gói của `packages/opencode`:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -68185,7 +68830,7 @@ msgstr ""
 "nhập khẩu chưa được giải quyết. Chạy lệnh chuẩn bị cho mỗi sửa đổi nguồn để "
 "các đầu vào được tạo ra không thể bị lỗi thời."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -68197,7 +68842,7 @@ msgstr ""
 "bộ xử lý gói, nguồn gốc liên quan đến dự án, kích thước byte, tổng hợp "
 "SHA-256 và mô-đun tài sản tạo nếu có."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -68212,7 +68857,7 @@ msgstr ""
 "tuyệt đối, và sử dụng dạng `$perryfs/<path>` rõ ràng khi bạn đặc biệt có "
 "nghĩa là bản sao nhúng."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -68224,19 +68869,19 @@ msgstr ""
 "clang phù hợp không phải là đầu tiên trên `PATH`. Việc nhúng mục tiêu chéo "
 "hiện không được hỗ trợ."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "Cờ Debug"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "In HIR (biểu diễn trung gian) ra stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -68245,11 +68890,11 @@ msgstr ""
 "phẩy: `hir` (HIR sau khi transform), `llvm` (mỗi module `.ll` vào `.perry-"
 "trace/llvm/`), hoặc `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -68259,7 +68904,7 @@ msgstr ""
 "`NAME`, loại bỏ các thông tin import/export/init. Ngụ ý `--trace hir` nếu "
 "không có giai đoạn nào được chỉ định"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -68273,11 +68918,11 @@ msgstr ""
 "tên cho nhiều tệp. Nếu không có `-o` chúng sẽ rơi vào thư mục hiện tại. Mỗi "
 "đường dẫn được in dưới dạng `Wrote object file: <path>`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -68287,47 +68932,47 @@ msgstr ""
 "dùng `PERRY_SKIP_CODEGEN=1`). Xem [Cấu hình dự án](../getting-started/"
 "project-config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "Giữ lại các file trung gian `.o` và `.asm`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr ""
 "Giữ symbols/DWARF (và phát ra một PDB Windows) thay vì loại bỏ kết quả."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr ""
 "Tắt cache đối tượng mỗi mô-đun cho bản xây dựng này; cũng là "
 "`PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr ""
 "Bỏ bỏ gốc bộ nhớ cache cục bộ máy; xem [Thư mục bộ nhớ đệm](cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
@@ -68335,28 +68980,28 @@ msgstr ""
 "Chạy bản địa đại diện giảm biến cố và buộc codegen thay vì tái sử dụng bộ "
 "nhớ cache."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr "Khóa Buffer/Uint8Array load/store hạ bản địa để chẩn đoán A/B."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr "Phát hành báo cáo bằng chứng loại giảm; ngụ ý xác minh khu vực gốc."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -68366,11 +69011,11 @@ msgstr ""
 "thể sửa nó. Văn bản theo mặc định; `--opt-report=json` phát ra một sơ đồ ổn "
 "định cho công cụ. Cũng có thể cài đặt thông qua `PERRY_OPT_REPORT=1`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -68383,7 +69028,7 @@ msgstr ""
 "gốc gốc (phương thức stack-map đơn giản và explicit-bridge cũng được đặt tên "
 "đã biến mất)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -68399,11 +69044,11 @@ msgstr ""
 "llvm` buộc recompile toàn bộ (cache object thường bỏ qua codegen cho các "
 "module không thay đổi, khiến thư mục trace trống)."
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report`  tại sao một giá trị vẫn được đặt trong hộp"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -68421,11 +69066,11 @@ msgstr ""
 "xét: nó in những gì đã được chứng minh, những gì không, và quy tắc nào đã "
 "thực hiện cuộc gọi."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "Mỗi giá trị bị từ chối mang theo:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -68435,7 +69080,7 @@ msgstr ""
 "cái đối tượng không bao giờ bị ràng buộc với một ngôn ngữ địa phương, ngôn "
 "ngữ `.map(x => ({...}))`)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
@@ -68443,7 +69088,7 @@ msgstr ""
 "**Nguyên tắc từ chối nó**, trong số của nhà sưu tập, vì vậy bạn có thể kiểm "
 "tra nó với tên tập tin nguồn."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -68455,7 +69100,7 @@ msgstr ""
 "không hành động), hoặc _Perry giới hạn_ (không phải là mã của bạn; tên vấn "
 "đề theo dõi nơi có một)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -68470,7 +69115,7 @@ msgstr ""
 "một lần mỗi phần tử, vì vậy chiều sâu vòng lặp duy nhất xếp hạng cuối cùng. "
 "Cũng không phải là một hồ sơ  họ là proxy tĩnh."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
@@ -68478,7 +69123,7 @@ msgstr ""
 "Những chiến thắng được báo cáo cùng với những thất bại, vì vậy tỷ lệ được "
 "nhìn thấy chứ không chỉ là những khiếu nại."
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -68493,7 +69138,7 @@ msgstr ""
 "không bao giờ trộn vào một tải `--format json` hoặc đầu ra của chương trình "
 "của bạn."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -68507,15 +69152,15 @@ msgstr ""
 "JSON của hai build khác nhau là một kiểm tra CI rẻ tiền chống lại một đại "
 "diện âm thầm lùi xuống bằng không."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "Tối ưu hóa Đầu ra"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -68536,11 +69181,11 @@ msgstr ""
 "native_tuning = false` là viết tắt của `generic`. Áp dụng cho mã ứng dụng và "
 "tự động tối ưu hóa runtime/stdlib xây dựng lại."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
@@ -68548,11 +69193,11 @@ msgstr ""
 "Định nghĩa các hằng số `__feature_NAME__` phân tách bằng dấu phẩy trong thời "
 "gian biên dịch để loại bỏ mã chết."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
@@ -68560,24 +69205,24 @@ msgstr ""
 "Sử dụng toàn bộ runtime/stdlib được xây dựng sẵn thay vì xây dựng lại bộ "
 "tính năng nhỏ nhất có thể tiếp cận."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr "Cho phép liên kết lại dấu phẩy động; xem [Fast-math](fast-math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "Kiểm soát hợp nhất tăng thêm co thắt riêng biệt từ tái liên kết."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -68585,11 +69230,11 @@ msgstr ""
 "Việc thu gọn (minification) loại bỏ comment, dồn khoảng trắng, và mã hóa tên "
 "biến cục bộ/tham số/hàm không export để có đầu ra nhỏ hơn."
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "Xây dựng tối ưu hóa kích thước"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -68601,11 +69246,11 @@ msgstr ""
 "kích thước thay vì tốc độ (chúng yêu cầu kiểm tra không gian làm việc Perry, "
 "giống như phần còn lại của tối ưu hóa tự động):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -68618,11 +69263,11 @@ msgstr ""
 "hơn). Các tệp lưu trữ tối ưu hóa kích thước và bình thường được lưu trữ bộ "
 "nhớ đệm độc lập."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -68631,11 +69276,11 @@ msgstr ""
 "lại (tái xây dựng chậm hơn, nhị phân nhỏ hơn). Chỉ có ý nghĩa cùng với "
 "`PERRY_SIZE_OPT`."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -68653,7 +69298,7 @@ msgstr ""
 "đó bị hủy bỏ mà không có dấu hiệu ngược  JS `throw`/`catch`, `finally`, "
 "chồng lỗi và `uncaughtException` không bị ảnh hưởng."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -68665,15 +69310,15 @@ msgstr ""
 "`PERRY_SIZE_PANIC=abort-immediate`. Các chương trình sử dụng nhiều thời gian "
 "chạy lại co lại ít hơn, tương ứng."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "Cờ Kiểm thử"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -68681,26 +69326,26 @@ msgstr ""
 "Nhúng máy chủ HTTP [Geisterhand](../testing/geisterhand.md) để kiểm thử UI "
 "bằng chương trình (cổng mặc định 7676)"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr ""
 "Đặt cổng tùy chỉnh cho máy chủ Geisterhand (mặc định bao hàm `--enable-"
 "geisterhand`)"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "Cờ Runtime"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "Bật runtime JavaScript V8 cho các package npm không được hỗ trợ"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -68710,15 +69355,15 @@ msgstr ""
 "`WebAssembly.*` được tham chiếu; chỉ cần thiết khi tải qua dlopen / FFI mà "
 "không có tham chiếu tĩnh)"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "Bật kiểm tra kiểu qua IPC tsgo"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -68735,11 +69380,11 @@ msgstr ""
 "(package.json hoặc perry.toml). `PERRY_ALLOW_EVAL=1` buộc nó phải tắt. Xem "
 "[Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -68763,11 +69408,11 @@ msgstr ""
 "không bị ảnh hưởng. Xem [Limitations](../language/limitations.md#no-eval-or-"
 "dynamic-code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -68776,22 +69421,22 @@ msgstr ""
 "nhưng chưa thực hiện được tham chiếu thay vì phát ra lỗi thời gian chạy trì "
 "hoãn."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr ""
 "Phát ra `<binary>.attest.json`; xem [Chứng nhận nhị phân](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr ""
 "Phân phối xe bên sandbox nền tảng; xem [Hồ sơ hộp cát](emit-sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
@@ -68799,31 +69444,31 @@ msgstr ""
 "Từ chối các bề mặt thực thi mã tùy ý có thể đạt được; xem [Lockdown]"
 "(lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "Biến Môi trường"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "Khóa license Perry Hub cho `perry publish`"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr "Mật khẩu cho chứng chỉ .p12"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -68831,61 +69476,61 @@ msgstr ""
 "Đường chuẩn CPU cho mã máy được tạo (tương tự giá trị như `--march`; cờ và "
 "perry.toml `[build] march` thắng hơn môi trường)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "Vô hiệu hóa kiểm tra cập nhật tự động"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "Tương tự, sử dụng toàn hệ sinh thái chính tả"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr ""
 "`off`/`notify`/`prompt`/`auto` cho một lần chạy  xem [Updates](updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "URL máy chủ cập nhật tùy chỉnh"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr ""
 "Tự động bỏ qua kiểm tra cập nhật (được đặt bởi hầu hết các hệ thống CI)"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "Mức độ ghi log debug (`debug`, `info`, `trace`)"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -68893,7 +69538,7 @@ msgstr ""
 "`1`/`text` hoặc `json`  giống như `--opt-report[=json]`, để điều khiển báo "
 "cáo từ môi trường mà việc thêm một biểu tượng là khó khăn"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -68907,15 +69552,15 @@ msgstr ""
 "đọc như đầu vào của người dùng  nó là một GC env nút thứ năm không có CI "
 "cánh tay, và đã được xóa theo chính sách GC nút giết CLAUDE.md."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "File Cấu hình"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml (dự án)"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -68995,11 +69640,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml (toàn cục)"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -69021,57 +69666,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# Chương trình CLI đơn giản"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# Ứng dụng iOS cho mô phỏng"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# Ứng dụng visionOS cho mô phỏng"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# Ứng dụng web (WASM với cầu DOM  biệt danh: --target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# Thư viện chia sẻ plugin"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# iOS widget với ID gói"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# Debug compilation"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# Bộ sưu tập từ ngữ"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# Việc biên soạn được kiểm tra kiểu"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# Raw WASM nhị phân (không có HTML wrapper)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# Khả năng xuất web nhỏ (nén cầu nối JS nhúng)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[Lệnh](commands.md) — Tất cả các lệnh CLI"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[Tổng quan Nền tảng](../platforms/overview.md) — Các target nền tảng"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"Mô-đun\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "Định dạng cache"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"Mô-đun\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"nguồn\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "\"Lodash\""
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"mục tiêu\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"công việc\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"pháp\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -69311,15 +70152,18 @@ msgid "CLI flag wins over env var, env var wins over package.json:"
 msgstr "Cờ CLI thắng biến môi trường, biến môi trường thắng package.json:"
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. Dấu hiệu CLI mỗi phiên bản"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. Môi trường mỗi lớp"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. Theo dự án package.json (thường gặp nhất)"
 
 #: src/cli/fast-math.md:35
@@ -69335,18 +70179,21 @@ msgid "Contraction is separate from reassociation:"
 msgstr "Co rút tách biệt với tái liên kết (reassociation):"
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# Chỉ cho phép co thắt FMA."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr ""
 "# Cho phép chế độ co thắt mạnh nhất của frontend mà không cần liên kết lại."
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# Giữ liên kết lại từ --fast-math nhưng chặn sự co thắt của FMA."
 
 #: src/cli/fast-math.md:55
@@ -70342,7 +71189,8 @@ msgid "Emit"
 msgstr "Phát hành"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -70429,7 +71277,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"kích thước\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -71644,10 +72492,6 @@ msgstr ""
 msgid "produces:"
 msgstr "tạo ra:"
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"Mô-đun\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -71731,9 +72575,10 @@ msgstr ""
 "được báo cáo dưới `<host source>`."
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "Trả về một lỗi rõ ràng nếu bản trình bày chưa tồn tại  `perry  compile` hoặc "
 "`perry run` viết nó trên mỗi bản dựng thành công."
@@ -73885,7 +74730,7 @@ msgstr ""
 msgid "Setting"
 msgstr "Thiết lập"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "Tệp"
 
@@ -73969,15 +74814,18 @@ msgstr ""
 "ghi chúng trở lại cả `perry.toml` và `~/.perry/config.toml`:"
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# Thiết lập chữ ký iOS (chứng chỉ, hồ sơ provisioning)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# Thiết lập chữ ký Android (keystore, Play Store key)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# Thiết lập phân phối macOS (App Store, chứng thực công chứng)"
 
 #: src/cli/perry-toml.md:605
@@ -74014,8 +74862,11 @@ msgstr ""
 "xác thực trong `perry.toml`:"
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# Ví dụ về hành động GitHub"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -75258,20 +76109,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Tàu Perry **hai kênh chọn tham gia độc lập** để gửi dữ liệu về nhà  không có "
-"gì rời máy tính của bạn mà không có một `enabled = true` hoặc `on` rõ ràng "
-"trong `~/.perry/config.toml`. Cả hai đều tôn trọng `PERRY_NO_TELEMETRY=1` và "
-"`CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. Phân tích sử dụng chung  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. Phân tích sử dụng chung  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -75281,14 +76132,16 @@ msgstr ""
 "POST. Gửi: tên lệnh, nền tảng (`darwin`/`linux`/...), phiên bản Perry, trạng "
 "thái success/error và UUID khách hàng ẩn danh."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. Báo cáo tương thích  `telemetry.compatibility_reports` (# 849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -75299,17 +76152,17 @@ msgstr ""
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "Ba chế độ:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr ""
 "`off`  không bao giờ gửi. Thủy thủng thậm chí còn không được lắp đặt, không "
 "có chi phí."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -75317,99 +76170,99 @@ msgstr ""
 "`ask` (bên mặc định)  khi kích hoạt chẩn đoán đủ điều kiện, nhắc một lần mỗi "
 "phiên: `[y] just this once / [a] always / [n] not this time / [N] never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  luôn gửi (sau khi dedup + redaction). Không có lời nhắc."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**Những gì được gửi (toàn bộ sơ đồ tải trọng):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"mã\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"Phân loại\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"Lỗ hổng-thể loại\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"bước\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"giảm cao hơn\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"người trang trí\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"node:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"os\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"Darwin-arm64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -75426,7 +76279,7 @@ msgstr ""
 "`<id1>`, `<id2>`, giới hạn 200 ký tự, với việc từ chối cứng nếu bất kỳ biến "
 "thể nào thất bại."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -75434,32 +76287,36 @@ msgstr ""
 "Một bộ nhớ cache dedup 30 ngày tại `~/.perry/.report-cache` ngăn chặn việc "
 "gửi lại cùng một `snippet_hash` trên mỗi lần nạp lại."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "Kiểm tra và quản lý"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# hiển thị chế độ hiện tại, sent/queued đếm"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# in sửa tải hữu ích xếp hàng chờ chạy này"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# xóa bộ nhớ cache dedup 30 ngày"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "Để từ chối ở cấp file, chỉnh sửa `~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -75468,7 +76325,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -75715,15 +76572,18 @@ msgstr ""
 "byte (`crates/perry-runtime/src/gc/types.rs`):"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// Đánh dấu | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// Tổng phân bổ kích thước, được sử dụng cho sân vận động khối đi bộ"
 
 #: src/internals/memory-model.md:69
@@ -76059,7 +76919,7 @@ msgstr ""
 "runtime exact helper barrier tại runtime cho mục đích benchmark/debug "
 "bisection. Khi không đặt, `=1`, `=on`, và `=true` giữ barrier được bật."
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -76248,10 +77108,11 @@ msgstr ""
 "retired_set=#N` trong `PERRY_GC_DIAG=1`."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -76479,10 +77340,24 @@ msgstr ""
 "những gì quá trình thực sự giữ được dưới áp lực."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "Bản đồ nguồn"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -76491,183 +77366,183 @@ msgstr ""
 "dẫn xuất, và mỗi hàng của bảng này một lần chỉ vào một `gc.rs` không còn tồn "
 "tại."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "Chủ đề"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "Biểu tượng để tìm kiếm"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "NaN-boxing tags"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`, hằng số kiểu/cờ"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "Các khung bóng (giảm gốc phục hồi)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "Các root scanner đã đăng ký"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "Phân bản nhỏ"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "Quảng cáo tại chỗ toàn bộ khối"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "Chính sách khuyến mãi"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "Mức ngưỡng thời gian làm việc thích nghi"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "Viết các rào cản"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "Đặt dấu rõ ràng"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "Tiền ngữ chân bảo thủ"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "Các thiết bị kích hoạt thu thập và cân bằng"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "Trang hoạt động hiện tại"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "Kế hoạch thiết kế (lịch sử)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -77098,12 +77973,18 @@ msgstr ""
 "heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "trên một quy trình desktop/server không bị hạn chế, quy mô đến một phần tám "
 "của ngân sách device/container với một sàn MiB. Dòng chảy tràn được trả lại "
@@ -77112,7 +77993,7 @@ msgstr ""
 "và làm trống hồ bơi khi bộ sưu tập đầy đủ hoàn thành việc phục hồi đấu "
 "trường."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -77123,101 +78004,215 @@ msgstr ""
 "dân số sống** cộng với delta gia tăng, không phải là một tổng của khối nước "
 "cao bù."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "Kiểm soát hỗ trợ"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr ""
 "Đây là các điều khiển hoạt động hữu ích nhất bên ngoài phát triển bộ sưu tập:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "Phòng lùi phân đoạn đến quét dấu hoàn toàn"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime rào cản cắt ngang; cũng lực lượng đầy đủ đánh dấu quét"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "vô hiệu hóa việc thu thập trực tiếp cho so sánh tốc độ"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "quay lại toàn bộ khối thăng tiến để sơ tán đối tượng"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "đặt nắp nhà trẻ nền"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "ghi lại ngân sách khối quá trình trong MiB"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "chọn gốc bóng trên một mục tiêu có khả năng gốc gốc"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "chẩn đoán quét đầy đủ trong bản gốc; vô hiệu hóa sao chép"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "phát ra các hồ sơ theo dõi theo chu kỳ có cấu trúc"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "phát ra các thiết bị chẩn đoán thu thập có thể đọc được bởi con người"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -77226,10 +78221,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "Năng lực bắt nguồn sử dụng `PERRY_GC_SCHEDULE_SEED`, "
 "`PERRY_GC_SCHEDULE_RATE`, `PERRY_GC_SCHEDULE_ALLOC_KB`, "
@@ -77244,7 +78240,7 @@ msgstr ""
 "`PERRY_STACKMAP_WALKER` được chấp nhận nhưng không phải là các chế độ thu "
 "thập hỗ trợ bổ sung."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -77272,11 +78268,11 @@ msgstr ""
 "đó thất bại `lint`, và thay đổi hành vi thất bại `cargo-test`; cả hai đều "
 "không thể im lặng trong khi trang này tiếp tục tuyên bố điều cũ."
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "Cơ quan xác nhận và CI"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -77288,38 +78284,38 @@ msgstr ""
 "testing/ci-tiers.md`; chính sách cấp là `scripts/ci_plan.py`). Mức bảo hiểm "
 "cụ thể cho GC được chia thành:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "nơi nó chạy"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "tình trạng cần thiết"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr ""
 "bảo vệ root-holder, GC-knob drift, và tuyên bố path/number của trang này"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "có (thông qua `pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr ""
 "bộ đơn vị thời gian chạy và ma trận bốn chế độ "
 "`run_memory_stability_tests.sh`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
@@ -77327,7 +78323,7 @@ msgstr ""
 "có (thông qua `pr-gate`; tầng PR có phạm vi khác nhau, các tầng sweep/full "
 "chạy không gian làm việc)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
@@ -77335,26 +78331,26 @@ msgstr ""
 "GC × ma trận lựa chọn đại diện, các dụng cụ root-bug, căng thẳng ngăn chặn "
 "ghi"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr ""
 "có (thông qua `pr-gate`; tập con PR trên PR, ma trận đầy đủ trong quét)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "sự thống trị gốc phát ra, bao gồm IR điểm trạng thái gốc"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
@@ -77362,27 +78358,27 @@ msgstr ""
 "không cần thiết cho chi nhánh; nhánh PR chọn thông qua `run-extended-tests`, "
 "mỗi sáu giờ trên `main`"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "Máy thu pin counters/RSS/wall ma trận"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "ngân sách thread-local mechanism/policy"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "Các lệnh trước chuyến bay hữu ích:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -77392,11 +78388,11 @@ msgstr ""
 "và máy chủ rộng hơn; tệp luồng công việc của họ là cơ quan cho các lệnh "
 "chính xác và bộ lọc liên quan."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "Bằng chứng lịch sử"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -77404,7 +78400,7 @@ msgstr ""
 "[Kế hoạch GC thế hệ](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): thiết kế ban đầu và nhật ký hạ cánh từng giai đoạn."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -77414,7 +78410,7 @@ msgstr ""
 "docs/statepoint-gc-experiment.md): các phép đo và sửa chữa nguyên mẫu theo "
 "thời gian dẫn đến mặc định gốc gốc."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -77422,7 +78418,7 @@ msgstr ""
 "[GC root invariant](gc-rooting-invariant.md): quy tắc hiệu quả mã hiện tại, "
 "chế độ kiểm tra, điểm mù được biết đến và các công cụ gỡ lỗi."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -77751,7 +78747,8 @@ msgstr ""
 "phải sửa chữa, là chi phí mỗi lần."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "5 cách mà nó thực sự bị phá vỡ"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -77907,14 +78904,55 @@ msgstr ""
 "commit."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "Cách kiểm tra công việc của bạn"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. Trình kiểm tra tĩnh  chạy cái này"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -77925,7 +78963,7 @@ msgstr ""
 "đó, nó là công cụ duy nhất nhìn thấy một khiếm khuyết trước khi nó va chạm, "
 "đó là lý do tại sao nó chạy đầu tiên."
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
@@ -77933,7 +78971,7 @@ msgstr ""
 "**Nó mù quáng với ba loại, tất cả đều tìm thấy theo cách khó khăn. Một bản "
 "báo cáo sạch sẽ không phải là bằng chứng cho bất cứ điều gì trong số đó:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -77942,7 +78980,7 @@ msgstr ""
 "và không thể nhìn thấy một tế bào thời gian chạy. Nói: thất bại 10/10 thay "
 "vì gián đoạn."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -77952,7 +78990,7 @@ msgstr ""
 "cùng một lý do. Nó đọc `0 violations` ở cả hai bên của một lỗi thực sự có "
 "sửa chữa là một dòng `GcSuppressScope` trong bootstrap `globalThis`."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -77970,7 +79008,7 @@ msgstr ""
 "đã bị loại bỏ bởi `--moving-only`. **Kiểm tra các tập hợp này so với những "
 "gì codegen thực sự phát ra, cách #7227 kiểm tra `ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -77980,7 +79018,7 @@ msgstr ""
 "quarantine bên dưới và khối lượng công việc quy mô phụ thuộc  # 7280 ghi lại "
 "25 tệp corpus được sắp xếp trong khi 20 dòng zod bị thất bại."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -77998,28 +79036,13 @@ msgstr ""
 "phải là mặc định trên bất kỳ mục tiêu khung đi bộ kể từ # 7370. **Chạy cả "
 "hai**, và biết bạn đã chạy một trong số đó:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# SHADOW (PERRY_RS4GC=0): vẫn giảm trên arm64_32 watchOS và ARM64"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# NATIVE (PERRY_RS4GC=1): mặc định ở mọi nơi khác. Lăng xích"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr ""
-"# `ptr addrspace(1)` phân bổ gốc và LLVM chèn các điểm an toàn sau đó, vì "
-"vậy các"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -78029,11 +79052,11 @@ msgstr ""
 "corpus gốc có không lưu trữ gốc, vì vậy `--min-binds` thất bại ở đó, và các "
 "corpus bóng có không điểm an toàn, vì vậy `--min-statepoints` thất bại ở đó."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "Điều gì `--statepoints` kiểm tra, và làm thế nào nó khác nhau"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -78045,7 +79068,7 @@ msgstr ""
 "safepoint là `gc.relocate` result. Vì vậy, \"cửa hàng rễ phải thống trị mọi "
 "điểm thu thập sau này\" trở thành:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
@@ -78053,7 +79076,7 @@ msgstr ""
 "Không có sổ đăng ký đặt tên đối tượng GC có thể được sử dụng dưới một điểm "
 "an toàn trừ khi nó là giá trị được di chuyển."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -78067,23 +79090,23 @@ msgstr ""
 "và Perry NaN-box, vì vậy một JSValue dành hầu hết cuộc sống của nó như là "
 "một `double`. Hai loại phán quyết, bởi vì họ có hai giải pháp khác nhau:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -78091,15 +79114,15 @@ msgstr ""
 "không có giá trị `ptr addrspace(1)` trong chuỗi đúc của sổ đăng ký trong gói "
 "trực tiếp của safepoint. Không có gì đánh dấu hoặc viết lại đối tượng."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "rễ nó"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
@@ -78107,11 +79130,11 @@ msgstr ""
 "đối tượng IS trong gói và được di chuyển, nhưng một bản sao thô của địa chỉ "
 "trước khi di chuyển của nó được sử dụng dưới đây"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "Tái dẫn xuất từ giá trị di chuyển (`OperandProtection::Reload`)"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -78127,7 +79150,7 @@ msgstr ""
 "toàn **tên của nó được bọc callee**, vì vậy `--moving-only` phân loại theo "
 "biểu tượng thực chứ không phải `llvm.experimental.gc.statepoint.p0`."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -78151,15 +79174,15 @@ msgstr ""
 "trống trong mô hình của nó chi phí một dương tính sai, không bao giờ một lỗi "
 "bỏ lỡ."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "Đối với một tệp duy nhất bạn đang lặp lại:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "Cả hai nút môi trường đều quan trọng, vì những lý do khác nhau."
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -78175,7 +79198,7 @@ msgstr ""
 "hai điểm của một cơ thể vòng tròn bất động khác không thể xuất hiện trong "
 "corpus mà không có nó."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -78197,7 +79220,7 @@ msgstr ""
 "hạn như `js_object_set_field_by_name`, `js_object_get_field_ic_miss` và "
 "`js_closure_call1`. Họ đang di chuyển mà không có cuộc thăm dò nào ở gần họ."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
@@ -78205,13 +79228,13 @@ msgstr ""
 "Vì vậy: bật nút, bởi vì nó mở rộng những gì các corpus có thể thể hiện, "
 "nhưng không đọc một poll-free chức năng an toàn."
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr ""
 "`POLL_CAPABLE_RUNTIME` là bởi EXACT phát ra biểu tượng, và đã cắn hai lần"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -78223,7 +79246,8 @@ msgstr ""
 "mãi, và trông giống như bảo hiểm trong khi làm điều đó. Hai vòng của điều "
 "này đã được đo:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -78234,7 +79258,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -78251,7 +79275,7 @@ msgstr ""
 "`clone` của zod. Người bảo vệ và người kiểm tra đã không đồng ý; người kiểm "
 "tra đã sai."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -78273,7 +79297,7 @@ msgstr ""
 "gồm không lần; các điểm đầu vào thực sự là `js_closure_callN`, mà "
 "`RECEIVER_SINKS` trong cùng một tập tin đã đánh vần chính xác."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -78293,60 +79317,60 @@ msgstr ""
 "danh sách ngắn, vì vậy hình dạng không bao giờ có thể bắt được trong chế độ "
 "CI chạy. Lập lại mã chính xác đó và chạy mọi chế độ (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (tầm ưu thế)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (sự hạ thấp mà tàu)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (không lọc)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (không lọc)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -78358,7 +79382,7 @@ msgstr ""
 "việc hạ tàu. Thêm một cái tên làm cho số vũ khí bị phá hoại lên 13 và 8 và "
 "để lại số vũ khí sạch ở 2 và 2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -78388,7 +79412,7 @@ msgstr ""
 "`POLL_CAPABLE_RUNTIME` trong cùng một cam kết.** Không có gì yêu cầu anh làm "
 "thế."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -78398,7 +79422,7 @@ msgstr ""
 "cho vòng 3; vòng 4 không có cổng. `gc-root-dominance.yml` chạy cùng với `--"
 "audit-alloc-re` trước khi xây dựng."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -78425,7 +79449,7 @@ msgstr ""
 "với ký hiệu codegen thực sự phát ra thay vì xóa nó  xóa biến kiểm toán màu "
 "xanh lá cây và rời khỏi lỗ."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -78455,19 +79479,15 @@ msgstr ""
 "được tước đi trước để tên được đề cập trong văn xuôi không thể trở thành "
 "tiền đề."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr "Kiểm tra một cái tên hợp lý là không đủ. Xác nhận so với IR phát ra:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -78475,7 +79495,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0` làm cho mỗi cửa hàng gốc gọi "
 "`js_shadow_slot_bind` hình thức checker neo trên."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -78491,7 +79511,7 @@ msgstr ""
 "đặt ra bởi danh sách phép, vì vậy trường hợp 3 và 4 chỉ nổi lên khi bạn chạy "
 "chế độ này bằng tay."
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -78507,7 +79527,7 @@ msgstr ""
 "năng sạch. Nó tìm thấy `lower_call/new.rs` của `this_slot` độc lập với bất "
 "kỳ thăm dò thời gian chạy nào."
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -78525,15 +79545,15 @@ msgstr ""
 "khe cắm bóng nào cả. Chạy nó bằng tay khi bạn chạm vào một trang web "
 "`alloca_entry`:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. Các thiết bị thời gian chạy  thứ hai, và chú ý đến độ sâu"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "Từ số 7196:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -78547,7 +79567,7 @@ msgstr ""
 "Thêm `PERRY_GC_SCHEDULE_ALLOC_KB=0` cho chế độ thực tế mỗi cuộc thăm dò khi "
 "cửa sổ bạn đang săn bắn chỉ được thực hiện một lần  nó chậm hơn nhiều."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -78555,11 +79575,12 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1`  `mprotect` từ không gian sau khi sơ tán để "
 "một lỗi đọc cũ ngay lập tức thay vì đọc rác hợp lý."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT`  giờ thực sự chạy."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -78567,7 +79588,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -78583,7 +79604,7 @@ msgstr ""
 "đó bạn có thể phân đôi. `scripts/gc_schedule_fuzz.sh <binary> [seed-count]` "
 "quét hạt giống và in lệnh tái tạo mỗi lần thất bại."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -78597,7 +79618,7 @@ msgstr ""
 "lỗi 1.7% ở 2.5%  không có bằng chứng nào cả. Sự thay đổi _when_ bộ sưu tập "
 "lửa là cách rẻ tiền duy nhất để khám phá không gian bọ thực sự sống trong."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -78609,7 +79630,7 @@ msgstr ""
 "cũ của bạn vào thời điểm nó bị loại bỏ. **Sử dụng 800.** Một lần chạy sạch ở "
 "độ sâu mặc định không có ý nghĩa gì cả."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -78636,7 +79657,7 @@ msgstr ""
 "tĩnh, nhìn vào kiểm tra đầu tiên. Đó là cách mà sự bất đồng về zod `clone` "
 "đã được giải quyết."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -78647,7 +79668,7 @@ msgstr ""
 "DEREFERENCE giá trị lỗi thời, thường không phải là khung sở hữu đăng ký  giá "
 "trị thường đến như một lập luận từ người gọi để nó trở nên lỗi thời."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -78659,11 +79680,11 @@ msgstr ""
 "điểm đó cho bất kỳ thăm dò thời gian chạy để nhận thấy. Những dụng cụ này sẽ "
 "bắt được hậu quả sau đó. Máy kiểm tra tĩnh bắt được nguyên nhân, ngay."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "Hình ảnh gương: một rào cản ghi thiếu (# 8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -78675,43 +79696,43 @@ msgstr ""
 "là đôi, và  đây là phần tiếp tục bắt người **Máy phát hiện của chúng đã được "
 "thay thế**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "rễ bọ"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted rào cản ghi"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "điều gì sai"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "một giá trị trực tiếp là vô hình cho quét gốc"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "một cạnh old→young vắng mặt trong tập hợp nhớ"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "khi mọi thứ không ổn"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "tại buổi thu thập, im lặng"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "Không phải ở cửa hàng; ở một số _thế sau_ nhỏ"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "máy dò"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -78721,30 +79742,30 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE`), cộng với trình kiểm tra tĩnh cho nửa hiển thị "
 "IR"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **khẳng định IR tĩnh**, và không có gì khác"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "điểm mù"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr ""
 "trình kiểm tra tĩnh không thể nhìn thấy bộ nhớ cache phía thời gian chạy của "
 "con trỏ heap (xem §5)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**mỗi đầu dò thời gian chạy chúng tôi có**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "Tại sao không có tàu thăm dò thời gian chạy có thể nhìn thấy nó"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -78759,16 +79780,16 @@ msgstr ""
 "một sự thất bại quan sát được cần một sự kết hợp mà chương trình phải cung "
 "cấp cho chính nó:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr "cha mẹ phải sống đến tuổi già (hoặc được thuê) **trước đây** cửa hàng;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "đứa trẻ vẫn phải ở trong phòng trẻ **ở vị trí nhỏ tiếp theo**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -78777,7 +79798,7 @@ msgstr ""
 "tất cả mọi thứ và giấy tờ trên toàn bộ lớp học  phải hạ cánh trong cửa sổ "
 "đó; và"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
@@ -78785,7 +79806,7 @@ msgstr ""
 "cạnh đó phải là con đường duy nhất đến con, hoặc một số gốc khác sẽ tìm thấy "
 "nó và bộ sưu tập sẽ sạch."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
@@ -78794,7 +79815,7 @@ msgstr ""
 "sẽ in ra câu trả lời đúng, và đầu dò sẽ báo cáo thành công. Không có gì được "
 "thử."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
@@ -78804,7 +79825,7 @@ msgstr ""
 "nhằm vào một tài sản hoàn toàn khác nhau, và nó là dễ dàng để đọc màu xanh "
 "lá cây của họ như bằng chứng:"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -78818,7 +79839,7 @@ msgstr ""
 "một khe cắm mà họ không viết lại. Nhớ và viết lại là các thuộc tính khác "
 "nhau, và trình xác minh chỉ hỏi về thuộc tính thứ hai."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -78830,7 +79851,7 @@ msgstr ""
 "không thể tiếp cận được. Một lần chạy màu xanh lá cây ở đây là bằng chứng "
 "mạnh mẽ nhất và trống rỗng nhất trong số ba."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -78842,7 +79863,7 @@ msgstr ""
 "nguồn của tính song phương. Chúng làm lỗi với một con trỏ treo từ không "
 "gian, không phải với một vật thể sống mà không bao giờ được theo dõi."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -78856,7 +79877,7 @@ msgstr ""
 "mặc định và báo cáo thành công  nguy cơ 4 một lần nữa, một cấp độ lên. Mỗi "
 "tên trong tài liệu này là một cổng đã xác nhận một parser sống sở hữu."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -78868,7 +79889,7 @@ msgstr ""
 "được quan sát bằng cách chạy chương trình.** Không có hành quyết nào mà "
 "trong đó \"rào cản không chạy\" là một sự kiện khác biệt."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -78887,12 +79908,12 @@ msgstr ""
 "**đầu ra bằng byte, đầu ra 0**, trên cả một vật cố định khoảng cách và một "
 "đối thủ lớn hơn. Thử nghiệm quang cực tĩnh là điều duy nhất nói không."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr ""
 "Những gì một PR thêm hoặc di chuyển một cửa hàng trên một khe cắm GC nợ"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
@@ -78902,7 +79923,7 @@ msgstr ""
 "bài kiểm tra hành vi. Bốn thứ nó phải gắn, mỗi thứ bởi vì một vụ phá hoại bỏ "
 "nó đã không bị bắt:"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -78912,7 +79933,7 @@ msgstr ""
 "chú bố cục và chuỗi addref. Bất cứ ai trong ba người mất tích là gia đình "
 "#5094 / #7511 của Silent Stranding."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -78927,7 +79948,7 @@ msgstr ""
 "hạnh phúc, và ban đầu được thông qua. Sự hiện diện của mã không phải là bằng "
 "chứng nó chạy."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -78937,7 +79958,7 @@ msgstr ""
 "Một rào cản rò rỉ vào nó có nghĩa là người phân biệt đã ngừng phân biệt, và "
 "\"tối ưu hóa\" không đo bất cứ điều gì."
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -78947,9 +79968,10 @@ msgstr ""
 "chuyển sang màu đỏ. Một thử nghiệm chưa bao giờ thất bại là một thử nghiệm "
 "mà phương thức thất bại của nó là không rõ."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -78965,34 +79987,25 @@ msgstr ""
 "codegen/src/expr/class_field_barrier_tests.rs`, `index_set_barrier_tests.rs` "
 "và `write_pic_barrier_tests.rs` là hình dạng."
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "`GC_STORE_AUDIT` đánh dấu, và những gì nó làm và không chứng minh"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr ""
 "Mỗi trang web cửa hàng có liên quan đến GC có một dấu hiệu gần đó đặt tên "
 "phán quyết của nó:"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "// GC_STORE_AUDIT(BARRIERED): các khe ghi là vô điều kiện; các rào cản"
-
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
 msgstr ""
-"// bên dưới chỉ được bảo vệ bởi một thử nghiệm trực tiếp rằng các bit được "
-"lưu trữ không mang đống"
 
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "// trỏ, đó là thử nghiệm đầu tiên của hàng rào."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -79005,7 +80018,7 @@ msgstr ""
 "đánh dấu **mới** Trang web cửa hàng không thể hạ cánh với câu hỏi không được "
 "trả lời."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
@@ -79014,7 +80027,7 @@ msgstr ""
 "không chỉ là nhận xét, cho hai lớp mà một tuyên bố sai liên quan đến các đối "
 "tượng:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -79055,7 +80068,7 @@ msgstr ""
 "cổng, di chuyển cuộc gọi ra khỏi khối của nó, bỏ qua cổng) chạy trong phòng "
 "chống lại mỗi thân."
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -79082,7 +80095,7 @@ msgstr ""
 "cản trong cùng một chức năng vẫn vượt qua), và các bản in kịch bản giới hạn "
 "đó."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -79104,11 +80117,11 @@ msgstr ""
 "vì đọc như một thông qua sạch rỗng (quan hệ `gc_rekeyed_key_tables.py`), và "
 "`--self-test` của nó cây hình mười lăm, mỗi trong số đó phải được phán quyết."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "Vấn đề corpus, và hai corpora (# 7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
@@ -79116,7 +80129,7 @@ msgstr ""
 "**Một corpus viết tay không thể thể hiện loại lỗi này ở quy mô phụ thuộc, và "
 "trong một thời gian không ai có thể nói, bởi vì nó là màu xanh lá cây.**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -79130,7 +80143,7 @@ msgstr ""
 "dưới `PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`. # 7280 đặt nó trong một câu: "
 "_25 tập tin được sắp xếp đi trong khi 20 dòng của cổ phiếu zod fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -79138,39 +80151,39 @@ msgstr ""
 "Đó không phải là vấn đề về kích thước. Cả hai cơ thể được đo trên cùng một "
 "trình biên dịch với `--stale-registers --moving-only`:"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "sử dụng cũ"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "điều gì chiếm ưu thế"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "Curated, 124 nguồn / 144 mô-đun"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "cửa sổ trợ giúp thuộc tính-GET, `js_number_coerce`, `js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "quy mô phụ thuộc, 81 mô-đun / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -79178,7 +80191,7 @@ msgstr ""
 "`js_object_assign_one` (sự phổ biến đối tượng) 137, "
 "`js_new_function_construct` 102, `js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -79195,7 +80208,7 @@ msgstr ""
 "**Các mối nguy hiểm bắt rễ sống trong hình dạng**, vì vậy một corpus không "
 "có hình dạng không thể thể hiện chúng bất kể nó có bao nhiêu tập tin."
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -79203,11 +80216,12 @@ msgstr ""
 "Vì vậy, có một corpus thứ hai, được tạo ra từ một sự phụ thuộc npm thực sự "
 "hơn là từ bất cứ điều gì được viết cho dịp này:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# zod là package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -79221,7 +80235,7 @@ msgstr ""
 "tra một kích thước sàn không thể, vì ~ 90 mô-đun của `zod` đầm lầy bất kỳ số "
 "liệu nào thiếu nguồn 40-dòng sẽ vượt qua."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -79233,11 +80247,11 @@ msgstr ""
 "tính trong số lệnh. Ngân sách `--stale-registers` là ngân sách đắt nhất (~ 5 "
 "phút): quét của nó siêu tuyến tính, và 62 MB là 62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "Cổng CI"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -79249,20 +80263,20 @@ msgstr ""
 "dịch; hai kiểm tra cổng là khoảng ba giây mỗi trên ~ 2000 và ~ 12900 chức "
 "năng."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr ""
 "Nó được xây dựng để có thể thất bại, chống lại tất cả bốn mối nguy hiểm "
 "trong CLAUDE.md:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr ""
 "trạng thái thoát của người kiểm tra là công việc  không có `continue-on-"
 "error`, không có ống;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
@@ -79270,7 +80284,7 @@ msgstr ""
 "`concurrency` chỉ hủy các run pull-request, vì vậy các run `main` không bao "
 "giờ bị bỏ đói;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -79280,7 +80294,7 @@ msgstr ""
 "trên một corpus quá mỏng để có thể thực hiện bất cứ điều gì, và chạy in "
 "`checked N functions / M modules` để chạy im lặng trống là hiển thị;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -79292,7 +80306,7 @@ msgstr ""
 "cả 40 được báo cáo  đó là cánh tay bắt người kiểm tra im lặng mất khả năng "
 "đọc đầu ra của Perry;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -79308,11 +80322,11 @@ msgstr ""
 "đều đã gửi các mục chết: chín trong `ALLOC_RE` qua hai vòng, mười trong "
 "`POLL_CAPABLE_RUNTIME`."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "Danh sách cho phép, và tại sao nó không phải là một con số"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -79322,7 +80336,7 @@ msgstr ""
 "gc_root_dominance_allowlist.json`, mỗi mục có một dấu vân tay, một vấn đề, "
 "và một lý do bằng văn bản."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -79334,11 +80348,11 @@ msgstr ""
 "hơn nữa, dưới thời hạn, cách rẻ nhất để làm màu xanh lá cây là tăng số bằng "
 "một, và không có gì trong sự khác biệt nói về những gì đã được thừa nhận."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "Vì vậy, người kiểm tra thực thi ba thuộc tính:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -79349,7 +80363,7 @@ msgstr ""
 "con bọ cố định không thể để lại một hòn đá mộ mà lặng lẽ mở rộng phạm vi bảo "
 "hiểm sau này."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -79357,13 +80371,13 @@ msgstr ""
 "**một mục không bao gồm `count`.** Một vi phạm thứ hai của cùng một hình "
 "dạng trong cùng một chức năng là mới, và thất bại."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr ""
 "**một vi phạm mà không có mục nhập thất bại**, bất kể có bao nhiêu mục nhập."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -79371,11 +80385,11 @@ msgstr ""
 "Thêm một mục là một sự kiện xem xét mã. Bumping một `count` để tạo màu xanh "
 "lá cây là điều chính xác mà tệp này tồn tại để ngăn chặn."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "Bảng quảng bá cổng này"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -79384,11 +80398,11 @@ msgstr ""
 "của cơ chế bảo vệ nhánh**, nghĩa là nó không thể làm một lần merge thất bại "
 "— rủi ro 2."
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "Cả hai điều kiện #7198 được đề cập đã được đáp ứng:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -79398,7 +80412,7 @@ msgstr ""
 "**trống** allowlist (các mục # 7211 đã bị xóa khi định nghĩa đó được cố định "
 "trong \\#7226);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -79408,7 +80422,7 @@ msgstr ""
 "(# 7236). Đó là một trong những nổi bật: nó là 98 trước # 7235, 2 sau đó, và "
 "0 một khi `Type::Symbol` ngừng được phân loại là một ngay lập tức."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -79416,7 +80430,7 @@ msgstr ""
 "Vì vậy, các bước còn lại là cho một **Quản trị repo** để thêm `gc-root-"
 "dominance` vào các ngữ cảnh yêu cầu của branch protection:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -79430,7 +80444,7 @@ msgstr ""
 "unrooted-allocas` bao gồm  một cổng chưa bao giờ màu xanh lá cây trong hình "
 "dạng hiện tại của nó chặn mọi PR mở vào ngày nó trở nên cần thiết."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -79453,11 +80467,11 @@ msgstr ""
 "nó khi dân số được cố định; một chương trình khuyến mãi đóng băng ngân sách "
 "nơi nó đã mua một số, không phải là một biến thể."
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "Quy tắc cơ bản"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -79472,7 +80486,7 @@ msgstr ""
 "giờ về các cuộc gọi `js_object_set_field_by_name` được phát ra của người hạ "
 "thấp."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -79480,7 +80494,7 @@ msgstr ""
 "**Đọc lại gốc sau mỗi điểm thu thập.** Không bao giờ lưu trữ tải ra khỏi khe "
 "root trong một cuộc gọi. `rooted_handle_get` tồn tại cho điều này."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -79490,7 +80504,7 @@ msgstr ""
 "nhiều operand, nơi một trong số đó được hiện thực trước khi một operand khác "
 "được hạ thấp, cần người đầu tiên được bắt nguồn."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -79498,7 +80512,7 @@ msgstr ""
 "**`--trace llvm` và đọc nó.** Ba giây của người kiểm tra đánh bại một ngày "
 "của cắt một `not a function` năm chu kỳ hạ lưu."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -79754,6 +80768,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "Chạy nó tại địa phương với:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "Xác thực tại Thời điểm Biên dịch"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "Người dùng chọn backend theo khối lượng công việc"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -80205,7 +81388,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj: String -- tên đăng ký, e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -80243,37 +81427,35 @@ msgid "Three types and one rule."
 msgstr "Ba loại và một quy tắc."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr ""
 "/// Một đăng ký chứa một giá trị được quản lý bởi GC mà KHÔNG được root."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// Mượn máy phát không thay đổi. Không phải Clone, không phải Copy."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr ""
 "/// Một gốc rễ hố bóng. Sống lâu hơn các điểm thu thập; không thể đọc trực "
 "tiếp."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// chỉ có thể lấy từ ShadowFrame:: alloc_slot"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr ""
 "/// Một sổ đăng ký chứa một cái gì đó mà GC không quản lý: i32, double, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr ""
-"/// một chỉ số khe. Có thể nhân bản tự do, không có thời gian sống, không "
-"mượn máy phát ra."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -80284,27 +81466,32 @@ msgstr ""
 "bằng cách họ có thể thu thập**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr ""
 "/// Không thể nhận được. Lấy &self, vì vậy xử lý `Raw` nổi bật vẫn còn hợp "
 "lệ."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr ""
 "/// có thể thu thập. Dùng &mut bản thân, kết thúc tất cả các khoản vay `Raw`."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr ""
 "/// Đọc lại khe cắm. Raw được trả lại là hợp lệ cho đến khi phát ra &mut "
 "tiếp theo."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr "/// tiêu thụ hồ sơ này thành một gốc. Cách duy nhất để làm ra Rooted."
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -80322,24 +81509,22 @@ msgstr ""
 "điểm thu thập** trình biên dịch từ chối nó."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// Raw<'_>, vay e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// nhu cầu và sự thay đổi"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "Obj mượn e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// có thể thay đổi"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// mượn từ trên"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -80348,7 +81533,8 @@ msgstr ""
 "Giải pháp là mã chính xác, và đó là con đường ngắn nhất để thoát khỏi lỗi:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// Đọc lại, đúng"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -80973,8 +82159,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**Cổng thoát hiểm**, miễn là bất kỳ người gọi nào cũng sử dụng nó."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -82577,18 +83764,36 @@ msgstr ""
 "xây dựng."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "Mô hình sidecar này không có lần chạy đầu tiên ghi, vì vậy chỉ đọc cài đặt "
 "thư mục được hỗ trợ. Di chuyển tập tin thực thi đòi hỏi phải di chuyển anh "
 "chị em `.perry-native` của nó. Các tệp bị thiếu hoặc không phù hợp với hash "
 "thất bại trước khi `dlopen` với lỗi đóng gói."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -82605,7 +83810,7 @@ msgstr ""
 "tính kiểm dịch từ các file nhị phân tải xuống không đáng tin cậy trong thời "
 "gian chạy."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -82623,11 +83828,11 @@ msgstr ""
 "trong trình quản lý gói trong khi ngăn chặn một tệp chủ `.node` nhập vào một "
 "hiện vật mục tiêu."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "Định dạng cache"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
@@ -82635,31 +83840,31 @@ msgstr ""
 "Bản biểu hiện addon thời gian biên dịch được sắp xếp xác định và đóng góp "
 "những điều sau đây cho danh tính build và link cache:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "phiên bản sơ đồ chính sách và phiên bản Node-API được quảng cáo;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "mục tiêu tuple và danh sách phép chuẩn;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "gói name/version được chọn và đường nhập tương đối;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 và kích thước của mỗi tệp tải hữu ích sidecar;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "Danh mục biểu tượng xuất khẩu theo yêu cầu;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "Mô hình vận chuyển (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -82674,11 +83879,11 @@ msgstr ""
 "dựng cấp cao nhất ngay cả khi tất cả các tệp TypeScript và đối tượng không "
 "thay đổi."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -82696,22 +83901,15 @@ msgstr ""
 "`never` có nghĩa là Perry xuất biểu tượng phiên bản-8 khi cần thiết cho độ "
 "phân giải nhị phân, nhưng nó báo cáo xác định các cơ sở không được hỗ trợ."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`: lõi đến phiên bản 4"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "Các điểm nhập cảnh"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -82719,49 +83917,56 @@ msgstr "Các điểm nhập cảnh"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "Lưu trữ ổn định theo môi trường"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "Các giá trị Singleton nhận được các tay cầm có phạm vi thông thường"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "Perry object/array phân bổ"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -82769,11 +83974,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN-box chuyển đổi"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -82781,37 +83986,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "Định hạn chiều dài; hỗ trợ `NAPI_AUTO_LENGTH`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "Các cuộc gọi lại gốc sử dụng các bản ghi máy chủ"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "`code` được cài đặt khi được cung cấp"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "Bao gồm chức năng, bên ngoài, biểu tượng và sự phân biệt bigint"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -82819,11 +84024,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "Kiểm tra hành vi type/status"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -82831,11 +84036,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "Bao gồm ngữ nghĩa chiều dài truy vấn và kết thúc NUL"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -82843,19 +84048,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "Mã người dùng bị mắc kẹt ngoại lệ"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "Thuật ngữ đối tượng chung"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -82863,11 +84068,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "Chữ chuỗi, biểu tượng và phím số"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -82875,11 +84080,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "Tên UTF-8"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -82887,43 +84092,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "Mảng và các đối tượng lập chỉ mục kỳ lạ"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "Các mô tả dữ liệu, phương pháp và truy cập"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "Không có phím tắt định danh trỏ"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "Callback-info cuộc sống là cuộc gọi bản địa"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -82931,11 +84136,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "Bảng siêu dữ liệu đối tượng gốc"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -82943,11 +84148,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "Thiết kế tham chiếu mạnh và yếu ở trên"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -82957,11 +84162,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "Xác nhận nghiêm ngặt về tổ và thế hệ"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -82969,19 +84174,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "Mô hình khe chờ"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "Có sẵn trong khi chờ"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -82989,37 +84194,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "Các con trỏ hỗ trợ ổn định"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "Tất cả mười một loại mảng được khai báo"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "Định dạng hỗ trợ và bù đắp được duy trì"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "Quay lại 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -83027,19 +84232,19 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "Các bản ghi bị trì hoãn là các nguồn gốc thuộc sở hữu môi trường"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
@@ -83047,40 +84252,40 @@ msgstr ""
 "Trả về `napi_generic_failure`; thực thi nguồn thời gian chạy tùy ý sẽ vi "
 "phạm mô hình không có động cơ thời gian chạy"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "Kế toán áp suất của máy thu"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`: phiên bản 5 đến 8"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "Đặt hàng đợi sau khi hoàn tất GC"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -83088,11 +84293,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "Độ chính xác tùy ý"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -83100,23 +84305,23 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "`lossless` chính xác và hành vi đếm từ"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "Chế độ thu thập, bộ lọc và chuyển đổi khóa được tôn trọng"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
@@ -83124,46 +84329,46 @@ msgstr ""
 "Một bản ghi cho mỗi môi trường; thay thế ghi đè mà không cần gọi cho người "
 "cuối cùng trước đó"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "Sự gia tăng tách hiện tại"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "128-bit tag trong siêu dữ liệu đối tượng"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "Máy mô tả Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`: phiên bản 9, phiên bản 10 và thử nghiệm"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -83171,16 +84376,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "Quảng cáo chỉ với bề mặt phiên bản-9 hoàn chỉnh"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -83188,11 +84393,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "Cần công việc chuỗi bên ngoài lifetime/accounting"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -83200,29 +84405,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "Phiên bản 10 tên giả đường nhanh"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "Không phải là một phần của ABI ổn định được quảng cáo"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -83230,33 +84435,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "Đăng ký Legacy và đường dẫn hủy"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "Tích hợp các hook không đồng bộ hiện có"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -83264,11 +84469,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer` danh tính và byte ổn định"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -83276,15 +84481,15 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "Máy tính trạng thái rõ ràng ở trên"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
@@ -83292,16 +84497,16 @@ msgstr ""
 "Trả về các thành phần semver của Perry với chuỗi phát hành `perry`; nó không "
 "yêu cầu phát hành Node"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr ""
 "Trả về `napi_generic_failure` và một vòng lặp không; Perry không có libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -83309,19 +84514,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "Chu kỳ đời của chủ đề"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "Nội dung không đồng bộ và tổ hợp chặt chẽ"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -83329,11 +84534,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "TSFN hỗ trợ bơm sự kiện"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -83341,35 +84546,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "Số lượng sợi và sự kiện vòng lặp giữ cuộc sống"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "Việc đóng cửa đang chờ kết thúc"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "Môi trường đã ghi lại giá trị trong tương lai"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "Quảng cáo với phiên bản 10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -83379,18 +84584,18 @@ msgstr ""
 "`napi_register_module_v1`; chúng được tìm kiếm trong addon và không phải là "
 "xuất host."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "Cổng cần thiết"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr ""
 "Việc thực hiện không hoàn tất cho đến khi các cổng dưới đây có thể thất bại "
 "một cách độc lập:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -83402,7 +84607,7 @@ msgstr ""
 "lỗi thời không xác nhận thế hệ; root-holder và rekey-table audit scripts are "
 "clean."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -83412,7 +84617,7 @@ msgstr ""
 "callback TSFN tất cả đều quay lại thông qua C trước khi Perry nâng; một "
 "addon có thiết bị khẳng định rằng không có unwind vào khung của nó."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -83422,7 +84627,7 @@ msgstr ""
 "gọi là `napi_*` và thử nghiệm chứng minh rằng địa chỉ thuộc về trình thực "
 "thi Perry. Số lượng cuộc gọi khói phải lớn hơn 0."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -83434,7 +84639,7 @@ msgstr ""
 "finalizers và bộ đệm. Phiên bản NAPI không được hỗ trợ, thiết bị NAN/V8 và "
 "`uv_*` khẳng định chẩn đoán chính xác của chúng."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -83445,7 +84650,7 @@ msgstr ""
 "nhất giống hệt nhau; cả hai bên đều khẳng định rằng thực hiện gốc của họ "
 "thực sự chạy."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -83455,7 +84660,7 @@ msgstr ""
 "vị trí chỉ đọc và tải thành công; xóa hoặc đột biến sidecar không kiểm tra "
 "băm biểu hiện."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
@@ -83463,7 +84668,7 @@ msgstr ""
 "**Cache gate:** thay đổi chỉ các byte bổ sung hoặc chính sách bỏ lỡ bộ nhớ "
 "cache xây dựng; xây dựng lại các đầu vào không thay đổi."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -83472,7 +84677,7 @@ msgstr ""
 "trống; báo cáo delta chỉ dành cho máy chủ cho một addon build và thực thi "
 "ngân sách 0.6 MB."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -84028,28 +85233,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "Sử dụng lệnh rõ ràng cho phạm vi rộng hơn:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# Loop sản phẩm feedback"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# Mỗi thành viên không gian làm việc tương thích với máy chủ (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$ gói\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# Kiểm tra hoặc xác nhận kiến trúc không gian làm việc"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -84202,7 +85393,8 @@ msgstr ""
 "dựng với `--no-default-features` để cắt đôi backend IR văn bản."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# Xây dựng sản phẩm mặc định và đóng phụ thuộc của nó"
 
 #: src/contributing/building.md:37
@@ -84325,7 +85517,8 @@ msgstr ""
 "môi trường người dùng của bạn, sau đó chạy Cargo qua gói:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# CLI phát triển mỏng, tối ưu"
 
 #: src/contributing/building.md:80
@@ -84359,26 +85552,31 @@ msgid "Build Specific Crates"
 msgstr "Build các crate cụ thể"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# Chỉ thời gian chạy (cần xây dựng lại stdlib nữa!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr ""
 "# Các kho lưu trữ tĩnh được phát ra bởi các thùng bọc riêng biệt (# 5422), "
 "do đó một"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr ""
 "# rõ ràng khi bạn cần libperry_runtime.a / libperry_stdlib.a (e.g. để liên "
 "kết"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# Chỉ có Codegen"
 
 #: src/contributing/building.md:106
@@ -84424,17 +85622,21 @@ msgid "Run Tests"
 msgstr "Chạy Tests"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# Mục tiêu đơn vị sản phẩm"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr ""
 "# Kiểm tra phạm vi thử nghiệm CI hàng đêm (tất cả các thùng thử nghiệm tương "
 "thích với Linux)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# Hộp cụ thể"
 
 #: src/contributing/building.md:137
@@ -84442,11 +85644,13 @@ msgid "Compile and Run TypeScript"
 msgstr "Biên dịch và chạy TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# Tóm lại tệp TypeScript"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# Debug: in HIR"
 
 #: src/contributing/building.md:148
@@ -84514,19 +85718,23 @@ msgstr ""
 "nhau."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# Chứng minh thanh toán là hiện tại và sạch."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# phải in 0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# Không được in gì cả"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# Kiểm tra chính sách và kịch bản nhanh chóng."
 
 #: src/contributing/releasing.md:23
@@ -84534,7 +85742,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr ""
 "# Kiểm tra hành vi của máy chủ. Những điều này cải thiện chuyển đổi, nhưng "
 "không"
@@ -84560,7 +85770,8 @@ msgstr ""
 "bình thường trước."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# Thay thế phiên bản đã có trong Cargo.toml."
 
 #: src/contributing/releasing.md:48
@@ -84580,7 +85791,8 @@ msgid "'[0-9]*.md'"
 msgstr "[0-9]*.md"
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\" # không được in bất cứ thứ gì"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -84684,9 +85896,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "Hành động được phép: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -84717,22 +85930,15 @@ msgstr ""
 "một bộ."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# một gói phát hành chạy: exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
 msgstr ""
-"                            # xuất bản + xác minh tất cả 9 thông qua OIDC, "
-"sau đó tạo"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub Phiên bản cuối cùng"
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# kiểm tra biên lai commit/run/package/Socket"
 
 #: src/contributing/releasing.md:128
@@ -84949,11 +86155,13 @@ msgstr ""
 "để xác minh một doc-ví dụ chạy mà không có một con người:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# biên dịch cho trình mô phỏng"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# Bắt đầu một thiết bị (một lần; sử dụng lại UDID trong các lần chạy)"
 
 #: src/contributing/releasing.md:178
@@ -84961,22 +86169,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# Cài đặt + khởi động với chế độ thử nghiệm"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr ""
-"# Ứng dụng thoát 0 sau khi hiển thị; ảnh chụp màn hình hạ cánh tại counter-"
-"ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -85244,6 +86439,10 @@ msgid "patch distance"
 msgstr "khoảng cách vá"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -85279,15 +86478,18 @@ msgstr ""
 "đóng lại khi registry bắt kịp."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# chứng minh nó có thể thất bại"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# đăng ký thực sự, không có vấn đề viết"
 
 #: src/contributing/releasing.md:289
@@ -85344,6 +86546,376 @@ msgstr ""
 "bại. Để thử lại các chân phân phối gói phát hành cũ, gửi nó với "
 "`existing_tag=vX.Y.Z`; chỉ thêm `publish_npm=true` khi chân npm idempotent "
 "cũng cần thử lại."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\"'"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr ""
+#~ "# chỉnh sửa src/lib.rs  thêm các chức năng `js_*` của bạn, tất cả chỉ sử "
+#~ "dụng"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr ""
+#~ "# chỉnh sửa src/index.ts  khai báo mã người dùng bề mặt TS nhập khẩu"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# Chỉnh sửa package.json  liệt kê tất cả các xuất js_* trong"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅ trình bày phù hợp với staticlib"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# release.yml được dựng lên"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr ""
+#~ "                                    # xây dựng các mục tiêu trước cho tất "
+#~ "cả các mục tiêu"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr ""
+#~ "                                    # và gắn chúng vào sự giải phóng"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"Native bindings for <upstream crate>\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string`  trích xuất văn bản từ bộ đệm PDF."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "/// # An toàn"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr ""
+#~ "/// `buf_ptr` phải là không hoặc hợp lệ cho `buf_len` bytes. Perry vượt "
+#~ "qua"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "/// cặp này từ một tham số biểu hiện `buffer+len`."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const kết quả = chờ spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding và Insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64 slice (mục tiêu thiết bị mặc định)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. điều chỉnh minos + bộ an toàn"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"nền tảng;android-35\" \"công cụ xây dựng;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"hình ảnh hệ thống;Android-34;Android-wear;arm64-v8a\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. Mục tiêu chéo Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. Tạo + khởi động một trình giả lập Wear OS (xem vòng)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Các gói npm và API Node.js bổ sung được Perry hỗ trợ. Tất cả được liệt kê "
+#~ "ở đây đều được nối qua registry binding native well-known của Perry "
+#~ "(#466) và biên dịch thành mã native mà không cần đến runtime JavaScript."
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr ""
+#~ "# 3) Kiểm tra sức khỏe tâm lý chữ ký tại địa phương trước khi tải lên bản "
+#~ "trình bày"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    ở đây dự đoán một xác minh vượt qua trên khách hàng."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr ""
+#~ "# 4) Giới thiệu CI ký biểu thức CLI, ràng buộc URL lưu trữ, nền tảng,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr ""
+#~ "// phát hiện mục tiêu: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos "
+#~ "SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "// biên dịch: swiftc -emit-library -static -target ... -sdk ... "
+#~ "-framework StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "// Liên kết: cargo:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"Công thức: application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "'{\"text\":\"hello world\"}'"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"value\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "\"{\"giá trị\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "'{\"chọn tắt\":\"s\"}'"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "IP của:"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# Để nó chạy trong 30 giây"
+
+#~ msgid "# Check stats"
+#~ msgstr "# Kiểm tra số liệu thống kê"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# {\"running\":true, \"events_fired\":600, \"uptime_secs\":30}"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# Chụp ảnh màn hình để xem trạng thái cuối cùng"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# Ngừng hỗn loạn"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# Kiểm tra ứng dụng vẫn còn hoạt động"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# Xây dựng cho iOS (cross compile)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr ""
+#~ "\"công việc\" | select(.status==\"in_progress\") | (tick)|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# Đường đợi sâu như thế nào, và trên những hồ bơi nào:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "\"công việc\" | select(.status==\"queued\") | (tick)|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"Native bindings cho libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\"'"
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Tàu Perry **hai kênh chọn tham gia độc lập** để gửi dữ liệu về nhà  không "
+#~ "có gì rời máy tính của bạn mà không có một `enabled = true` hoặc `on` rõ "
+#~ "ràng trong `~/.perry/config.toml`. Cả hai đều tôn trọng "
+#~ "`PERRY_NO_TELEMETRY=1` và `CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr ""
+#~ "phát ra các thiết bị chẩn đoán thu thập có thể đọc được bởi con người"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# NATIVE (PERRY_RS4GC=1): mặc định ở mọi nơi khác. Lăng xích"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr ""
+#~ "# `ptr addrspace(1)` phân bổ gốc và LLVM chèn các điểm an toàn sau đó, vì "
+#~ "vậy các"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr ""
+#~ "// GC_STORE_AUDIT(BARRIERED): các khe ghi là vô điều kiện; các rào cản"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr ""
+#~ "// bên dưới chỉ được bảo vệ bởi một thử nghiệm trực tiếp rằng các bit "
+#~ "được lưu trữ không mang đống"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "// trỏ, đó là thử nghiệm đầu tiên của hàng rào."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr ""
+#~ "/// Mượn máy phát không thay đổi. Không phải Clone, không phải Copy."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr ""
+#~ "/// một chỉ số khe. Có thể nhân bản tự do, không có thời gian sống, không "
+#~ "mượn máy phát ra."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "Obj mượn e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// có thể thay đổi"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// mượn từ trên"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$ gói\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# Kiểm tra hoặc xác nhận kiến trúc không gian làm việc"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# một gói phát hành chạy: exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr ""
+#~ "                            # xuất bản + xác minh tất cả 9 thông qua "
+#~ "OIDC, sau đó tạo"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub Phiên bản cuối cùng"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr ""
+#~ "# Ứng dụng thoát 0 sau khi hiển thị; ảnh chụp màn hình hạ cánh tại "
+#~ "counter-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -86389,9 +87961,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "Biến môi trường `LANG` / `LC_ALL` / `LC_MESSAGES`"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "Xác thực tại Thời điểm Biên dịch"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr ""
 #~ "Perry xác thực các tham số trên tất cả các locale trong quá trình biên "
@@ -86486,13 +88055,6 @@ msgstr ""
 #~ "Sử dụng [`SKStoreReviewController.requestReview(in:)`](https://"
 #~ "developer.apple.com/documentation/storekit/skstorereviewcontroller/"
 #~ "requestreview(in:)) từ StoreKit."
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# Ví dụ GitHub Actions\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "Chỉ tạo file object, bỏ qua linking"

--- a/docs/po/zh-CN.po
+++ b/docs/po/zh-CN.po
@@ -214,7 +214,7 @@ msgstr "钩子"
 
 #: src/SUMMARY.md:66 src/threading/parallel-map.md:157
 #: src/threading/parallel-filter.md:78 src/threading/spawn.md:191
-#: src/tui/examples.md:1 src/cli/flags.md:383
+#: src/tui/examples.md:1 src/cli/flags.md:427
 msgid "Examples"
 msgstr "示例"
 
@@ -570,139 +570,147 @@ msgid "CI Tiers (PR gate / sweep / full)"
 msgstr "CI 层级（PR 检查 / 扫描 / 完整测试套件）"
 
 #: src/SUMMARY.md:158
+msgid "Claude Code Bundle Parity"
+msgstr ""
+
+#: src/SUMMARY.md:159
 msgid "CI Gate Scheduling"
 msgstr "CI 检查调度"
 
-#: src/SUMMARY.md:160
+#: src/SUMMARY.md:161
 msgid "CLI Reference"
 msgstr "CLI 参考"
 
-#: src/SUMMARY.md:162
+#: src/SUMMARY.md:163
 msgid "Commands"
 msgstr "命令"
 
-#: src/SUMMARY.md:163 src/cli/flags.md:1
+#: src/SUMMARY.md:164 src/cli/flags.md:1
 msgid "Compiler Flags"
 msgstr "编译器标志"
 
-#: src/SUMMARY.md:164
+#: src/SUMMARY.md:165
 msgid "Cache Directory"
 msgstr "缓存目录"
 
-#: src/SUMMARY.md:165
+#: src/SUMMARY.md:166
 msgid "Fast-math (`--fast-math`)"
 msgstr "Fast-math(`--fast-math`)"
 
-#: src/SUMMARY.md:166
+#: src/SUMMARY.md:167
 msgid "Dynamic Stdlib Dispatch"
 msgstr "动态标准库调度"
 
-#: src/SUMMARY.md:167
+#: src/SUMMARY.md:168
 msgid "JS Runtime Opt-In"
 msgstr "JS Runtime 启用"
 
-#: src/SUMMARY.md:168 src/cli/sandbox-buildrs.md:1
+#: src/SUMMARY.md:169 src/cli/sandbox-buildrs.md:1
 msgid "`PERRY_SANDBOX_BUILDRS`"
 msgstr "`PERRY_SANDBOX_BUILDRS`"
 
-#: src/SUMMARY.md:169 src/cli/emit-attest.md:1
+#: src/SUMMARY.md:170 src/cli/emit-attest.md:1
 msgid "`--emit-attest` (binary attestation sidecar)"
 msgstr "`--emit-attest`（二进制证明附件）"
 
-#: src/SUMMARY.md:170 src/cli/flags.md:305
+#: src/SUMMARY.md:171 src/cli/flags.md:349
 msgid "`--emit-sandbox`"
 msgstr "`--emit-sandbox`"
 
-#: src/SUMMARY.md:171 src/cli/flags.md:306
+#: src/SUMMARY.md:172 src/cli/flags.md:350
 msgid "`--lockdown`"
 msgstr "`--lockdown`"
 
-#: src/SUMMARY.md:172
+#: src/SUMMARY.md:173
 msgid "Egress Allowlist (`allowedHosts`)"
 msgstr "出口白名单（`allowedHosts`）"
 
-#: src/SUMMARY.md:173 src/cli/capabilities.md:1
+#: src/SUMMARY.md:174 src/cli/capabilities.md:1
 msgid "Per-Package Capabilities (`perry.permissions`)"
 msgstr "按包权限配置（`perry.permissions`）"
 
-#: src/SUMMARY.md:174
+#: src/SUMMARY.md:175
 msgid "`perry audit --sbom`"
 msgstr "`perry audit --sbom`"
 
-#: src/SUMMARY.md:175
+#: src/SUMMARY.md:176
 msgid "Host Allowlist (nativeLibrary, compilePackages)"
 msgstr "宿主白名单（nativeLibrary、compilePackages）"
 
-#: src/SUMMARY.md:176 src/cli/perry-toml.md:1
+#: src/SUMMARY.md:177 src/cli/perry-toml.md:1
 msgid "perry.toml Reference"
 msgstr "perry.toml 参考"
 
-#: src/SUMMARY.md:177 src/cli/updates.md:1
+#: src/SUMMARY.md:178 src/cli/updates.md:1
 msgid "Updates"
 msgstr "Updates"
 
-#: src/SUMMARY.md:178
+#: src/SUMMARY.md:179
 msgid "Update Checks in Your Apps"
 msgstr "在应用中检查更新"
 
-#: src/SUMMARY.md:179 src/cli/telemetry.md:1
+#: src/SUMMARY.md:180 src/cli/telemetry.md:1
 msgid "Privacy & Telemetry"
 msgstr "隐私与遥测"
 
-#: src/SUMMARY.md:183
+#: src/SUMMARY.md:184
 msgid "Internals"
 msgstr "内部机制"
 
-#: src/SUMMARY.md:185 src/internals/memory-model.md:1
+#: src/SUMMARY.md:186 src/internals/memory-model.md:1
 msgid "Memory Model"
 msgstr "内存模型"
 
-#: src/SUMMARY.md:186
+#: src/SUMMARY.md:187
 msgid "Garbage Collector"
 msgstr "垃圾回收器"
 
-#: src/SUMMARY.md:187 src/internals/explicit-memory.md:1
+#: src/SUMMARY.md:188 src/internals/explicit-memory.md:1
 msgid "Explicit Memory Control"
 msgstr "显式内存管理"
 
-#: src/SUMMARY.md:188 src/internals/gc-rooting-invariant.md:1
+#: src/SUMMARY.md:189 src/internals/gc-rooting-invariant.md:1
 msgid "The GC rooting invariant (codegen)"
 msgstr "GC 根引用不变量（代码生成）"
 
-#: src/SUMMARY.md:189 src/internals/local-binding-type-evidence.md:1
+#: src/SUMMARY.md:190 src/internals/local-binding-type-evidence.md:1
 msgid "Local binding type evidence"
 msgstr "局部绑定的类型依据"
 
-#: src/SUMMARY.md:190
+#: src/SUMMARY.md:191 src/internals/codegen-mechanisms.md:1
+msgid "Codegen mechanisms and workload evidence"
+msgstr ""
+
+#: src/SUMMARY.md:192
 msgid "Incremental GC step bounds"
 msgstr "增量 GC 步骤边界"
 
-#: src/SUMMARY.md:191 src/internals/rfc-rooting-by-construction.md:1
+#: src/SUMMARY.md:193 src/internals/rfc-rooting-by-construction.md:1
 msgid "RFC: rooting by construction"
 msgstr "RFC：通过构造保证 GC 根引用"
 
-#: src/SUMMARY.md:192 src/internals/node-api-host.md:1
+#: src/SUMMARY.md:194 src/internals/node-api-host.md:1
 msgid "Node-API host design"
 msgstr "Node-API host design"
 
-#: src/SUMMARY.md:194
+#: src/SUMMARY.md:196
 msgid "Contributing"
 msgstr "贡献"
 
-#: src/SUMMARY.md:196 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
+#: src/SUMMARY.md:198 src/platforms/watchos.md:25 src/platforms/harmonyos.md:5
 #: src/testing/geisterhand.md:683 src/contributing/architecture.md:1
 msgid "Architecture"
 msgstr "架构"
 
-#: src/SUMMARY.md:197 src/contributing/crate-policy.md:1
+#: src/SUMMARY.md:199 src/contributing/crate-policy.md:1
 msgid "Crate policy"
 msgstr "crate 策略"
 
-#: src/SUMMARY.md:198 src/contributing/building.md:1
+#: src/SUMMARY.md:200 src/contributing/building.md:1
 msgid "Building from Source"
 msgstr "从源码构建"
 
-#: src/SUMMARY.md:199 src/contributing/releasing.md:1
+#: src/SUMMARY.md:201 src/contributing/releasing.md:1
 msgid "Releasing Perry"
 msgstr "发布 Perry"
 
@@ -926,7 +934,8 @@ msgstr ""
 "```"
 
 #: src/introduction.md:76
-msgid "# Opens a native macOS/Windows/Linux window"
+#, fuzzy
+msgid "# Opens a native macOS/Windows/Linux window\n"
 msgstr "# 打开一个原生 macOS/Windows/Linux 窗口"
 
 #: src/introduction.md:79
@@ -957,11 +966,11 @@ msgstr ""
 
 #: src/introduction.md:96 src/getting-started/hello-world.md:155
 #: src/getting-started/first-app.md:184
-#: src/getting-started/project-config.md:296
+#: src/getting-started/project-config.md:297
 #: src/language/supported-features.md:631 src/language/type-system.md:149
 #: src/language/limitations.md:336 src/threading/overview.md:350
 #: src/ui/overview.md:182 src/ui/widgets.md:685 src/ui/layout.md:367
-#: src/ui/styling.md:375 src/ui/state.md:226 src/ui/events.md:167
+#: src/ui/styling.md:378 src/ui/state.md:226 src/ui/events.md:167
 #: src/ui/canvas.md:93 src/ui/menus.md:119 src/ui/tray.md:106
 #: src/ui/dialogs.md:166 src/ui/table.md:150 src/ui/animation.md:71
 #: src/ui/multi-window.md:158 src/ui/theming.md:166 src/ui/camera.md:143
@@ -970,9 +979,9 @@ msgstr ""
 #: src/platforms/watchos.md:316 src/platforms/android.md:92
 #: src/platforms/wearos.md:208 src/platforms/windows.md:144
 #: src/platforms/linux.md:84 src/platforms/web.md:21 src/platforms/wasm.md:191
-#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:392
+#: src/stdlib/overview.md:136 src/stdlib/fs.md:98 src/stdlib/http.md:408
 #: src/stdlib/database.md:107 src/stdlib/crypto.md:87
-#: src/stdlib/utilities.md:111 src/stdlib/other.md:392 src/i18n/overview.md:108
+#: src/stdlib/utilities.md:111 src/stdlib/other.md:450 src/i18n/overview.md:108
 #: src/updater/overview.md:445 src/system/overview.md:77
 #: src/system/preferences.md:44 src/system/keychain.md:35
 #: src/system/notifications.md:131 src/system/audio.md:109
@@ -982,7 +991,7 @@ msgstr ""
 #: src/plugins/overview.md:96 src/plugins/creating-plugins.md:162
 #: src/plugins/hooks-and-events.md:144 src/plugins/native-extensions.md:324
 #: src/plugins/appstore-review.md:199 src/cli/commands.md:438
-#: src/cli/flags.md:420 src/contributing/architecture.md:100
+#: src/cli/flags.md:464 src/contributing/architecture.md:100
 #: src/contributing/building.md:179
 msgid "Next Steps"
 msgstr "后续步骤"
@@ -1051,27 +1060,33 @@ msgid "Linux linker toolchain by distribution:"
 msgstr "根据分布的Linux链接工具链:"
 
 #: src/getting-started/installation.md:22
-msgid "# Debian / Ubuntu / Pop!_OS / Mint"
+#, fuzzy
+msgid "# Debian / Ubuntu / Pop!_OS / Mint\n"
 msgstr "# 在 Debian / Ubuntu / Pop!_OS / Mint 中使用"
 
 #: src/getting-started/installation.md:24
-msgid "# Arch / Manjaro / CachyOS / EndeavourOS"
+#, fuzzy
+msgid "# Arch / Manjaro / CachyOS / EndeavourOS\n"
 msgstr "# 导读:Arch / Manjaro / CachyOS / EndeavourOS"
 
 #: src/getting-started/installation.md:27
-msgid "# Fedora / RHEL / CentOS Stream"
+#, fuzzy
+msgid "# Fedora / RHEL / CentOS Stream\n"
 msgstr "# 在 Fedora / RHEL / CentOS 流中"
 
 #: src/getting-started/installation.md:30
-msgid "# openSUSE"
+#, fuzzy
+msgid "# openSUSE\n"
 msgstr "# openSUSE"
 
 #: src/getting-started/installation.md:33
-msgid "# Alpine / musl-based"
+#, fuzzy
+msgid "# Alpine / musl-based\n"
 msgstr "# 基于阿尔卑斯山/的"
 
 #: src/getting-started/installation.md:36
-msgid "# Void Linux"
+#, fuzzy
+msgid "# Void Linux\n"
 msgstr "# 无效的Linux"
 
 #: src/getting-started/installation.md:41
@@ -1110,15 +1125,18 @@ msgstr ""
 "musl, Windows x64):"
 
 #: src/getting-started/installation.md:54
-msgid "# Project-local (pins Perry's version alongside your deps)"
+#, fuzzy
+msgid "# Project-local (pins Perry's version alongside your deps)\n"
 msgstr "# 项目-本地 (将Perry的版本贴在您的 deps旁边)"
 
 #: src/getting-started/installation.md:57
-msgid "# Global"
+#, fuzzy
+msgid "# Global\n"
 msgstr "# Global"
 
 #: src/getting-started/installation.md:61
-msgid "# Zero-install, one-shot"
+#, fuzzy
+msgid "# Zero-install, one-shot\n"
 msgstr "# 零安装,一次投射"
 
 #: src/getting-started/installation.md:66
@@ -1307,7 +1325,8 @@ msgid "The binary is at `target/release/perry`. Add it to your PATH:"
 msgstr "二进制位于 `target/release/perry`。将其加入 PATH:"
 
 #: src/getting-started/installation.md:128
-msgid "# Add to ~/.zshrc or ~/.bashrc"
+#, fuzzy
+msgid "# Add to ~/.zshrc or ~/.bashrc\n"
 msgstr "# 添加到 ~/.zshrc 或 ~/.bashrc"
 
 #: src/getting-started/installation.md:129
@@ -1436,16 +1455,14 @@ msgstr ""
 "linux` 构建时才需要 — 纯命令行应用或交叉编译到其他平台无需安装。）"
 
 #: src/getting-started/installation.md:183 src/platforms/linux.md:12
-msgid "# Ubuntu / Debian"
+#, fuzzy
+msgid "# Ubuntu / Debian\n"
 msgstr "# 在Ubuntu/Debian中"
 
 #: src/getting-started/installation.md:185 src/platforms/linux.md:14
-msgid "# Fedora"
+#, fuzzy
+msgid "# Fedora\n"
 msgstr "# Fedora"
-
-#: src/getting-started/installation.md:189 src/platforms/linux.md:18
-msgid "# Arch"
-msgstr "# Arch"
 
 #: src/getting-started/installation.md:196
 msgid "Two toolchain options — pick one. Both produce identical binaries."
@@ -2107,24 +2124,29 @@ msgid "The same code runs on all 6 platforms:"
 msgstr "同一份代码可以在全部 6 个平台上运行:"
 
 #: src/getting-started/first-app.md:121
-msgid "# macOS (default)"
+#, fuzzy
+msgid "# macOS (default)\n"
 msgstr "# macOS (默认)"
 
 #: src/getting-started/first-app.md:124
-msgid "# iOS Simulator"
+#, fuzzy
+msgid "# iOS Simulator\n"
 msgstr "# 模拟器 iOS"
 
 #: src/getting-started/first-app.md:127
+#, fuzzy
 msgid ""
-"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)"
+"# Web (compiles to WebAssembly + DOM bridge in a self-contained HTML file)\n"
 msgstr "# 网页 (编译为 WebAssembly + DOM 桥在一个独立的 HTML 文件中)"
 
 #: src/getting-started/first-app.md:129 src/platforms/overview.md:31
-msgid "# alias: --target wasm"
+#, fuzzy
+msgid "# alias: --target wasm\n"
 msgstr "# 别名:--target wasm"
 
 #: src/getting-started/first-app.md:131
-msgid "# Other platforms"
+#, fuzzy
+msgid "# Other platforms\n"
 msgstr "# 其他平台"
 
 #: src/getting-started/first-app.md:138
@@ -2358,7 +2380,7 @@ msgstr "\"src/main.ts\""
 #: src/native-libraries/zero-config-and-faithfulness.md:25
 #: src/platforms/ios.md:168 src/platforms/ios.md:181
 #: src/platforms/android.md:57 src/platforms/android.md:72
-#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:333
+#: src/stdlib/overview.md:120 src/stdlib/http.md:186 src/stdlib/http.md:349
 #: src/plugins/native-extensions.md:61 src/plugins/appstore-review.md:187
 #: src/cli/fast-math.md:34 src/cli/dynamic-dispatch.md:101
 #: src/cli/dynamic-dispatch.md:117 src/cli/allow-js-runtime.md:44
@@ -2376,7 +2398,7 @@ msgstr "\"perry\""
 #: src/getting-started/project-config.md:58
 #: src/getting-started/project-config.md:59 src/packages/porting.md:85
 #: src/native-libraries/zero-config-and-faithfulness.md:26
-#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:334
+#: src/stdlib/overview.md:121 src/stdlib/http.md:187 src/stdlib/http.md:350
 #: src/cli/allow-perry-features.md:53 src/cli/allow-perry-features.md:56
 #: src/cli/allow-perry-features.md:71 src/cli/allow-perry-features.md:83
 msgid "\"compilePackages\""
@@ -2580,7 +2602,8 @@ msgstr ""
 "JIT 编译；其 **standalone** 模式则将相同的校验器输出为普通源码。生成器脚本："
 
 #: src/getting-started/project-config.md:107
-msgid "// scripts/generate-validators.mjs"
+#, fuzzy
+msgid "// scripts/generate-validators.mjs\n"
 msgstr "// scripts/generate-validators.mjs"
 
 #: src/getting-started/project-config.md:108
@@ -2612,7 +2635,8 @@ msgid "\"port\""
 msgstr "\"港口\""
 
 #: src/getting-started/project-config.md:120
-msgid "// standalone source"
+#, fuzzy
+msgid "// standalone source\n"
 msgstr "// 独立源"
 
 #: src/getting-started/project-config.md:122
@@ -2855,19 +2879,20 @@ msgstr "\"splash/themes.xml\""
 #: src/native-libraries/manifest-v1.md:173
 #: src/native-libraries/manifest-v1.md:318
 #: src/native-libraries/manifest-v1.md:357 src/ui/webview.md:184
-#: src/container/containers.md:43 src/container/networking.md:25
-#: src/container/volumes.md:37 src/container/security.md:14
-#: src/updater/overview.md:106 src/plugins/native-extensions.md:92
-#: src/plugins/native-extensions.md:102 src/cli/perry-toml.md:117
-#: src/cli/perry-toml.md:128 src/cli/perry-toml.md:156
-#: src/cli/perry-toml.md:172 src/cli/perry-toml.md:182
-#: src/cli/perry-toml.md:188 src/cli/perry-toml.md:198
-#: src/cli/perry-toml.md:248 src/cli/perry-toml.md:261
-#: src/cli/perry-toml.md:267 src/cli/perry-toml.md:275
-#: src/cli/perry-toml.md:306 src/cli/perry-toml.md:317
-#: src/cli/perry-toml.md:334 src/cli/perry-toml.md:353
-#: src/cli/perry-toml.md:365 src/cli/perry-toml.md:385
-#: src/cli/perry-toml.md:414 src/cli/perry-toml.md:441
+#: src/stdlib/other.md:259 src/container/containers.md:43
+#: src/container/networking.md:25 src/container/volumes.md:37
+#: src/container/security.md:14 src/updater/overview.md:106
+#: src/plugins/native-extensions.md:92 src/plugins/native-extensions.md:102
+#: src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
+#: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
+#: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
+#: src/cli/perry-toml.md:261 src/cli/perry-toml.md:267
+#: src/cli/perry-toml.md:275 src/cli/perry-toml.md:306
+#: src/cli/perry-toml.md:317 src/cli/perry-toml.md:334
+#: src/cli/perry-toml.md:353 src/cli/perry-toml.md:365
+#: src/cli/perry-toml.md:385 src/cli/perry-toml.md:414
+#: src/cli/perry-toml.md:441
 msgid "Field"
 msgstr "字段"
 
@@ -2882,9 +2907,9 @@ msgstr "字段"
 #: src/cli/commands.md:183 src/cli/commands.md:216 src/cli/commands.md:230
 #: src/cli/commands.md:268 src/cli/commands.md:283 src/cli/commands.md:295
 #: src/cli/flags.md:11 src/cli/flags.md:66 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:276 src/cli/flags.md:289 src/cli/flags.md:296
-#: src/cli/flags.md:310 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:320 src/cli/flags.md:333 src/cli/flags.md:340
+#: src/cli/flags.md:354 src/cli/perry-toml.md:117 src/cli/perry-toml.md:128
 #: src/cli/perry-toml.md:156 src/cli/perry-toml.md:172
 #: src/cli/perry-toml.md:182 src/cli/perry-toml.md:188
 #: src/cli/perry-toml.md:198 src/cli/perry-toml.md:248
@@ -3002,11 +3027,13 @@ msgid ""
 msgstr "Perry 原生支持许多流行的 npm 包，无需任何配置："
 
 #: src/getting-started/project-config.md:226
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: importing built-in stdlib npm packages (project-config.md)\n"
 "// docs: docs/src/getting-started/project-config.md\n"
 "// platforms: macos, linux, windows\n"
+"// requires: auto-optimize\n"
 "// run: false\n"
 "\n"
 "// These four imports are Perry's most-used built-in stdlib shims:\n"
@@ -3061,7 +3088,7 @@ msgstr ""
 "console.log(typeof app, typeof db, typeof redis, hashed.length)\n"
 "```"
 
-#: src/getting-started/project-config.md:254
+#: src/getting-started/project-config.md:255
 msgid ""
 "These are compiled to native code using Perry's built-in implementations. "
 "See [Standard Library](../stdlib/overview.md) for the full list."
@@ -3069,7 +3096,7 @@ msgstr ""
 "这些包通过 Perry 的内建实现编译为原生代码。完整列表见 [Standard Library](../"
 "stdlib/overview.md)。"
 
-#: src/getting-started/project-config.md:256
+#: src/getting-started/project-config.md:257
 msgid ""
 "For packages not natively supported, use `compilePackages` for pure TS/JS "
 "packages, or the JavaScript runtime fallback for complex packages."
@@ -3077,44 +3104,47 @@ msgstr ""
 "对于未原生支持的包，纯 TS/JS 包可使用 `compilePackages`，复杂的包则可回退到 "
 "JavaScript 运行时。"
 
-#: src/getting-started/project-config.md:258 src/contributing/building.md:155
+#: src/getting-started/project-config.md:259 src/contributing/building.md:155
 msgid "Project Structure"
 msgstr "项目结构"
 
-#: src/getting-started/project-config.md:260
+#: src/getting-started/project-config.md:261
 msgid "Perry is flexible about project structure. Common patterns:"
 msgstr "Perry 对项目结构非常灵活。常见模式："
 
-#: src/getting-started/project-config.md:270
+#: src/getting-started/project-config.md:271
 msgid "For UI apps:"
 msgstr "对于 UI 应用："
 
-#: src/getting-started/project-config.md:281 src/widgets/watchos.md:60
+#: src/getting-started/project-config.md:282 src/widgets/watchos.md:60
 #: src/widgets/wearos.md:61
 msgid "Compilation"
 msgstr "编译"
 
-#: src/getting-started/project-config.md:284
-msgid "# Compile a file"
+#: src/getting-started/project-config.md:285
+#, fuzzy
+msgid "# Compile a file\n"
 msgstr "# 编译一个文件"
 
-#: src/getting-started/project-config.md:286
-msgid "# Compile with a specific target"
+#: src/getting-started/project-config.md:287
+#, fuzzy
+msgid "# Compile with a specific target\n"
 msgstr "# 用特定目标编译"
 
-#: src/getting-started/project-config.md:289
-msgid "# Debug: print intermediate representation"
+#: src/getting-started/project-config.md:290
+#, fuzzy
+msgid "# Debug: print intermediate representation\n"
 msgstr "# 调试:打印中间表示"
 
-#: src/getting-started/project-config.md:294
+#: src/getting-started/project-config.md:295
 msgid "See [CLI Commands](../cli/commands.md) for all options."
 msgstr "全部选项见 [CLI Commands](../cli/commands.md)。"
 
-#: src/getting-started/project-config.md:298
+#: src/getting-started/project-config.md:299
 msgid "[CLI Commands](../cli/commands.md) — All compiler commands and flags"
 msgstr "[CLI Commands](../cli/commands.md) —— 全部编译器命令与标志"
 
-#: src/getting-started/project-config.md:299
+#: src/getting-started/project-config.md:300
 msgid ""
 "[Supported Features](../language/supported-features.md) — What TypeScript "
 "features work"
@@ -3122,7 +3152,7 @@ msgstr ""
 "[Supported Features](../language/supported-features.md) —— 支持哪些 "
 "TypeScript 特性"
 
-#: src/getting-started/project-config.md:300
+#: src/getting-started/project-config.md:301
 msgid "[Standard Library](../stdlib/overview.md) — Supported npm packages"
 msgstr "[Standard Library](../stdlib/overview.md) —— 受支持的 npm 包"
 
@@ -3259,32 +3289,33 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/language/supported-features.md:60 src/api/reference.md:249
-#: src/api/reference.md:283 src/api/reference.md:317 src/api/reference.md:391
-#: src/api/reference.md:397 src/api/reference.md:460 src/api/reference.md:507
-#: src/api/reference.md:528 src/api/reference.md:573 src/api/reference.md:848
-#: src/api/reference.md:864 src/api/reference.md:1023 src/api/reference.md:1071
-#: src/api/reference.md:1091 src/api/reference.md:1200
-#: src/api/reference.md:1278 src/api/reference.md:1324
-#: src/api/reference.md:1419 src/api/reference.md:1447
-#: src/api/reference.md:1608 src/api/reference.md:1811
-#: src/api/reference.md:1834 src/api/reference.md:1888
-#: src/api/reference.md:1919 src/api/reference.md:1939
-#: src/api/reference.md:1959 src/api/reference.md:2040
-#: src/api/reference.md:2135 src/api/reference.md:2159
-#: src/api/reference.md:2189 src/api/reference.md:2317
-#: src/api/reference.md:2476 src/api/reference.md:2697
-#: src/api/reference.md:3037 src/api/reference.md:3186
-#: src/api/reference.md:3226 src/api/reference.md:3239
-#: src/api/reference.md:3249 src/api/reference.md:3320
-#: src/api/reference.md:3382 src/api/reference.md:3491
-#: src/api/reference.md:3517 src/api/reference.md:3530
-#: src/api/reference.md:3541 src/api/reference.md:3668
-#: src/api/reference.md:3713 src/api/reference.md:3767
-#: src/api/reference.md:3787 src/api/reference.md:3816
-#: src/api/reference.md:3924 src/api/reference.md:3992
-#: src/api/reference.md:4028 src/api/reference.md:4046
-#: src/api/reference.md:4094 src/api/reference.md:4125
+#: src/language/supported-features.md:60 src/api/reference.md:250
+#: src/api/reference.md:284 src/api/reference.md:318 src/api/reference.md:392
+#: src/api/reference.md:398 src/api/reference.md:422 src/api/reference.md:498
+#: src/api/reference.md:545 src/api/reference.md:566 src/api/reference.md:611
+#: src/api/reference.md:886 src/api/reference.md:902 src/api/reference.md:1061
+#: src/api/reference.md:1109 src/api/reference.md:1129
+#: src/api/reference.md:1238 src/api/reference.md:1316
+#: src/api/reference.md:1362 src/api/reference.md:1457
+#: src/api/reference.md:1485 src/api/reference.md:1646
+#: src/api/reference.md:1849 src/api/reference.md:1872
+#: src/api/reference.md:1926 src/api/reference.md:1957
+#: src/api/reference.md:1977 src/api/reference.md:1997
+#: src/api/reference.md:2078 src/api/reference.md:2173
+#: src/api/reference.md:2197 src/api/reference.md:2227
+#: src/api/reference.md:2355 src/api/reference.md:2514
+#: src/api/reference.md:2735 src/api/reference.md:3075
+#: src/api/reference.md:3224 src/api/reference.md:3264
+#: src/api/reference.md:3277 src/api/reference.md:3287
+#: src/api/reference.md:3358 src/api/reference.md:3420
+#: src/api/reference.md:3529 src/api/reference.md:3555
+#: src/api/reference.md:3568 src/api/reference.md:3579
+#: src/api/reference.md:3706 src/api/reference.md:3751
+#: src/api/reference.md:3805 src/api/reference.md:3825
+#: src/api/reference.md:3854 src/api/reference.md:3962
+#: src/api/reference.md:4030 src/api/reference.md:4066
+#: src/api/reference.md:4084 src/api/reference.md:4132
+#: src/api/reference.md:4166
 msgid "Classes"
 msgstr "类"
 
@@ -5245,6 +5276,7 @@ msgid ""
 msgstr "Perry 解析遗留/实验性 TypeScript 装饰器语法，并支持两种路径："
 
 #: src/language/decorators.md:30
+#, fuzzy
 msgid ""
 "**Legacy class decorators, method decorators, property decorators, "
 "constructor parameter decorators, and method parameter decorators** for Nest-"
@@ -5254,7 +5286,11 @@ msgid ""
 "`Reflect.getMetadataKeys`, `Reflect.getOwnMetadataKeys`, "
 "`Reflect.deleteMetadata`, and `@Reflect.metadata(...)` are available. Perry "
 "emits `design:paramtypes` for decorated classes/methods and `design:type` "
-"for decorated properties."
+"for decorated properties. A member decorator receives the same `target` "
+"`tsc` hands it: `Class.prototype` for an instance member and the constructor "
+"for a static one, so the NestJS idiom `Reflect.defineMetadata(key, value, "
+"target.constructor)` lands on the class, and `Class.constructor === "
+"Function` as in node."
 msgstr ""
 "**遗留类装饰器、方法装饰器、属性装饰器、构造函数参数装饰器和方法参数装饰器"
 "**，用于 Nest 风格的 DI 和路由元数据探针。装饰器函数以副作用形式运行，"
@@ -5264,7 +5300,7 @@ msgstr ""
 "`@Reflect.metadata(...)` 均可使用。Perry 为装饰的类/方法生成 "
 "`design:paramtypes`，为装饰的属性生成 `design:type`。"
 
-#: src/language/decorators.md:40
+#: src/language/decorators.md:44
 msgid ""
 "**Compile-time-only transforms.** The bundled `@log` transform is the "
 "canonical example — it rewrites a decorated method into a wrapper that "
@@ -5275,15 +5311,15 @@ msgstr ""
 "为打印进入/退出信息的包装器，完全不涉及运行时装饰器机制。实现详见 `crates/"
 "perry-hir/src/decorator_log.rs`。"
 
-#: src/language/decorators.md:46
+#: src/language/decorators.md:50
 msgid "What does not work"
 msgstr "不工作的内容"
 
-#: src/language/decorators.md:48
+#: src/language/decorators.md:52
 msgid "Accessor decorators and descriptor replacement"
 msgstr "访问器装饰器与描述符替换"
 
-#: src/language/decorators.md:49
+#: src/language/decorators.md:53
 msgid ""
 "Decorator class replacement return values. If a class decorator returns "
 "anything other than `undefined`, Perry throws a `TypeError` at decorator "
@@ -5297,15 +5333,15 @@ msgstr ""
 "resolver 包装器等实际装饰器需要针对 Perry 的适配移植——降级后的类在 IR 中已固"
 "定，无法在运行时替换。"
 
-#: src/language/decorators.md:55
+#: src/language/decorators.md:59
 msgid "General `Reflect.metadata(...)` helper calls outside decorator syntax"
 msgstr "装饰器语法之外的通用 `Reflect.metadata(...)` 辅助调用"
 
-#: src/language/decorators.md:56
+#: src/language/decorators.md:60
 msgid "`Symbol(...)` as a metadata key"
 msgstr "将 `Symbol(...)` 作为元数据键使用"
 
-#: src/language/decorators.md:57
+#: src/language/decorators.md:61
 msgid ""
 "`emitDecoratorMetadata` beyond class/method `design:paramtypes` and property "
 "`design:type`"
@@ -5313,7 +5349,7 @@ msgstr ""
 "超出类/方法 `design:paramtypes` 及属性 `design:type` 范围的 "
 "`emitDecoratorMetadata`"
 
-#: src/language/decorators.md:59
+#: src/language/decorators.md:63
 msgid ""
 "Runtime DI containers that resolve dependencies by type beyond the reduced "
 "class-constructor canary (`tsyringe`, full NestJS injector behavior, "
@@ -5322,11 +5358,11 @@ msgstr ""
 "通过类型解析依赖项的运行时 DI 容器，超出简化的类构造函数探针范围"
 "（`tsyringe`、完整 NestJS 注入器行为、Angular 根注入器）"
 
-#: src/language/decorators.md:62
+#: src/language/decorators.md:66
 msgid "`class-validator`, `type-graphql`, `TypeORM` runtime metadata flows"
 msgstr "`class-validator`、`type-graphql`、`TypeORM` 的运行时元数据流程"
 
-#: src/language/decorators.md:64
+#: src/language/decorators.md:68
 msgid ""
 "If your code depends on any of these, the port path is still explicit wiring "
 "or a dedicated AOT transform, not relying on the full legacy TypeScript "
@@ -5335,11 +5371,11 @@ msgstr ""
 "如果您的代码依赖上述任何功能，移植路径仍是显式连接或专用 AOT 转换，而非依赖完"
 "整的遗留 TypeScript 装饰器运行时。"
 
-#: src/language/decorators.md:68
+#: src/language/decorators.md:72
 msgid "Recommended pattern: explicit construction"
 msgstr "推荐模式：显式构造"
 
-#: src/language/decorators.md:70
+#: src/language/decorators.md:74
 msgid ""
 "The Perry-native idiom is plain classes wired together in a single "
 "`services.ts` module in dependency order. This is how a Go or Rust program "
@@ -5350,7 +5386,7 @@ msgstr ""
 "起。Go 或 Rust 程序就是这样组合服务的，无装饰器的 TS 框架（Hono、tRPC 服务"
 "器、Drizzle 应用）也已经这样运作。"
 
-#: src/language/decorators.md:75
+#: src/language/decorators.md:79
 msgid ""
 "```typescript,no-test\n"
 "// services.ts\n"
@@ -5366,7 +5402,7 @@ msgstr ""
 "export const chat = new ChatService(api, rating);\n"
 "```"
 
-#: src/language/decorators.md:82
+#: src/language/decorators.md:86
 msgid ""
 "There is no container, no `@Injectable`, no `providedIn: 'root'` — "
 "construction order _is_ the dependency graph, and it is checked by the "
@@ -5375,11 +5411,11 @@ msgstr ""
 "没有容器,没有`@Injectable`,没有`providedIn: 'root'` —构建顺序 _是_依赖度图,并"
 "且由TypeScript编译器检查."
 
-#: src/language/decorators.md:86
+#: src/language/decorators.md:90
 msgid "Migration recipe: an Angular service"
 msgstr "迁移配方：一个 Angular 服务"
 
-#: src/language/decorators.md:88
+#: src/language/decorators.md:92
 msgid ""
 "The example below is a real service from sharity-app (`src/app/services/"
 "rating.service.ts`, ~80 lines), shown in its original Angular form and "
@@ -5388,25 +5424,25 @@ msgstr ""
 "下方示例是 sharity-app 中的真实服务（`src/app/services/rating.service.ts`，"
 "约 80 行），展示其原始的 Angular 形态以及移植到 Perry 后的样子。"
 
-#: src/language/decorators.md:92
+#: src/language/decorators.md:96
 msgid "Before — Angular"
 msgstr "之前 —— Angular"
 
-#: src/language/decorators.md:128
+#: src/language/decorators.md:132
 msgid "After — Perry"
 msgstr "之后 —— Perry"
 
-#: src/language/decorators.md:130
+#: src/language/decorators.md:134
 msgid "Three mechanical changes:"
 msgstr "三处机械式改动："
 
-#: src/language/decorators.md:132
+#: src/language/decorators.md:136
 msgid ""
 "**Drop `@Injectable`.** It carried no information that the class shape does "
 "not already carry."
 msgstr "**移除 `@Injectable`。** 它没有提供类形状之外的任何信息。"
 
-#: src/language/decorators.md:134
+#: src/language/decorators.md:138
 msgid ""
 "**Replace `Observable<T>` with `Promise<T>`** for HTTP calls. Most Angular "
 "Observables-from-HTTP are single-value and behave like Promises. (For multi-"
@@ -5416,7 +5452,7 @@ msgstr ""
 "Angular Observable 都是单值的，行为类似 Promise。（对于多值流，使用 "
 "`AsyncIterable`。）"
 
-#: src/language/decorators.md:137
+#: src/language/decorators.md:141
 msgid ""
 "**Replace constructor-parameter properties** (`private api: ApiService`) "
 "with explicit field declarations. Perry supports parameter properties, but "
@@ -5426,11 +5462,11 @@ msgstr ""
 "**用显式字段声明替换构造函数参数属性**（如 `private api: ApiService`）。"
 "Perry 支持参数属性，但当类是手动实例化而非由容器实例化时，显式字段更清晰。"
 
-#: src/language/decorators.md:177
+#: src/language/decorators.md:181
 msgid "Wiring"
 msgstr "接线"
 
-#: src/language/decorators.md:179
+#: src/language/decorators.md:183
 msgid ""
 "```typescript,no-test\n"
 "// services.ts — single source of truth for service construction\n"
@@ -5450,7 +5486,7 @@ msgstr ""
 "export const rating = new RatingService(api);\n"
 "```"
 
-#: src/language/decorators.md:188
+#: src/language/decorators.md:192
 msgid ""
 "```typescript,no-test\n"
 "// any consumer\n"
@@ -5468,7 +5504,7 @@ msgstr ""
 "const list = await rating.getUserRatings('user-123');\n"
 "```"
 
-#: src/language/decorators.md:196
+#: src/language/decorators.md:200
 msgid ""
 "That is the entire migration. The `@Injectable` decorator, the `providedIn: "
 "'root'` token, the implicit container lookup — all of it collapses into one "
@@ -5477,11 +5513,11 @@ msgstr ""
 "整个迁移就是这样。`@Injectable` 装饰器、`providedIn: 'root'` 标记、隐式的容器"
 "查找 —— 全部塌缩为 `services.ts` 中的一行 `new RatingService(api)`。"
 
-#: src/language/decorators.md:200
+#: src/language/decorators.md:204
 msgid "What about Angular components, NestJS controllers, TypeORM entities?"
 msgstr "那 Angular 组件、NestJS 控制器、TypeORM 实体怎么办？"
 
-#: src/language/decorators.md:202
+#: src/language/decorators.md:206
 msgid ""
 "Perry's reduced legacy path is enough for small Nest-style constructor-"
 "injection and route-metadata canaries, but it is not full Angular, NestJS, "
@@ -5500,11 +5536,11 @@ msgstr ""
 "(https://github.com/PerryTS/perry/issues/581). 目前的建议是一样的:尽可能放下"
 "装饰器,写出同等的明确构造,将路线或方案注册为单纯函数调用/模块级常数."
 
-#: src/language/decorators.md:214
+#: src/language/decorators.md:218
 msgid "Future direction"
 msgstr "未来方向"
 
-#: src/language/decorators.md:216
+#: src/language/decorators.md:220
 msgid ""
 "New feature work should prefer the [TC39 stage-3 form](https://github.com/"
 "tc39/proposal-decorators) because it aligns better with Perry's \"types "
@@ -6155,12 +6191,13 @@ msgstr ""
 "西."
 
 #: src/language/limitations.md:292
+#, fuzzy
 msgid ""
 "**Literal static calls** (`WebAssembly.instantiate(bytes)` written against "
 "the global) lower to the opt-in wasmi host runtime (issue #76, `--enable-"
 "wasm-runtime`, auto-linked when usage is detected). These run real "
 "WebAssembly through the wasmi interpreter but require `libperry_wasm_host.a` "
-"to be built (`cargo build --release -p  perry-wasm-host`); without it the "
+"to be built (`cargo build --release -p perry-wasm-host`); without it the "
 "build fails with that instruction."
 msgstr ""
 "**字面上的静态调用** (`WebAssembly.instantiate(bytes)`写在全球) 低到选择的 "
@@ -7643,52 +7680,13 @@ msgid "Authoring a binding — the 60-second tour"
 msgstr "编写绑定——60 秒导览"
 
 #: src/native-libraries/overview.md:292
-msgid "# Scaffold"
+#, fuzzy
+msgid "# Scaffold\n"
 msgstr "# Scaffold"
 
 #: src/native-libraries/overview.md:293
 msgid "\"PDF rendering bindings\""
 msgstr "\"PDF rendering bindings\""
-
-#: src/native-libraries/overview.md:294
-msgid "'pdfium-render = \"0.8\"'"
-msgstr "\"pdfium-render = \"0.8\" 这个字符号"
-
-#: src/native-libraries/overview.md:296
-msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
-msgstr "# 编辑 src/lib.rs 添加您的 `js_*` 函数,所有只使用"
-
-#: src/native-libraries/overview.md:300
-msgid "# Edit src/index.ts — declare the TS surface user code imports"
-msgstr "# 编辑 src/index.ts 声明 TS 表面用户代码进口"
-
-#: src/native-libraries/overview.md:303
-msgid "# Edit package.json — list every js_* export in the"
-msgstr "# 编辑package.json 列出每个js_*出口"
-
-#: src/native-libraries/overview.md:307
-msgid "# Verify"
-msgstr "# Verify"
-
-#: src/native-libraries/overview.md:309
-msgid "# ✅ manifest matches the staticlib"
-msgstr "# ✅公示表与静态表匹配"
-
-#: src/native-libraries/overview.md:311
-msgid "# Publish"
-msgstr "# Publish"
-
-#: src/native-libraries/overview.md:313
-msgid "# the scaffolded release.yml"
-msgstr "# 架式的release.yml"
-
-#: src/native-libraries/overview.md:313
-msgid "                                    # builds prebuilts for all targets"
-msgstr "                                    # 为所有目标构建预先构建"
-
-#: src/native-libraries/overview.md:314
-msgid "                                    # and attaches them to the release"
-msgstr "                                    # 然后,我把它们绑在子上,"
 
 #: src/native-libraries/overview.md:319
 msgid ""
@@ -8044,7 +8042,7 @@ msgstr "目前情况"
 msgid "`perry-ext-ads`"
 msgstr "`perry-ext-ads`"
 
-#: src/native-libraries/governance.md:87 src/api/reference.md:2513
+#: src/native-libraries/governance.md:87 src/api/reference.md:2551
 msgid "`perry/ads`"
 msgstr "`perry/ads`"
 
@@ -8064,7 +8062,7 @@ msgstr "包装; 待移动"
 msgid "`perry-ext-argon2`"
 msgstr "`perry-ext-argon2`"
 
-#: src/native-libraries/governance.md:88 src/api/reference.md:240
+#: src/native-libraries/governance.md:88 src/api/reference.md:241
 msgid "`argon2`"
 msgstr "`argon2`"
 
@@ -8116,7 +8114,7 @@ msgstr "包装;正在等待迁移"
 msgid "`perry-ext-axios`"
 msgstr "`perry-ext-axios`"
 
-#: src/native-libraries/governance.md:89 src/api/reference.md:348
+#: src/native-libraries/governance.md:89 src/api/reference.md:349
 msgid "`axios`"
 msgstr "`axios`"
 
@@ -8176,7 +8174,7 @@ msgstr "编译上游包源"
 msgid "`perry-ext-bcrypt`"
 msgstr "`perry-ext-bcrypt`"
 
-#: src/native-libraries/governance.md:90 src/api/reference.md:364
+#: src/native-libraries/governance.md:90 src/api/reference.md:365
 msgid "`bcrypt`"
 msgstr "`bcrypt`"
 
@@ -8184,7 +8182,7 @@ msgstr "`bcrypt`"
 msgid "`perry-ext-better-sqlite3`"
 msgstr "`perry-ext-better-sqlite3`"
 
-#: src/native-libraries/governance.md:91 src/api/reference.md:371
+#: src/native-libraries/governance.md:91 src/api/reference.md:372
 msgid "`better-sqlite3`"
 msgstr "`better-sqlite3`"
 
@@ -8192,7 +8190,7 @@ msgstr "`better-sqlite3`"
 msgid "`perry-ext-cheerio`"
 msgstr "`perry-ext-cheerio`"
 
-#: src/native-libraries/governance.md:92 src/api/reference.md:487
+#: src/native-libraries/governance.md:92 src/api/reference.md:525
 msgid "`cheerio`"
 msgstr "`cheerio`"
 
@@ -8200,7 +8198,7 @@ msgstr "`cheerio`"
 msgid "`perry-ext-commander`"
 msgstr "`perry-ext-commander`"
 
-#: src/native-libraries/governance.md:93 src/api/reference.md:551
+#: src/native-libraries/governance.md:93 src/api/reference.md:589
 msgid "`commander`"
 msgstr "`commander`"
 
@@ -8232,7 +8230,7 @@ msgstr "`bignumber.js`<br>`decimal.js`"
 msgid "`perry-ext-dotenv`"
 msgstr "`perry-ext-dotenv`"
 
-#: src/native-libraries/governance.md:97 src/api/reference.md:1304
+#: src/native-libraries/governance.md:97 src/api/reference.md:1342
 msgid "`dotenv`"
 msgstr "`dotenv`"
 
@@ -8240,7 +8238,7 @@ msgstr "`dotenv`"
 msgid "`perry-ext-ethers`"
 msgstr "`perry-ext-ethers`"
 
-#: src/native-libraries/governance.md:98 src/api/reference.md:1311
+#: src/native-libraries/governance.md:98 src/api/reference.md:1349
 msgid "`ethers`"
 msgstr "`ethers`"
 
@@ -8248,7 +8246,7 @@ msgstr "`ethers`"
 msgid "`perry-ext-events`"
 msgstr "`perry-ext-events`"
 
-#: src/native-libraries/governance.md:99 src/api/reference.md:1322
+#: src/native-libraries/governance.md:99 src/api/reference.md:1360
 msgid "`events`"
 msgstr "`events`"
 
@@ -8280,7 +8278,7 @@ msgstr "包装;保留"
 msgid "`perry-ext-exponential-backoff`"
 msgstr "`perry-ext-exponential-backoff`"
 
-#: src/native-libraries/governance.md:100 src/api/reference.md:1371
+#: src/native-libraries/governance.md:100 src/api/reference.md:1409
 msgid "`exponential-backoff`"
 msgstr "`exponential-backoff`"
 
@@ -8288,7 +8286,7 @@ msgstr "`exponential-backoff`"
 msgid "`perry-ext-fastify`"
 msgstr "`perry-ext-fastify`"
 
-#: src/native-libraries/governance.md:101 src/api/reference.md:1377
+#: src/native-libraries/governance.md:101 src/api/reference.md:1415
 msgid "`fastify`"
 msgstr "`fastify`"
 
@@ -8320,7 +8318,7 @@ msgstr "`ioredis`<br>`iovalkey`<br>`redis`"
 msgid "`perry-ext-jsonwebtoken`"
 msgstr "`perry-ext-jsonwebtoken`"
 
-#: src/native-libraries/governance.md:105 src/api/reference.md:1983
+#: src/native-libraries/governance.md:105 src/api/reference.md:2021
 msgid "`jsonwebtoken`"
 msgstr "`jsonwebtoken`"
 
@@ -8328,7 +8326,7 @@ msgstr "`jsonwebtoken`"
 msgid "`perry-ext-lru-cache`"
 msgstr "`perry-ext-lru-cache`"
 
-#: src/native-libraries/governance.md:106 src/api/reference.md:2025
+#: src/native-libraries/governance.md:106 src/api/reference.md:2063
 msgid "`lru-cache`"
 msgstr "`lru-cache`"
 
@@ -8336,7 +8334,7 @@ msgstr "`lru-cache`"
 msgid "`perry-ext-moment`"
 msgstr "`perry-ext-moment`"
 
-#: src/native-libraries/governance.md:107 src/api/reference.md:2082
+#: src/native-libraries/governance.md:107 src/api/reference.md:2120
 msgid "`moment`"
 msgstr "`moment`"
 
@@ -8344,7 +8342,7 @@ msgstr "`moment`"
 msgid "`perry-ext-mongodb`"
 msgstr "`perry-ext-mongodb`"
 
-#: src/native-libraries/governance.md:108 src/api/reference.md:2114
+#: src/native-libraries/governance.md:108 src/api/reference.md:2152
 msgid "`mongodb`"
 msgstr "`mongodb`"
 
@@ -8360,7 +8358,7 @@ msgstr "`mysql2`<br>`mysql2/promise`"
 msgid "`perry-ext-nanoid`"
 msgstr "`perry-ext-nanoid`"
 
-#: src/native-libraries/governance.md:110 src/api/reference.md:2181
+#: src/native-libraries/governance.md:110 src/api/reference.md:2219
 msgid "`nanoid`"
 msgstr "`nanoid`"
 
@@ -8368,7 +8366,7 @@ msgstr "`nanoid`"
 msgid "`perry-ext-net`"
 msgstr "`perry-ext-net`"
 
-#: src/native-libraries/governance.md:111 src/api/reference.md:2187
+#: src/native-libraries/governance.md:111 src/api/reference.md:2225
 msgid "`net`"
 msgstr "`net`"
 
@@ -8376,7 +8374,7 @@ msgstr "`net`"
 msgid "`perry-ext-node-forge`"
 msgstr "`perry-ext-node-forge`"
 
-#: src/native-libraries/governance.md:112 src/api/reference.md:2329
+#: src/native-libraries/governance.md:112 src/api/reference.md:2367
 msgid "`node-forge`"
 msgstr "`node-forge`"
 
@@ -8384,7 +8382,7 @@ msgstr "`node-forge`"
 msgid "`perry-ext-nodemailer`"
 msgstr "`perry-ext-nodemailer`"
 
-#: src/native-libraries/governance.md:113 src/api/reference.md:2356
+#: src/native-libraries/governance.md:113 src/api/reference.md:2394
 msgid "`nodemailer`"
 msgstr "`nodemailer`"
 
@@ -8408,7 +8406,7 @@ msgstr ""
 msgid "`perry-ext-pdf`"
 msgstr "`perry-ext-pdf`"
 
-#: src/native-libraries/governance.md:115 src/api/reference.md:218
+#: src/native-libraries/governance.md:115 src/api/reference.md:219
 msgid "`@perryts/pdf`"
 msgstr "`@perryts/pdf`"
 
@@ -8416,7 +8414,7 @@ msgstr "`@perryts/pdf`"
 msgid "`perry-ext-pg`"
 msgstr "`perry-ext-pg`"
 
-#: src/native-libraries/governance.md:116 src/api/reference.md:3035
+#: src/native-libraries/governance.md:116 src/api/reference.md:3073
 msgid "`pg`"
 msgstr "`pg`"
 
@@ -8424,7 +8422,7 @@ msgstr "`pg`"
 msgid "`perry-ext-qs`"
 msgstr "`perry-ext-qs`"
 
-#: src/native-libraries/governance.md:117 src/api/reference.md:3161
+#: src/native-libraries/governance.md:117 src/api/reference.md:3199
 msgid "`qs`"
 msgstr "`qs`"
 
@@ -8432,7 +8430,7 @@ msgstr "`qs`"
 msgid "`perry-ext-ratelimit`"
 msgstr "`perry-ext-ratelimit`"
 
-#: src/native-libraries/governance.md:118 src/api/reference.md:3184
+#: src/native-libraries/governance.md:118 src/api/reference.md:3222
 msgid "`rate-limiter-flexible`"
 msgstr "`rate-limiter-flexible`"
 
@@ -8440,7 +8438,7 @@ msgstr "`rate-limiter-flexible`"
 msgid "`perry-ext-sharp`"
 msgstr "`perry-ext-sharp`"
 
-#: src/native-libraries/governance.md:119 src/api/reference.md:3290
+#: src/native-libraries/governance.md:119 src/api/reference.md:3328
 msgid "`sharp`"
 msgstr "`sharp`"
 
@@ -8448,7 +8446,7 @@ msgstr "`sharp`"
 msgid "`perry-ext-streams`"
 msgstr "`perry-ext-streams`"
 
-#: src/native-libraries/governance.md:120 src/api/reference.md:3515
+#: src/native-libraries/governance.md:120 src/api/reference.md:3553
 msgid "`streams`"
 msgstr "`streams`"
 
@@ -8456,7 +8454,7 @@ msgstr "`streams`"
 msgid "`perry-ext-typescript`"
 msgstr "`perry-ext-typescript`"
 
-#: src/native-libraries/governance.md:121 src/api/reference.md:3752
+#: src/native-libraries/governance.md:121 src/api/reference.md:3790
 msgid "`typescript`"
 msgstr "`typescript`"
 
@@ -8464,7 +8462,7 @@ msgstr "`typescript`"
 msgid "`perry-ext-undici`"
 msgstr "`perry-ext-undici`"
 
-#: src/native-libraries/governance.md:122 src/api/reference.md:3765
+#: src/native-libraries/governance.md:122 src/api/reference.md:3803
 msgid "`undici`"
 msgstr "`undici`"
 
@@ -8472,7 +8470,7 @@ msgstr "`undici`"
 msgid "`perry-ext-uuid`"
 msgstr "`perry-ext-uuid`"
 
-#: src/native-libraries/governance.md:123 src/api/reference.md:3910
+#: src/native-libraries/governance.md:123 src/api/reference.md:3948
 msgid "`uuid`"
 msgstr "`uuid`"
 
@@ -8480,7 +8478,7 @@ msgstr "`uuid`"
 msgid "`perry-ext-validator`"
 msgstr "`perry-ext-validator`"
 
-#: src/native-libraries/governance.md:124 src/api/reference.md:3980
+#: src/native-libraries/governance.md:124 src/api/reference.md:4018
 msgid "`validator`"
 msgstr "`validator`"
 
@@ -8488,7 +8486,7 @@ msgstr "`validator`"
 msgid "`perry-ext-ws`"
 msgstr "`perry-ext-ws`"
 
-#: src/native-libraries/governance.md:125 src/api/reference.md:4092
+#: src/native-libraries/governance.md:125 src/api/reference.md:4130
 msgid "`ws`"
 msgstr "`ws`"
 
@@ -8496,7 +8494,7 @@ msgstr "`ws`"
 msgid "`perry-ext-zlib`"
 msgstr "`perry-ext-zlib`"
 
-#: src/native-libraries/governance.md:126 src/api/reference.md:4123
+#: src/native-libraries/governance.md:126 src/api/reference.md:4164
 msgid "`zlib`"
 msgstr "`zlib`"
 
@@ -8546,14 +8544,6 @@ msgstr "如果你希望预构建的 release-CI 脚手架开箱即用，则需要
 msgid "1. Scaffold"
 msgstr "1. 生成脚手架"
 
-#: src/native-libraries/authoring-guide.md:23
-msgid "\"Native bindings for <upstream crate>\""
-msgstr "\"<upstream crate> 的本地绑定\""
-
-#: src/native-libraries/authoring-guide.md:24
-msgid "'<crate-name> = \"<version>\"'"
-msgstr "'<crate-name> = \"<version>\"'"
-
 #: src/native-libraries/authoring-guide.md:30
 msgid "This creates:"
 msgstr "这将创建："
@@ -8584,26 +8574,14 @@ msgstr ""
 "使用来自 `perry_ffi` 的类型："
 
 #: src/native-libraries/authoring-guide.md:57
-msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
-msgstr "/// `pdf.parse(buf) -> string` 从PDF缓冲区中提取文本."
-
-#: src/native-libraries/authoring-guide.md:58
-#: src/native-libraries/authoring-guide.md:60
-#: src/internals/rfc-rooting-by-construction.md:68
-msgid "///"
-msgstr "///"
-
-#: src/native-libraries/authoring-guide.md:59
-msgid "/// # Safety"
-msgstr "#安全性"
-
-#: src/native-libraries/authoring-guide.md:61
-msgid "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
-msgstr "/// `buf_ptr`必须为 `buf_len`字节为 null 或有效. 通过Perry"
-
-#: src/native-libraries/authoring-guide.md:62
-msgid "/// this pair from a `buffer+len` manifest parameter."
-msgstr "这对来自一个`buffer+len`显示参数."
+msgid ""
+"/// `pdf.parse(buf) -> string` — extract text from a PDF buffer.\n"
+"///\n"
+"/// # Safety\n"
+"///\n"
+"/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes\n"
+"/// this pair from a `buffer+len` manifest parameter.\n"
+msgstr ""
 
 #: src/native-libraries/authoring-guide.md:65
 #: src/native-libraries/authoring-guide.md:360
@@ -8734,7 +8712,7 @@ msgstr "\"js_pdf_parse\""
 #: src/native-libraries/manifest-v1.md:155
 #: src/native-libraries/manifest-v1.md:161
 #: src/native-libraries/manifest-v1.md:192
-#: src/native-libraries/manifest-v1.md:386
+#: src/native-libraries/manifest-v1.md:386 src/cli/flags.md:515
 msgid "\"kind\""
 msgstr "\"善良的\""
 
@@ -8966,7 +8944,8 @@ msgid "In a separate directory:"
 msgstr "在另一个目录中："
 
 #: src/native-libraries/authoring-guide.md:216
-msgid "# or any path your tooling supports"
+#, fuzzy
+msgid "# or any path your tooling supports\n"
 msgstr "# 或您的工具支持的任何路径"
 
 #: src/native-libraries/authoring-guide.md:219
@@ -9346,7 +9325,8 @@ msgid "Event listeners (`.on(event, cb)`)"
 msgstr "事件监听器（`.on(event, cb)`）"
 
 #: src/native-libraries/authoring-guide.md:415
-msgid "// closure pointers, kept alive by the GC scanner below"
+#, fuzzy
+msgid "// closure pointers, kept alive by the GC scanner below\n"
 msgstr "// 关闭指针,由下面的GC扫描仪保持活跃"
 
 #: src/native-libraries/authoring-guide.md:458
@@ -9754,7 +9734,8 @@ msgid "\".env\""
 msgstr "\".env\""
 
 #: src/native-libraries/abi.md:153
-msgid "// … read file, set env vars, return 1.0 / 0.0 …"
+#, fuzzy
+msgid "// … read file, set env vars, return 1.0 / 0.0 …\n"
 msgstr "// ...阅读文件,设置环境,返回1.0 / 0.0 "
 
 #: src/native-libraries/abi.md:165
@@ -10046,8 +10027,8 @@ msgstr "必填"
 #: src/platforms/tvos.md:149 src/platforms/watchos.md:137
 #: src/platforms/wearos.md:23 src/container/containers.md:129
 #: src/system/media.md:37 src/testing/geisterhand.md:257 src/cli/flags.md:27
-#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:504
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:565
+#: src/cli/cache-dir.md:42 src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:579
 msgid "Notes"
 msgstr "说明"
 
@@ -10105,14 +10086,14 @@ msgstr "string"
 #: src/native-libraries/manifest-v1.md:111 src/platforms/windows-7.md:37
 #: src/testing/ci-tiers.md:26 src/testing/ci-tiers.md:27
 #: src/testing/ci-tiers.md:28 src/testing/ci-tiers.md:29
-#: src/testing/ci-tiers.md:31 src/testing/ci-tiers.md:32
-#: src/testing/ci-tiers.md:33 src/testing/ci-tiers.md:34
-#: src/testing/ci-tiers.md:35 src/testing/ci-tiers.md:36
-#: src/testing/ci-tiers.md:37 src/testing/ci-tiers.md:38
-#: src/testing/ci-tiers.md:39 src/testing/ci-tiers.md:40
-#: src/testing/ci-tiers.md:41 src/testing/ci-tiers.md:42
-#: src/testing/ci-tiers.md:43 src/testing/ci-tiers.md:44
-#: src/testing/ci-tiers.md:45 src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:30 src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34 src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36 src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38 src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40 src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42 src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44 src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46 src/testing/ci-tiers.md:47
 #: src/internals/rfc-rooting-by-construction.md:277
 #: src/internals/rfc-rooting-by-construction.md:278
 #: src/internals/rfc-rooting-by-construction.md:279
@@ -11760,28 +11741,35 @@ msgid "Tooling — `scripts/binding_pins.mjs`"
 msgstr "工具  `scripts/binding_pins.mjs`"
 
 #: src/native-libraries/upstream-pins.md:52
+#, fuzzy
 msgid ""
-"# Provision or bump one pin to a specific version (default: latest stable)"
+"# Provision or bump one pin to a specific version (default: latest stable)\n"
 msgstr "# 提供或将一个引脚放到特定版本 (默认:最新稳定)"
 
 #: src/native-libraries/upstream-pins.md:54
-msgid "# Provision every currently-unpinned binding at its latest stable"
+#, fuzzy
+msgid "# Provision every currently-unpinned binding at its latest stable\n"
 msgstr "# 提供每一个目前未固定的绑定在其最新稳定"
 
 #: src/native-libraries/upstream-pins.md:57
+#, fuzzy
 msgid ""
-"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on any"
+"# Offline gate (CI): pins present, lock-stepped, crates exist. Exit 1 on "
+"any\n"
 msgstr "# 离线门 (CI):存在引脚,锁定,存在盒子. 任何一个路口的1号出口"
 
 #: src/native-libraries/upstream-pins.md:61
+#, fuzzy
 msgid ""
-"# Advisory: additionally flag pins whose upstream has a newer stable release"
+"# Advisory: additionally flag pins whose upstream has a newer stable "
+"release\n"
 msgstr "# 建议:在上游有较新的稳定释放的旗针"
 
 #: src/native-libraries/upstream-pins.md:65
+#, fuzzy
 msgid ""
 "# Materialize the upstream repo at the pinned ref into gitignored upstream/"
-"<name>"
+"<name>\n"
 msgstr "# 在固定的ref中将上游repo转化为gitignored上游/<name>"
 
 #: src/native-libraries/upstream-pins.md:71
@@ -11989,15 +11977,15 @@ msgid "For CI that must never substitute a partial wrapper, set:"
 msgstr "对于永远不能替代部分包装的CI,设置:"
 
 #: src/native-libraries/zero-config-and-faithfulness.md:86 src/ui/layout.md:224
-#: src/tui/widgets.md:59 src/platforms/watchos.md:72
-#: src/platforms/watchos-app-store.md:41 src/platforms/windows-7.md:25
-#: src/container/overview.md:71 src/container/security.md:105
-#: src/container/production-patterns.md:295 src/container/determinism.md:59
+#: src/tui/widgets.md:59 src/platforms/watchos-app-store.md:41
+#: src/platforms/windows-7.md:25 src/container/overview.md:71
+#: src/container/security.md:105 src/container/determinism.md:59
 #: src/testing/geisterhand.md:87 src/testing/geisterhand.md:101
-#: src/cli/fast-math.md:30 src/cli/dynamic-dispatch.md:123
+#: src/cli/flags.md:481 src/cli/dynamic-dispatch.md:123
 #: src/cli/allow-js-runtime.md:67 src/cli/sandbox-buildrs.md:25
 #: src/cli/sandbox-buildrs.md:53 src/cli/perry-toml.md:431
-#: src/internals/gc-rooting-invariant.md:229
+#: src/internals/gc-rooting-invariant.md:258
+#: src/internals/codegen-mechanisms.md:56
 #: src/internals/rfc-rooting-by-construction.md:354
 #: src/contributing/releasing.md:183
 msgid "1"
@@ -12141,7 +12129,7 @@ msgstr "实情"
 msgid "**Node.js**"
 msgstr "**Node.js**"
 
-#: src/threading/overview.md:40 src/api/reference.md:4044
+#: src/threading/overview.md:40 src/api/reference.md:4082
 msgid "`worker_threads`"
 msgstr "`worker_threads`"
 
@@ -12158,7 +12146,7 @@ msgid "**Deno**"
 msgstr "**Deno**"
 
 #: src/threading/overview.md:41 src/threading/overview.md:42
-#: src/api/reference.md:530 src/api/reference.md:4051
+#: src/api/reference.md:568 src/api/reference.md:4089
 msgid "`Worker`"
 msgstr "`Worker`"
 
@@ -14065,19 +14053,19 @@ msgid "Compared to Node.js worker_threads"
 msgstr "与 Node.js worker_threads 比较"
 
 #: src/threading/spawn.md:168
-msgid "// ── Node.js: ~15 lines, separate file needed ──────────"
+#, fuzzy
+msgid ""
+"// ── Node.js: ~15 lines, separate file needed ──────────\n"
+"// worker.js\n"
 msgstr "// ── Node.js: ~15行,需要单独的文件 ───────────────"
-
-#: src/threading/spawn.md:168
-msgid "// worker.js"
-msgstr "// worker.js"
 
 #: src/threading/spawn.md:170 src/threading/spawn.md:175
 msgid "\"worker_threads\""
 msgstr "\"worker_threads\""
 
 #: src/threading/spawn.md:173
-msgid "// main.js"
+#, fuzzy
+msgid "// main.js\n"
 msgstr "// main.js"
 
 #: src/threading/spawn.md:176
@@ -14097,14 +14085,13 @@ msgid "/* handle */"
 msgstr "/* handle */"
 
 #: src/threading/spawn.md:184
-msgid "// ── Perry: 1 line ─────────────────────────────────────"
+#, fuzzy
+msgid ""
+"// ── Perry: 1 line ─────────────────────────────────────\n"
+"// const result = await spawn(() => heavyComputation(inputData));\n"
 msgstr ""
 "// ── Perry: 一行 "
 "─────────────────────────────────────────────────────────────────────────"
-
-#: src/threading/spawn.md:185
-msgid "// const result = await spawn(() => heavyComputation(inputData));"
-msgstr "// const结果 = 等待spawn(() => heavyComputation(inputData));"
 
 #: src/threading/spawn.md:189
 msgid ""
@@ -14315,13 +14302,14 @@ msgid "Mental Model"
 msgstr "心智模型"
 
 #: src/ui/overview.md:31
+#, fuzzy
 msgid ""
 "Perry's UI follows the same model as SwiftUI and Flutter: you compose native "
 "widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), "
 "control alignment and distribution, and style widgets via free functions "
 "that take the widget handle as their first argument (`textSetColor(label, r, "
-"g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from "
-"web development, the key shift is:"
+"g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web "
+"development, the key shift is:"
 msgstr ""
 "Perry 的 UI 沿用与 SwiftUI 和 Flutter 相同的模型:你通过基于栈的布局容器"
 "(`VStack`、`HStack`、`ZStack`)组合原生控件,控制对齐与分布,并通过以控件句柄作"
@@ -14402,7 +14390,7 @@ msgstr "`App({})` 接受一个具有以下属性的配置对象:"
 msgid "Property"
 msgstr "属性"
 
-#: src/ui/overview.md:59 src/api/reference.md:3142
+#: src/ui/overview.md:59 src/api/reference.md:3180
 msgid "`title`"
 msgstr "`title`"
 
@@ -14839,7 +14827,7 @@ msgstr "NSMenu"
 #: src/cli/perry-toml.md:389 src/cli/perry-toml.md:418
 #: src/cli/app-updates.md:56 src/cli/app-updates.md:57
 #: src/cli/app-updates.md:58 src/cli/app-updates.md:60
-#: src/internals/memory-model.md:314 src/internals/memory-model.md:315
+#: src/internals/memory-model.md:325 src/internals/memory-model.md:326
 #: src/contributing/building.md:50
 msgid "—"
 msgstr "—"
@@ -14861,7 +14849,7 @@ msgid ""
 "Platform-specific behavior is noted on each widget's documentation page."
 msgstr "平台特定行为会在每个控件的文档页中标注。"
 
-#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:377
+#: src/ui/overview.md:184 src/ui/layout.md:370 src/ui/styling.md:380
 #: src/ui/state.md:229 src/ui/events.md:170 src/ui/canvas.md:95
 #: src/ui/table.md:152 src/ui/animation.md:74 src/ui/camera.md:145
 #: src/ui/webview.md:241
@@ -16451,7 +16439,8 @@ msgid "Double-click handler"
 msgstr "双击处理器"
 
 #: src/ui/widgets.md:678
-msgid "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
+#, fuzzy
+msgid "`setPadding(w, value)` / `setPadding(w, top, left, bottom, right)`"
 msgstr "`widgetSetEdgeInsets(w, top, left, bottom, right)`"
 
 #: src/ui/widgets.md:678
@@ -16510,12 +16499,13 @@ msgstr ""
 "layout/snippets.ts) —— CI 会在每次 PR 时编译并运行它。"
 
 #: src/ui/layout.md:8
+#, fuzzy
 msgid ""
 "Layout helpers are free functions: `widgetAddChild(parent, child)`, "
-"`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, "
-"bottom,  right)`, etc. Stack constructors take a numeric spacing followed by "
-"a child array; everything else (alignment, distribution, padding, sizing) is "
-"applied post-construction via the free functions on the widget handle."
+"`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, "
+"right)`, etc. Stack constructors take a numeric spacing followed by a child "
+"array; everything else (alignment, distribution, padding, sizing) is applied "
+"post-construction via the free functions on the widget handle."
 msgstr ""
 "布局辅助器是免费的功能:`widgetAddChild(parent, "
 "child)`,`stackSetAlignment(stack, value)`,`widgetSetEdgeInsets(w, top, left, "
@@ -16980,7 +16970,7 @@ msgstr "效果"
 
 #: src/ui/layout.md:197 src/testing/geisterhand.md:91
 #: src/testing/geisterhand.md:105 src/cli/perry-toml.md:427
-#: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
 msgid "5"
 msgstr "5"
 
@@ -16993,7 +16983,7 @@ msgid "Children align to the leading (left) edge"
 msgstr "子项对齐到前导(左)边缘"
 
 #: src/ui/layout.md:198 src/tui/widgets.md:64
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:592
 msgid "9"
 msgstr "9"
 
@@ -17006,7 +16996,7 @@ msgid "Children centered horizontally"
 msgstr "子项水平居中"
 
 #: src/ui/layout.md:199 src/tui/widgets.md:63 src/testing/geisterhand.md:93
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "7"
 msgstr "7"
 
@@ -17027,7 +17017,7 @@ msgstr "**HStack 对齐**(交叉轴 = 垂直):"
 #: src/container/determinism.md:61 src/testing/geisterhand.md:89
 #: src/testing/geisterhand.md:103 src/cli/perry-toml.md:429
 #: src/internals/rfc-rooting-by-construction.md:356
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
 msgid "3"
 msgstr "3"
 
@@ -17054,8 +17044,8 @@ msgstr "子项垂直居中"
 #: src/ui/layout.md:207 src/ui/layout.md:227 src/tui/widgets.md:62
 #: src/container/overview.md:74 src/container/determinism.md:62
 #: src/testing/geisterhand.md:90 src/testing/geisterhand.md:104
-#: src/cli/perry-toml.md:428 src/internals/node-api-host.md:575
-#: src/internals/node-api-host.md:576
+#: src/testing/cc-parity.md:65 src/cli/perry-toml.md:428
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
 msgid "4"
 msgstr "4"
 
@@ -17107,9 +17097,9 @@ msgstr "行为"
 #: src/ui/styling-matrix.md:92 src/ui/styling-matrix.md:93
 #: src/ui/styling-matrix.md:94 src/ui/styling-matrix.md:95
 #: src/ui/styling-matrix.md:96 src/testing/geisterhand.md:86
-#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:229
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/testing/geisterhand.md:100 src/internals/gc-rooting-invariant.md:258
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "0"
 msgstr "0"
 
@@ -17132,11 +17122,11 @@ msgstr "所有子项获得相等尺寸"
 #: src/ui/layout.md:225 src/tui/widgets.md:60 src/platforms/windows-7.md:26
 #: src/container/overview.md:72 src/container/determinism.md:60
 #: src/testing/geisterhand.md:88 src/testing/geisterhand.md:102
-#: src/testing/ci-tiers.md:118 src/cli/perry-toml.md:430
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-tiers.md:127 src/cli/perry-toml.md:430
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 #: src/internals/rfc-rooting-by-construction.md:355
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "2"
 msgstr "2"
 
@@ -17323,9 +17313,10 @@ msgid "Stacks with Built-in Padding"
 msgstr "带内置内边距的 Stacks"
 
 #: src/ui/layout.md:298
+#, fuzzy
 msgid ""
 "Create a stack with padding in a single call. The order is **top, left, "
-"bottom, right** (CSS-shorthand-style), not top/right/bottom/left:"
+"bottom, right**, matching the per-side `setPadding` overload:"
 msgstr ""
 "通过单次调用创建带内边距的 stack。顺序为 **top、left、bottom、right**(CSS 简"
 "写风格),而不是 top/right/bottom/left:"
@@ -17349,11 +17340,12 @@ msgstr ""
 "```"
 
 #: src/ui/layout.md:309
+#, fuzzy
 msgid ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal "
-"counterpart. Equivalent to creating a stack and then calling "
-"`widgetSetEdgeInsets`, but more concise. Children are added via "
-"`widgetAddChild` rather than the constructor array."
+"counterpart. Equivalent to creating a stack and then calling `setPadding`, "
+"but more concise. Children are added via `widgetAddChild` rather than the "
+"constructor array."
 msgstr ""
 "`HStackWithInsets(spacing, top, left, bottom, right)` 是其水平对应版本。等同"
 "于先创建 stack 再调用 `widgetSetEdgeInsets`,但更简洁。子项通过 "
@@ -17636,8 +17628,9 @@ msgid "number \\| `{ top, right, bottom, left }`"
 msgstr "number \\| `{ top, right, bottom, left }`"
 
 #: src/ui/styling.md:52
-msgid "`widgetSetEdgeInsets`"
-msgstr "`widgetSetEdgeInsets`"
+#, fuzzy
+msgid "`setPadding`"
+msgstr "`padding`"
 
 #: src/ui/styling.md:53 src/ui/styling-matrix.md:17
 #: src/platforms/watchos.md:164
@@ -18014,6 +18007,7 @@ msgstr ""
 "的 API 始终是编译器实际接受的 API。"
 
 #: src/ui/styling.md:163
+#, fuzzy
 msgid ""
 "```typescript\n"
 "import {\n"
@@ -18025,7 +18019,6 @@ msgid ""
 "    widgetAddChild,\n"
 "    widgetSetBackgroundColor, widgetSetBackgroundGradient,\n"
 "    widgetSetBorderColor, widgetSetBorderWidth,\n"
-"    widgetSetEdgeInsets,\n"
 "    widgetSetWidth, widgetSetHeight, widgetMatchParentWidth,\n"
 "    widgetSetOpacity,\n"
 "    widgetSetControlSize,\n"
@@ -18053,11 +18046,11 @@ msgstr ""
 "} from \"perry/ui\"\n"
 "```"
 
-#: src/ui/styling.md:182
+#: src/ui/styling.md:181
 msgid "Colors"
 msgstr "颜色"
 
-#: src/ui/styling.md:184
+#: src/ui/styling.md:183
 msgid ""
 "```typescript\n"
 "const colored = Text(\"Colored text\")\n"
@@ -18073,11 +18066,11 @@ msgstr ""
 "widgetSetBackgroundColor(colored, 0.94, 0.94, 0.94, 1.0)\n"
 "```"
 
-#: src/ui/styling.md:190
+#: src/ui/styling.md:189
 msgid "Fonts"
 msgstr "字体"
 
-#: src/ui/styling.md:192
+#: src/ui/styling.md:191
 msgid ""
 "```typescript\n"
 "const font = Text(\"Styled text\")\n"
@@ -18093,15 +18086,15 @@ msgstr ""
 "textSetFontWeight(font, 24, 700)           // Re-set size + weight together\n"
 "```"
 
-#: src/ui/styling.md:199
+#: src/ui/styling.md:198
 msgid "Use `\"monospaced\"` for the system monospaced font."
 msgstr "使用 `\"monospaced\"` 来获取系统等宽字体。"
 
-#: src/ui/styling.md:201
+#: src/ui/styling.md:200
 msgid "Corner Radius"
 msgstr "圆角半径"
 
-#: src/ui/styling.md:203
+#: src/ui/styling.md:202
 msgid ""
 "```typescript\n"
 "const rounded = Button(\"Rounded\", () => {})\n"
@@ -18113,21 +18106,21 @@ msgstr ""
 "setCornerRadius(rounded, 12)\n"
 "```"
 
-#: src/ui/styling.md:208
+#: src/ui/styling.md:207
 msgid "Borders"
 msgstr "边框"
 
-#: src/ui/styling.md:216
-msgid "Padding and Insets"
-msgstr "Padding 与 Insets"
+#: src/ui/styling.md:215 src/widgets/components.md:155
+msgid "Padding"
+msgstr "内边距"
 
-#: src/ui/styling.md:218
+#: src/ui/styling.md:217
+#, fuzzy
 msgid ""
 "```typescript\n"
 "const padded = VStack(8, [Text(\"Padded content\")])\n"
-"// Both names accept (widget, top, left, bottom, right):\n"
-"setPadding(padded, 16, 16, 16, 16)\n"
-"widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
+"setPadding(padded, 16)                 // uniform padding\n"
+"setPadding(padded, 10, 20, 10, 20)    // top, left, bottom, right\n"
 "```"
 msgstr ""
 "```typescript\n"
@@ -18137,11 +18130,19 @@ msgstr ""
 "widgetSetEdgeInsets(padded, 10, 20, 10, 20)\n"
 "```"
 
-#: src/ui/styling.md:225
+#: src/ui/styling.md:223
+msgid ""
+"Use `setPadding(widget, value)` for uniform padding, or `setPadding(widget, "
+"top, left, bottom, right)` for individual sides. The old "
+"`widgetSetEdgeInsets` name is deprecated and remains an alias during the "
+"deprecation window."
+msgstr ""
+
+#: src/ui/styling.md:228
 msgid "Sizing"
 msgstr "尺寸"
 
-#: src/ui/styling.md:227
+#: src/ui/styling.md:230
 msgid ""
 "```typescript\n"
 "const sized = VStack(0, [])\n"
@@ -18157,11 +18158,11 @@ msgstr ""
 "widgetMatchParentWidth(sized) // expand to fill parent's width\n"
 "```"
 
-#: src/ui/styling.md:234 src/ui/theming.md:144
+#: src/ui/styling.md:237 src/ui/theming.md:144
 msgid "Opacity"
 msgstr "不透明度"
 
-#: src/ui/styling.md:236
+#: src/ui/styling.md:239
 msgid ""
 "```typescript\n"
 "const dim = Text(\"Semi-transparent\")\n"
@@ -18173,11 +18174,11 @@ msgstr ""
 "widgetSetOpacity(dim, 0.5) // 0.0 to 1.0\n"
 "```"
 
-#: src/ui/styling.md:241
+#: src/ui/styling.md:244
 msgid "Background Gradient"
 msgstr "背景渐变"
 
-#: src/ui/styling.md:243
+#: src/ui/styling.md:246
 msgid ""
 "```typescript\n"
 "const grad = VStack(0, [])\n"
@@ -18199,11 +18200,11 @@ msgstr ""
 ")\n"
 "```"
 
-#: src/ui/styling.md:253
+#: src/ui/styling.md:256
 msgid "Control Size"
 msgstr "控件尺寸"
 
-#: src/ui/styling.md:255
+#: src/ui/styling.md:258
 msgid ""
 "```typescript\n"
 "const small = Button(\"Small\", () => {})\n"
@@ -18215,17 +18216,17 @@ msgstr ""
 "widgetSetControlSize(small, 0) // 0=mini, 1=small, 2=regular, 3=large\n"
 "```"
 
-#: src/ui/styling.md:260
+#: src/ui/styling.md:263
 msgid ""
 "**macOS**: Maps to `NSControl.ControlSize`. Other platforms may interpret "
 "differently."
 msgstr "**macOS**:对应 `NSControl.ControlSize`。其他平台可能有不同解释。"
 
-#: src/ui/styling.md:262
+#: src/ui/styling.md:265
 msgid "Tooltips"
 msgstr "工具提示"
 
-#: src/ui/styling.md:264
+#: src/ui/styling.md:267
 msgid ""
 "```typescript\n"
 "const tip = Button(\"Hover me\", () => {})\n"
@@ -18237,7 +18238,7 @@ msgstr ""
 "widgetSetTooltip(tip, \"Click to perform action\")\n"
 "```"
 
-#: src/ui/styling.md:269
+#: src/ui/styling.md:272
 msgid ""
 "**macOS/Windows/Linux**: Native tooltips. **iOS/Android**: No tooltip "
 "support. **Web**: HTML `title` attribute."
@@ -18245,11 +18246,11 @@ msgstr ""
 "**macOS/Windows/Linux**:原生工具提示。**iOS/Android**:不支持工具提示。"
 "**Web**:HTML `title` 属性。"
 
-#: src/ui/styling.md:271
+#: src/ui/styling.md:274
 msgid "Enabled/Disabled"
 msgstr "启用/禁用"
 
-#: src/ui/styling.md:273
+#: src/ui/styling.md:276
 msgid ""
 "```typescript\n"
 "const submit = Button(\"Submit\", () => {})\n"
@@ -18261,11 +18262,12 @@ msgstr ""
 "widgetSetEnabled(submit, 0)  // 0 = disabled, 1 = enabled\n"
 "```"
 
-#: src/ui/styling.md:278
+#: src/ui/styling.md:281
 msgid "Complete Imperative Example"
 msgstr "完整命令式示例"
 
-#: src/ui/styling.md:280
+#: src/ui/styling.md:283
+#, fuzzy
 msgid ""
 "```typescript\n"
 "// demonstrates: a styled counter card using the real free-function API\n"
@@ -18285,7 +18287,7 @@ msgid ""
 "    textSetFontFamily,\n"
 "    textSetColor,\n"
 "    widgetSetBackgroundColor,\n"
-"    widgetSetEdgeInsets,\n"
+"    setPadding,\n"
 "    setCornerRadius,\n"
 "} from \"perry/ui\"\n"
 "\n"
@@ -18313,10 +18315,10 @@ msgid ""
 "widgetSetBackgroundColor(incBtn, 0.204, 0.78, 0.349, 1.0)\n"
 "\n"
 "const controls = HStack(8, [decBtn, Spacer(), incBtn])\n"
-"widgetSetEdgeInsets(controls, 20, 20, 20, 20)\n"
+"setPadding(controls, 20)\n"
 "\n"
 "const container = VStack(16, [title, display, controls])\n"
-"widgetSetEdgeInsets(container, 40, 40, 40, 40)\n"
+"setPadding(container, 40)\n"
 "setCornerRadius(container, 16)\n"
 "widgetSetBackgroundColor(container, 1.0, 1.0, 1.0, 1.0)\n"
 "\n"
@@ -18389,15 +18391,15 @@ msgstr ""
 "})\n"
 "```"
 
-#: src/ui/styling.md:341
+#: src/ui/styling.md:344
 msgid "Composing Styles (imperative helper functions)"
 msgstr "组合样式(命令式辅助函数)"
 
-#: src/ui/styling.md:343
+#: src/ui/styling.md:346
 msgid "Reduce repetition by creating helper functions:"
 msgstr "通过创建辅助函数来减少重复:"
 
-#: src/ui/styling.md:357
+#: src/ui/styling.md:360
 msgid ""
 "For larger apps, use the `perry-styling` package to define design tokens in "
 "JSON and generate a typed theme file. See [Theming](theming.md) for the full "
@@ -18406,11 +18408,11 @@ msgstr ""
 "对于较大的应用,可使用 `perry-styling` 包以 JSON 形式定义设计令牌并生成带类型"
 "的主题文件。完整流程参见 [Theming](theming.md)。"
 
-#: src/ui/styling.md:359 src/system/background.md:76
+#: src/ui/styling.md:362 src/system/background.md:76
 msgid "Platform support"
 msgstr "平台支持情况"
 
-#: src/ui/styling.md:361
+#: src/ui/styling.md:364
 msgid ""
 "Per-prop, per-platform support is tracked in the [styling matrix](styling-"
 "matrix.md) — auto-generated from `crates/perry-ui/src/styling_matrix.rs` and "
@@ -18420,7 +18422,7 @@ msgstr ""
 "`crates/perry-ui/src/styling_matrix.rs` 自动生成,并在每个 PR 上由 CI 与各后端"
 "的 `lib.rs` 导出比对校验。"
 
-#: src/ui/styling.md:366
+#: src/ui/styling.md:369
 msgid ""
 "The generated summary is the source of truth. It currently reports all 47 "
 "tracked properties wired, with zero stubs or missing exports, on macOS, iOS, "
@@ -18437,15 +18439,15 @@ msgstr ""
 "issues/202)和[\\#210](https://github.com/PerryTS/perry/issues/210)中. 不要将"
 "计数复制到另一个手动维护的表格中;请查看矩阵,以便文档不能从后端库存中漂移."
 
-#: src/ui/styling.md:378 src/ui/state.md:230 src/ui/table.md:153
+#: src/ui/styling.md:381 src/ui/state.md:230 src/ui/table.md:153
 msgid "[Layout](layout.md) — Layout containers"
 msgstr "[Layout](layout.md) — 布局容器"
 
-#: src/ui/styling.md:379
+#: src/ui/styling.md:382
 msgid "[Animation](animation.md) — Animate style changes"
 msgstr "[Animation](animation.md) — 为样式变化添加动画"
 
-#: src/ui/styling.md:380
+#: src/ui/styling.md:383
 msgid "[Theming](theming.md) — Design tokens via the `perry-styling` package"
 msgstr "[Theming](theming.md) — 通过 `perry-styling` 包使用设计令牌"
 
@@ -19757,8 +19759,8 @@ msgstr "实现"
 #: src/ui/canvas.md:76 src/platforms/overview.md:7 src/system/media.md:84
 #: src/testing/geisterhand.md:298
 #: src/internals/rfc-rooting-by-construction.md:352
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Status"
 msgstr "状态"
 
@@ -23189,7 +23191,7 @@ msgstr "清除此 WebView 数据存储的 Cookie / localStorage / IndexedDB。"
 msgid "Options"
 msgstr "选项"
 
-#: src/ui/webview.md:186 src/api/reference.md:3785 src/cli/perry-toml.md:443
+#: src/ui/webview.md:186 src/api/reference.md:3823 src/cli/perry-toml.md:443
 #: src/cli/app-updates.md:57 src/cli/app-updates.md:80
 msgid "`url`"
 msgstr "`url`"
@@ -24697,7 +24699,7 @@ msgstr "与 ink 的等价关系"
 msgid "ink"
 msgstr "ink"
 
-#: src/tui/hooks.md:169 src/api/reference.md:2778
+#: src/tui/hooks.md:169 src/api/reference.md:2816
 msgid "`perry/tui`"
 msgstr "`perry/tui`"
 
@@ -25407,15 +25409,18 @@ msgid "Cross-Compilation"
 msgstr "交叉编译"
 
 #: src/platforms/overview.md:23
-msgid "# Default: compile for current platform"
+#, fuzzy
+msgid "# Default: compile for current platform\n"
 msgstr "# 默认:为当前平台编译"
 
 #: src/platforms/overview.md:25
-msgid "# Compile for a specific target"
+#, fuzzy
+msgid "# Compile for a specific target\n"
 msgstr "# 为特定目标编译"
 
 #: src/platforms/overview.md:35
-msgid "# Wear OS — Android on a watch"
+#, fuzzy
+msgid "# Wear OS — Android on a watch\n"
 msgstr "# 在手表上Wear OS  Android"
 
 #: src/platforms/overview.md:38 src/platforms/visionos.md:49
@@ -25626,7 +25631,8 @@ msgid "Building"
 msgstr "构建"
 
 #: src/platforms/macos.md:13
-msgid "# macOS is the default target"
+#, fuzzy
+msgid "# macOS is the default target\n"
 msgstr "# macOS 是默认的目标"
 
 #: src/platforms/macos.md:18
@@ -25727,7 +25733,8 @@ msgid "App Store Distribution"
 msgstr "App Store 分发"
 
 #: src/platforms/macos.md:58
-msgid "# Sign with App Store certificate"
+#, fuzzy
+msgid "# Sign with App Store certificate\n"
 msgstr "# 使用应用商店证书签名"
 
 #: src/platforms/macos.md:60
@@ -25735,7 +25742,8 @@ msgid "\"3rd Party Mac Developer Application: Your Name\""
 msgstr "\"3rd Party Mac Developer Application: Your Name\""
 
 #: src/platforms/macos.md:60
-msgid "# Package"
+#, fuzzy
+msgid "# Package\n"
 msgstr "# Package"
 
 #: src/platforms/macos.md:62
@@ -25861,15 +25869,18 @@ msgid "The easiest way to build and run on iOS is `perry run`:"
 msgstr "在 iOS 上构建并运行的最简单方式是 `perry run`："
 
 #: src/platforms/ios.md:35
-msgid "# Auto-detect device/simulator"
+#, fuzzy
+msgid "# Auto-detect device/simulator\n"
 msgstr "# 自动检测device/simulator"
 
 #: src/platforms/ios.md:36
-msgid "# Stream live stdout/stderr"
+#, fuzzy
+msgid "# Stream live stdout/stderr\n"
 msgstr "# 在线播放stdout/stderr"
 
 #: src/platforms/ios.md:37
-msgid "# Use Perry Hub build server"
+#, fuzzy
+msgid "# Use Perry Hub build server\n"
 msgstr "# 使用PerryHub构建服务器"
 
 #: src/platforms/ios.md:40
@@ -26471,7 +26482,8 @@ msgid "This produces an ARM64 binary for physical Apple TV hardware."
 msgstr "这会为物理 Apple TV 硬件生成 ARM64 二进制文件。"
 
 #: src/platforms/tvos.md:35
-msgid "# Auto-detect booted Apple TV simulator"
+#, fuzzy
+msgid "# Auto-detect booted Apple TV simulator\n"
 msgstr "# 自动检测启动的果电视模拟器"
 
 #: src/platforms/tvos.md:39
@@ -26937,11 +26949,13 @@ msgstr ""
 "std` (见[为设备建造](#building-for-device)):"
 
 #: src/platforms/watchos.md:16
-msgid "# simulator (tier 2)"
+#, fuzzy
+msgid "# simulator (tier 2)\n"
 msgstr "# 模拟器 (2级)"
 
 #: src/platforms/watchos.md:17
-msgid "# for device build-std"
+#, fuzzy
+msgid "# for device build-std\n"
 msgstr "# for device build-std"
 
 #: src/platforms/watchos.md:20
@@ -27044,20 +27058,14 @@ msgstr ""
 "`PERRY_RUNTIME_DIR`:"
 
 #: src/platforms/watchos.md:59
-msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target"
+#, fuzzy
+msgid "# arm64 (Series 9+ / watchOS 26+) — the default device target\n"
 msgstr "# arm64 (系列 9+ / watchOS 26+) 默认设备目标"
 
-#: src/platforms/watchos.md:63
-msgid "target/aarch64-apple-watchos/release"
-msgstr "target/aarch64-apple-watchos/release"
-
 #: src/platforms/watchos.md:68
-msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32"
+#, fuzzy
+msgid "# arm64_32 (Series 4-8 / SE) — opt in with PERRY_WATCHOS_ARM64_32\n"
 msgstr "# arm64_32 (系列4-8 / SE) 选择使用PERRY_WATCHOS_ARM64_32"
-
-#: src/platforms/watchos.md:73
-msgid "target/arm64_32-apple-watchos/release"
-msgstr "target/arm64_32-apple-watchos/release"
 
 #: src/platforms/watchos.md:77
 msgid ""
@@ -27073,7 +27081,7 @@ msgid "Build environment variables"
 msgstr "构建环境变量"
 
 #: src/platforms/watchos.md:82 src/container/overview.md:112
-#: src/cli/flags.md:276 src/cli/flags.md:310 src/cli/perry-toml.md:518
+#: src/cli/flags.md:320 src/cli/flags.md:354 src/cli/perry-toml.md:518
 #: src/cli/perry-toml.md:530 src/cli/perry-toml.md:540
 msgid "Variable"
 msgstr "变量"
@@ -27181,7 +27189,8 @@ msgstr ""
 "不可调用的,结果的`TypeError`值强迫将封闭作为一个对象."
 
 #: src/platforms/watchos.md:122
-msgid "# Auto-detect booted watch simulator"
+#, fuzzy
+msgid "# Auto-detect booted watch simulator\n"
 msgstr "# 自动检测启动时钟模拟器"
 
 #: src/platforms/watchos.md:126
@@ -27741,36 +27750,13 @@ msgstr ""
 "`lipo` 他们一起:"
 
 #: src/platforms/watchos-app-store.md:40
-msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)"
+#, fuzzy
+msgid "# 1. arm64_32 slice at the shared deployment target (e.g. 10.0)\n"
 msgstr "# 1. 在共享部署目标 (e.g) 上切割arm64_32. 10.0)"
 
 #: src/platforms/watchos-app-store.md:41
 msgid "10.0"
 msgstr "10.0"
-
-#: src/platforms/watchos-app-store.md:42
-msgid "_perry_user_main"
-msgstr "_perry_user_main"
-
-#: src/platforms/watchos-app-store.md:43
-msgid ".../arm64_32-apple-watchos/release"
-msgstr ".../arm64_32-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:45
-msgid "# 2. arm64 slice (default device target)"
-msgstr "# 2. arm64切片 (默认设备目标)"
-
-#: src/platforms/watchos-app-store.md:47
-msgid ".../aarch64-apple-watchos/release"
-msgstr ".../aarch64-apple-watchos/release"
-
-#: src/platforms/watchos-app-store.md:49
-msgid "# 3. align minos + fuse"
-msgstr "# 3. 调整子 + 安全"
-
-#: src/platforms/watchos-app-store.md:54
-msgid "# => arm64_32 arm64"
-msgstr "# => arm64_32 arm64 没有"
 
 #: src/platforms/watchos-app-store.md:57
 msgid ""
@@ -27885,19 +27871,8 @@ msgstr ""
 "需要 **自己的新应用程序记录** 在App Store连接中."
 
 #: src/platforms/watchos-app-store.md:116
-#: src/platforms/watchos-app-store.md:118
 msgid "\"Apple Distribution: <Team>\""
 msgstr "\"果发行:<Team>\""
-
-#: src/platforms/watchos-app-store.md:117
-msgid "\"Container.app/Watch/WatchApp.app\""
-msgstr "\"Container.app/Watch/WatchApp.app\""
-
-#: src/platforms/watchos-app-store.md:119
-#: src/platforms/watchos-app-store.md:120
-#: src/platforms/watchos-app-store.md:128
-msgid "\"Container.app\""
-msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:123
 msgid "Uploading"
@@ -27908,6 +27883,10 @@ msgid ""
 "`altool` cannot upload watch apps (\"cannot determine platform\"). Use "
 "Transporter:"
 msgstr "`altool`无法上传观看应用程序 (\"无法确定平台\"). 使用传输器:"
+
+#: src/platforms/watchos-app-store.md:128
+msgid "\"Container.app\""
+msgstr "\"Container.app\""
 
 #: src/platforms/watchos-app-store.md:133
 msgid ""
@@ -28239,19 +28218,22 @@ msgid "One-time setup (macOS example)"
 msgstr "一次性设置 (macOS示例)"
 
 #: src/platforms/wearos.md:35
+#, fuzzy
 msgid ""
-"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)"
+"# 1. JDK 17 + Gradle 8.x (Homebrew's `gradle` may be 9.x — pin 8.x if so)\n"
 msgstr ""
 "# 1. JDK 17 + Gradle 8.x (如果是这样,Homebrew 的 `gradle` 可能是 9.x  pin "
 "8.x)"
 
 #: src/platforms/wearos.md:37
-msgid "# or any Gradle 8.10.2+"
+#, fuzzy
+msgid "# or any Gradle 8.10.2+\n"
 msgstr "# 或任何Gradle 8.10.2+"
 
 #: src/platforms/wearos.md:38
+#, fuzzy
 msgid ""
-"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)"
+"# 2. Point the env at the SDK / NDK / JDK 17 (add to your shell profile)\n"
 msgstr "# 2. 指向SDK/NDK/JDK 17的 env (添加到你的 shell 配置文件)"
 
 #: src/platforms/wearos.md:40
@@ -28259,7 +28241,8 @@ msgid "\"$HOME/Library/Android/sdk\""
 msgstr "\"$HOME/Library/Android/sdk\""
 
 #: src/platforms/wearos.md:41
-msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358"
+#, fuzzy
+msgid "\"$ANDROID_HOME/ndk/<installed-version>\"   # e.g. 28.2.13676358\n"
 msgstr ""
 "\"$ANDROID_HOME/ndk/<installed-version>\"#e.g. 这里是我们在线观看. "
 "28.2.13676358"
@@ -28273,32 +28256,13 @@ msgid "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 msgstr "\"$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$PATH\""
 
 #: src/platforms/wearos.md:44
-msgid "# 3. SDK packages + a Wear OS arm64 image"
+#, fuzzy
+msgid "# 3. SDK packages + a Wear OS arm64 image\n"
 msgstr "# 3. SDK包 + 一个 Wear OS arm64 图像"
 
 #: src/platforms/wearos.md:47
 msgid "\"platform-tools\" \"emulator\""
 msgstr "\"平台工具\" \"模拟器\""
-
-#: src/platforms/wearos.md:48
-msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
-msgstr "\"平台;安卓-35\" \"构建工具;35.0.0\""
-
-#: src/platforms/wearos.md:49
-msgid "\"ndk;28.2.13676358\""
-msgstr "\"ndk;28.2.13676358\""
-
-#: src/platforms/wearos.md:50 src/platforms/wearos.md:57
-msgid "\"system-images;android-34;android-wear;arm64-v8a\""
-msgstr "\"系统图像;安卓-34;安卓穿戴;ARM64-V8A\""
-
-#: src/platforms/wearos.md:51
-msgid "# 4. The Rust cross target"
-msgstr "# 4. 交叉目标Rust"
-
-#: src/platforms/wearos.md:54
-msgid "# 5. Create + boot a Wear OS emulator (round watch)"
-msgstr "# 5. 创建 + 启动一个 Wear OS 模拟器 (全程观看)"
 
 #: src/platforms/wearos.md:61
 msgid ""
@@ -28321,7 +28285,8 @@ msgstr ""
 "android`相同的文物. 在运行时间 (下面) 进行包装到手表APK中."
 
 #: src/platforms/wearos.md:79
-msgid "# Auto-detect a connected watch / booted Wear emulator"
+#, fuzzy
+msgid "# Auto-detect a connected watch / booted Wear emulator\n"
 msgstr "# 自动检测连接的手表/启动的 Wear 模拟器"
 
 #: src/platforms/wearos.md:82
@@ -30201,7 +30166,8 @@ msgstr ""
 "`GskRenderer` 进行像素精确捕获。"
 
 #: src/platforms/linux.md:76
-msgid "# In another terminal:"
+#, fuzzy
+msgid "# In another terminal:\n"
 msgstr "# 在另一个航站楼:"
 
 #: src/platforms/linux.md:82
@@ -30218,7 +30184,8 @@ msgstr ""
 "HTML 文件,内嵌 WebAssembly 以及用于 DOM 控件的 JavaScript 桥接层。"
 
 #: src/platforms/web.md:6
-msgid "# same output as --target wasm"
+#, fuzzy
+msgid "# same output as --target wasm\n"
 msgstr "# 与 --target 的输出相同"
 
 #: src/platforms/web.md:10
@@ -30291,15 +30258,18 @@ msgstr ""
 "Web Worker 线程。"
 
 #: src/platforms/wasm.md:10
-msgid "# Self-contained HTML (default)"
+#, fuzzy
+msgid "# Self-contained HTML (default)\n"
 msgstr "# 独立的HTML (默认)"
 
 #: src/platforms/wasm.md:13
-msgid "# Same thing"
+#, fuzzy
+msgid "# Same thing\n"
 msgstr "# 同样的事情"
 
 #: src/platforms/wasm.md:16
-msgid "# Raw .wasm binary (no HTML wrapper)"
+#, fuzzy
+msgid "# Raw .wasm binary (no HTML wrapper)\n"
 msgstr "# 原始.wasm二进制 (没有HTML包装)"
 
 #: src/platforms/wasm.md:21
@@ -30606,11 +30576,13 @@ msgid "Provide them when instantiating:"
 msgstr "在实例化时提供它们:"
 
 #: src/platforms/wasm.md:88
-msgid "// Via __ffiImports global (set before boot)"
+#, fuzzy
+msgid "// Via __ffiImports global (set before boot)\n"
 msgstr "// 通过 __ffiImports 全球 (启动前设置)"
 
 #: src/platforms/wasm.md:90
-msgid "// Or via bootPerryWasm second argument"
+#, fuzzy
+msgid "// Or via bootPerryWasm second argument\n"
 msgstr "// 或通过bootPerryWasm第二参数"
 
 #: src/platforms/wasm.md:95
@@ -31124,7 +31096,7 @@ msgstr "完整标准库"
 msgid "The compiler links only the required runtime components."
 msgstr "编译器仅链接所需的运行时组件。"
 
-#: src/stdlib/overview.md:93 src/stdlib/other.md:373
+#: src/stdlib/overview.md:93 src/stdlib/other.md:431
 msgid "External native bindings"
 msgstr "外部原生绑定"
 
@@ -31231,7 +31203,7 @@ msgstr "[文件系统](fs.md)"
 msgid "[HTTP & Networking](http.md)"
 msgstr "[HTTP 与网络](http.md)"
 
-#: src/stdlib/overview.md:140 src/stdlib/http.md:394
+#: src/stdlib/overview.md:140 src/stdlib/http.md:410
 msgid "[Databases](database.md)"
 msgstr "[数据库](database.md)"
 
@@ -31449,8 +31421,8 @@ msgid ""
 "Pass file paths across thread boundaries and reopen files inside the worker."
 msgstr "跨线程边界传递文件路径，并在工作线程内重新打开文件。"
 
-#: src/stdlib/fs.md:101 src/stdlib/http.md:395 src/stdlib/database.md:110
-#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:394
+#: src/stdlib/fs.md:101 src/stdlib/http.md:411 src/stdlib/database.md:110
+#: src/stdlib/crypto.md:90 src/stdlib/utilities.md:114 src/stdlib/other.md:452
 msgid "[Overview](overview.md) — All stdlib modules"
 msgstr "[概览](overview.md) —— 所有标准库模块"
 
@@ -31546,10 +31518,11 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:47
+#, fuzzy
 msgid ""
 "Supported on `IncomingMessage`: `.method`, `.url`, `.headers`, "
 "`.rawHeaders`, `.httpVersion`, `.complete`, `.aborted`, `.destroyed`, "
-"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'|  "
+"`.socket.remoteAddress`, `.socket.remotePort`, `.on('data'|'end'|'close'| "
 "'error', cb)`, `.read()`, `.pause()`, `.resume()`, `.destroy()`."
 msgstr ""
 "支持"
@@ -31557,10 +31530,11 @@ msgstr ""
 "'error', cb)`,`.read()`,`.pause()`,`.resume()`,`.destroy()`"
 
 #: src/stdlib/http.md:52
+#, fuzzy
 msgid ""
 "Supported on `ServerResponse`: `.statusCode` (get/set), `.statusMessage` "
 "(set), "
-"`.setHeader/.getHeader/.removeHeader/.hasHeader/  .getHeaders/.getHeaderNames`, "
+"`.setHeader/.getHeader/.removeHeader/.hasHeader/ .getHeaders/.getHeaderNames`, "
 "`.headersSent`, `.writableEnded`, `.writableFinished`, `.writeHead(status, "
 "msg?, headers?)`, `.write(chunk)`, `.end(chunk?)`, `.flushHeaders()`, "
 "`.on('finish'|'close', cb)`. Auto Content-Length on `.end()` when no "
@@ -32148,10 +32122,36 @@ msgstr ""
 "```"
 
 #: src/stdlib/http.md:327
+msgid ""
+"`new WebSocketServer({ server: httpServer })` shares an existing HTTP "
+"server's port: ordinary requests still reach the HTTP handler and WebSocket "
+"upgrades fire `wss.on(\"connection\", (ws, req) => ...)`. `wss.address()` "
+"reports the host server's address. Closing the WebSocket server detaches it "
+"without closing the shared HTTP listener."
+msgstr ""
+
+#: src/stdlib/http.md:333
+msgid ""
+"For manual routing, create `new WebSocketServer({ noServer: true })` and "
+"call `wss.handleUpgrade(req, socket, head, (ws, req) => "
+"wss.emit(\"connection\", ws, req))` from the HTTP server's `upgrade` "
+"listener. The callback runs once; it controls whether the connection event "
+"is emitted. The native HTTP transport performs the handshake before "
+"dispatching `upgrade`, as described above."
+msgstr ""
+
+#: src/stdlib/http.md:339
+msgid ""
+"A standalone `new WebSocketServer({ port: 0 })` binds an ephemeral port and "
+"emits `listening`. Read `wss.address().port` inside that listener to connect "
+"to it. Its address object contains `address`, `family`, and `port`."
+msgstr ""
+
+#: src/stdlib/http.md:343
 msgid "AWS S3 / S3-Compatible Object Storage"
 msgstr "AWS S3 / 兼容 S3 的对象存储"
 
-#: src/stdlib/http.md:329
+#: src/stdlib/http.md:345
 msgid ""
 "[`@bradenmacdonald/s3-lite-client`](https://github.com/bradenmacdonald/s3-"
 "lite-client) is a zero-dependency, MIT-licensed S3 client (~1.9k LoC, "
@@ -32166,11 +32166,11 @@ msgstr ""
 "`perry.compilePackages` 下原生编译，无需任何补丁——经过验证可以与 `bun` 在 "
 "SigV4 预签名 URL 上达到逐字节一致（issue #551）。"
 
-#: src/stdlib/http.md:334
+#: src/stdlib/http.md:350
 msgid "\"@bradenmacdonald/s3-lite-client\""
 msgstr "\"@bradenmacdonald/s3-lite-client\""
 
-#: src/stdlib/http.md:339
+#: src/stdlib/http.md:355
 msgid ""
 "```typescript,no-test\n"
 "import { S3Client } from \"@bradenmacdonald/s3-lite-client\"\n"
@@ -32244,76 +32244,76 @@ msgstr ""
 "await s3.deleteObject(\"path/to/object.txt\")\n"
 "```"
 
-#: src/stdlib/http.md:374
+#: src/stdlib/http.md:390
 msgid ""
 "Same code works against any S3-compatible service — only `endPoint` changes:"
 msgstr "同样的代码可对任何兼容 S3 的服务工作——只需更改 `endPoint`："
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "Service"
 msgstr "服务"
 
-#: src/stdlib/http.md:376
+#: src/stdlib/http.md:392
 msgid "`endPoint`"
 msgstr "`endPoint`"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "AWS S3"
 msgstr "AWS S3"
 
-#: src/stdlib/http.md:378
+#: src/stdlib/http.md:394
 msgid "`https://s3.<region>.amazonaws.com`"
 msgstr "`https://s3.<region>.amazonaws.com`"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "Cloudflare R2"
 msgstr "Cloudflare R2"
 
-#: src/stdlib/http.md:379
+#: src/stdlib/http.md:395
 msgid "`https://<account>.r2.cloudflarestorage.com`"
 msgstr "`https://<account>.r2.cloudflarestorage.com`"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "MinIO"
 msgstr "MinIO"
 
-#: src/stdlib/http.md:380
+#: src/stdlib/http.md:396
 msgid "`http://localhost:9000`"
 msgstr "`http://localhost:9000`"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "Backblaze B2"
 msgstr "Backblaze B2"
 
-#: src/stdlib/http.md:381
+#: src/stdlib/http.md:397
 msgid "`https://s3.<region>.backblazeb2.com`"
 msgstr "`https://s3.<region>.backblazeb2.com`"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "DigitalOcean Spaces"
 msgstr "DigitalOcean Spaces"
 
-#: src/stdlib/http.md:382
+#: src/stdlib/http.md:398
 msgid "`https://<region>.digitaloceanspaces.com`"
 msgstr "`https://<region>.digitaloceanspaces.com`"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "Supabase Storage"
 msgstr "Supabase Storage"
 
-#: src/stdlib/http.md:383
+#: src/stdlib/http.md:399
 msgid "`https://<project>.supabase.co/storage/v1/s3`"
 msgstr "`https://<project>.supabase.co/storage/v1/s3`"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "LocalStack (testing)"
 msgstr "LocalStack（测试用）"
 
-#: src/stdlib/http.md:384
+#: src/stdlib/http.md:400
 msgid "`http://localhost:4566`"
 msgstr "`http://localhost:4566`"
 
-#: src/stdlib/http.md:386
+#: src/stdlib/http.md:402
 msgid ""
 "The full SigV4 signing chain (Web Crypto HMAC-SHA-256 + SHA-256, "
 "TextEncoder, URLSearchParams, Headers iteration, typed-array byte "
@@ -32328,7 +32328,7 @@ msgstr ""
 "`presignedGetObject`、`presignedPostObject`）均通过固定测试向量与 `bun` 逐字"
 "节比对验证，并能针对真实 S3 完成认证。"
 
-#: src/stdlib/http.md:388
+#: src/stdlib/http.md:404
 msgid ""
 "Multipart uploads (`putObject` with a `ReadableStream` source large enough "
 "to chunk) exercise additional surface — `WritableStream` / `TransformStream` "
@@ -32339,7 +32339,7 @@ msgstr ""
 "外的接口面——`WritableStream` / `TransformStream` 子类化（按 #562）——该路径可"
 "以编译，但此处未单独通过固定向量进行验证。"
 
-#: src/stdlib/http.md:390
+#: src/stdlib/http.md:406
 msgid ""
 "For the AWS SDK v3 (`@aws-sdk/client-s3`): Perry currently can't compile it. "
 "Its dependency tree pulls in `@smithy/*` and runtime middleware registration "
@@ -32970,9 +32970,10 @@ msgstr ""
 "和`inRange`."
 
 #: src/stdlib/utilities.md:13
+#, fuzzy
 msgid ""
 "Use named imports: the default-import receiver form (`import _ from "
-"\"lodash\";  _.chunk(...)`) is not routed to these native signatures because "
+"\"lodash\"; _.chunk(...)`) is not routed to these native signatures because "
 "it would pass the module object as an extra receiver argument."
 msgstr ""
 "使用命名进口:默认进口接收器表格 (`import _ from \"lodash\";  _.chunk(...)`) "
@@ -33179,19 +33180,15 @@ msgstr ""
 
 #: src/stdlib/other.md:3
 msgid ""
-"Additional npm packages and Node.js APIs supported by Perry. All listed here "
-"are wired through Perry's well-known native bindings registry (#466) and "
-"compile to native code with no JavaScript runtime involvement."
+"Additional npm packages and runtime APIs supported by Perry. These APIs "
+"compile to native code."
 msgstr ""
-"Perry 支持的其他 npm 包和 Node.js API。此处列出的所有项均通过 Perry 的 well-"
-"known 原生绑定注册表（#466）接入，并编译为原生代码，不涉及 JavaScript 运行"
-"时。"
 
-#: src/stdlib/other.md:7
+#: src/stdlib/other.md:6
 msgid "sharp (Image Processing)"
 msgstr "sharp（图像处理）"
 
-#: src/stdlib/other.md:9
+#: src/stdlib/other.md:8
 msgid ""
 "Native bindings via `perry-ext-sharp` (v0.5.551). Resizes, format "
 "conversion, and buffer/file output all work."
@@ -33199,7 +33196,7 @@ msgstr ""
 "通过 `perry-ext-sharp` 提供的原生绑定（v0.5.551）。缩放、格式转换以及缓冲区/"
 "文件输出均可使用。"
 
-#: src/stdlib/other.md:12
+#: src/stdlib/other.md:11
 msgid ""
 "```typescript,no-test\n"
 "import sharp from \"sharp\";\n"
@@ -33249,15 +33246,15 @@ msgstr ""
 "  .toBuffer();\n"
 "```"
 
-#: src/stdlib/other.md:36
+#: src/stdlib/other.md:35
 msgid "cheerio (HTML Parsing)"
 msgstr "cheerio（HTML 解析）"
 
-#: src/stdlib/other.md:38
+#: src/stdlib/other.md:37
 msgid "Native bindings via `perry-ext-cheerio` (v0.5.550)."
 msgstr "通过 `perry-ext-cheerio` 提供的原生绑定（v0.5.550）。"
 
-#: src/stdlib/other.md:40
+#: src/stdlib/other.md:39
 msgid ""
 "```typescript,no-test\n"
 "import * as cheerio from \"cheerio\";\n"
@@ -33275,11 +33272,11 @@ msgstr ""
 "console.log($(\"h1\").text()); // \"Hello\"\n"
 "```"
 
-#: src/stdlib/other.md:48
+#: src/stdlib/other.md:47
 msgid "nodemailer (Email)"
 msgstr "nodemailer（邮件）"
 
-#: src/stdlib/other.md:50
+#: src/stdlib/other.md:49
 msgid ""
 "```typescript,no-test\n"
 "import nodemailer from \"nodemailer\"\n"
@@ -33319,15 +33316,15 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:69
+#: src/stdlib/other.md:68
 msgid "zlib (Compression)"
 msgstr "zlib（压缩）"
 
-#: src/stdlib/other.md:71
+#: src/stdlib/other.md:70
 msgid "Native bindings via `perry-ext-zlib` (v0.5.541)."
 msgstr "通过 `perry-ext-zlib` 提供的原生绑定（v0.5.541）。"
 
-#: src/stdlib/other.md:73
+#: src/stdlib/other.md:72
 msgid ""
 "```typescript,no-test\n"
 "import zlib from \"zlib\";\n"
@@ -33345,11 +33342,11 @@ msgstr ""
 "console.log(decompressed.toString()); // \"Hello, World!\"\n"
 "```"
 
-#: src/stdlib/other.md:81
+#: src/stdlib/other.md:80
 msgid "cron / node-cron (Job Scheduling)"
 msgstr "cron / node-cron（任务调度）"
 
-#: src/stdlib/other.md:83
+#: src/stdlib/other.md:82
 msgid ""
 "Native bindings via `perry-ext-cron` (v0.5.564). Both `cron` and `node-cron` "
 "package names route to the same backend."
@@ -33357,7 +33354,7 @@ msgstr ""
 "通过 `perry-ext-cron` 提供的原生绑定（v0.5.564）。`cron` 和 `node-cron` 两个"
 "包名均路由到同一个后端。"
 
-#: src/stdlib/other.md:86
+#: src/stdlib/other.md:85
 msgid ""
 "```typescript,no-test\n"
 "import { CronJob } from \"cron\";\n"
@@ -33377,11 +33374,11 @@ msgstr ""
 "job.start();\n"
 "```"
 
-#: src/stdlib/other.md:95
+#: src/stdlib/other.md:94
 msgid "ethers (Ethereum)"
 msgstr "ethers（以太坊）"
 
-#: src/stdlib/other.md:97
+#: src/stdlib/other.md:96
 msgid ""
 "Native bindings via `perry-ext-ethers` (v0.5.556) — backed by [`ethers-rs`]"
 "(https://github.com/gakonst/ethers-rs)\\-style ABI plumbing through `perry-"
@@ -33391,7 +33388,7 @@ msgstr ""
 "BigInt 与 Buffer 接口面，借助 [`ethers-rs`](https://github.com/gakonst/"
 "ethers-rs) 风格的 ABI 管道实现。"
 
-#: src/stdlib/other.md:101
+#: src/stdlib/other.md:100
 msgid ""
 "```typescript,no-test\n"
 "import { ethers } from \"ethers\";\n"
@@ -33409,11 +33406,11 @@ msgstr ""
 "console.log(\"private key:\", wallet.privateKey);\n"
 "```"
 
-#: src/stdlib/other.md:109
+#: src/stdlib/other.md:108
 msgid "events (EventEmitter)"
 msgstr "events（EventEmitter）"
 
-#: src/stdlib/other.md:111
+#: src/stdlib/other.md:110
 msgid ""
 "Native bindings via `perry-ext-events` (v0.5.546). The `EventEmitter` shape "
 "matches Node.js — `on`, `off`, `once`, `emit`, `removeAllListeners`."
@@ -33421,7 +33418,7 @@ msgstr ""
 "通过 `perry-ext-events` 提供的原生绑定（v0.5.546）。`EventEmitter` 形态与 "
 "Node.js 一致——`on`、`off`、`once`、`emit`、`removeAllListeners`。"
 
-#: src/stdlib/other.md:114
+#: src/stdlib/other.md:113
 msgid ""
 "```typescript,no-test\n"
 "import { EventEmitter } from \"events\";\n"
@@ -33439,15 +33436,15 @@ msgstr ""
 "ee.emit(\"data\", \"hello\");\n"
 "```"
 
-#: src/stdlib/other.md:122
+#: src/stdlib/other.md:121
 msgid "exponential-backoff (Retry Logic)"
 msgstr "exponential-backoff（重试逻辑）"
 
-#: src/stdlib/other.md:124
+#: src/stdlib/other.md:123
 msgid "Native bindings via `perry-ext-exponential-backoff` (v0.5.542)."
 msgstr "通过 `perry-ext-exponential-backoff` 提供的原生绑定（v0.5.542）。"
 
-#: src/stdlib/other.md:126
+#: src/stdlib/other.md:125
 msgid ""
 "```typescript,no-test\n"
 "import { backOff } from \"exponential-backoff\";\n"
@@ -33469,11 +33466,11 @@ msgstr ""
 "});\n"
 "```"
 
-#: src/stdlib/other.md:136
+#: src/stdlib/other.md:135
 msgid "decimal.js / bignumber.js (Arbitrary Precision)"
 msgstr "decimal.js / bignumber.js（任意精度）"
 
-#: src/stdlib/other.md:138
+#: src/stdlib/other.md:137
 msgid ""
 "Native bindings via `perry-ext-decimal` (v0.5.547). Both package names route "
 "to the same backend — `Decimal` and `BigNumber` are both exposed."
@@ -33481,7 +33478,7 @@ msgstr ""
 "通过 `perry-ext-decimal` 提供的原生绑定（v0.5.547）。两个包名均路由到同一个后"
 "端——`Decimal` 和 `BigNumber` 都已暴露。"
 
-#: src/stdlib/other.md:141
+#: src/stdlib/other.md:140
 msgid ""
 "```typescript,no-test\n"
 "import Decimal from \"decimal.js\"\n"
@@ -33517,11 +33514,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:158
+#: src/stdlib/other.md:157
 msgid "dayjs / date-fns (Date Manipulation)"
 msgstr "dayjs / date-fns（日期处理）"
 
-#: src/stdlib/other.md:160
+#: src/stdlib/other.md:159
 msgid ""
 "Native bindings via `perry-ext-dayjs` (v0.5.548). Both package names route "
 "to the same Rust backend — same parse/format/diff surface."
@@ -33529,7 +33526,7 @@ msgstr ""
 "通过 `perry-ext-dayjs` 提供的原生绑定（v0.5.548）。两个包名均路由到同一个 "
 "Rust 后端——具有相同的解析/格式化/差值接口面。"
 
-#: src/stdlib/other.md:163
+#: src/stdlib/other.md:162
 msgid ""
 "```typescript,no-test\n"
 "import dayjs from \"dayjs\";\n"
@@ -33547,11 +33544,11 @@ msgstr ""
 "console.log(tomorrow.format(\"YYYY-MM-DD\"));\n"
 "```"
 
-#: src/stdlib/other.md:171
+#: src/stdlib/other.md:170
 msgid "moment (Legacy Date)"
 msgstr "moment（旧版日期）"
 
-#: src/stdlib/other.md:173
+#: src/stdlib/other.md:172
 msgid ""
 "Native bindings via `perry-ext-moment` (v0.5.549). `moment` is in "
 "maintenance mode upstream — prefer `dayjs` for new code, but Perry supports "
@@ -33560,7 +33557,7 @@ msgstr ""
 "通过 `perry-ext-moment` 提供的原生绑定（v0.5.549）。`moment` 在上游已进入维护"
 "模式——新代码请优先选择 `dayjs`，但 Perry 为现有代码库同时支持二者。"
 
-#: src/stdlib/other.md:177
+#: src/stdlib/other.md:176
 msgid ""
 "```typescript,no-test\n"
 "import moment from \"moment\";\n"
@@ -33576,11 +33573,11 @@ msgstr ""
 "console.log(m.format());\n"
 "```"
 
-#: src/stdlib/other.md:184
+#: src/stdlib/other.md:183
 msgid "rate-limiter-flexible"
 msgstr "rate-limiter-flexible"
 
-#: src/stdlib/other.md:186
+#: src/stdlib/other.md:185
 msgid ""
 "Native bindings via `perry-ext-ratelimit` (v0.5.552). In-memory limiter is "
 "wired; Redis / cluster backing stores are follow-ups."
@@ -33588,7 +33585,7 @@ msgstr ""
 "通过 `perry-ext-ratelimit` 提供的原生绑定（v0.5.552）。内存限流器已接入；"
 "Redis / 集群后端存储为后续工作。"
 
-#: src/stdlib/other.md:189
+#: src/stdlib/other.md:188
 msgid ""
 "```typescript,no-test\n"
 "import { RateLimiterMemory } from \"rate-limiter-flexible\";\n"
@@ -33612,11 +33609,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:200
+#: src/stdlib/other.md:199
 msgid "worker_threads"
 msgstr "worker_threads"
 
-#: src/stdlib/other.md:202
+#: src/stdlib/other.md:201
 msgid ""
 "Perry compiles statically resolvable worker entry files as separate native "
 "module entry functions. Both the Node `worker_threads` API and the Web/Bun "
@@ -33632,7 +33629,7 @@ msgstr ""
 "作,`parallelMap` / `parallelFilter` / `spawn` 从 `perry/thread` 仍然是最简单"
 "的接口 (见 [Threading](../threading/overview.md))."
 
-#: src/stdlib/other.md:209
+#: src/stdlib/other.md:208
 msgid ""
 "```text\n"
 "import { Worker, parentPort, workerData } from \"worker_threads\";\n"
@@ -33670,12 +33667,12 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:227
+#: src/stdlib/other.md:226
 msgid ""
 "Web Worker module URLs are discovered relative to the importing source file:"
 msgstr "网络工作者模块URL与导入源文件相比被发现:"
 
-#: src/stdlib/other.md:229
+#: src/stdlib/other.md:228
 msgid ""
 "```typescript,no-test\n"
 "// main.ts\n"
@@ -33708,10 +33705,183 @@ msgstr ""
 "```"
 
 #: src/stdlib/other.md:244
+msgid "bun:jsc"
+msgstr ""
+
+#: src/stdlib/other.md:246
+msgid ""
+"`heapStats()` and `heapStats(true)` return memory diagnostics for the "
+"calling thread. Static imports, dynamic imports, and `require(\"bun:jsc\")` "
+"expose the same function. The optional argument is accepted for Bun "
+"compatibility and ignored."
+msgstr ""
+
+#: src/stdlib/other.md:250
+msgid ""
+"```typescript,no-test\n"
+"import { heapStats } from \"bun:jsc\";\n"
+"const stats = heapStats();\n"
+"console.log(stats.heapSize, stats.objectCount, stats.objectTypeCounts);\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:256
+msgid ""
+"The [Bun HeapStats API](https://bun.com/reference/bun/jsc/HeapStats) uses "
+"JavaScriptCore measurements. Perry supplies its own heap and allocator "
+"counters:"
+msgstr ""
+
+#: src/stdlib/other.md:259
+#, fuzzy
+msgid "Perry meaning"
+msgstr "meaning"
+
+#: src/stdlib/other.md:261
+#, fuzzy
+msgid "`heapSize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:261
+msgid "Allocated arena bytes plus tracked malloc GC blocks, including headers."
+msgstr ""
+
+#: src/stdlib/other.md:262
+#, fuzzy
+msgid "`heapCapacity`"
+msgstr "`opacity`"
+
+#: src/stdlib/other.md:262
+msgid ""
+"Reserved arena bytes plus tracked malloc GC blocks; at least `heapSize`."
+msgstr ""
+
+#: src/stdlib/other.md:263
+#, fuzzy
+msgid "`extraMemorySize`"
+msgstr "`maxHeaderSize`"
+
+#: src/stdlib/other.md:263
+msgid "Zero; external backing storage is not separately measured."
+msgstr ""
+
+#: src/stdlib/other.md:264
+#, fuzzy
+msgid "`objectCount`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:264
+msgid "Allocated GC cells found by the heap walk."
+msgstr ""
+
+#: src/stdlib/other.md:265
+#, fuzzy
+msgid "`objectTypeCounts`"
+msgstr "`object`"
+
+#: src/stdlib/other.md:265
+msgid "Cell counts keyed by Perry's GC type names."
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "`protectedObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:266
+msgid "Pinned GC cells, approximating native protection."
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "`protectedObjectTypeCounts`"
+msgstr ""
+
+#: src/stdlib/other.md:267
+msgid "Pinned cell counts by Perry GC type."
+msgstr ""
+
+#: src/stdlib/other.md:268
+#, fuzzy
+msgid "`globalObjectCount`"
+msgstr "`globalAgent`"
+
+#: src/stdlib/other.md:268
+msgid "One context for the calling thread."
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "`protectedGlobalObjectCount`"
+msgstr ""
+
+#: src/stdlib/other.md:269
+msgid "Zero; protected globals are not separately counted."
+msgstr ""
+
+#: src/stdlib/other.md:270
+#, fuzzy
+msgid "`mimalloc`"
+msgstr "`gc_malloc`"
+
+#: src/stdlib/other.md:270
+msgid ""
+"Object with `arenaUsed`, `arenaReserved`, `gcMallocBytes`, and "
+"`gcMallocObjectCount`."
+msgstr ""
+
+#: src/stdlib/other.md:272
+msgid ""
+"All counters are finite, non-negative numbers; sizes are bytes. The snapshot "
+"covers the calling thread's heap and does not force collection. It excludes "
+"free slots and forwarding headers, but can include garbage awaiting "
+"collection or unreclaimed arena residents. For comparisons, retain the "
+"objects of interest and call `gc(true)` from `bun` before each measurement. "
+"The returned report is a snapshot taken before allocating the report itself."
+msgstr ""
+
+#: src/stdlib/other.md:279
+msgid "Only `heapStats` is implemented from this module."
+msgstr ""
+
+#: src/stdlib/other.md:281
+msgid "Worker entries can also pass through small module-local helper chains:"
+msgstr ""
+
+#: src/stdlib/other.md:283
+msgid ""
+"```typescript,no-test\n"
+"const workerUrl = (name: string) => new URL(`./${name}.ts`, "
+"import.meta.url);\n"
+"function entry() { return workerUrl(\"worker\"); }\n"
+"const worker = new Worker(entry());\n"
+"```"
+msgstr ""
+
+#: src/stdlib/other.md:289
+msgid ""
+"Helpers must have simple parameters, static string or URL arguments, and a "
+"body containing only one return expression (including concise arrows). "
+"Supported return expressions include string concatenation, static path "
+"operations, module URLs, and bounded path registries. Reassigned bindings, "
+"effectful bodies, opaque calls, and recursion remain unresolved. URL "
+"arguments can be passed through helpers, but coercing them to strings is "
+"outside this static subset."
+msgstr ""
+
+#: src/stdlib/other.md:296
+msgid ""
+"Collection must identify exactly one entry per Worker. Helper resolution is "
+"bounded to 64 candidates, 64 expression levels, 4096 resolution steps, and "
+"64 KiB per path; unsupported or over-budget helpers emit a diagnostic and "
+"throw if the Worker is constructed. The original filename expression still "
+"runs at runtime. Static `file:` URLs are decoded before file lookup, "
+"including Bun embedded paths such as `file:///$bunfs/root/worker.js` mapped "
+"through `--bunfs-root`."
+msgstr ""
+
+#: src/stdlib/other.md:302
 msgid "commander (CLI Parsing)"
 msgstr "commander（CLI 解析）"
 
-#: src/stdlib/other.md:246
+#: src/stdlib/other.md:304
 msgid ""
 "```typescript,no-test\n"
 "import { Command } from \"commander\"\n"
@@ -33753,11 +33923,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:265
+#: src/stdlib/other.md:323
 msgid "lru-cache"
 msgstr "lru-cache"
 
-#: src/stdlib/other.md:267
+#: src/stdlib/other.md:325
 msgid ""
 "The wired constructor takes the npm v7+ options-object shape (`new "
 "LRUCache({ max: 100 })`) and validates it the way npm does, throwing the "
@@ -33776,7 +33946,7 @@ msgstr ""
 "`ttl`,`updateAgeOnGet`和`peek`都得到了认可;`maxSize`/"
 "`sizeCalculation`,`dispose`,`fetch`,`allowStale`以及代器表面尚未实现."
 
-#: src/stdlib/other.md:277
+#: src/stdlib/other.md:335
 msgid ""
 "```typescript,no-test\n"
 "import { LRUCache } from \"lru-cache\"\n"
@@ -33806,11 +33976,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:291
+#: src/stdlib/other.md:349
 msgid "child_process"
 msgstr "child_process"
 
-#: src/stdlib/other.md:293
+#: src/stdlib/other.md:351
 msgid ""
 "```typescript,no-test\n"
 "// `spawnBackground` / `getProcessStatus` / `killProcess` are Perry "
@@ -33860,11 +34030,11 @@ msgstr ""
 "}\n"
 "```"
 
-#: src/stdlib/other.md:313
+#: src/stdlib/other.md:371
 msgid "node-pty (Pseudo-terminals)"
 msgstr "node-pty (Pseudo-terminals)"
 
-#: src/stdlib/other.md:315
+#: src/stdlib/other.md:373
 msgid ""
 "A runtime-native pty (#6563) — `openpty`/`fork` with the slave as the "
 "child's controlling terminal, no N-API addon. Importable as both `node-pty` "
@@ -33877,7 +34047,7 @@ msgstr ""
 "`import()`进行进口. 目前只有POSIX (macOS + Linux);在其他主机上,`spawn`投放,这"
 "引发了消费者的非空缺后备路径."
 
-#: src/stdlib/other.md:321
+#: src/stdlib/other.md:379
 msgid ""
 "`onData` delivers UTF-8 strings (multi-byte sequences split across reads are "
 "reassembled); `onExit` fires `{ exitCode, signal }` with the numeric signal "
@@ -33888,7 +34058,7 @@ msgstr ""
 "`{ exitCode, signal }`用于数字信号死亡,否则是`undefined`; `kill()`默认为"
 "`SIGHUP`,如节点-pty. 孩子的`TERM`来自`name`."
 
-#: src/stdlib/other.md:326
+#: src/stdlib/other.md:384
 msgid ""
 "```typescript,no-test\n"
 "import { spawn } from \"node-pty\";\n"
@@ -33934,11 +34104,11 @@ msgstr ""
 "sub.dispose();          // unsubscribe onData\n"
 "```"
 
-#: src/stdlib/other.md:348
+#: src/stdlib/other.md:406
 msgid "@parcel/watcher"
 msgstr "@parcel/watcher"
 
-#: src/stdlib/other.md:350
+#: src/stdlib/other.md:408
 msgid ""
 "Perry provides the low-level `@parcel/watcher` binding object and all eight "
 "published platform-package names through one `notify`\\-backed native "
@@ -33952,7 +34122,7 @@ msgstr ""
 "它的目标依赖平台 `require` 在编译时折叠到原生外墙上. 行为与`@parcel/watcher` "
 "2.5.1进行了检查."
 
-#: src/stdlib/other.md:356
+#: src/stdlib/other.md:414
 msgid ""
 "Subscriptions use FSEvents on macOS, inotify on Linux, ReadDirectoryChangesW "
 "on Windows, and notify's native backend on other supported systems. An "
@@ -33969,7 +34139,7 @@ msgstr ""
 "`create`,创建后删除消失,并将旧路径更名为 `delete`,新路径加上 `create`. 后端 "
 "overflow/rescan 通知触发一个新树快照并发出其差异."
 
-#: src/stdlib/other.md:365
+#: src/stdlib/other.md:423
 msgid ""
 "`ignorePaths` are absolute path prefixes. `ignoreGlobs` are the regex "
 "sources produced by the package's JS wrapper and match root-relative paths, "
@@ -33985,7 +34155,7 @@ msgstr ""
 "持活动循环. `writeSnapshot` 和 `getEventsSince` 使用与溢出恢复相同的快照差异"
 "语义."
 
-#: src/stdlib/other.md:375
+#: src/stdlib/other.md:433
 msgid ""
 "Two packages live in their own GitHub repos with their own semver — they're "
 "imported by `bun add` like any npm package, but Rust-backed and compiled "
@@ -33994,7 +34164,7 @@ msgstr ""
 "有两个包位于各自独立的 GitHub 仓库中并使用各自的 semver 版本号——它们像普通 "
 "npm 包一样通过 `bun add` 导入，但由 Rust 实现并通过 `perry-ffi` 原生编译："
 
-#: src/stdlib/other.md:379
+#: src/stdlib/other.md:437
 msgid ""
 "**`@perryts/tursodb`** — Turso (libSQL fork) database client. See [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)."
@@ -34002,7 +34172,7 @@ msgstr ""
 "**`@perryts/tursodb`** —— Turso（libSQL 分支）数据库客户端。参见 [PerryTS/"
 "tursodb-bindings](https://github.com/PerryTS/tursodb-bindings)。"
 
-#: src/stdlib/other.md:381
+#: src/stdlib/other.md:439
 msgid ""
 "**`@perryts/iroh`** — Iroh peer-to-peer networking. See [PerryTS/iroh-"
 "bindings](https://github.com/PerryTS/iroh-bindings)."
@@ -34010,11 +34180,11 @@ msgstr ""
 "**`@perryts/iroh`** —— Iroh 点对点网络。参见 [PerryTS/iroh-bindings](https://"
 "github.com/PerryTS/iroh-bindings)。"
 
-#: src/stdlib/other.md:384
+#: src/stdlib/other.md:442
 msgid "Pure-TypeScript drivers compiled via `compilePackages`:"
 msgstr "通过 `compilePackages` 编译的纯 TypeScript 驱动："
 
-#: src/stdlib/other.md:386
+#: src/stdlib/other.md:444
 msgid ""
 "**`@perryts/postgres`**, **`@perryts/mysql`**, **`@perryts/mongodb`**, "
 "**`@perryts/redis`** — wire-protocol clients that also run on Node.js and "
@@ -34023,7 +34193,7 @@ msgstr ""
 "**`@perryts/postgres`**、**`@perryts/mysql`**、**`@perryts/mongodb`**、"
 "**`@perryts/redis`** — 线路协议客户端，同样可在 Node.js 和 Bun 上无缝运行。"
 
-#: src/stdlib/other.md:389
+#: src/stdlib/other.md:447
 msgid ""
 "See [Native Bindings — Overview](../native-libraries/overview.md) for the "
 "contract these external packages follow."
@@ -34031,11 +34201,11 @@ msgstr ""
 "请参见 [原生绑定 —— 概览](../native-libraries/overview.md) 了解这些外部包遵循"
 "的契约。"
 
-#: src/stdlib/other.md:395
+#: src/stdlib/other.md:453
 msgid "[File System](fs.md) — fs and path APIs"
 msgstr "[文件系统](fs.md) —— fs 与 path API"
 
-#: src/stdlib/other.md:396
+#: src/stdlib/other.md:454
 msgid "[Native Bindings](../native-libraries/overview.md) — Authoring your own"
 msgstr "[原生绑定](../native-libraries/overview.md) —— 编写你自己的"
 
@@ -34057,7 +34227,8 @@ msgstr ""
 "选目标上运行时无操作。"
 
 #: src/api/reference.md:5
-msgid "Total: 3019 entries across 138 modules."
+#, fuzzy
+msgid "Total: 3051 entries across 139 modules."
 msgstr "总数为138个模块的3019份."
 
 #: src/api/reference.md:9
@@ -34154,4831 +34325,4978 @@ msgid "[`bun:ffi`](#bunffi)"
 msgstr "[`bun:ffi`](#bunffi)"
 
 #: src/api/reference.md:32
+#, fuzzy
+msgid "[`bun:jsc`](#bunjsc)"
+msgstr "[`bun`](#bun)"
+
+#: src/api/reference.md:33
 msgid "[`bun:sqlite`](#bunsqlite)"
 msgstr "[`bun:sqlite`](#bunsqlite)"
 
-#: src/api/reference.md:33
+#: src/api/reference.md:34
 msgid "[`cheerio`](#cheerio)"
 msgstr "[`cheerio`](#cheerio)"
 
-#: src/api/reference.md:34
+#: src/api/reference.md:35
 msgid "[`child_process`](#child_process)"
 msgstr "[`child_process`](#child_process)"
 
-#: src/api/reference.md:35
+#: src/api/reference.md:36
 msgid "[`cluster`](#cluster)"
 msgstr "[`cluster`](#cluster)"
 
-#: src/api/reference.md:36
+#: src/api/reference.md:37
 msgid "[`commander`](#commander)"
 msgstr "[`commander`](#commander)"
 
-#: src/api/reference.md:37
+#: src/api/reference.md:38
 msgid "[`console`](#console)"
 msgstr "[`console`](#console)"
 
-#: src/api/reference.md:38
+#: src/api/reference.md:39
 msgid "[`constants`](#constants)"
 msgstr "[`constants`](#constants)"
 
-#: src/api/reference.md:39
+#: src/api/reference.md:40
 msgid "[`cron`](#cron)"
 msgstr "[`cron`](#cron)"
 
-#: src/api/reference.md:40
+#: src/api/reference.md:41
 msgid "[`crypto`](#crypto)"
 msgstr "[`crypto`](#crypto)"
 
-#: src/api/reference.md:41
+#: src/api/reference.md:42
 msgid "[`date-fns`](#date-fns)"
 msgstr "[`date-fns`](#date-fns)"
 
-#: src/api/reference.md:42
+#: src/api/reference.md:43
 msgid "[`dayjs`](#dayjs)"
 msgstr "[`dayjs`](#dayjs)"
 
-#: src/api/reference.md:43
+#: src/api/reference.md:44
 msgid "[`decimal.js`](#decimaljs)"
 msgstr "[`decimal.js`](#decimaljs)"
 
-#: src/api/reference.md:44
+#: src/api/reference.md:45
 msgid "[`dgram`](#dgram)"
 msgstr "[`dgram`](#dgram)"
 
-#: src/api/reference.md:45
+#: src/api/reference.md:46
 msgid "[`diagnostics_channel`](#diagnostics_channel)"
 msgstr "[`diagnostics_channel`](#diagnostics_channel)"
 
-#: src/api/reference.md:46
+#: src/api/reference.md:47
 msgid "[`dns`](#dns)"
 msgstr "[`dns`](#dns)"
 
-#: src/api/reference.md:47
+#: src/api/reference.md:48
 msgid "[`dns/promises`](#dnspromises)"
 msgstr "[`dns/promises`](#dnspromises)"
 
-#: src/api/reference.md:48
+#: src/api/reference.md:49
 msgid "[`domain`](#domain)"
 msgstr "[`domain`](#domain)"
 
-#: src/api/reference.md:49
+#: src/api/reference.md:50
 msgid "[`dotenv`](#dotenv)"
 msgstr "[`dotenv`](#dotenv)"
 
-#: src/api/reference.md:50
+#: src/api/reference.md:51
 msgid "[`ethers`](#ethers)"
 msgstr "[`ethers`](#ethers)"
 
-#: src/api/reference.md:51
+#: src/api/reference.md:52
 msgid "[`events`](#events)"
 msgstr "[`events`](#events)"
 
-#: src/api/reference.md:52
+#: src/api/reference.md:53
 msgid "[`exponential-backoff`](#exponential-backoff)"
 msgstr "[`exponential-backoff`](#exponential-backoff)"
 
-#: src/api/reference.md:53
+#: src/api/reference.md:54
 msgid "[`fastify`](#fastify)"
 msgstr "[`fastify`](#fastify)"
 
-#: src/api/reference.md:54
+#: src/api/reference.md:55
 msgid "[`fetch`](#fetch)"
 msgstr "[`fetch`](#fetch)"
 
-#: src/api/reference.md:55
+#: src/api/reference.md:56
 msgid "[`ffi`](#ffi)"
 msgstr "[`ffi`](#ffi)"
 
-#: src/api/reference.md:56
+#: src/api/reference.md:57
 msgid "[`fs`](#fs)"
 msgstr "[`fs`](#fs)"
 
-#: src/api/reference.md:57
+#: src/api/reference.md:58
 msgid "[`fs/promises`](#fspromises)"
 msgstr "[`fs/promises`](#fspromises)"
 
-#: src/api/reference.md:58
+#: src/api/reference.md:59
 msgid "[`http`](#http)"
 msgstr "[`http`](#http)"
 
-#: src/api/reference.md:59
+#: src/api/reference.md:60
 msgid "[`http2`](#http2)"
 msgstr "[`http2`](#http2)"
 
-#: src/api/reference.md:60
+#: src/api/reference.md:61
 msgid "[`https`](#https)"
 msgstr "[`https`](#https)"
 
-#: src/api/reference.md:61
+#: src/api/reference.md:62
 msgid "[`inspector`](#inspector)"
 msgstr "[`inspector`](#inspector)"
 
-#: src/api/reference.md:62
+#: src/api/reference.md:63
 msgid "[`inspector/promises`](#inspectorpromises)"
 msgstr "[`inspector/promises`](#inspectorpromises)"
 
-#: src/api/reference.md:63
+#: src/api/reference.md:64
 msgid "[`ioredis`](#ioredis)"
 msgstr "[`ioredis`](#ioredis)"
 
-#: src/api/reference.md:64
+#: src/api/reference.md:65
 msgid "[`iovalkey`](#iovalkey)"
 msgstr "[`iovalkey`](#iovalkey)"
 
-#: src/api/reference.md:65
+#: src/api/reference.md:66
 msgid "[`iroh`](#iroh)"
 msgstr "[`iroh`](#iroh)"
 
-#: src/api/reference.md:66
+#: src/api/reference.md:67
 msgid "[`jsonwebtoken`](#jsonwebtoken)"
 msgstr "[`jsonwebtoken`](#jsonwebtoken)"
 
-#: src/api/reference.md:67
+#: src/api/reference.md:68
 msgid "[`lodash`](#lodash)"
 msgstr "[`lodash`](#lodash)"
 
-#: src/api/reference.md:68
+#: src/api/reference.md:69
 msgid "[`lru-cache`](#lru-cache)"
 msgstr "[`lru-cache`](#lru-cache)"
 
-#: src/api/reference.md:69
+#: src/api/reference.md:70
 msgid "[`module`](#module)"
 msgstr "[`module`](#module)"
 
-#: src/api/reference.md:70
+#: src/api/reference.md:71
 msgid "[`moment`](#moment)"
 msgstr "[`moment`](#moment)"
 
-#: src/api/reference.md:71
+#: src/api/reference.md:72
 msgid "[`mongodb`](#mongodb)"
 msgstr "[`mongodb`](#mongodb)"
 
-#: src/api/reference.md:72
+#: src/api/reference.md:73
 msgid "[`mysql2`](#mysql2)"
 msgstr "[`mysql2`](#mysql2)"
 
-#: src/api/reference.md:73
+#: src/api/reference.md:74
 msgid "[`mysql2/promise`](#mysql2promise)"
 msgstr "[`mysql2/promise`](#mysql2promise)"
 
-#: src/api/reference.md:74
+#: src/api/reference.md:75
 msgid "[`nanoid`](#nanoid)"
 msgstr "[`nanoid`](#nanoid)"
 
-#: src/api/reference.md:75
+#: src/api/reference.md:76
 msgid "[`net`](#net)"
 msgstr "[`net`](#net)"
 
-#: src/api/reference.md:76
+#: src/api/reference.md:77
 msgid "[`node-cron`](#node-cron)"
 msgstr "[`node-cron`](#node-cron)"
 
-#: src/api/reference.md:77
+#: src/api/reference.md:78
 msgid "[`node-fetch`](#node-fetch)"
 msgstr "[`node-fetch`](#node-fetch)"
 
-#: src/api/reference.md:78
+#: src/api/reference.md:79
 msgid "[`node-forge`](#node-forge)"
 msgstr "[`node-forge`](#node-forge)"
 
-#: src/api/reference.md:79
+#: src/api/reference.md:80
 msgid "[`node-pty`](#node-pty)"
 msgstr "[`node-pty`](#node-pty)"
 
-#: src/api/reference.md:80
+#: src/api/reference.md:81
 msgid "[`nodemailer`](#nodemailer)"
 msgstr "[`nodemailer`](#nodemailer)"
 
-#: src/api/reference.md:81
+#: src/api/reference.md:82
 msgid "[`os`](#os)"
 msgstr "[`os`](#os)"
 
-#: src/api/reference.md:82
+#: src/api/reference.md:83
 msgid "[`path`](#path)"
 msgstr "[`path`](#path)"
 
-#: src/api/reference.md:83
+#: src/api/reference.md:84
 msgid "[`path/posix`](#pathposix)"
 msgstr "[`path/posix`](#pathposix)"
 
-#: src/api/reference.md:84
+#: src/api/reference.md:85
 msgid "[`path/win32`](#pathwin32)"
 msgstr "[`path/win32`](#pathwin32)"
 
-#: src/api/reference.md:85
+#: src/api/reference.md:86
 msgid "[`perf_hooks`](#perf_hooks)"
 msgstr "[`perf_hooks`](#perf_hooks)"
 
-#: src/api/reference.md:86
+#: src/api/reference.md:87
 msgid "[`perry`](#perry)"
 msgstr "[`perry`](#perry)"
 
-#: src/api/reference.md:87
+#: src/api/reference.md:88
 msgid "[`perry/ads`](#perryads)"
 msgstr "[`perry/ads`](#perryads)"
 
-#: src/api/reference.md:88
+#: src/api/reference.md:89
 msgid "[`perry/audio`](#perryaudio)"
 msgstr "[`perry/audio`](#perryaudio)"
 
-#: src/api/reference.md:89
+#: src/api/reference.md:90
 msgid "[`perry/background`](#perrybackground)"
 msgstr "[`perry/background`](#perrybackground)"
 
-#: src/api/reference.md:90
+#: src/api/reference.md:91
 msgid "[`perry/compose`](#perrycompose)"
 msgstr "[`perry/compose`](#perrycompose)"
 
-#: src/api/reference.md:91
+#: src/api/reference.md:92
 msgid "[`perry/container`](#perrycontainer)"
 msgstr "[`perry/container`](#perrycontainer)"
 
-#: src/api/reference.md:92
+#: src/api/reference.md:93
 msgid "[`perry/container-compose`](#perrycontainer-compose)"
 msgstr "[`perry/container-compose`](#perrycontainer-compose)"
 
-#: src/api/reference.md:93
+#: src/api/reference.md:94
 msgid "[`perry/gc`](#perrygc)"
 msgstr "[`perry/gc`](#perrygc)"
 
-#: src/api/reference.md:94
+#: src/api/reference.md:95
 msgid "[`perry/i18n`](#perryi18n)"
 msgstr "[`perry/i18n`](#perryi18n)"
 
-#: src/api/reference.md:95
+#: src/api/reference.md:96
 msgid "[`perry/ios`](#perryios)"
 msgstr "[`perry/ios`](#perryios)"
 
-#: src/api/reference.md:96
+#: src/api/reference.md:97
 msgid "[`perry/media`](#perrymedia)"
 msgstr "[`perry/media`](#perrymedia)"
 
-#: src/api/reference.md:97
+#: src/api/reference.md:98
 msgid "[`perry/native`](#perrynative)"
 msgstr "[`perry/native`](#perrynative)"
 
-#: src/api/reference.md:98
+#: src/api/reference.md:99
 msgid "[`perry/plugin`](#perryplugin)"
 msgstr "[`perry/plugin`](#perryplugin)"
 
-#: src/api/reference.md:99
+#: src/api/reference.md:100
 msgid "[`perry/system`](#perrysystem)"
 msgstr "[`perry/system`](#perrysystem)"
 
-#: src/api/reference.md:100
+#: src/api/reference.md:101
 msgid "[`perry/thread`](#perrythread)"
 msgstr "[`perry/thread`](#perrythread)"
 
-#: src/api/reference.md:101
+#: src/api/reference.md:102
 msgid "[`perry/tui`](#perrytui)"
 msgstr "[`perry/tui`](#perrytui)"
 
-#: src/api/reference.md:102
+#: src/api/reference.md:103
 msgid "[`perry/ui`](#perryui)"
 msgstr "[`perry/ui`](#perryui)"
 
-#: src/api/reference.md:103
+#: src/api/reference.md:104
 msgid "[`perry/updater`](#perryupdater)"
 msgstr "[`perry/updater`](#perryupdater)"
 
-#: src/api/reference.md:104
+#: src/api/reference.md:105
 msgid "[`perry/widget`](#perrywidget)"
 msgstr "[`perry/widget`](#perrywidget)"
 
-#: src/api/reference.md:105
+#: src/api/reference.md:106
 msgid "[`perry/workloads`](#perryworkloads)"
 msgstr "[`perry/workloads`](#perryworkloads)"
 
-#: src/api/reference.md:106
+#: src/api/reference.md:107
 msgid "[`perry/yoga`](#perryyoga)"
 msgstr "[`perry/yoga`](#perryyoga)"
 
-#: src/api/reference.md:107
+#: src/api/reference.md:108
 msgid "[`pg`](#pg)"
 msgstr "[`pg`](#pg)"
 
-#: src/api/reference.md:108
+#: src/api/reference.md:109
 msgid "[`process`](#process)"
 msgstr "[`process`](#process)"
 
-#: src/api/reference.md:109
+#: src/api/reference.md:110
 msgid "[`punycode`](#punycode)"
 msgstr "[`punycode`](#punycode)"
 
-#: src/api/reference.md:110
+#: src/api/reference.md:111
 msgid "[`qs`](#qs)"
 msgstr "[`qs`](#qs)"
 
-#: src/api/reference.md:111
+#: src/api/reference.md:112
 msgid "[`querystring`](#querystring)"
 msgstr "[`querystring`](#querystring)"
 
-#: src/api/reference.md:112
+#: src/api/reference.md:113
 msgid "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 msgstr "[`rate-limiter-flexible`](#rate-limiter-flexible)"
 
-#: src/api/reference.md:113
+#: src/api/reference.md:114
 msgid "[`readline`](#readline)"
 msgstr "[`readline`](#readline)"
 
-#: src/api/reference.md:114
+#: src/api/reference.md:115
 msgid "[`readline/promises`](#readlinepromises)"
 msgstr "[`readline/promises`](#readlinepromises)"
 
-#: src/api/reference.md:115
+#: src/api/reference.md:116
 msgid "[`redis`](#redis)"
 msgstr "[`redis`](#redis)"
 
-#: src/api/reference.md:116
+#: src/api/reference.md:117
 msgid "[`repl`](#repl)"
 msgstr "[`repl`](#repl)"
 
-#: src/api/reference.md:117
+#: src/api/reference.md:118
 msgid "[`sea`](#sea)"
 msgstr "[`sea`](#sea)"
 
-#: src/api/reference.md:118
+#: src/api/reference.md:119
 msgid "[`sharp`](#sharp)"
 msgstr "[`sharp`](#sharp)"
 
-#: src/api/reference.md:119
+#: src/api/reference.md:120
 msgid "[`sqlite`](#sqlite)"
 msgstr "[`sqlite`](#sqlite)"
 
-#: src/api/reference.md:120
+#: src/api/reference.md:121
 msgid "[`stream`](#stream)"
 msgstr "[`stream`](#stream)"
 
-#: src/api/reference.md:121
+#: src/api/reference.md:122
 msgid "[`stream/consumers`](#streamconsumers)"
 msgstr "[`stream/consumers`](#streamconsumers)"
 
-#: src/api/reference.md:122
+#: src/api/reference.md:123
 msgid "[`stream/promises`](#streampromises)"
 msgstr "[`stream/promises`](#streampromises)"
 
-#: src/api/reference.md:123
+#: src/api/reference.md:124
 msgid "[`stream/web`](#streamweb)"
 msgstr "[`stream/web`](#streamweb)"
 
-#: src/api/reference.md:124
+#: src/api/reference.md:125
 msgid "[`streams`](#streams)"
 msgstr "[`streams`](#streams)"
 
-#: src/api/reference.md:125
+#: src/api/reference.md:126
 msgid "[`string_decoder`](#string_decoder)"
 msgstr "[`string_decoder`](#string_decoder)"
 
-#: src/api/reference.md:126
+#: src/api/reference.md:127
 msgid "[`sys`](#sys)"
 msgstr "[`sys`](#sys)"
 
-#: src/api/reference.md:127
+#: src/api/reference.md:128
 msgid "[`test`](#test)"
 msgstr "[`test`](#test)"
 
-#: src/api/reference.md:128
+#: src/api/reference.md:129
 msgid "[`test/reporters`](#testreporters)"
 msgstr "[`test/reporters`](#testreporters)"
 
-#: src/api/reference.md:129
+#: src/api/reference.md:130
 msgid "[`timers`](#timers)"
 msgstr "[`timers`](#timers)"
 
-#: src/api/reference.md:130
+#: src/api/reference.md:131
 msgid "[`timers/promises`](#timerspromises)"
 msgstr "[`timers/promises`](#timerspromises)"
 
-#: src/api/reference.md:131
+#: src/api/reference.md:132
 msgid "[`tls`](#tls)"
 msgstr "[`tls`](#tls)"
 
-#: src/api/reference.md:132
+#: src/api/reference.md:133
 msgid "[`tty`](#tty)"
 msgstr "[`tty`](#tty)"
 
-#: src/api/reference.md:133
+#: src/api/reference.md:134
 msgid "[`tursodb`](#tursodb)"
 msgstr "[`tursodb`](#tursodb)"
 
-#: src/api/reference.md:134
+#: src/api/reference.md:135
 msgid "[`typescript`](#typescript)"
 msgstr "[`typescript`](#typescript)"
 
-#: src/api/reference.md:135
+#: src/api/reference.md:136
 msgid "[`undici`](#undici)"
 msgstr "[`undici`](#undici)"
 
-#: src/api/reference.md:136
+#: src/api/reference.md:137
 msgid "[`url`](#url)"
 msgstr "[`url`](#url)"
 
-#: src/api/reference.md:137
+#: src/api/reference.md:138
 msgid "[`util`](#util)"
 msgstr "[`util`](#util)"
 
-#: src/api/reference.md:138
+#: src/api/reference.md:139
 msgid "[`util/types`](#utiltypes)"
 msgstr "[`util/types`](#utiltypes)"
 
-#: src/api/reference.md:139
+#: src/api/reference.md:140
 msgid "[`uuid`](#uuid)"
 msgstr "[`uuid`](#uuid)"
 
-#: src/api/reference.md:140
+#: src/api/reference.md:141
 msgid "[`v8`](#v8)"
 msgstr "[`v8`](#v8)"
 
-#: src/api/reference.md:141
+#: src/api/reference.md:142
 msgid "[`validator`](#validator)"
 msgstr "[`validator`](#validator)"
 
-#: src/api/reference.md:142
+#: src/api/reference.md:143
 msgid "[`vm`](#vm)"
 msgstr "[`vm`](#vm)"
 
-#: src/api/reference.md:143
+#: src/api/reference.md:144
 msgid "[`wasi`](#wasi)"
 msgstr "[`wasi`](#wasi)"
 
-#: src/api/reference.md:144
+#: src/api/reference.md:145
 msgid "[`worker_threads`](#worker_threads)"
 msgstr "[`worker_threads`](#worker_threads)"
 
-#: src/api/reference.md:145
+#: src/api/reference.md:146
 msgid "[`ws`](#ws)"
 msgstr "[`ws`](#ws)"
 
-#: src/api/reference.md:146
+#: src/api/reference.md:147
 msgid "[`zlib`](#zlib)"
 msgstr "[`zlib`](#zlib)"
 
-#: src/api/reference.md:150
+#: src/api/reference.md:151
 msgid "`@lydell/node-pty`"
 msgstr "`@lydell/node-pty`"
 
-#: src/api/reference.md:152 src/api/reference.md:162 src/api/reference.md:172
-#: src/api/reference.md:178 src/api/reference.md:184 src/api/reference.md:190
-#: src/api/reference.md:196 src/api/reference.md:202 src/api/reference.md:208
-#: src/api/reference.md:214 src/api/reference.md:220 src/api/reference.md:230
-#: src/api/reference.md:242 src/api/reference.md:254 src/api/reference.md:288
-#: src/api/reference.md:322 src/api/reference.md:350 src/api/reference.md:366
-#: src/api/reference.md:373 src/api/reference.md:403 src/api/reference.md:421
-#: src/api/reference.md:440 src/api/reference.md:465 src/api/reference.md:489
-#: src/api/reference.md:511 src/api/reference.md:532 src/api/reference.md:553
-#: src/api/reference.md:577 src/api/reference.md:852 src/api/reference.md:874
-#: src/api/reference.md:947 src/api/reference.md:964 src/api/reference.md:993
-#: src/api/reference.md:1027 src/api/reference.md:1076
-#: src/api/reference.md:1095 src/api/reference.md:1204
-#: src/api/reference.md:1282 src/api/reference.md:1306
-#: src/api/reference.md:1313 src/api/reference.md:1329
-#: src/api/reference.md:1373 src/api/reference.md:1379
-#: src/api/reference.md:1427 src/api/reference.md:1433
-#: src/api/reference.md:1458 src/api/reference.md:1563
-#: src/api/reference.md:1622 src/api/reference.md:1816
-#: src/api/reference.md:1840 src/api/reference.md:1892
-#: src/api/reference.md:1923 src/api/reference.md:1943
-#: src/api/reference.md:1963 src/api/reference.md:1969
-#: src/api/reference.md:1985 src/api/reference.md:1993
-#: src/api/reference.md:2027 src/api/reference.md:2045
-#: src/api/reference.md:2084 src/api/reference.md:2116
-#: src/api/reference.md:2139 src/api/reference.md:2163
-#: src/api/reference.md:2183 src/api/reference.md:2197
-#: src/api/reference.md:2310 src/api/reference.md:2325
-#: src/api/reference.md:2331 src/api/reference.md:2348
-#: src/api/reference.md:2358 src/api/reference.md:2366
-#: src/api/reference.md:2398 src/api/reference.md:2424
-#: src/api/reference.md:2450 src/api/reference.md:2486
-#: src/api/reference.md:2504 src/api/reference.md:2515
-#: src/api/reference.md:2527 src/api/reference.md:2556
-#: src/api/reference.md:2564 src/api/reference.md:2578
-#: src/api/reference.md:2606 src/api/reference.md:2620
-#: src/api/reference.md:2628 src/api/reference.md:2641
-#: src/api/reference.md:2653 src/api/reference.md:2673
-#: src/api/reference.md:2701 src/api/reference.md:2718
-#: src/api/reference.md:2772 src/api/reference.md:2780
-#: src/api/reference.md:2845 src/api/reference.md:2974
-#: src/api/reference.md:2998 src/api/reference.md:3004
-#: src/api/reference.md:3018 src/api/reference.md:3042
-#: src/api/reference.md:3054 src/api/reference.md:3148
-#: src/api/reference.md:3163 src/api/reference.md:3170
-#: src/api/reference.md:3191 src/api/reference.md:3202
-#: src/api/reference.md:3231 src/api/reference.md:3243
-#: src/api/reference.md:3254 src/api/reference.md:3278
-#: src/api/reference.md:3292 src/api/reference.md:3327
-#: src/api/reference.md:3391 src/api/reference.md:3467
-#: src/api/reference.md:3482 src/api/reference.md:3534
-#: src/api/reference.md:3548 src/api/reference.md:3589
-#: src/api/reference.md:3627 src/api/reference.md:3641
-#: src/api/reference.md:3656 src/api/reference.md:3672
-#: src/api/reference.md:3718 src/api/reference.md:3741
-#: src/api/reference.md:3754 src/api/reference.md:3772
-#: src/api/reference.md:3794 src/api/reference.md:3823
-#: src/api/reference.md:3864 src/api/reference.md:3912
-#: src/api/reference.md:3932 src/api/reference.md:3982
-#: src/api/reference.md:3996 src/api/reference.md:4032
-#: src/api/reference.md:4053 src/api/reference.md:4100
-#: src/api/reference.md:4148
+#: src/api/reference.md:153 src/api/reference.md:163 src/api/reference.md:173
+#: src/api/reference.md:179 src/api/reference.md:185 src/api/reference.md:191
+#: src/api/reference.md:197 src/api/reference.md:203 src/api/reference.md:209
+#: src/api/reference.md:215 src/api/reference.md:221 src/api/reference.md:231
+#: src/api/reference.md:243 src/api/reference.md:255 src/api/reference.md:289
+#: src/api/reference.md:323 src/api/reference.md:351 src/api/reference.md:367
+#: src/api/reference.md:374 src/api/reference.md:404 src/api/reference.md:426
+#: src/api/reference.md:472 src/api/reference.md:492 src/api/reference.md:503
+#: src/api/reference.md:527 src/api/reference.md:549 src/api/reference.md:570
+#: src/api/reference.md:591 src/api/reference.md:615 src/api/reference.md:890
+#: src/api/reference.md:912 src/api/reference.md:985 src/api/reference.md:1002
+#: src/api/reference.md:1031 src/api/reference.md:1065
+#: src/api/reference.md:1114 src/api/reference.md:1133
+#: src/api/reference.md:1242 src/api/reference.md:1320
+#: src/api/reference.md:1344 src/api/reference.md:1351
+#: src/api/reference.md:1367 src/api/reference.md:1411
+#: src/api/reference.md:1417 src/api/reference.md:1465
+#: src/api/reference.md:1471 src/api/reference.md:1496
+#: src/api/reference.md:1601 src/api/reference.md:1660
+#: src/api/reference.md:1854 src/api/reference.md:1878
+#: src/api/reference.md:1930 src/api/reference.md:1961
+#: src/api/reference.md:1981 src/api/reference.md:2001
+#: src/api/reference.md:2007 src/api/reference.md:2023
+#: src/api/reference.md:2031 src/api/reference.md:2065
+#: src/api/reference.md:2083 src/api/reference.md:2122
+#: src/api/reference.md:2154 src/api/reference.md:2177
+#: src/api/reference.md:2201 src/api/reference.md:2221
+#: src/api/reference.md:2235 src/api/reference.md:2348
+#: src/api/reference.md:2363 src/api/reference.md:2369
+#: src/api/reference.md:2386 src/api/reference.md:2396
+#: src/api/reference.md:2404 src/api/reference.md:2436
+#: src/api/reference.md:2462 src/api/reference.md:2488
+#: src/api/reference.md:2524 src/api/reference.md:2542
+#: src/api/reference.md:2553 src/api/reference.md:2565
+#: src/api/reference.md:2594 src/api/reference.md:2602
+#: src/api/reference.md:2616 src/api/reference.md:2644
+#: src/api/reference.md:2658 src/api/reference.md:2666
+#: src/api/reference.md:2679 src/api/reference.md:2691
+#: src/api/reference.md:2711 src/api/reference.md:2739
+#: src/api/reference.md:2756 src/api/reference.md:2810
+#: src/api/reference.md:2818 src/api/reference.md:2883
+#: src/api/reference.md:3012 src/api/reference.md:3036
+#: src/api/reference.md:3042 src/api/reference.md:3056
+#: src/api/reference.md:3080 src/api/reference.md:3092
+#: src/api/reference.md:3186 src/api/reference.md:3201
+#: src/api/reference.md:3208 src/api/reference.md:3229
+#: src/api/reference.md:3240 src/api/reference.md:3269
+#: src/api/reference.md:3281 src/api/reference.md:3292
+#: src/api/reference.md:3316 src/api/reference.md:3330
+#: src/api/reference.md:3365 src/api/reference.md:3429
+#: src/api/reference.md:3505 src/api/reference.md:3520
+#: src/api/reference.md:3572 src/api/reference.md:3586
+#: src/api/reference.md:3627 src/api/reference.md:3665
+#: src/api/reference.md:3679 src/api/reference.md:3694
+#: src/api/reference.md:3710 src/api/reference.md:3756
+#: src/api/reference.md:3779 src/api/reference.md:3792
+#: src/api/reference.md:3810 src/api/reference.md:3832
+#: src/api/reference.md:3861 src/api/reference.md:3902
+#: src/api/reference.md:3950 src/api/reference.md:3970
+#: src/api/reference.md:4020 src/api/reference.md:4034
+#: src/api/reference.md:4070 src/api/reference.md:4091
+#: src/api/reference.md:4138 src/api/reference.md:4189
 msgid "Methods"
 msgstr "方法"
 
-#: src/api/reference.md:154 src/api/reference.md:519 src/api/reference.md:2350
-#: src/api/reference.md:2776
+#: src/api/reference.md:155 src/api/reference.md:445 src/api/reference.md:557
+#: src/api/reference.md:2388 src/api/reference.md:2814
 msgid "`spawn` — module"
 msgstr "`spawn` — 模块"
 
-#: src/api/reference.md:156 src/api/reference.md:277 src/api/reference.md:311
-#: src/api/reference.md:343 src/api/reference.md:412 src/api/reference.md:432
-#: src/api/reference.md:452 src/api/reference.md:482 src/api/reference.md:522
-#: src/api/reference.md:539 src/api/reference.md:567 src/api/reference.md:606
-#: src/api/reference.md:938 src/api/reference.md:1065 src/api/reference.md:1085
-#: src/api/reference.md:1139 src/api/reference.md:1248
-#: src/api/reference.md:1298 src/api/reference.md:1362
-#: src/api/reference.md:1441 src/api/reference.md:1556
-#: src/api/reference.md:1601 src/api/reference.md:1801
-#: src/api/reference.md:1826 src/api/reference.md:1882
-#: src/api/reference.md:1911 src/api/reference.md:1933
-#: src/api/reference.md:2071 src/api/reference.md:2352
-#: src/api/reference.md:2389 src/api/reference.md:2414
-#: src/api/reference.md:2440 src/api/reference.md:2466
-#: src/api/reference.md:2496 src/api/reference.md:2509
-#: src/api/reference.md:2691 src/api/reference.md:3011
-#: src/api/reference.md:3112 src/api/reference.md:3155
-#: src/api/reference.md:3180 src/api/reference.md:3269
-#: src/api/reference.md:3286 src/api/reference.md:3376
-#: src/api/reference.md:3460 src/api/reference.md:3476
-#: src/api/reference.md:3511 src/api/reference.md:3582
-#: src/api/reference.md:3619 src/api/reference.md:3635
-#: src/api/reference.md:3650 src/api/reference.md:3662
-#: src/api/reference.md:3701 src/api/reference.md:3759
-#: src/api/reference.md:3810 src/api/reference.md:3857
-#: src/api/reference.md:3975 src/api/reference.md:4021
-#: src/api/reference.md:4040 src/api/reference.md:4080
-#: src/api/reference.md:4116 src/api/reference.md:4185
+#: src/api/reference.md:157 src/api/reference.md:278 src/api/reference.md:312
+#: src/api/reference.md:344 src/api/reference.md:413 src/api/reference.md:457
+#: src/api/reference.md:484 src/api/reference.md:520 src/api/reference.md:560
+#: src/api/reference.md:577 src/api/reference.md:605 src/api/reference.md:644
+#: src/api/reference.md:976 src/api/reference.md:1103 src/api/reference.md:1123
+#: src/api/reference.md:1177 src/api/reference.md:1286
+#: src/api/reference.md:1336 src/api/reference.md:1400
+#: src/api/reference.md:1479 src/api/reference.md:1594
+#: src/api/reference.md:1639 src/api/reference.md:1839
+#: src/api/reference.md:1864 src/api/reference.md:1920
+#: src/api/reference.md:1949 src/api/reference.md:1971
+#: src/api/reference.md:2109 src/api/reference.md:2390
+#: src/api/reference.md:2427 src/api/reference.md:2452
+#: src/api/reference.md:2478 src/api/reference.md:2504
+#: src/api/reference.md:2534 src/api/reference.md:2547
+#: src/api/reference.md:2729 src/api/reference.md:3049
+#: src/api/reference.md:3150 src/api/reference.md:3193
+#: src/api/reference.md:3218 src/api/reference.md:3307
+#: src/api/reference.md:3324 src/api/reference.md:3414
+#: src/api/reference.md:3498 src/api/reference.md:3514
+#: src/api/reference.md:3549 src/api/reference.md:3620
+#: src/api/reference.md:3657 src/api/reference.md:3673
+#: src/api/reference.md:3688 src/api/reference.md:3700
+#: src/api/reference.md:3739 src/api/reference.md:3797
+#: src/api/reference.md:3848 src/api/reference.md:3895
+#: src/api/reference.md:4013 src/api/reference.md:4059
+#: src/api/reference.md:4078 src/api/reference.md:4118
+#: src/api/reference.md:4157 src/api/reference.md:4226
 msgid "Properties"
 msgstr "属性"
 
-#: src/api/reference.md:158 src/api/reference.md:346 src/api/reference.md:524
-#: src/api/reference.md:543 src/api/reference.md:843 src/api/reference.md:1067
-#: src/api/reference.md:1087 src/api/reference.md:1195
-#: src/api/reference.md:1274 src/api/reference.md:1366
-#: src/api/reference.md:1604 src/api/reference.md:1829
-#: src/api/reference.md:1915 src/api/reference.md:1935
-#: src/api/reference.md:2079 src/api/reference.md:2354
-#: src/api/reference.md:2393 src/api/reference.md:2416
-#: src/api/reference.md:2442 src/api/reference.md:2468
-#: src/api/reference.md:2499 src/api/reference.md:3157
-#: src/api/reference.md:3182 src/api/reference.md:3274
-#: src/api/reference.md:3288 src/api/reference.md:3478
-#: src/api/reference.md:3513 src/api/reference.md:3584
-#: src/api/reference.md:3637 src/api/reference.md:3812
-#: src/api/reference.md:3859 src/api/reference.md:4024
+#: src/api/reference.md:159 src/api/reference.md:347 src/api/reference.md:562
+#: src/api/reference.md:581 src/api/reference.md:881 src/api/reference.md:1105
+#: src/api/reference.md:1125 src/api/reference.md:1233
+#: src/api/reference.md:1312 src/api/reference.md:1404
+#: src/api/reference.md:1642 src/api/reference.md:1867
+#: src/api/reference.md:1953 src/api/reference.md:1973
+#: src/api/reference.md:2117 src/api/reference.md:2392
+#: src/api/reference.md:2431 src/api/reference.md:2454
+#: src/api/reference.md:2480 src/api/reference.md:2506
+#: src/api/reference.md:2537 src/api/reference.md:3195
+#: src/api/reference.md:3220 src/api/reference.md:3312
+#: src/api/reference.md:3326 src/api/reference.md:3516
+#: src/api/reference.md:3551 src/api/reference.md:3622
+#: src/api/reference.md:3675 src/api/reference.md:3850
+#: src/api/reference.md:3897 src/api/reference.md:4062
 msgid "`default`"
 msgstr "`default`"
 
-#: src/api/reference.md:160
+#: src/api/reference.md:161
 msgid "`@parcel/watcher`"
 msgstr "`@parcel/watcher`"
 
-#: src/api/reference.md:164
+#: src/api/reference.md:165
 msgid "`__nativeEventCount` — module"
 msgstr "模块 `__nativeEventCount`"
 
-#: src/api/reference.md:165
+#: src/api/reference.md:166
 msgid "`getEventsSince` — module"
 msgstr "模块 `getEventsSince`"
 
-#: src/api/reference.md:166 src/api/reference.md:174 src/api/reference.md:180
-#: src/api/reference.md:186 src/api/reference.md:192 src/api/reference.md:198
-#: src/api/reference.md:204 src/api/reference.md:210 src/api/reference.md:216
-#: src/api/reference.md:1081
+#: src/api/reference.md:167 src/api/reference.md:175 src/api/reference.md:181
+#: src/api/reference.md:187 src/api/reference.md:193 src/api/reference.md:199
+#: src/api/reference.md:205 src/api/reference.md:211 src/api/reference.md:217
+#: src/api/reference.md:1119
 msgid "`subscribe` — module"
 msgstr "`subscribe` — 模块"
 
-#: src/api/reference.md:167 src/api/reference.md:1083
+#: src/api/reference.md:168 src/api/reference.md:1121
 msgid "`unsubscribe` — module"
 msgstr "`unsubscribe` — 模块"
 
-#: src/api/reference.md:168
+#: src/api/reference.md:169
 msgid "`writeSnapshot` — module"
 msgstr "模块 `writeSnapshot`"
 
-#: src/api/reference.md:170
+#: src/api/reference.md:171
 msgid "`@parcel/watcher-darwin-arm64`"
 msgstr "`@parcel/watcher-darwin-arm64`"
 
-#: src/api/reference.md:176
+#: src/api/reference.md:177
 msgid "`@parcel/watcher-darwin-x64`"
 msgstr "`@parcel/watcher-darwin-x64`"
 
-#: src/api/reference.md:182
+#: src/api/reference.md:183
 msgid "`@parcel/watcher-linux-arm64-glibc`"
 msgstr "`@parcel/watcher-linux-arm64-glibc`"
 
-#: src/api/reference.md:188
+#: src/api/reference.md:189
 msgid "`@parcel/watcher-linux-arm64-musl`"
 msgstr "`@parcel/watcher-linux-arm64-musl`"
 
-#: src/api/reference.md:194
+#: src/api/reference.md:195
 msgid "`@parcel/watcher-linux-x64-glibc`"
 msgstr "`@parcel/watcher-linux-x64-glibc`"
 
-#: src/api/reference.md:200
+#: src/api/reference.md:201
 msgid "`@parcel/watcher-linux-x64-musl`"
 msgstr "`@parcel/watcher-linux-x64-musl`"
 
-#: src/api/reference.md:206
+#: src/api/reference.md:207
 msgid "`@parcel/watcher-win32-arm64`"
 msgstr "`@parcel/watcher-win32-arm64`"
 
-#: src/api/reference.md:212
+#: src/api/reference.md:213
 msgid "`@parcel/watcher-win32-x64`"
 msgstr "`@parcel/watcher-win32-x64`"
 
-#: src/api/reference.md:222
+#: src/api/reference.md:223
 msgid "`createPdf` — module"
 msgstr "`createPdf` — 模块"
 
-#: src/api/reference.md:223
+#: src/api/reference.md:224
 msgid "`pdfAddLine` — module"
 msgstr "`pdfAddLine` — 模块"
 
-#: src/api/reference.md:224
+#: src/api/reference.md:225
 msgid "`pdfAddText` — module"
 msgstr "`pdfAddText` — 模块"
 
-#: src/api/reference.md:225
+#: src/api/reference.md:226
 msgid "`pdfNewPage` — module"
 msgstr "`pdfNewPage` — 模块"
 
-#: src/api/reference.md:226
+#: src/api/reference.md:227
 msgid "`pdfSave` — module"
 msgstr "`pdfSave` — 模块"
 
-#: src/api/reference.md:228
+#: src/api/reference.md:229
 msgid "`__disposable__`"
 msgstr "`__disposable__`"
 
-#: src/api/reference.md:232
+#: src/api/reference.md:233
 msgid "`adopt` — instance"
 msgstr "`adopt` — 实例"
 
-#: src/api/reference.md:233
+#: src/api/reference.md:234
 msgid "`defer` — instance"
 msgstr "`defer` — 实例"
 
-#: src/api/reference.md:234
+#: src/api/reference.md:235
 msgid "`dispose` — instance"
 msgstr "`dispose` — 实例"
 
-#: src/api/reference.md:235
+#: src/api/reference.md:236
 msgid "`disposeAsync` — instance"
 msgstr "`disposeAsync` — 实例"
 
-#: src/api/reference.md:236
+#: src/api/reference.md:237
 msgid "`disposed` — instance"
 msgstr "`disposed` — 实例"
 
-#: src/api/reference.md:237
+#: src/api/reference.md:238
 msgid "`move` — instance"
 msgstr "`move` — 实例"
 
-#: src/api/reference.md:238
+#: src/api/reference.md:239
 msgid "`use` — instance"
 msgstr "`use` — 实例"
 
-#: src/api/reference.md:244 src/api/reference.md:369 src/api/reference.md:426
-#: src/api/reference.md:915
+#: src/api/reference.md:245 src/api/reference.md:370 src/api/reference.md:439
+#: src/api/reference.md:953
 msgid "`hash` — module"
 msgstr "`hash` — 模块"
 
-#: src/api/reference.md:245 src/api/reference.md:936 src/api/reference.md:1989
+#: src/api/reference.md:246 src/api/reference.md:974 src/api/reference.md:2027
 msgid "`verify` — module"
 msgstr "`verify` — 模块"
 
-#: src/api/reference.md:247 src/api/reference.md:3621
+#: src/api/reference.md:248 src/api/reference.md:3659
 msgid "`assert`"
 msgstr "`assert`"
 
-#: src/api/reference.md:251 src/api/reference.md:285
+#: src/api/reference.md:252 src/api/reference.md:286
 msgid "`Assert`"
 msgstr "`Assert`"
 
-#: src/api/reference.md:252 src/api/reference.md:286
+#: src/api/reference.md:253 src/api/reference.md:287
 msgid "`AssertionError`"
 msgstr "`AssertionError`"
 
-#: src/api/reference.md:256 src/api/reference.md:290
+#: src/api/reference.md:257 src/api/reference.md:291
 msgid "`deepEqual` — module"
 msgstr "`deepEqual` — 模块"
 
-#: src/api/reference.md:257 src/api/reference.md:291
+#: src/api/reference.md:258 src/api/reference.md:292
 msgid "`deepStrictEqual` — module"
 msgstr "`deepStrictEqual` — 模块"
 
-#: src/api/reference.md:258 src/api/reference.md:292 src/api/reference.md:354
-#: src/api/reference.md:378 src/api/reference.md:971 src/api/reference.md:1386
-#: src/api/reference.md:1429 src/api/reference.md:2030
-#: src/api/reference.md:2090 src/api/reference.md:2327
-#: src/api/reference.md:3298 src/api/reference.md:3402
-#: src/api/reference.md:3595
+#: src/api/reference.md:259 src/api/reference.md:293 src/api/reference.md:355
+#: src/api/reference.md:379 src/api/reference.md:1009 src/api/reference.md:1424
+#: src/api/reference.md:1467 src/api/reference.md:2068
+#: src/api/reference.md:2128 src/api/reference.md:2365
+#: src/api/reference.md:3336 src/api/reference.md:3440
+#: src/api/reference.md:3633
 msgid "`default` — module"
 msgstr "`default` — 模块"
 
-#: src/api/reference.md:259 src/api/reference.md:293
+#: src/api/reference.md:260 src/api/reference.md:294
 msgid "`doesNotMatch` — module"
 msgstr "`doesNotMatch` — 模块"
 
-#: src/api/reference.md:260 src/api/reference.md:294
+#: src/api/reference.md:261 src/api/reference.md:295
 msgid "`doesNotReject` — module"
 msgstr "`doesNotReject` — 模块"
 
-#: src/api/reference.md:261 src/api/reference.md:295
+#: src/api/reference.md:262 src/api/reference.md:296
 msgid "`doesNotThrow` — module"
 msgstr "`doesNotThrow` — 模块"
 
-#: src/api/reference.md:262 src/api/reference.md:296
+#: src/api/reference.md:263 src/api/reference.md:297
 msgid "`equal` — module"
 msgstr "`equal` — 模块"
 
-#: src/api/reference.md:263 src/api/reference.md:297
+#: src/api/reference.md:264 src/api/reference.md:298
 msgid "`fail` — module"
 msgstr "`fail` — 模块"
 
-#: src/api/reference.md:264 src/api/reference.md:298
+#: src/api/reference.md:265 src/api/reference.md:299
 msgid "`ifError` — module"
 msgstr "`ifError` — 模块"
 
-#: src/api/reference.md:265 src/api/reference.md:299
+#: src/api/reference.md:266 src/api/reference.md:300
 msgid "`match` — module"
 msgstr "`match` — 模块"
 
-#: src/api/reference.md:266 src/api/reference.md:300
+#: src/api/reference.md:267 src/api/reference.md:301
 msgid "`notDeepEqual` — module"
 msgstr "`notDeepEqual` — 模块"
 
-#: src/api/reference.md:267 src/api/reference.md:301
+#: src/api/reference.md:268 src/api/reference.md:302
 msgid "`notDeepStrictEqual` — module"
 msgstr "`notDeepStrictEqual` — 模块"
 
-#: src/api/reference.md:268 src/api/reference.md:302
+#: src/api/reference.md:269 src/api/reference.md:303
 msgid "`notEqual` — module"
 msgstr "`notEqual` — 模块"
 
-#: src/api/reference.md:269 src/api/reference.md:303
+#: src/api/reference.md:270 src/api/reference.md:304
 msgid "`notStrictEqual` — module"
 msgstr "`notStrictEqual` — 模块"
 
-#: src/api/reference.md:270 src/api/reference.md:304
+#: src/api/reference.md:271 src/api/reference.md:305
 msgid "`ok` — module"
 msgstr "`ok` — 模块"
 
-#: src/api/reference.md:271 src/api/reference.md:305
+#: src/api/reference.md:272 src/api/reference.md:306
 msgid "`partialDeepStrictEqual` — module"
 msgstr "`partialDeepStrictEqual` — 模块"
 
-#: src/api/reference.md:272 src/api/reference.md:306
+#: src/api/reference.md:273 src/api/reference.md:307
 msgid "`rejects` — module"
 msgstr "`rejects` — 模块"
 
-#: src/api/reference.md:273 src/api/reference.md:307
+#: src/api/reference.md:274 src/api/reference.md:308
 msgid "`strict` — module"
 msgstr "`strict` — 模块"
 
-#: src/api/reference.md:274 src/api/reference.md:308
+#: src/api/reference.md:275 src/api/reference.md:309
 msgid "`strictEqual` — module"
 msgstr "`strictEqual` — 模块"
 
-#: src/api/reference.md:275 src/api/reference.md:309
+#: src/api/reference.md:276 src/api/reference.md:310
 msgid "`throws` — module"
 msgstr "`throws` — 模块"
 
-#: src/api/reference.md:279 src/api/reference.md:313
+#: src/api/reference.md:280 src/api/reference.md:314
 msgid "`strict`"
 msgstr "`strict`"
 
-#: src/api/reference.md:281
+#: src/api/reference.md:282
 msgid "`assert/strict`"
 msgstr "`assert/strict`"
 
-#: src/api/reference.md:315
+#: src/api/reference.md:316
 msgid "`async_hooks`"
 msgstr "`async_hooks`"
 
-#: src/api/reference.md:319
+#: src/api/reference.md:320
 msgid "`AsyncLocalStorage`"
 msgstr "`AsyncLocalStorage`"
 
-#: src/api/reference.md:320
+#: src/api/reference.md:321
 msgid "`AsyncResource`"
 msgstr "`AsyncResource`"
 
-#: src/api/reference.md:324
+#: src/api/reference.md:325
 msgid "`asyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`asyncId` — 实例 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:325
+#: src/api/reference.md:326
 msgid "`bind` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`bind` — 模块 _(类：`AsyncLocalStorage`)_"
 
-#: src/api/reference.md:326
+#: src/api/reference.md:327
 msgid "`bind` — module _(class: `AsyncResource`)_"
 msgstr "`bind` — 模块 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:327
+#: src/api/reference.md:328
 msgid "`bind` — instance _(class: `AsyncResource`)_"
 msgstr "`bind` — 实例 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:328
+#: src/api/reference.md:329
 msgid "`createHook` — module"
 msgstr "`createHook` — 模块"
 
-#: src/api/reference.md:329
+#: src/api/reference.md:330
 msgid "`disable` — instance"
 msgstr "`disable` — 实例"
 
-#: src/api/reference.md:330
+#: src/api/reference.md:331
 msgid "`emitDestroy` — instance _(class: `AsyncResource`)_"
 msgstr "`emitDestroy` — 实例 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:331
+#: src/api/reference.md:332
 msgid "`enable` — instance _(class: `AsyncHook`)_"
 msgstr "`enable` — 实例 _(类：`AsyncHook`)_"
 
-#: src/api/reference.md:332
+#: src/api/reference.md:333
 msgid "`enterWith` — instance"
 msgstr "`enterWith` — 实例"
 
-#: src/api/reference.md:333
+#: src/api/reference.md:334
 msgid "`executionAsyncId` — module"
 msgstr "`executionAsyncId` — 模块"
 
-#: src/api/reference.md:334
+#: src/api/reference.md:335
 msgid "`executionAsyncResource` — module"
 msgstr "`executionAsyncResource` — 模块"
 
-#: src/api/reference.md:335 src/api/reference.md:1292
+#: src/api/reference.md:336 src/api/reference.md:1330
 msgid "`exit` — instance"
 msgstr "`exit` — 实例"
 
-#: src/api/reference.md:336
+#: src/api/reference.md:337
 msgid "`getStore` — instance"
 msgstr "`getStore` — 实例"
 
-#: src/api/reference.md:337 src/api/reference.md:386 src/api/reference.md:1296
-#: src/api/reference.md:3366
+#: src/api/reference.md:338 src/api/reference.md:387 src/api/reference.md:1334
+#: src/api/reference.md:3404
 msgid "`run` — instance"
 msgstr "`run` — 实例"
 
-#: src/api/reference.md:338
+#: src/api/reference.md:339
 msgid "`runInAsyncScope` — instance _(class: `AsyncResource`)_"
 msgstr "`runInAsyncScope` — 实例 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:339
+#: src/api/reference.md:340
 msgid "`snapshot` — module _(class: `AsyncLocalStorage`)_"
 msgstr "`snapshot` — 模块 _(类：`AsyncLocalStorage`)_"
 
-#: src/api/reference.md:340
+#: src/api/reference.md:341
 msgid "`triggerAsyncId` — module"
 msgstr "`triggerAsyncId` — 模块"
 
-#: src/api/reference.md:341
+#: src/api/reference.md:342
 msgid "`triggerAsyncId` — instance _(class: `AsyncResource`)_"
 msgstr "`triggerAsyncId` — 实例 _(类：`AsyncResource`)_"
 
-#: src/api/reference.md:345
+#: src/api/reference.md:346
 msgid "`asyncWrapProviders`"
 msgstr "`asyncWrapProviders`"
 
-#: src/api/reference.md:352
+#: src/api/reference.md:353
 msgid "`all` — module"
 msgstr "`all` — 模块"
 
-#: src/api/reference.md:353 src/api/reference.md:1288 src/api/reference.md:2335
-#: src/api/reference.md:2581
+#: src/api/reference.md:354 src/api/reference.md:1326 src/api/reference.md:2373
+#: src/api/reference.md:2619
 msgid "`create` — module"
 msgstr "`create` — 模块"
 
-#: src/api/reference.md:355
+#: src/api/reference.md:356
 msgid "`delete` — module"
 msgstr "`delete` — 模块"
 
-#: src/api/reference.md:356 src/api/reference.md:1724 src/api/reference.md:1866
+#: src/api/reference.md:357 src/api/reference.md:1762 src/api/reference.md:1904
 msgid "`get` — module"
 msgstr "`get` — 模块"
 
-#: src/api/reference.md:357 src/api/reference.md:2003
+#: src/api/reference.md:358 src/api/reference.md:2041
 msgid "`head` — module"
 msgstr "`head` — 模块"
 
-#: src/api/reference.md:358
+#: src/api/reference.md:359
 msgid "`options` — module"
 msgstr "`options` — 模块"
 
-#: src/api/reference.md:359
+#: src/api/reference.md:360
 msgid "`patch` — module"
 msgstr "`patch` — 模块"
 
-#: src/api/reference.md:360
+#: src/api/reference.md:361
 msgid "`post` — module"
 msgstr "`post` — 模块"
 
-#: src/api/reference.md:361
+#: src/api/reference.md:362
 msgid "`put` — module"
 msgstr "`put` — 模块"
 
-#: src/api/reference.md:362 src/api/reference.md:1765 src/api/reference.md:1876
-#: src/api/reference.md:3782
+#: src/api/reference.md:363 src/api/reference.md:1803 src/api/reference.md:1914
+#: src/api/reference.md:3820
 msgid "`request` — module"
 msgstr "`request` — 模块"
 
-#: src/api/reference.md:368
+#: src/api/reference.md:369
 msgid "`compare` — module"
 msgstr "`compare` — 模块"
 
-#: src/api/reference.md:375 src/api/reference.md:1382 src/api/reference.md:3336
+#: src/api/reference.md:376 src/api/reference.md:1420 src/api/reference.md:3374
 msgid "`all` — instance"
 msgstr "`all` — 实例"
 
-#: src/api/reference.md:376 src/api/reference.md:1384 src/api/reference.md:1974
-#: src/api/reference.md:2118 src/api/reference.md:3206
-#: src/api/reference.md:3233 src/api/reference.md:3342
-#: src/api/reference.md:3743 src/api/reference.md:4105
+#: src/api/reference.md:377 src/api/reference.md:1422 src/api/reference.md:2012
+#: src/api/reference.md:2156 src/api/reference.md:3244
+#: src/api/reference.md:3271 src/api/reference.md:3380
+#: src/api/reference.md:3781 src/api/reference.md:4145
 msgid "`close` — instance"
 msgstr "`close` — 实例"
 
-#: src/api/reference.md:377 src/api/reference.md:3343
+#: src/api/reference.md:378 src/api/reference.md:3381
 msgid "`columns` — instance"
 msgstr "`columns` — 实例"
 
-#: src/api/reference.md:379 src/api/reference.md:3350 src/api/reference.md:3744
+#: src/api/reference.md:380 src/api/reference.md:3388 src/api/reference.md:3782
 msgid "`exec` — instance"
 msgstr "`exec` — 实例"
 
-#: src/api/reference.md:380 src/api/reference.md:1388 src/api/reference.md:1952
-#: src/api/reference.md:2032 src/api/reference.md:3196
-#: src/api/reference.md:3354
+#: src/api/reference.md:381 src/api/reference.md:1426 src/api/reference.md:1990
+#: src/api/reference.md:2070 src/api/reference.md:3234
+#: src/api/reference.md:3392
 msgid "`get` — instance"
 msgstr "`get` — 实例"
 
-#: src/api/reference.md:381 src/api/reference.md:3358
+#: src/api/reference.md:382 src/api/reference.md:3396
 msgid "`iterate` — instance"
 msgstr "`iterate` — 实例"
 
-#: src/api/reference.md:382
+#: src/api/reference.md:383
 msgid "`pluck` — instance"
 msgstr "`pluck` — 实例"
 
-#: src/api/reference.md:383
+#: src/api/reference.md:384
 msgid "`pragma` — instance"
 msgstr "`pragma` — 实例"
 
-#: src/api/reference.md:384 src/api/reference.md:3364
+#: src/api/reference.md:385 src/api/reference.md:3402
 msgid "`prepare` — instance"
 msgstr "`prepare` — 实例"
 
-#: src/api/reference.md:385
+#: src/api/reference.md:386
 msgid "`raw` — instance"
 msgstr "`raw` — 实例"
 
-#: src/api/reference.md:387
+#: src/api/reference.md:388
 msgid "`transaction` — instance"
 msgstr "`transaction` — 实例"
 
-#: src/api/reference.md:389
+#: src/api/reference.md:390
 msgid "`bignumber.js`"
 msgstr "`bignumber.js`"
 
-#: src/api/reference.md:393
+#: src/api/reference.md:394
 msgid "`BigNumber`"
 msgstr "`BigNumber`"
 
-#: src/api/reference.md:395
+#: src/api/reference.md:396
 msgid "`buffer`"
 msgstr "`buffer`"
 
-#: src/api/reference.md:399 src/api/reference.md:1421 src/api/reference.md:2319
+#: src/api/reference.md:400 src/api/reference.md:1459 src/api/reference.md:2357
 msgid "`Blob`"
 msgstr "`Blob`"
 
-#: src/api/reference.md:400
+#: src/api/reference.md:401
 msgid "`Buffer`"
 msgstr "`Buffer`"
 
-#: src/api/reference.md:401
+#: src/api/reference.md:402
 msgid "`File`"
 msgstr "`File`"
 
-#: src/api/reference.md:405
+#: src/api/reference.md:406
 msgid "`atob` — module"
 msgstr "`atob` — 模块"
 
-#: src/api/reference.md:406
+#: src/api/reference.md:407
 msgid "`btoa` — module"
 msgstr "`btoa` — 模块"
 
-#: src/api/reference.md:407
+#: src/api/reference.md:408
 msgid "`isAscii` — module"
 msgstr "`isAscii` — 模块"
 
-#: src/api/reference.md:408
+#: src/api/reference.md:409
 msgid "`isUtf8` — module"
 msgstr "`isUtf8` — 模块"
 
-#: src/api/reference.md:409
+#: src/api/reference.md:410
 msgid "`resolveObjectURL` — module"
 msgstr "`resolveObjectURL` — 模块"
 
-#: src/api/reference.md:410
+#: src/api/reference.md:411
 msgid "`transcode` — module"
 msgstr "`transcode` — 模块"
 
-#: src/api/reference.md:414
+#: src/api/reference.md:415
 msgid "`INSPECT_MAX_BYTES`"
 msgstr "`INSPECT_MAX_BYTES`"
 
-#: src/api/reference.md:415 src/api/reference.md:604 src/api/reference.md:941
-#: src/api/reference.md:1558 src/api/reference.md:1603
-#: src/api/reference.md:1828 src/api/reference.md:2078
-#: src/api/reference.md:2392 src/api/reference.md:2498
-#: src/api/reference.md:3378 src/api/reference.md:4023
-#: src/api/reference.md:4188
+#: src/api/reference.md:416 src/api/reference.md:642 src/api/reference.md:979
+#: src/api/reference.md:1596 src/api/reference.md:1641
+#: src/api/reference.md:1866 src/api/reference.md:2116
+#: src/api/reference.md:2430 src/api/reference.md:2536
+#: src/api/reference.md:3416 src/api/reference.md:4061
+#: src/api/reference.md:4229
 msgid "`constants`"
 msgstr "`constants`"
 
-#: src/api/reference.md:416
+#: src/api/reference.md:417
 msgid "`kMaxLength`"
 msgstr "`kMaxLength`"
 
-#: src/api/reference.md:417
+#: src/api/reference.md:418
 msgid "`kStringMaxLength`"
 msgstr "`kStringMaxLength`"
 
-#: src/api/reference.md:419
+#: src/api/reference.md:420
 msgid "`bun`"
 msgstr "`bun`"
 
-#: src/api/reference.md:423
+#: src/api/reference.md:424
+#, fuzzy
+msgid "`Transpiler`"
+msgstr "传输"
+
+#: src/api/reference.md:428
 msgid "`Glob` — module"
 msgstr "模块 `Glob`"
 
-#: src/api/reference.md:424
+#: src/api/reference.md:429
+#, fuzzy
+msgid "`SQL` — module"
+msgstr "`t` — 模块"
+
+#: src/api/reference.md:430
+#, fuzzy
+msgid "`Terminal` — module"
+msgstr "`onTerminate` — 模块"
+
+#: src/api/reference.md:431
+#, fuzzy
+msgid "`Transpiler` — module"
+msgstr "`range` — 模块"
+
+#: src/api/reference.md:432
+#, fuzzy
+msgid "`build` — module"
+msgstr "`bind` — 模块"
+
+#: src/api/reference.md:433 src/api/reference.md:1856 src/api/reference.md:2158
+#: src/api/reference.md:2260 src/api/reference.md:3083
+#: src/api/reference.md:3719
+msgid "`connect` — module"
+msgstr "`connect` — 模块"
+
+#: src/api/reference.md:434
+#, fuzzy
+msgid "`deepEquals` — module"
+msgstr "`deepEqual` — 模块"
+
+#: src/api/reference.md:435
 msgid "`file` — module"
 msgstr "模块 `file`"
 
-#: src/api/reference.md:425 src/api/reference.md:3800
+#: src/api/reference.md:436 src/api/reference.md:3838
 msgid "`fileURLToPath` — module"
 msgstr "`fileURLToPath` — 模块"
 
-#: src/api/reference.md:427 src/api/reference.md:3804
+#: src/api/reference.md:437
+#, fuzzy
+msgid "`gc` — module"
+msgstr "`cp` — 模块"
+
+#: src/api/reference.md:438
+#, fuzzy
+msgid "`generateHeapSnapshot` — module"
+msgstr "`getHeapSnapshot` — 模块"
+
+#: src/api/reference.md:440
+#, fuzzy
+msgid "`listen` — module"
+msgstr "`list` — 模块"
+
+#: src/api/reference.md:441 src/api/reference.md:3842
 msgid "`pathToFileURL` — module"
 msgstr "`pathToFileURL` — 模块"
 
-#: src/api/reference.md:428
+#: src/api/reference.md:442
+#, fuzzy
+msgid "`scan` — instance _(class: `Transpiler`)_"
+msgstr "`cancel` — 实例 _(类：`Resolver`)_"
+
+#: src/api/reference.md:443
+#, fuzzy
+msgid "`scanImports` — instance _(class: `Transpiler`)_"
+msgstr "`start` — 实例 _(类：`GCProfiler`)_"
+
+#: src/api/reference.md:444
+#, fuzzy
+msgid "`serve` — module"
+msgstr "`Server` — 模块"
+
+#: src/api/reference.md:446
 msgid "`stringWidth` — module"
 msgstr "模块 `stringWidth`"
 
-#: src/api/reference.md:429
+#: src/api/reference.md:447
+#, fuzzy
+msgid "`stripANSI` — module"
+msgstr "`strict` — 模块"
+
+#: src/api/reference.md:448
+#, fuzzy
+msgid "`transform` — instance _(class: `Transpiler`)_"
+msgstr "`start` — 实例 _(类：`GCProfiler`)_"
+
+#: src/api/reference.md:449
+#, fuzzy
+msgid "`transformSync` — instance _(class: `Transpiler`)_"
+msgstr "`transaction` 实例 _ ((类:`Database`)"
+
+#: src/api/reference.md:450
 msgid "`unsupported` — module"
 msgstr "模块 `unsupported`"
 
-#: src/api/reference.md:430 src/api/reference.md:1549
+#: src/api/reference.md:451
+#, fuzzy
+msgid "`which` — module"
+msgstr "`watch` — 模块"
+
+#: src/api/reference.md:452
+#, fuzzy
+msgid "`wrapAnsi` — module"
+msgstr "`warn` — 模块"
+
+#: src/api/reference.md:453 src/api/reference.md:1587
 msgid "`write` — module"
 msgstr "`write` — 模块"
 
-#: src/api/reference.md:434 src/api/reference.md:3139
+#: src/api/reference.md:454 src/api/reference.md:4223
+msgid "`zstdDecompress` — module"
+msgstr "`zstdDecompress` — 模块"
+
+#: src/api/reference.md:455 src/api/reference.md:4224
+msgid "`zstdDecompressSync` — module"
+msgstr "`zstdDecompressSync` — 模块"
+
+#: src/api/reference.md:459
+#, fuzzy
+msgid "`JSONL`"
+msgstr "JSON"
+
+#: src/api/reference.md:460
+msgid "`TOML`"
+msgstr ""
+
+#: src/api/reference.md:461
+msgid "`YAML`"
+msgstr ""
+
+#: src/api/reference.md:462
+msgid "`ant`"
+msgstr ""
+
+#: src/api/reference.md:463 src/api/reference.md:2549
+msgid "`isStandaloneExecutable`"
+msgstr "`isStandaloneExecutable`"
+
+#: src/api/reference.md:464
+#, fuzzy
+msgid "`semver`"
+msgstr "`server`"
+
+#: src/api/reference.md:465 src/api/reference.md:3177
 msgid "`stderr`"
 msgstr "`stderr`"
 
-#: src/api/reference.md:435 src/api/reference.md:3140
+#: src/api/reference.md:466 src/api/reference.md:3178
 msgid "`stdin`"
 msgstr "`stdin`"
 
-#: src/api/reference.md:436 src/api/reference.md:3141
+#: src/api/reference.md:467 src/api/reference.md:3179
 msgid "`stdout`"
 msgstr "`stdout`"
 
-#: src/api/reference.md:438
+#: src/api/reference.md:468 src/api/reference.md:3181 src/api/reference.md:3197
+#: src/updater/overview.md:109 src/cli/perry-toml.md:120
+msgid "`version`"
+msgstr "`version`"
+
+#: src/api/reference.md:470
 msgid "`bun:ffi`"
 msgstr "`bun:ffi`"
 
-#: src/api/reference.md:442
+#: src/api/reference.md:474
 msgid "`CFunction` — module"
 msgstr "模块 `CFunction`"
 
-#: src/api/reference.md:443
+#: src/api/reference.md:475
 msgid "`CString` — module"
 msgstr "模块 `CString`"
 
-#: src/api/reference.md:444
+#: src/api/reference.md:476
 msgid "`JSCallback` — module"
 msgstr "模块 `JSCallback`"
 
-#: src/api/reference.md:445 src/api/reference.md:1435 src/api/reference.md:3075
+#: src/api/reference.md:477 src/api/reference.md:1473 src/api/reference.md:3113
 msgid "`dlopen` — module"
 msgstr "`dlopen` — 模块"
 
-#: src/api/reference.md:446
+#: src/api/reference.md:478
 msgid "`linkSymbols` — module"
 msgstr "模块 `linkSymbols`"
 
-#: src/api/reference.md:447
+#: src/api/reference.md:479
 msgid "`ptr` — module"
 msgstr "模块 `ptr`"
 
-#: src/api/reference.md:448 src/api/reference.md:1437
+#: src/api/reference.md:480 src/api/reference.md:1475
 msgid "`toArrayBuffer` — module"
 msgstr "模块 `toArrayBuffer`"
 
-#: src/api/reference.md:449 src/api/reference.md:1438
+#: src/api/reference.md:481 src/api/reference.md:1476
 msgid "`toBuffer` — module"
 msgstr "模块 `toBuffer`"
 
-#: src/api/reference.md:450
+#: src/api/reference.md:482
 msgid "`viewSource` — module"
 msgstr "模块 `viewSource`"
 
-#: src/api/reference.md:454
+#: src/api/reference.md:486
 msgid "`FFIType`"
 msgstr "`FFIType`"
 
-#: src/api/reference.md:455
+#: src/api/reference.md:487
 msgid "`read`"
 msgstr "`read`"
 
-#: src/api/reference.md:456 src/api/reference.md:1443
+#: src/api/reference.md:488 src/api/reference.md:1481
 msgid "`suffix`"
 msgstr "`suffix`"
 
-#: src/api/reference.md:458
+#: src/api/reference.md:490
+#, fuzzy
+msgid "`bun:jsc`"
+msgstr "`bun`"
+
+#: src/api/reference.md:494
+#, fuzzy
+msgid "`heapStats` — module"
+msgstr "`State` — 模块"
+
+#: src/api/reference.md:496
 msgid "`bun:sqlite`"
 msgstr "`bun:sqlite`"
 
-#: src/api/reference.md:462
+#: src/api/reference.md:500
 msgid "`Database`"
 msgstr "`Database`"
 
-#: src/api/reference.md:463
+#: src/api/reference.md:501
 msgid "`Statement`"
 msgstr "`Statement`"
 
-#: src/api/reference.md:467
+#: src/api/reference.md:505
 msgid "`Database` — module"
 msgstr "模块 `Database`"
 
-#: src/api/reference.md:468
+#: src/api/reference.md:506
 msgid "`all` — instance _(class: `Statement`)_"
 msgstr "`all` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:469
+#: src/api/reference.md:507
 msgid "`close` — instance _(class: `Database`)_"
 msgstr "`close` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:470
+#: src/api/reference.md:508
 msgid "`finalize` — instance _(class: `Statement`)_"
 msgstr "`finalize` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:471
+#: src/api/reference.md:509
 msgid "`get` — instance _(class: `Statement`)_"
 msgstr "`get` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:472
+#: src/api/reference.md:510
 msgid "`loadExtension` — instance _(class: `Database`)_"
 msgstr "`loadExtension` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:473
+#: src/api/reference.md:511
 msgid "`prepare` — instance _(class: `Database`)_"
 msgstr "`prepare` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:474
+#: src/api/reference.md:512
 msgid "`query` — instance _(class: `Database`)_"
 msgstr "`query` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:475
+#: src/api/reference.md:513
 msgid "`run` — instance _(class: `Database`)_"
 msgstr "`run` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:476
+#: src/api/reference.md:514
 msgid "`run` — instance _(class: `Statement`)_"
 msgstr "`run` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:477
+#: src/api/reference.md:515
 msgid "`safeIntegers` — instance _(class: `Statement`)_"
 msgstr "`safeIntegers` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:478
+#: src/api/reference.md:516
 msgid "`serialize` — instance _(class: `Database`)_"
 msgstr "`serialize` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:479
+#: src/api/reference.md:517
 msgid "`transaction` — instance _(class: `Database`)_"
 msgstr "`transaction` 实例 _ ((类:`Database`)"
 
-#: src/api/reference.md:480
+#: src/api/reference.md:518
 msgid "`values` — instance _(class: `Statement`)_"
 msgstr "`values` 实例 _ ((类:`Statement`)"
 
-#: src/api/reference.md:484
+#: src/api/reference.md:522
 msgid "`filename`"
 msgstr "`filename`"
 
-#: src/api/reference.md:485
+#: src/api/reference.md:523
 msgid "`inTransaction`"
 msgstr "`inTransaction`"
 
-#: src/api/reference.md:491
+#: src/api/reference.md:529
 msgid "`attr` — instance"
 msgstr "`attr` — 实例"
 
-#: src/api/reference.md:492
+#: src/api/reference.md:530
 msgid "`children` — instance"
 msgstr "`children` — 实例"
 
-#: src/api/reference.md:493 src/api/reference.md:999
+#: src/api/reference.md:531 src/api/reference.md:1037
 msgid "`eq` — instance"
 msgstr "`eq` — 实例"
 
-#: src/api/reference.md:494 src/api/reference.md:2126
+#: src/api/reference.md:532 src/api/reference.md:2164
 msgid "`find` — instance"
 msgstr "`find` — 实例"
 
-#: src/api/reference.md:495
+#: src/api/reference.md:533
 msgid "`first` — instance"
 msgstr "`first` — 实例"
 
-#: src/api/reference.md:496
+#: src/api/reference.md:534
 msgid "`hasClass` — instance"
 msgstr "`hasClass` — 实例"
 
-#: src/api/reference.md:497 src/api/reference.md:1392
+#: src/api/reference.md:535 src/api/reference.md:1430
 msgid "`html` — instance"
 msgstr "`html` — 实例"
 
-#: src/api/reference.md:498
+#: src/api/reference.md:536
 msgid "`last` — instance"
 msgstr "`last` — 实例"
 
-#: src/api/reference.md:499
+#: src/api/reference.md:537
 msgid "`length` — instance"
 msgstr "`length` — 实例"
 
-#: src/api/reference.md:500
+#: src/api/reference.md:538
 msgid "`load` — module"
 msgstr "`load` — 模块"
 
-#: src/api/reference.md:501
+#: src/api/reference.md:539
 msgid "`parent` — instance"
 msgstr "`parent` — 实例"
 
-#: src/api/reference.md:502
+#: src/api/reference.md:540
 msgid "`select` — instance"
 msgstr "`select` — 实例"
 
-#: src/api/reference.md:503 src/api/reference.md:1412
+#: src/api/reference.md:541 src/api/reference.md:1450
 msgid "`text` — instance"
 msgstr "`text` — 实例"
 
-#: src/api/reference.md:505
+#: src/api/reference.md:543
 msgid "`child_process`"
 msgstr "`child_process`"
 
-#: src/api/reference.md:509
+#: src/api/reference.md:547
 msgid "`ChildProcess`"
 msgstr "`ChildProcess`"
 
-#: src/api/reference.md:513
+#: src/api/reference.md:551
 msgid "`_forkChild` — module"
 msgstr "`_forkChild` — 模块"
 
-#: src/api/reference.md:514 src/api/reference.md:2568 src/api/reference.md:2585
-#: src/api/reference.md:2610
+#: src/api/reference.md:552 src/api/reference.md:2606 src/api/reference.md:2623
+#: src/api/reference.md:2648
 msgid "`exec` — module"
 msgstr "`exec` — 模块"
 
-#: src/api/reference.md:515
+#: src/api/reference.md:553
 msgid "`execFile` — module"
 msgstr "`execFile` — 模块"
 
-#: src/api/reference.md:516
+#: src/api/reference.md:554
 msgid "`execFileSync` — module"
 msgstr "`execFileSync` — 模块"
 
-#: src/api/reference.md:517
+#: src/api/reference.md:555
 msgid "`execSync` — module"
 msgstr "`execSync` — 模块"
 
-#: src/api/reference.md:518 src/api/reference.md:535
+#: src/api/reference.md:556 src/api/reference.md:573
 msgid "`fork` — module"
 msgstr "`fork` — 模块"
 
-#: src/api/reference.md:520
+#: src/api/reference.md:558
 msgid "`spawnSync` — module"
 msgstr "`spawnSync` — 模块"
 
-#: src/api/reference.md:526
+#: src/api/reference.md:564
 msgid "`cluster`"
 msgstr "`cluster`"
 
-#: src/api/reference.md:534
+#: src/api/reference.md:572
 msgid "`disconnect` — module"
 msgstr "`disconnect` — 模块"
 
-#: src/api/reference.md:536
+#: src/api/reference.md:574
 msgid "`setupMaster` — module"
 msgstr "`setupMaster` — 模块"
 
-#: src/api/reference.md:537
+#: src/api/reference.md:575
 msgid "`setupPrimary` — module"
 msgstr "`setupPrimary` — 模块"
 
-#: src/api/reference.md:541
+#: src/api/reference.md:579
 msgid "`SCHED_NONE`"
 msgstr "`SCHED_NONE`"
 
-#: src/api/reference.md:542
+#: src/api/reference.md:580
 msgid "`SCHED_RR`"
 msgstr "`SCHED_RR`"
 
-#: src/api/reference.md:544
+#: src/api/reference.md:582
 msgid "`isMaster`"
 msgstr "`isMaster`"
 
-#: src/api/reference.md:545
+#: src/api/reference.md:583
 msgid "`isPrimary`"
 msgstr "`isPrimary`"
 
-#: src/api/reference.md:546
+#: src/api/reference.md:584
 msgid "`isWorker`"
 msgstr "`isWorker`"
 
-#: src/api/reference.md:547
+#: src/api/reference.md:585
 msgid "`schedulingPolicy`"
 msgstr "`schedulingPolicy`"
 
-#: src/api/reference.md:548
+#: src/api/reference.md:586
 msgid "`settings`"
 msgstr "`settings`"
 
-#: src/api/reference.md:549
+#: src/api/reference.md:587
 msgid "`workers`"
 msgstr "`workers`"
 
-#: src/api/reference.md:555
+#: src/api/reference.md:593
 msgid "`action` — instance"
 msgstr "`action` — 实例"
 
-#: src/api/reference.md:556
+#: src/api/reference.md:594
 msgid "`args` — instance"
 msgstr "`args` 实例"
 
-#: src/api/reference.md:557
+#: src/api/reference.md:595
 msgid "`argument` — instance"
 msgstr "`argument` 实例"
 
-#: src/api/reference.md:558
+#: src/api/reference.md:596
 msgid "`command` — instance"
 msgstr "`command` — 实例"
 
-#: src/api/reference.md:559
+#: src/api/reference.md:597
 msgid "`description` — instance"
 msgstr "`description` — 实例"
 
-#: src/api/reference.md:560
+#: src/api/reference.md:598
 msgid "`name` — instance"
 msgstr "`name` — 实例"
 
-#: src/api/reference.md:561
+#: src/api/reference.md:599
 msgid "`option` — instance"
 msgstr "`option` — 实例"
 
-#: src/api/reference.md:562
+#: src/api/reference.md:600
 msgid "`opts` — instance"
 msgstr "`opts` — 实例"
 
-#: src/api/reference.md:563
+#: src/api/reference.md:601
 msgid "`parse` — instance"
 msgstr "`parse` — 实例"
 
-#: src/api/reference.md:564
+#: src/api/reference.md:602
 msgid "`requiredOption` — instance"
 msgstr "`requiredOption` — 实例"
 
-#: src/api/reference.md:565
+#: src/api/reference.md:603
 msgid "`version` — instance"
 msgstr "`version` — 实例"
 
-#: src/api/reference.md:569
+#: src/api/reference.md:607
 msgid "`args`"
 msgstr "`args`"
 
-#: src/api/reference.md:571 src/api/reference.md:1914
+#: src/api/reference.md:609 src/api/reference.md:1952
 msgid "`console`"
 msgstr "`console`"
 
-#: src/api/reference.md:575
+#: src/api/reference.md:613
 msgid "`Console`"
 msgstr "`Console`"
 
-#: src/api/reference.md:579
+#: src/api/reference.md:617
 msgid "`assert` — module"
 msgstr "`assert` — 模块"
 
-#: src/api/reference.md:580
+#: src/api/reference.md:618
 msgid "`clear` — module"
 msgstr "`clear` — 模块"
 
-#: src/api/reference.md:581
+#: src/api/reference.md:619
 msgid "`context` — module"
 msgstr "`context` — 模块"
 
-#: src/api/reference.md:582
+#: src/api/reference.md:620
 msgid "`count` — module"
 msgstr "`count` — 模块"
 
-#: src/api/reference.md:583
+#: src/api/reference.md:621
 msgid "`countReset` — module"
 msgstr "`countReset` — 模块"
 
-#: src/api/reference.md:584
+#: src/api/reference.md:622
 msgid "`createTask` — module"
 msgstr "`createTask` — 模块"
 
-#: src/api/reference.md:585 src/api/reference.md:3558 src/api/reference.md:3833
+#: src/api/reference.md:623 src/api/reference.md:3596 src/api/reference.md:3871
 msgid "`debug` — module"
 msgstr "`debug` — 模块"
 
-#: src/api/reference.md:586
+#: src/api/reference.md:624
 msgid "`dir` — module"
 msgstr "`dir` — 模块"
 
-#: src/api/reference.md:587
+#: src/api/reference.md:625
 msgid "`dirxml` — module"
 msgstr "`dirxml` — 模块"
 
-#: src/api/reference.md:588
+#: src/api/reference.md:626
 msgid "`error` — module"
 msgstr "`error` — 模块"
 
-#: src/api/reference.md:589
+#: src/api/reference.md:627
 msgid "`group` — module"
 msgstr "`group` — 模块"
 
-#: src/api/reference.md:590
+#: src/api/reference.md:628
 msgid "`groupCollapsed` — module"
 msgstr "`groupCollapsed` — 模块"
 
-#: src/api/reference.md:591
+#: src/api/reference.md:629
 msgid "`groupEnd` — module"
 msgstr "`groupEnd` — 模块"
 
-#: src/api/reference.md:592
+#: src/api/reference.md:630
 msgid "`info` — module"
 msgstr "`info` — 模块"
 
-#: src/api/reference.md:593
+#: src/api/reference.md:631
 msgid "`log` — module"
 msgstr "`log` — 模块"
 
-#: src/api/reference.md:594
+#: src/api/reference.md:632
 msgid "`profile` — module"
 msgstr "`profile` — 模块"
 
-#: src/api/reference.md:595
+#: src/api/reference.md:633
 msgid "`profileEnd` — module"
 msgstr "`profileEnd` — 模块"
 
-#: src/api/reference.md:596
+#: src/api/reference.md:634
 msgid "`table` — module"
 msgstr "`table` — 模块"
 
-#: src/api/reference.md:597
+#: src/api/reference.md:635
 msgid "`time` — module"
 msgstr "`time` — 模块"
 
-#: src/api/reference.md:598
+#: src/api/reference.md:636
 msgid "`timeEnd` — module"
 msgstr "`timeEnd` — 模块"
 
-#: src/api/reference.md:599
+#: src/api/reference.md:637
 msgid "`timeLog` — module"
 msgstr "`timeLog` — 模块"
 
-#: src/api/reference.md:600
+#: src/api/reference.md:638
 msgid "`timeStamp` — module"
 msgstr "`timeStamp` — 模块"
 
-#: src/api/reference.md:601
+#: src/api/reference.md:639
 msgid "`trace` — module"
 msgstr "`trace` — 模块"
 
-#: src/api/reference.md:602
+#: src/api/reference.md:640
 msgid "`warn` — module"
 msgstr "`warn` — 模块"
 
-#: src/api/reference.md:608
+#: src/api/reference.md:646
 msgid "`COPYFILE_EXCL`"
 msgstr "`COPYFILE_EXCL`"
 
-#: src/api/reference.md:609
+#: src/api/reference.md:647
 msgid "`COPYFILE_FICLONE`"
 msgstr "`COPYFILE_FICLONE`"
 
-#: src/api/reference.md:610
+#: src/api/reference.md:648
 msgid "`COPYFILE_FICLONE_FORCE`"
 msgstr "`COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:611
+#: src/api/reference.md:649
 msgid "`DH_CHECK_P_NOT_PRIME`"
 msgstr "`DH_CHECK_P_NOT_PRIME`"
 
-#: src/api/reference.md:612
+#: src/api/reference.md:650
 msgid "`DH_CHECK_P_NOT_SAFE_PRIME`"
 msgstr "`DH_CHECK_P_NOT_SAFE_PRIME`"
 
-#: src/api/reference.md:613
+#: src/api/reference.md:651
 msgid "`DH_NOT_SUITABLE_GENERATOR`"
 msgstr "`DH_NOT_SUITABLE_GENERATOR`"
 
-#: src/api/reference.md:614
+#: src/api/reference.md:652
 msgid "`DH_UNABLE_TO_CHECK_GENERATOR`"
 msgstr "`DH_UNABLE_TO_CHECK_GENERATOR`"
 
-#: src/api/reference.md:615
+#: src/api/reference.md:653
 msgid "`E2BIG`"
 msgstr "`E2BIG`"
 
-#: src/api/reference.md:616
+#: src/api/reference.md:654
 msgid "`EACCES`"
 msgstr "`EACCES`"
 
-#: src/api/reference.md:617
+#: src/api/reference.md:655
 msgid "`EADDRINUSE`"
 msgstr "`EADDRINUSE`"
 
-#: src/api/reference.md:618
+#: src/api/reference.md:656
 msgid "`EADDRNOTAVAIL`"
 msgstr "`EADDRNOTAVAIL`"
 
-#: src/api/reference.md:619
+#: src/api/reference.md:657
 msgid "`EAFNOSUPPORT`"
 msgstr "`EAFNOSUPPORT`"
 
-#: src/api/reference.md:620
+#: src/api/reference.md:658
 msgid "`EAGAIN`"
 msgstr "`EAGAIN`"
 
-#: src/api/reference.md:621
+#: src/api/reference.md:659
 msgid "`EALREADY`"
 msgstr "`EALREADY`"
 
-#: src/api/reference.md:622
+#: src/api/reference.md:660
 msgid "`EBADF`"
 msgstr "`EBADF`"
 
-#: src/api/reference.md:623
+#: src/api/reference.md:661
 msgid "`EBADMSG`"
 msgstr "`EBADMSG`"
 
-#: src/api/reference.md:624
+#: src/api/reference.md:662
 msgid "`EBUSY`"
 msgstr "`EBUSY`"
 
-#: src/api/reference.md:625
+#: src/api/reference.md:663
 msgid "`ECANCELED`"
 msgstr "`ECANCELED`"
 
-#: src/api/reference.md:626
+#: src/api/reference.md:664
 msgid "`ECHILD`"
 msgstr "`ECHILD`"
 
-#: src/api/reference.md:627
+#: src/api/reference.md:665
 msgid "`ECONNABORTED`"
 msgstr "`ECONNABORTED`"
 
-#: src/api/reference.md:628
+#: src/api/reference.md:666
 msgid "`ECONNREFUSED`"
 msgstr "`ECONNREFUSED`"
 
-#: src/api/reference.md:629
+#: src/api/reference.md:667
 msgid "`ECONNRESET`"
 msgstr "`ECONNRESET`"
 
-#: src/api/reference.md:630
+#: src/api/reference.md:668
 msgid "`EDEADLK`"
 msgstr "`EDEADLK`"
 
-#: src/api/reference.md:631
+#: src/api/reference.md:669
 msgid "`EDESTADDRREQ`"
 msgstr "`EDESTADDRREQ`"
 
-#: src/api/reference.md:632
+#: src/api/reference.md:670
 msgid "`EDOM`"
 msgstr "`EDOM`"
 
-#: src/api/reference.md:633
+#: src/api/reference.md:671
 msgid "`EDQUOT`"
 msgstr "`EDQUOT`"
 
-#: src/api/reference.md:634
+#: src/api/reference.md:672
 msgid "`EEXIST`"
 msgstr "`EEXIST`"
 
-#: src/api/reference.md:635
+#: src/api/reference.md:673
 msgid "`EFAULT`"
 msgstr "`EFAULT`"
 
-#: src/api/reference.md:636
+#: src/api/reference.md:674
 msgid "`EFBIG`"
 msgstr "`EFBIG`"
 
-#: src/api/reference.md:637
+#: src/api/reference.md:675
 msgid "`EHOSTUNREACH`"
 msgstr "`EHOSTUNREACH`"
 
-#: src/api/reference.md:638
+#: src/api/reference.md:676
 msgid "`EIDRM`"
 msgstr "`EIDRM`"
 
-#: src/api/reference.md:639
+#: src/api/reference.md:677
 msgid "`EILSEQ`"
 msgstr "`EILSEQ`"
 
-#: src/api/reference.md:640
+#: src/api/reference.md:678
 msgid "`EINPROGRESS`"
 msgstr "`EINPROGRESS`"
 
-#: src/api/reference.md:641
+#: src/api/reference.md:679
 msgid "`EINTR`"
 msgstr "`EINTR`"
 
-#: src/api/reference.md:642
+#: src/api/reference.md:680
 msgid "`EINVAL`"
 msgstr "`EINVAL`"
 
-#: src/api/reference.md:643
+#: src/api/reference.md:681
 msgid "`EIO`"
 msgstr "`EIO`"
 
-#: src/api/reference.md:644
+#: src/api/reference.md:682
 msgid "`EISCONN`"
 msgstr "`EISCONN`"
 
-#: src/api/reference.md:645
+#: src/api/reference.md:683
 msgid "`EISDIR`"
 msgstr "`EISDIR`"
 
-#: src/api/reference.md:646
+#: src/api/reference.md:684
 msgid "`ELOOP`"
 msgstr "`ELOOP`"
 
-#: src/api/reference.md:647
+#: src/api/reference.md:685
 msgid "`EMFILE`"
 msgstr "`EMFILE`"
 
-#: src/api/reference.md:648
+#: src/api/reference.md:686
 msgid "`EMLINK`"
 msgstr "`EMLINK`"
 
-#: src/api/reference.md:649
+#: src/api/reference.md:687
 msgid "`EMSGSIZE`"
 msgstr "`EMSGSIZE`"
 
-#: src/api/reference.md:650
+#: src/api/reference.md:688
 msgid "`EMULTIHOP`"
 msgstr "`EMULTIHOP`"
 
-#: src/api/reference.md:651
+#: src/api/reference.md:689
 msgid "`ENAMETOOLONG`"
 msgstr "`ENAMETOOLONG`"
 
-#: src/api/reference.md:652
+#: src/api/reference.md:690
 msgid "`ENETDOWN`"
 msgstr "`ENETDOWN`"
 
-#: src/api/reference.md:653
+#: src/api/reference.md:691
 msgid "`ENETRESET`"
 msgstr "`ENETRESET`"
 
-#: src/api/reference.md:654
+#: src/api/reference.md:692
 msgid "`ENETUNREACH`"
 msgstr "`ENETUNREACH`"
 
-#: src/api/reference.md:655
+#: src/api/reference.md:693
 msgid "`ENFILE`"
 msgstr "`ENFILE`"
 
-#: src/api/reference.md:656
+#: src/api/reference.md:694
 msgid "`ENGINE_METHOD_ALL`"
 msgstr "`ENGINE_METHOD_ALL`"
 
-#: src/api/reference.md:657
+#: src/api/reference.md:695
 msgid "`ENGINE_METHOD_CIPHERS`"
 msgstr "`ENGINE_METHOD_CIPHERS`"
 
-#: src/api/reference.md:658
+#: src/api/reference.md:696
 msgid "`ENGINE_METHOD_DH`"
 msgstr "`ENGINE_METHOD_DH`"
 
-#: src/api/reference.md:659
+#: src/api/reference.md:697
 msgid "`ENGINE_METHOD_DIGESTS`"
 msgstr "`ENGINE_METHOD_DIGESTS`"
 
-#: src/api/reference.md:660
+#: src/api/reference.md:698
 msgid "`ENGINE_METHOD_DSA`"
 msgstr "`ENGINE_METHOD_DSA`"
 
-#: src/api/reference.md:661
+#: src/api/reference.md:699
 msgid "`ENGINE_METHOD_EC`"
 msgstr "`ENGINE_METHOD_EC`"
 
-#: src/api/reference.md:662
+#: src/api/reference.md:700
 msgid "`ENGINE_METHOD_NONE`"
 msgstr "`ENGINE_METHOD_NONE`"
 
-#: src/api/reference.md:663
+#: src/api/reference.md:701
 msgid "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_ASN1_METHS`"
 
-#: src/api/reference.md:664
+#: src/api/reference.md:702
 msgid "`ENGINE_METHOD_PKEY_METHS`"
 msgstr "`ENGINE_METHOD_PKEY_METHS`"
 
-#: src/api/reference.md:665
+#: src/api/reference.md:703
 msgid "`ENGINE_METHOD_RAND`"
 msgstr "`ENGINE_METHOD_RAND`"
 
-#: src/api/reference.md:666
+#: src/api/reference.md:704
 msgid "`ENGINE_METHOD_RSA`"
 msgstr "`ENGINE_METHOD_RSA`"
 
-#: src/api/reference.md:667
+#: src/api/reference.md:705
 msgid "`ENOBUFS`"
 msgstr "`ENOBUFS`"
 
-#: src/api/reference.md:668
+#: src/api/reference.md:706
 msgid "`ENODATA`"
 msgstr "`ENODATA`"
 
-#: src/api/reference.md:669
+#: src/api/reference.md:707
 msgid "`ENODEV`"
 msgstr "`ENODEV`"
 
-#: src/api/reference.md:670
+#: src/api/reference.md:708
 msgid "`ENOENT`"
 msgstr "`ENOENT`"
 
-#: src/api/reference.md:671
+#: src/api/reference.md:709
 msgid "`ENOEXEC`"
 msgstr "`ENOEXEC`"
 
-#: src/api/reference.md:672
+#: src/api/reference.md:710
 msgid "`ENOLCK`"
 msgstr "`ENOLCK`"
 
-#: src/api/reference.md:673
+#: src/api/reference.md:711
 msgid "`ENOLINK`"
 msgstr "`ENOLINK`"
 
-#: src/api/reference.md:674
+#: src/api/reference.md:712
 msgid "`ENOMEM`"
 msgstr "`ENOMEM`"
 
-#: src/api/reference.md:675
+#: src/api/reference.md:713
 msgid "`ENOMSG`"
 msgstr "`ENOMSG`"
 
-#: src/api/reference.md:676
+#: src/api/reference.md:714
 msgid "`ENOPROTOOPT`"
 msgstr "`ENOPROTOOPT`"
 
-#: src/api/reference.md:677
+#: src/api/reference.md:715
 msgid "`ENOSPC`"
 msgstr "`ENOSPC`"
 
-#: src/api/reference.md:678
+#: src/api/reference.md:716
 msgid "`ENOSR`"
 msgstr "`ENOSR`"
 
-#: src/api/reference.md:679
+#: src/api/reference.md:717
 msgid "`ENOSTR`"
 msgstr "`ENOSTR`"
 
-#: src/api/reference.md:680
+#: src/api/reference.md:718
 msgid "`ENOSYS`"
 msgstr "`ENOSYS`"
 
-#: src/api/reference.md:681
+#: src/api/reference.md:719
 msgid "`ENOTCONN`"
 msgstr "`ENOTCONN`"
 
-#: src/api/reference.md:682
+#: src/api/reference.md:720
 msgid "`ENOTDIR`"
 msgstr "`ENOTDIR`"
 
-#: src/api/reference.md:683
+#: src/api/reference.md:721
 msgid "`ENOTEMPTY`"
 msgstr "`ENOTEMPTY`"
 
-#: src/api/reference.md:684
+#: src/api/reference.md:722
 msgid "`ENOTSOCK`"
 msgstr "`ENOTSOCK`"
 
-#: src/api/reference.md:685
+#: src/api/reference.md:723
 msgid "`ENOTSUP`"
 msgstr "`ENOTSUP`"
 
-#: src/api/reference.md:686
+#: src/api/reference.md:724
 msgid "`ENOTTY`"
 msgstr "`ENOTTY`"
 
-#: src/api/reference.md:687
+#: src/api/reference.md:725
 msgid "`ENXIO`"
 msgstr "`ENXIO`"
 
-#: src/api/reference.md:688
+#: src/api/reference.md:726
 msgid "`EOPNOTSUPP`"
 msgstr "`EOPNOTSUPP`"
 
-#: src/api/reference.md:689
+#: src/api/reference.md:727
 msgid "`EOVERFLOW`"
 msgstr "`EOVERFLOW`"
 
-#: src/api/reference.md:690
+#: src/api/reference.md:728
 msgid "`EPERM`"
 msgstr "`EPERM`"
 
-#: src/api/reference.md:691
+#: src/api/reference.md:729
 msgid "`EPIPE`"
 msgstr "`EPIPE`"
 
-#: src/api/reference.md:692
+#: src/api/reference.md:730
 msgid "`EPROTO`"
 msgstr "`EPROTO`"
 
-#: src/api/reference.md:693
+#: src/api/reference.md:731
 msgid "`EPROTONOSUPPORT`"
 msgstr "`EPROTONOSUPPORT`"
 
-#: src/api/reference.md:694
+#: src/api/reference.md:732
 msgid "`EPROTOTYPE`"
 msgstr "`EPROTOTYPE`"
 
-#: src/api/reference.md:695
+#: src/api/reference.md:733
 msgid "`ERANGE`"
 msgstr "`ERANGE`"
 
-#: src/api/reference.md:696
+#: src/api/reference.md:734
 msgid "`EROFS`"
 msgstr "`EROFS`"
 
-#: src/api/reference.md:697
+#: src/api/reference.md:735
 msgid "`ESPIPE`"
 msgstr "`ESPIPE`"
 
-#: src/api/reference.md:698
+#: src/api/reference.md:736
 msgid "`ESRCH`"
 msgstr "`ESRCH`"
 
-#: src/api/reference.md:699
+#: src/api/reference.md:737
 msgid "`ESTALE`"
 msgstr "`ESTALE`"
 
-#: src/api/reference.md:700
+#: src/api/reference.md:738
 msgid "`ETIME`"
 msgstr "`ETIME`"
 
-#: src/api/reference.md:701
+#: src/api/reference.md:739
 msgid "`ETIMEDOUT`"
 msgstr "`ETIMEDOUT`"
 
-#: src/api/reference.md:702
+#: src/api/reference.md:740
 msgid "`ETXTBSY`"
 msgstr "`ETXTBSY`"
 
-#: src/api/reference.md:703
+#: src/api/reference.md:741
 msgid "`EWOULDBLOCK`"
 msgstr "`EWOULDBLOCK`"
 
-#: src/api/reference.md:704
+#: src/api/reference.md:742
 msgid "`EXDEV`"
 msgstr "`EXDEV`"
 
-#: src/api/reference.md:705
+#: src/api/reference.md:743
 msgid "`F_OK`"
 msgstr "`F_OK`"
 
-#: src/api/reference.md:706
+#: src/api/reference.md:744
 msgid "`OPENSSL_VERSION_NUMBER`"
 msgstr "`OPENSSL_VERSION_NUMBER`"
 
-#: src/api/reference.md:707
+#: src/api/reference.md:745
 msgid "`O_APPEND`"
 msgstr "`O_APPEND`"
 
-#: src/api/reference.md:708
+#: src/api/reference.md:746
 msgid "`O_CREAT`"
 msgstr "`O_CREAT`"
 
-#: src/api/reference.md:709
+#: src/api/reference.md:747
 msgid "`O_DIRECT`"
 msgstr "`O_DIRECT`"
 
-#: src/api/reference.md:710
+#: src/api/reference.md:748
 msgid "`O_DIRECTORY`"
 msgstr "`O_DIRECTORY`"
 
-#: src/api/reference.md:711
+#: src/api/reference.md:749
 msgid "`O_DSYNC`"
 msgstr "`O_DSYNC`"
 
-#: src/api/reference.md:712
+#: src/api/reference.md:750
 msgid "`O_EXCL`"
 msgstr "`O_EXCL`"
 
-#: src/api/reference.md:713
+#: src/api/reference.md:751
 msgid "`O_NOATIME`"
 msgstr "`O_NOATIME`"
 
-#: src/api/reference.md:714
+#: src/api/reference.md:752
 msgid "`O_NOCTTY`"
 msgstr "`O_NOCTTY`"
 
-#: src/api/reference.md:715
+#: src/api/reference.md:753
 msgid "`O_NOFOLLOW`"
 msgstr "`O_NOFOLLOW`"
 
-#: src/api/reference.md:716
+#: src/api/reference.md:754
 msgid "`O_NONBLOCK`"
 msgstr "`O_NONBLOCK`"
 
-#: src/api/reference.md:717
+#: src/api/reference.md:755
 msgid "`O_RDONLY`"
 msgstr "`O_RDONLY`"
 
-#: src/api/reference.md:718
+#: src/api/reference.md:756
 msgid "`O_RDWR`"
 msgstr "`O_RDWR`"
 
-#: src/api/reference.md:719
+#: src/api/reference.md:757
 msgid "`O_SYMLINK`"
 msgstr "`O_SYMLINK`"
 
-#: src/api/reference.md:720
+#: src/api/reference.md:758
 msgid "`O_SYNC`"
 msgstr "`O_SYNC`"
 
-#: src/api/reference.md:721
+#: src/api/reference.md:759
 msgid "`O_TRUNC`"
 msgstr "`O_TRUNC`"
 
-#: src/api/reference.md:722
+#: src/api/reference.md:760
 msgid "`O_WRONLY`"
 msgstr "`O_WRONLY`"
 
-#: src/api/reference.md:723
+#: src/api/reference.md:761
 msgid "`POINT_CONVERSION_COMPRESSED`"
 msgstr "`POINT_CONVERSION_COMPRESSED`"
 
-#: src/api/reference.md:724
+#: src/api/reference.md:762
 msgid "`POINT_CONVERSION_HYBRID`"
 msgstr "`POINT_CONVERSION_HYBRID`"
 
-#: src/api/reference.md:725
+#: src/api/reference.md:763
 msgid "`POINT_CONVERSION_UNCOMPRESSED`"
 msgstr "`POINT_CONVERSION_UNCOMPRESSED`"
 
-#: src/api/reference.md:726
+#: src/api/reference.md:764
 msgid "`PRIORITY_ABOVE_NORMAL`"
 msgstr "`PRIORITY_ABOVE_NORMAL`"
 
-#: src/api/reference.md:727
+#: src/api/reference.md:765
 msgid "`PRIORITY_BELOW_NORMAL`"
 msgstr "`PRIORITY_BELOW_NORMAL`"
 
-#: src/api/reference.md:728
+#: src/api/reference.md:766
 msgid "`PRIORITY_HIGH`"
 msgstr "`PRIORITY_HIGH`"
 
-#: src/api/reference.md:729
+#: src/api/reference.md:767
 msgid "`PRIORITY_HIGHEST`"
 msgstr "`PRIORITY_HIGHEST`"
 
-#: src/api/reference.md:730
+#: src/api/reference.md:768
 msgid "`PRIORITY_LOW`"
 msgstr "`PRIORITY_LOW`"
 
-#: src/api/reference.md:731
+#: src/api/reference.md:769
 msgid "`PRIORITY_NORMAL`"
 msgstr "`PRIORITY_NORMAL`"
 
-#: src/api/reference.md:732
+#: src/api/reference.md:770
 msgid "`RSA_NO_PADDING`"
 msgstr "`RSA_NO_PADDING`"
 
-#: src/api/reference.md:733
+#: src/api/reference.md:771
 msgid "`RSA_PKCS1_OAEP_PADDING`"
 msgstr "`RSA_PKCS1_OAEP_PADDING`"
 
-#: src/api/reference.md:734
+#: src/api/reference.md:772
 msgid "`RSA_PKCS1_PADDING`"
 msgstr "`RSA_PKCS1_PADDING`"
 
-#: src/api/reference.md:735
+#: src/api/reference.md:773
 msgid "`RSA_PKCS1_PSS_PADDING`"
 msgstr "`RSA_PKCS1_PSS_PADDING`"
 
-#: src/api/reference.md:736
+#: src/api/reference.md:774
 msgid "`RSA_PSS_SALTLEN_AUTO`"
 msgstr "`RSA_PSS_SALTLEN_AUTO`"
 
-#: src/api/reference.md:737
+#: src/api/reference.md:775
 msgid "`RSA_PSS_SALTLEN_DIGEST`"
 msgstr "`RSA_PSS_SALTLEN_DIGEST`"
 
-#: src/api/reference.md:738
+#: src/api/reference.md:776
 msgid "`RSA_PSS_SALTLEN_MAX_SIGN`"
 msgstr "`RSA_PSS_SALTLEN_MAX_SIGN`"
 
-#: src/api/reference.md:739
+#: src/api/reference.md:777
 msgid "`RSA_X931_PADDING`"
 msgstr "`RSA_X931_PADDING`"
 
-#: src/api/reference.md:740
+#: src/api/reference.md:778
 msgid "`RTLD_DEEPBIND`"
 msgstr "`RTLD_DEEPBIND`"
 
-#: src/api/reference.md:741
+#: src/api/reference.md:779
 msgid "`RTLD_GLOBAL`"
 msgstr "`RTLD_GLOBAL`"
 
-#: src/api/reference.md:742
+#: src/api/reference.md:780
 msgid "`RTLD_LAZY`"
 msgstr "`RTLD_LAZY`"
 
-#: src/api/reference.md:743
+#: src/api/reference.md:781
 msgid "`RTLD_LOCAL`"
 msgstr "`RTLD_LOCAL`"
 
-#: src/api/reference.md:744
+#: src/api/reference.md:782
 msgid "`RTLD_NOW`"
 msgstr "`RTLD_NOW`"
 
-#: src/api/reference.md:745
+#: src/api/reference.md:783
 msgid "`R_OK`"
 msgstr "`R_OK`"
 
-#: src/api/reference.md:746
+#: src/api/reference.md:784
 msgid "`SIGABRT`"
 msgstr "`SIGABRT`"
 
-#: src/api/reference.md:747
+#: src/api/reference.md:785
 msgid "`SIGALRM`"
 msgstr "`SIGALRM`"
 
-#: src/api/reference.md:748
+#: src/api/reference.md:786
 msgid "`SIGBUS`"
 msgstr "`SIGBUS`"
 
-#: src/api/reference.md:749
+#: src/api/reference.md:787
 msgid "`SIGCHLD`"
 msgstr "`SIGCHLD`"
 
-#: src/api/reference.md:750
+#: src/api/reference.md:788
 msgid "`SIGCONT`"
 msgstr "`SIGCONT`"
 
-#: src/api/reference.md:751
+#: src/api/reference.md:789
 msgid "`SIGFPE`"
 msgstr "`SIGFPE`"
 
-#: src/api/reference.md:752
+#: src/api/reference.md:790
 msgid "`SIGHUP`"
 msgstr "`SIGHUP`"
 
-#: src/api/reference.md:753
+#: src/api/reference.md:791
 msgid "`SIGILL`"
 msgstr "`SIGILL`"
 
-#: src/api/reference.md:754
+#: src/api/reference.md:792
 msgid "`SIGINFO`"
 msgstr "`SIGINFO`"
 
-#: src/api/reference.md:755
+#: src/api/reference.md:793
 msgid "`SIGINT`"
 msgstr "`SIGINT`"
 
-#: src/api/reference.md:756
+#: src/api/reference.md:794
 msgid "`SIGIO`"
 msgstr "`SIGIO`"
 
-#: src/api/reference.md:757
+#: src/api/reference.md:795
 msgid "`SIGIOT`"
 msgstr "`SIGIOT`"
 
-#: src/api/reference.md:758
+#: src/api/reference.md:796
 msgid "`SIGKILL`"
 msgstr "`SIGKILL`"
 
-#: src/api/reference.md:759
+#: src/api/reference.md:797
 msgid "`SIGPIPE`"
 msgstr "`SIGPIPE`"
 
-#: src/api/reference.md:760
+#: src/api/reference.md:798
 msgid "`SIGPOLL`"
 msgstr "`SIGPOLL`"
 
-#: src/api/reference.md:761
+#: src/api/reference.md:799
 msgid "`SIGPROF`"
 msgstr "`SIGPROF`"
 
-#: src/api/reference.md:762
+#: src/api/reference.md:800
 msgid "`SIGPWR`"
 msgstr "`SIGPWR`"
 
-#: src/api/reference.md:763
+#: src/api/reference.md:801
 msgid "`SIGQUIT`"
 msgstr "`SIGQUIT`"
 
-#: src/api/reference.md:764
+#: src/api/reference.md:802
 msgid "`SIGSEGV`"
 msgstr "`SIGSEGV`"
 
-#: src/api/reference.md:765
+#: src/api/reference.md:803
 msgid "`SIGSTKFLT`"
 msgstr "`SIGSTKFLT`"
 
-#: src/api/reference.md:766
+#: src/api/reference.md:804
 msgid "`SIGSTOP`"
 msgstr "`SIGSTOP`"
 
-#: src/api/reference.md:767
+#: src/api/reference.md:805
 msgid "`SIGSYS`"
 msgstr "`SIGSYS`"
 
-#: src/api/reference.md:768
+#: src/api/reference.md:806
 msgid "`SIGTERM`"
 msgstr "`SIGTERM`"
 
-#: src/api/reference.md:769
+#: src/api/reference.md:807
 msgid "`SIGTRAP`"
 msgstr "`SIGTRAP`"
 
-#: src/api/reference.md:770
+#: src/api/reference.md:808
 msgid "`SIGTSTP`"
 msgstr "`SIGTSTP`"
 
-#: src/api/reference.md:771
+#: src/api/reference.md:809
 msgid "`SIGTTIN`"
 msgstr "`SIGTTIN`"
 
-#: src/api/reference.md:772
+#: src/api/reference.md:810
 msgid "`SIGTTOU`"
 msgstr "`SIGTTOU`"
 
-#: src/api/reference.md:773
+#: src/api/reference.md:811
 msgid "`SIGURG`"
 msgstr "`SIGURG`"
 
-#: src/api/reference.md:774
+#: src/api/reference.md:812
 msgid "`SIGUSR1`"
 msgstr "`SIGUSR1`"
 
-#: src/api/reference.md:775
+#: src/api/reference.md:813
 msgid "`SIGUSR2`"
 msgstr "`SIGUSR2`"
 
-#: src/api/reference.md:776
+#: src/api/reference.md:814
 msgid "`SIGVTALRM`"
 msgstr "`SIGVTALRM`"
 
-#: src/api/reference.md:777
+#: src/api/reference.md:815
 msgid "`SIGWINCH`"
 msgstr "`SIGWINCH`"
 
-#: src/api/reference.md:778
+#: src/api/reference.md:816
 msgid "`SIGXCPU`"
 msgstr "`SIGXCPU`"
 
-#: src/api/reference.md:779
+#: src/api/reference.md:817
 msgid "`SIGXFSZ`"
 msgstr "`SIGXFSZ`"
 
-#: src/api/reference.md:780
+#: src/api/reference.md:818
 msgid "`SSL_OP_ALL`"
 msgstr "`SSL_OP_ALL`"
 
-#: src/api/reference.md:781
+#: src/api/reference.md:819
 msgid "`SSL_OP_ALLOW_NO_DHE_KEX`"
 msgstr "`SSL_OP_ALLOW_NO_DHE_KEX`"
 
-#: src/api/reference.md:782
+#: src/api/reference.md:820
 msgid "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 msgstr "`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`"
 
-#: src/api/reference.md:783
+#: src/api/reference.md:821
 msgid "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 msgstr "`SSL_OP_CIPHER_SERVER_PREFERENCE`"
 
-#: src/api/reference.md:784
+#: src/api/reference.md:822
 msgid "`SSL_OP_CISCO_ANYCONNECT`"
 msgstr "`SSL_OP_CISCO_ANYCONNECT`"
 
-#: src/api/reference.md:785
+#: src/api/reference.md:823
 msgid "`SSL_OP_COOKIE_EXCHANGE`"
 msgstr "`SSL_OP_COOKIE_EXCHANGE`"
 
-#: src/api/reference.md:786
+#: src/api/reference.md:824
 msgid "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 msgstr "`SSL_OP_CRYPTOPRO_TLSEXT_BUG`"
 
-#: src/api/reference.md:787
+#: src/api/reference.md:825
 msgid "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 msgstr "`SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`"
 
-#: src/api/reference.md:788
+#: src/api/reference.md:826
 msgid "`SSL_OP_LEGACY_SERVER_CONNECT`"
 msgstr "`SSL_OP_LEGACY_SERVER_CONNECT`"
 
-#: src/api/reference.md:789
+#: src/api/reference.md:827
 msgid "`SSL_OP_NO_COMPRESSION`"
 msgstr "`SSL_OP_NO_COMPRESSION`"
 
-#: src/api/reference.md:790
+#: src/api/reference.md:828
 msgid "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 msgstr "`SSL_OP_NO_ENCRYPT_THEN_MAC`"
 
-#: src/api/reference.md:791
+#: src/api/reference.md:829
 msgid "`SSL_OP_NO_QUERY_MTU`"
 msgstr "`SSL_OP_NO_QUERY_MTU`"
 
-#: src/api/reference.md:792
+#: src/api/reference.md:830
 msgid "`SSL_OP_NO_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_RENEGOTIATION`"
 
-#: src/api/reference.md:793
+#: src/api/reference.md:831
 msgid "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 msgstr "`SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION`"
 
-#: src/api/reference.md:794
+#: src/api/reference.md:832
 msgid "`SSL_OP_NO_SSLv2`"
 msgstr "`SSL_OP_NO_SSLv2`"
 
-#: src/api/reference.md:795
+#: src/api/reference.md:833
 msgid "`SSL_OP_NO_SSLv3`"
 msgstr "`SSL_OP_NO_SSLv3`"
 
-#: src/api/reference.md:796
+#: src/api/reference.md:834
 msgid "`SSL_OP_NO_TICKET`"
 msgstr "`SSL_OP_NO_TICKET`"
 
-#: src/api/reference.md:797
+#: src/api/reference.md:835
 msgid "`SSL_OP_NO_TLSv1`"
 msgstr "`SSL_OP_NO_TLSv1`"
 
-#: src/api/reference.md:798
+#: src/api/reference.md:836
 msgid "`SSL_OP_NO_TLSv1_1`"
 msgstr "`SSL_OP_NO_TLSv1_1`"
 
-#: src/api/reference.md:799
+#: src/api/reference.md:837
 msgid "`SSL_OP_NO_TLSv1_2`"
 msgstr "`SSL_OP_NO_TLSv1_2`"
 
-#: src/api/reference.md:800
+#: src/api/reference.md:838
 msgid "`SSL_OP_NO_TLSv1_3`"
 msgstr "`SSL_OP_NO_TLSv1_3`"
 
-#: src/api/reference.md:801
+#: src/api/reference.md:839
 msgid "`SSL_OP_PRIORITIZE_CHACHA`"
 msgstr "`SSL_OP_PRIORITIZE_CHACHA`"
 
-#: src/api/reference.md:802
+#: src/api/reference.md:840
 msgid "`SSL_OP_TLS_ROLLBACK_BUG`"
 msgstr "`SSL_OP_TLS_ROLLBACK_BUG`"
 
-#: src/api/reference.md:803
+#: src/api/reference.md:841
 msgid "`S_IFBLK`"
 msgstr "`S_IFBLK`"
 
-#: src/api/reference.md:804
+#: src/api/reference.md:842
 msgid "`S_IFCHR`"
 msgstr "`S_IFCHR`"
 
-#: src/api/reference.md:805
+#: src/api/reference.md:843
 msgid "`S_IFDIR`"
 msgstr "`S_IFDIR`"
 
-#: src/api/reference.md:806
+#: src/api/reference.md:844
 msgid "`S_IFIFO`"
 msgstr "`S_IFIFO`"
 
-#: src/api/reference.md:807
+#: src/api/reference.md:845
 msgid "`S_IFLNK`"
 msgstr "`S_IFLNK`"
 
-#: src/api/reference.md:808
+#: src/api/reference.md:846
 msgid "`S_IFMT`"
 msgstr "`S_IFMT`"
 
-#: src/api/reference.md:809
+#: src/api/reference.md:847
 msgid "`S_IFREG`"
 msgstr "`S_IFREG`"
 
-#: src/api/reference.md:810
+#: src/api/reference.md:848
 msgid "`S_IFSOCK`"
 msgstr "`S_IFSOCK`"
 
-#: src/api/reference.md:811
+#: src/api/reference.md:849
 msgid "`S_IRGRP`"
 msgstr "`S_IRGRP`"
 
-#: src/api/reference.md:812
+#: src/api/reference.md:850
 msgid "`S_IROTH`"
 msgstr "`S_IROTH`"
 
-#: src/api/reference.md:813
+#: src/api/reference.md:851
 msgid "`S_IRUSR`"
 msgstr "`S_IRUSR`"
 
-#: src/api/reference.md:814
+#: src/api/reference.md:852
 msgid "`S_IRWXG`"
 msgstr "`S_IRWXG`"
 
-#: src/api/reference.md:815
+#: src/api/reference.md:853
 msgid "`S_IRWXO`"
 msgstr "`S_IRWXO`"
 
-#: src/api/reference.md:816
+#: src/api/reference.md:854
 msgid "`S_IRWXU`"
 msgstr "`S_IRWXU`"
 
-#: src/api/reference.md:817
+#: src/api/reference.md:855
 msgid "`S_IWGRP`"
 msgstr "`S_IWGRP`"
 
-#: src/api/reference.md:818
+#: src/api/reference.md:856
 msgid "`S_IWOTH`"
 msgstr "`S_IWOTH`"
 
-#: src/api/reference.md:819
+#: src/api/reference.md:857
 msgid "`S_IWUSR`"
 msgstr "`S_IWUSR`"
 
-#: src/api/reference.md:820
+#: src/api/reference.md:858
 msgid "`S_IXGRP`"
 msgstr "`S_IXGRP`"
 
-#: src/api/reference.md:821
+#: src/api/reference.md:859
 msgid "`S_IXOTH`"
 msgstr "`S_IXOTH`"
 
-#: src/api/reference.md:822
+#: src/api/reference.md:860
 msgid "`S_IXUSR`"
 msgstr "`S_IXUSR`"
 
-#: src/api/reference.md:823
+#: src/api/reference.md:861
 msgid "`TLS1_1_VERSION`"
 msgstr "`TLS1_1_VERSION`"
 
-#: src/api/reference.md:824
+#: src/api/reference.md:862
 msgid "`TLS1_2_VERSION`"
 msgstr "`TLS1_2_VERSION`"
 
-#: src/api/reference.md:825
+#: src/api/reference.md:863
 msgid "`TLS1_3_VERSION`"
 msgstr "`TLS1_3_VERSION`"
 
-#: src/api/reference.md:826
+#: src/api/reference.md:864
 msgid "`TLS1_VERSION`"
 msgstr "`TLS1_VERSION`"
 
-#: src/api/reference.md:827
+#: src/api/reference.md:865
 msgid "`UV_DIRENT_BLOCK`"
 msgstr "`UV_DIRENT_BLOCK`"
 
-#: src/api/reference.md:828
+#: src/api/reference.md:866
 msgid "`UV_DIRENT_CHAR`"
 msgstr "`UV_DIRENT_CHAR`"
 
-#: src/api/reference.md:829
+#: src/api/reference.md:867
 msgid "`UV_DIRENT_DIR`"
 msgstr "`UV_DIRENT_DIR`"
 
-#: src/api/reference.md:830
+#: src/api/reference.md:868
 msgid "`UV_DIRENT_FIFO`"
 msgstr "`UV_DIRENT_FIFO`"
 
-#: src/api/reference.md:831
+#: src/api/reference.md:869
 msgid "`UV_DIRENT_FILE`"
 msgstr "`UV_DIRENT_FILE`"
 
-#: src/api/reference.md:832
+#: src/api/reference.md:870
 msgid "`UV_DIRENT_LINK`"
 msgstr "`UV_DIRENT_LINK`"
 
-#: src/api/reference.md:833
+#: src/api/reference.md:871
 msgid "`UV_DIRENT_SOCKET`"
 msgstr "`UV_DIRENT_SOCKET`"
 
-#: src/api/reference.md:834
+#: src/api/reference.md:872
 msgid "`UV_DIRENT_UNKNOWN`"
 msgstr "`UV_DIRENT_UNKNOWN`"
 
-#: src/api/reference.md:835
+#: src/api/reference.md:873
 msgid "`UV_FS_COPYFILE_EXCL`"
 msgstr "`UV_FS_COPYFILE_EXCL`"
 
-#: src/api/reference.md:836
+#: src/api/reference.md:874
 msgid "`UV_FS_COPYFILE_FICLONE`"
 msgstr "`UV_FS_COPYFILE_FICLONE`"
 
-#: src/api/reference.md:837
+#: src/api/reference.md:875
 msgid "`UV_FS_COPYFILE_FICLONE_FORCE`"
 msgstr "`UV_FS_COPYFILE_FICLONE_FORCE`"
 
-#: src/api/reference.md:838
+#: src/api/reference.md:876
 msgid "`UV_FS_O_FILEMAP`"
 msgstr "`UV_FS_O_FILEMAP`"
 
-#: src/api/reference.md:839
+#: src/api/reference.md:877
 msgid "`UV_FS_SYMLINK_DIR`"
 msgstr "`UV_FS_SYMLINK_DIR`"
 
-#: src/api/reference.md:840
+#: src/api/reference.md:878
 msgid "`UV_FS_SYMLINK_JUNCTION`"
 msgstr "`UV_FS_SYMLINK_JUNCTION`"
 
-#: src/api/reference.md:841
+#: src/api/reference.md:879
 msgid "`W_OK`"
 msgstr "`W_OK`"
 
-#: src/api/reference.md:842
+#: src/api/reference.md:880
 msgid "`X_OK`"
 msgstr "`X_OK`"
 
-#: src/api/reference.md:844
+#: src/api/reference.md:882
 msgid "`defaultCoreCipherList`"
 msgstr "`defaultCoreCipherList`"
 
-#: src/api/reference.md:846
+#: src/api/reference.md:884
 msgid "`cron`"
 msgstr "`cron`"
 
-#: src/api/reference.md:850
+#: src/api/reference.md:888
 msgid "`CronJob`"
 msgstr "`CronJob`"
 
-#: src/api/reference.md:854 src/api/reference.md:3596
+#: src/api/reference.md:892 src/api/reference.md:3634
 msgid "`describe` — module"
 msgstr "`describe` — 模块"
 
-#: src/api/reference.md:855
+#: src/api/reference.md:893
 msgid "`isRunning` — instance"
 msgstr "`isRunning` — 实例"
 
-#: src/api/reference.md:856
+#: src/api/reference.md:894
 msgid "`nextDate` — instance"
 msgstr "`nextDate` — 实例"
 
-#: src/api/reference.md:857 src/api/reference.md:2312 src/api/reference.md:2560
+#: src/api/reference.md:895 src/api/reference.md:2350 src/api/reference.md:2598
 msgid "`schedule` — module"
 msgstr "`schedule` — 模块"
 
-#: src/api/reference.md:858
+#: src/api/reference.md:896
 msgid "`start` — instance"
 msgstr "`start` — 实例"
 
-#: src/api/reference.md:859
+#: src/api/reference.md:897
 msgid "`stop` — instance"
 msgstr "`stop` — 实例"
 
-#: src/api/reference.md:860 src/api/reference.md:2313 src/api/reference.md:3919
+#: src/api/reference.md:898 src/api/reference.md:2351 src/api/reference.md:3957
 msgid "`validate` — module"
 msgstr "`validate` — 模块"
 
-#: src/api/reference.md:862 src/cli/capabilities.md:52
+#: src/api/reference.md:900 src/cli/capabilities.md:52
 msgid "`crypto`"
 msgstr "`crypto`"
 
-#: src/api/reference.md:866
+#: src/api/reference.md:904
 msgid "`Cipheriv`"
 msgstr "`Cipheriv`"
 
-#: src/api/reference.md:867
+#: src/api/reference.md:905
 msgid "`Decipheriv`"
 msgstr "`Decipheriv`"
 
-#: src/api/reference.md:868
+#: src/api/reference.md:906
 msgid "`DiffieHellman`"
 msgstr "`DiffieHellman`"
 
-#: src/api/reference.md:869
+#: src/api/reference.md:907
 msgid "`DiffieHellmanGroup`"
 msgstr "`DiffieHellmanGroup`"
 
-#: src/api/reference.md:870
+#: src/api/reference.md:908
 msgid "`ECDH`"
 msgstr "`ECDH`"
 
-#: src/api/reference.md:871
+#: src/api/reference.md:909
 msgid "`KeyObject`"
 msgstr "`KeyObject`"
 
-#: src/api/reference.md:872
+#: src/api/reference.md:910
 msgid "`X509Certificate`"
 msgstr "`X509Certificate`"
 
-#: src/api/reference.md:876
+#: src/api/reference.md:914
 msgid "`Hash` — module"
 msgstr "`Hash` — 模块"
 
-#: src/api/reference.md:877
+#: src/api/reference.md:915
 msgid "`Hmac` — module"
 msgstr "`Hmac` — 模块"
 
-#: src/api/reference.md:878
+#: src/api/reference.md:916
 msgid "`Sign` — module"
 msgstr "`Sign` — 模块"
 
-#: src/api/reference.md:879
+#: src/api/reference.md:917
 msgid "`Verify` — module"
 msgstr "`Verify` — 模块"
 
-#: src/api/reference.md:880
+#: src/api/reference.md:918
 msgid "`argon2` — module"
 msgstr "`argon2` — 模块"
 
-#: src/api/reference.md:881
+#: src/api/reference.md:919
 msgid "`argon2Sync` — module"
 msgstr "`argon2Sync` — 模块"
 
-#: src/api/reference.md:882
+#: src/api/reference.md:920
 msgid "`checkPrime` — module"
 msgstr "`checkPrime` — 模块"
 
-#: src/api/reference.md:883
+#: src/api/reference.md:921
 msgid "`checkPrimeSync` — module"
 msgstr "`checkPrimeSync` — 模块"
 
-#: src/api/reference.md:884
+#: src/api/reference.md:922
 msgid "`createCipheriv` — module"
 msgstr "`createCipheriv` — 模块"
 
-#: src/api/reference.md:885
+#: src/api/reference.md:923
 msgid "`createDecipheriv` — module"
 msgstr "`createDecipheriv` — 模块"
 
-#: src/api/reference.md:886
+#: src/api/reference.md:924
 msgid "`createDiffieHellman` — module"
 msgstr "`createDiffieHellman` — 模块"
 
-#: src/api/reference.md:887
+#: src/api/reference.md:925
 msgid "`createDiffieHellmanGroup` — module"
 msgstr "`createDiffieHellmanGroup` — 模块"
 
-#: src/api/reference.md:888
+#: src/api/reference.md:926
 msgid "`createECDH` — module"
 msgstr "`createECDH` — 模块"
 
-#: src/api/reference.md:889
+#: src/api/reference.md:927
 msgid "`createHash` — module"
 msgstr "`createHash` — 模块"
 
-#: src/api/reference.md:890
+#: src/api/reference.md:928
 msgid "`createHmac` — module"
 msgstr "`createHmac` — 模块"
 
-#: src/api/reference.md:891
+#: src/api/reference.md:929
 msgid "`createPrivateKey` — module"
 msgstr "`createPrivateKey` — 模块"
 
-#: src/api/reference.md:892
+#: src/api/reference.md:930
 msgid "`createPublicKey` — module"
 msgstr "`createPublicKey` — 模块"
 
-#: src/api/reference.md:893
+#: src/api/reference.md:931
 msgid "`createSecretKey` — module"
 msgstr "`createSecretKey` — 模块"
 
-#: src/api/reference.md:894 src/api/reference.md:895
+#: src/api/reference.md:932 src/api/reference.md:933
 msgid "`createSign` — module"
 msgstr "`createSign` — 模块"
 
-#: src/api/reference.md:896 src/api/reference.md:897
+#: src/api/reference.md:934 src/api/reference.md:935
 msgid "`createVerify` — module"
 msgstr "`createVerify` — 模块"
 
-#: src/api/reference.md:898
+#: src/api/reference.md:936
 msgid "`decapsulate` — module"
 msgstr "`decapsulate` — 模块"
 
-#: src/api/reference.md:899
+#: src/api/reference.md:937
 msgid "`diffieHellman` — module"
 msgstr "`diffieHellman` — 模块"
 
-#: src/api/reference.md:900
+#: src/api/reference.md:938
 msgid "`encapsulate` — module"
 msgstr "`encapsulate` — 模块"
 
-#: src/api/reference.md:901
+#: src/api/reference.md:939
 msgid "`generateKey` — module"
 msgstr "`generateKey` — 模块"
 
-#: src/api/reference.md:902 src/api/reference.md:2337
+#: src/api/reference.md:940 src/api/reference.md:2375
 msgid "`generateKeyPair` — module"
 msgstr "`generateKeyPair` — 模块"
 
-#: src/api/reference.md:903 src/api/reference.md:904
+#: src/api/reference.md:941 src/api/reference.md:942
 msgid "`generateKeyPairSync` — module"
 msgstr "`generateKeyPairSync` — 模块"
 
-#: src/api/reference.md:905
+#: src/api/reference.md:943
 msgid "`generateKeySync` — module"
 msgstr "`generateKeySync` — 模块"
 
-#: src/api/reference.md:906
+#: src/api/reference.md:944
 msgid "`generatePrime` — module"
 msgstr "`generatePrime` — 模块"
 
-#: src/api/reference.md:907
+#: src/api/reference.md:945
 msgid "`generatePrimeSync` — module"
 msgstr "`generatePrimeSync` — 模块"
 
-#: src/api/reference.md:908
+#: src/api/reference.md:946
 msgid "`getCipherInfo` — module"
 msgstr "`getCipherInfo` — 模块"
 
-#: src/api/reference.md:909 src/api/reference.md:3688
+#: src/api/reference.md:947 src/api/reference.md:3726
 msgid "`getCiphers` — module"
 msgstr "`getCiphers` — 模块"
 
-#: src/api/reference.md:910
+#: src/api/reference.md:948
 msgid "`getCurves` — module"
 msgstr "`getCurves` — 模块"
 
-#: src/api/reference.md:911
+#: src/api/reference.md:949
 msgid "`getDiffieHellman` — module"
 msgstr "`getDiffieHellman` — 模块"
 
-#: src/api/reference.md:912
+#: src/api/reference.md:950
 msgid "`getFips` — module"
 msgstr "`getFips` — 模块"
 
-#: src/api/reference.md:913
+#: src/api/reference.md:951
 msgid "`getHashes` — module"
 msgstr "`getHashes` — 模块"
 
-#: src/api/reference.md:914
+#: src/api/reference.md:952
 msgid "`getRandomValues` — module"
 msgstr "`getRandomValues` — 模块"
 
-#: src/api/reference.md:916
+#: src/api/reference.md:954
 msgid "`hkdf` — module"
 msgstr "`hkdf` — 模块"
 
-#: src/api/reference.md:917
+#: src/api/reference.md:955
 msgid "`hkdfSync` — module"
 msgstr "`hkdfSync` — 模块"
 
-#: src/api/reference.md:918
+#: src/api/reference.md:956
 msgid "`pbkdf2` — module"
 msgstr "`pbkdf2` — 模块"
 
-#: src/api/reference.md:919
+#: src/api/reference.md:957
 msgid "`pbkdf2Sync` — module"
 msgstr "`pbkdf2Sync` — 模块"
 
-#: src/api/reference.md:920
+#: src/api/reference.md:958
 msgid "`privateDecrypt` — module"
 msgstr "`privateDecrypt` — 模块"
 
-#: src/api/reference.md:921
+#: src/api/reference.md:959
 msgid "`privateEncrypt` — module"
 msgstr "`privateEncrypt` — 模块"
 
-#: src/api/reference.md:922
+#: src/api/reference.md:960
 msgid "`publicDecrypt` — module"
 msgstr "`publicDecrypt` — 模块"
 
-#: src/api/reference.md:923
+#: src/api/reference.md:961
 msgid "`publicEncrypt` — module"
 msgstr "`publicEncrypt` — 模块"
 
-#: src/api/reference.md:924
+#: src/api/reference.md:962
 msgid "`randomBytes` — module"
 msgstr "`randomBytes` — 模块"
 
-#: src/api/reference.md:925
+#: src/api/reference.md:963
 msgid "`randomFill` — module"
 msgstr "`randomFill` — 模块"
 
-#: src/api/reference.md:926
+#: src/api/reference.md:964
 msgid "`randomFillSync` — module"
 msgstr "`randomFillSync` — 模块"
 
-#: src/api/reference.md:927 src/api/reference.md:928
+#: src/api/reference.md:965 src/api/reference.md:966
 msgid "`randomInt` — module"
 msgstr "`randomInt` — 模块"
 
-#: src/api/reference.md:929
+#: src/api/reference.md:967
 msgid "`randomUUID` — module"
 msgstr "`randomUUID` — 模块"
 
-#: src/api/reference.md:930
+#: src/api/reference.md:968
 msgid "`scrypt` — module"
 msgstr "`scrypt` — 模块"
 
-#: src/api/reference.md:931
+#: src/api/reference.md:969
 msgid "`scryptSync` — module"
 msgstr "`scryptSync` — 模块"
 
-#: src/api/reference.md:932
+#: src/api/reference.md:970
 msgid "`secureHeapUsed` — module"
 msgstr "`secureHeapUsed` — 模块"
 
-#: src/api/reference.md:933
+#: src/api/reference.md:971
 msgid "`setFips` — module"
 msgstr "`setFips` — 模块"
 
-#: src/api/reference.md:934 src/api/reference.md:1988
+#: src/api/reference.md:972 src/api/reference.md:2026
 msgid "`sign` — module"
 msgstr "`sign` — 模块"
 
-#: src/api/reference.md:935
+#: src/api/reference.md:973
 msgid "`timingSafeEqual` — module"
 msgstr "`timingSafeEqual` — 模块"
 
-#: src/api/reference.md:940
+#: src/api/reference.md:978
 msgid "`Certificate`"
 msgstr "`Certificate`"
 
-#: src/api/reference.md:942
+#: src/api/reference.md:980
 msgid "`subtle`"
 msgstr "`subtle`"
 
-#: src/api/reference.md:943
+#: src/api/reference.md:981
 msgid "`webcrypto`"
 msgstr "`webcrypto`"
 
-#: src/api/reference.md:945
+#: src/api/reference.md:983
 msgid "`date-fns`"
 msgstr "`date-fns`"
 
-#: src/api/reference.md:949
+#: src/api/reference.md:987
 msgid "`addDays` — module"
 msgstr "`addDays` — 模块"
 
-#: src/api/reference.md:950
+#: src/api/reference.md:988
 msgid "`addMonths` — module"
 msgstr "`addMonths` — 模块"
 
-#: src/api/reference.md:951
+#: src/api/reference.md:989
 msgid "`addYears` — module"
 msgstr "`addYears` — 模块"
 
-#: src/api/reference.md:952
+#: src/api/reference.md:990
 msgid "`differenceInDays` — module"
 msgstr "`differenceInDays` — 模块"
 
-#: src/api/reference.md:953
+#: src/api/reference.md:991
 msgid "`differenceInHours` — module"
 msgstr "`differenceInHours` — 模块"
 
-#: src/api/reference.md:954
+#: src/api/reference.md:992
 msgid "`differenceInMinutes` — module"
 msgstr "`differenceInMinutes` — 模块"
 
-#: src/api/reference.md:955
+#: src/api/reference.md:993
 msgid "`endOfDay` — module"
 msgstr "`endOfDay` — 模块"
 
-#: src/api/reference.md:956 src/api/reference.md:2404 src/api/reference.md:2430
-#: src/api/reference.md:2456 src/api/reference.md:3562
-#: src/api/reference.md:3802 src/api/reference.md:3837
+#: src/api/reference.md:994 src/api/reference.md:2442 src/api/reference.md:2468
+#: src/api/reference.md:2494 src/api/reference.md:3600
+#: src/api/reference.md:3840 src/api/reference.md:3875
 msgid "`format` — module"
 msgstr "`format` — 模块"
 
-#: src/api/reference.md:957
+#: src/api/reference.md:995
 msgid "`isAfter` — module"
 msgstr "`isAfter` — 模块"
 
-#: src/api/reference.md:958
+#: src/api/reference.md:996
 msgid "`isBefore` — module"
 msgstr "`isBefore` — 模块"
 
-#: src/api/reference.md:959
+#: src/api/reference.md:997
 msgid "`parseISO` — module"
 msgstr "`parseISO` — 模块"
 
-#: src/api/reference.md:960
+#: src/api/reference.md:998
 msgid "`startOfDay` — module"
 msgstr "`startOfDay` — 模块"
 
-#: src/api/reference.md:962
+#: src/api/reference.md:1000
 msgid "`dayjs`"
 msgstr "`dayjs`"
 
-#: src/api/reference.md:966 src/api/reference.md:1285 src/api/reference.md:2086
+#: src/api/reference.md:1004 src/api/reference.md:1323
+#: src/api/reference.md:2124
 msgid "`add` — instance"
 msgstr "`add` — 实例"
 
-#: src/api/reference.md:967 src/api/reference.md:2087
+#: src/api/reference.md:1005 src/api/reference.md:2125
 msgid "`clone` — instance"
 msgstr "`clone` — 实例"
 
-#: src/api/reference.md:968 src/api/reference.md:2088
+#: src/api/reference.md:1006 src/api/reference.md:2126
 msgid "`date` — instance"
 msgstr "`date` — 实例"
 
-#: src/api/reference.md:969 src/api/reference.md:2089
+#: src/api/reference.md:1007 src/api/reference.md:2127
 msgid "`day` — instance"
 msgstr "`day` — 实例"
 
-#: src/api/reference.md:970
+#: src/api/reference.md:1008
 msgid "`dayjs` — module"
 msgstr "`dayjs` — 模块"
 
-#: src/api/reference.md:972 src/api/reference.md:2091
+#: src/api/reference.md:1010 src/api/reference.md:2129
 msgid "`diff` — instance"
 msgstr "`diff` — 实例"
 
-#: src/api/reference.md:973 src/api/reference.md:2092
+#: src/api/reference.md:1011 src/api/reference.md:2130
 msgid "`endOf` — instance"
 msgstr "`endOf` — 实例"
 
-#: src/api/reference.md:974 src/api/reference.md:2093
+#: src/api/reference.md:1012 src/api/reference.md:2131
 msgid "`format` — instance"
 msgstr "`format` — 实例"
 
-#: src/api/reference.md:975 src/api/reference.md:2095
+#: src/api/reference.md:1013 src/api/reference.md:2133
 msgid "`hour` — instance"
 msgstr "`hour` — 实例"
 
-#: src/api/reference.md:976 src/api/reference.md:2096
+#: src/api/reference.md:1014 src/api/reference.md:2134
 msgid "`isAfter` — instance"
 msgstr "`isAfter` — 实例"
 
-#: src/api/reference.md:977 src/api/reference.md:2097
+#: src/api/reference.md:1015 src/api/reference.md:2135
 msgid "`isBefore` — instance"
 msgstr "`isBefore` — 实例"
 
-#: src/api/reference.md:978 src/api/reference.md:2099
+#: src/api/reference.md:1016 src/api/reference.md:2137
 msgid "`isSame` — instance"
 msgstr "`isSame` — 实例"
 
-#: src/api/reference.md:979 src/api/reference.md:2100
+#: src/api/reference.md:1017 src/api/reference.md:2138
 msgid "`isValid` — instance"
 msgstr "`isValid` — 实例"
 
-#: src/api/reference.md:980 src/api/reference.md:2101
+#: src/api/reference.md:1018 src/api/reference.md:2139
 msgid "`millisecond` — instance"
 msgstr "`millisecond` — 实例"
 
-#: src/api/reference.md:981 src/api/reference.md:2102
+#: src/api/reference.md:1019 src/api/reference.md:2140
 msgid "`minute` — instance"
 msgstr "`minute` — 实例"
 
-#: src/api/reference.md:982 src/api/reference.md:2104
+#: src/api/reference.md:1020 src/api/reference.md:2142
 msgid "`month` — instance"
 msgstr "`month` — 实例"
 
-#: src/api/reference.md:983 src/api/reference.md:2105
+#: src/api/reference.md:1021 src/api/reference.md:2143
 msgid "`second` — instance"
 msgstr "`second` — 实例"
 
-#: src/api/reference.md:984 src/api/reference.md:2106
+#: src/api/reference.md:1022 src/api/reference.md:2144
 msgid "`startOf` — instance"
 msgstr "`startOf` — 实例"
 
-#: src/api/reference.md:985 src/api/reference.md:2107
+#: src/api/reference.md:1023 src/api/reference.md:2145
 msgid "`subtract` — instance"
 msgstr "`subtract` — 实例"
 
-#: src/api/reference.md:986 src/api/reference.md:2109
+#: src/api/reference.md:1024 src/api/reference.md:2147
 msgid "`toISOString` — instance"
 msgstr "`toISOString` — 实例"
 
-#: src/api/reference.md:987 src/api/reference.md:2110
+#: src/api/reference.md:1025 src/api/reference.md:2148
 msgid "`unix` — instance"
 msgstr "`unix` — 实例"
 
-#: src/api/reference.md:988 src/api/reference.md:1019 src/api/reference.md:2111
+#: src/api/reference.md:1026 src/api/reference.md:1057
+#: src/api/reference.md:2149
 msgid "`valueOf` — instance"
 msgstr "`valueOf` — 实例"
 
-#: src/api/reference.md:989 src/api/reference.md:2112
+#: src/api/reference.md:1027 src/api/reference.md:2150
 msgid "`year` — instance"
 msgstr "`year` — 实例"
 
-#: src/api/reference.md:991
+#: src/api/reference.md:1029
 msgid "`decimal.js`"
 msgstr "`decimal.js`"
 
-#: src/api/reference.md:995
+#: src/api/reference.md:1033
 msgid "`abs` — instance"
 msgstr "`abs` — 实例"
 
-#: src/api/reference.md:996
+#: src/api/reference.md:1034
 msgid "`ceil` — instance"
 msgstr "`ceil` — 实例"
 
-#: src/api/reference.md:997
+#: src/api/reference.md:1035
 msgid "`cmp` — instance"
 msgstr "`cmp` — 实例"
 
-#: src/api/reference.md:998
+#: src/api/reference.md:1036
 msgid "`div` — instance"
 msgstr "`div` — 实例"
 
-#: src/api/reference.md:1000
+#: src/api/reference.md:1038
 msgid "`floor` — instance"
 msgstr "`floor` — 实例"
 
-#: src/api/reference.md:1001
+#: src/api/reference.md:1039
 msgid "`gt` — instance"
 msgstr "`gt` — 实例"
 
-#: src/api/reference.md:1002
+#: src/api/reference.md:1040
 msgid "`gte` — instance"
 msgstr "`gte` — 实例"
 
-#: src/api/reference.md:1003
+#: src/api/reference.md:1041
 msgid "`isNegative` — instance"
 msgstr "`isNegative` — 实例"
 
-#: src/api/reference.md:1004
+#: src/api/reference.md:1042
 msgid "`isPositive` — instance"
 msgstr "`isPositive` — 实例"
 
-#: src/api/reference.md:1005
+#: src/api/reference.md:1043
 msgid "`isZero` — instance"
 msgstr "`isZero` — 实例"
 
-#: src/api/reference.md:1006
+#: src/api/reference.md:1044
 msgid "`lt` — instance"
 msgstr "`lt` — 实例"
 
-#: src/api/reference.md:1007
+#: src/api/reference.md:1045
 msgid "`lte` — instance"
 msgstr "`lte` — 实例"
 
-#: src/api/reference.md:1008
+#: src/api/reference.md:1046
 msgid "`minus` — instance"
 msgstr "`minus` — 实例"
 
-#: src/api/reference.md:1009
+#: src/api/reference.md:1047
 msgid "`mod` — instance"
 msgstr "`mod` — 实例"
 
-#: src/api/reference.md:1010
+#: src/api/reference.md:1048
 msgid "`neg` — instance"
 msgstr "`neg` — 实例"
 
-#: src/api/reference.md:1011
+#: src/api/reference.md:1049
 msgid "`plus` — instance"
 msgstr "`plus` — 实例"
 
-#: src/api/reference.md:1012
+#: src/api/reference.md:1050
 msgid "`pow` — instance"
 msgstr "`pow` — 实例"
 
-#: src/api/reference.md:1013
+#: src/api/reference.md:1051
 msgid "`round` — instance"
 msgstr "`round` — 实例"
 
-#: src/api/reference.md:1014
+#: src/api/reference.md:1052
 msgid "`sqrt` — instance"
 msgstr "`sqrt` — 实例"
 
-#: src/api/reference.md:1015
+#: src/api/reference.md:1053
 msgid "`times` — instance"
 msgstr "`times` — 实例"
 
-#: src/api/reference.md:1016
+#: src/api/reference.md:1054
 msgid "`toFixed` — instance"
 msgstr "`toFixed` — 实例"
 
-#: src/api/reference.md:1017
+#: src/api/reference.md:1055
 msgid "`toNumber` — instance"
 msgstr "`toNumber` — 实例"
 
-#: src/api/reference.md:1018
+#: src/api/reference.md:1056
 msgid "`toString` — instance"
 msgstr "`toString` — 实例"
 
-#: src/api/reference.md:1021
+#: src/api/reference.md:1059
 msgid "`dgram`"
 msgstr "`dgram`"
 
-#: src/api/reference.md:1025 src/api/reference.md:2193
+#: src/api/reference.md:1063 src/api/reference.md:2231
 msgid "`Socket`"
 msgstr "`Socket`"
 
-#: src/api/reference.md:1029 src/api/reference.md:2201
+#: src/api/reference.md:1067 src/api/reference.md:2239
 msgid "`Socket` — module"
 msgstr "`Socket` — 模块"
 
-#: src/api/reference.md:1030 src/api/reference.md:2209
+#: src/api/reference.md:1068 src/api/reference.md:2247
 msgid "`addListener` — instance _(class: `Socket`)_"
 msgstr "`addListener` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1031
+#: src/api/reference.md:1069
 msgid "`addMembership` — instance _(class: `Socket`)_"
 msgstr "`addMembership` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1032
+#: src/api/reference.md:1070
 msgid "`addSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`addSourceSpecificMembership` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1033 src/api/reference.md:2213
+#: src/api/reference.md:1071 src/api/reference.md:2251
 msgid "`address` — instance _(class: `Socket`)_"
 msgstr "`address` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1034
+#: src/api/reference.md:1072
 msgid "`bind` — instance _(class: `Socket`)_"
 msgstr "`bind` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1035
+#: src/api/reference.md:1073
 msgid "`close` — instance _(class: `Socket`)_"
 msgstr "`close` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1036 src/api/reference.md:2223
+#: src/api/reference.md:1074 src/api/reference.md:2261
 msgid "`connect` — instance _(class: `Socket`)_"
 msgstr "`connect` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:1037
+#: src/api/reference.md:1075
 msgid "`createSocket` — module"
 msgstr "`createSocket` — 模块"
 
-#: src/api/reference.md:1038
+#: src/api/reference.md:1076
 msgid "`disconnect` — instance _(class: `Socket`)_"
 msgstr "`disconnect` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1039
+#: src/api/reference.md:1077
 msgid "`dropMembership` — instance _(class: `Socket`)_"
 msgstr "`dropMembership` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1040
+#: src/api/reference.md:1078
 msgid "`dropSourceSpecificMembership` — instance _(class: `Socket`)_"
 msgstr "`dropSourceSpecificMembership` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1041
+#: src/api/reference.md:1079
 msgid "`emit` — instance _(class: `Socket`)_"
 msgstr "`emit` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1042 src/api/reference.md:2232
+#: src/api/reference.md:1080 src/api/reference.md:2270
 msgid "`eventNames` — instance _(class: `Socket`)_"
 msgstr "`eventNames` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1043
+#: src/api/reference.md:1081
 msgid "`getRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getRecvBufferSize` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1044
+#: src/api/reference.md:1082
 msgid "`getSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`getSendBufferSize` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1045
+#: src/api/reference.md:1083
 msgid "`getSendQueueCount` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueCount` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1046
+#: src/api/reference.md:1084
 msgid "`getSendQueueSize` — instance _(class: `Socket`)_"
 msgstr "`getSendQueueSize` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1047 src/api/reference.md:2259
+#: src/api/reference.md:1085 src/api/reference.md:2297
 msgid "`listenerCount` — instance _(class: `Socket`)_"
 msgstr "`listenerCount` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1048 src/api/reference.md:2268
+#: src/api/reference.md:1086 src/api/reference.md:2306
 msgid "`off` — instance _(class: `Socket`)_"
 msgstr "`off` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1049 src/api/reference.md:2270
+#: src/api/reference.md:1087 src/api/reference.md:2308
 msgid "`on` — instance _(class: `Socket`)_"
 msgstr "`on` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:1050 src/api/reference.md:2271
+#: src/api/reference.md:1088 src/api/reference.md:2309
 msgid "`once` — instance _(class: `Socket`)_"
 msgstr "`once` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1051 src/api/reference.md:2280
+#: src/api/reference.md:1089 src/api/reference.md:2318
 msgid "`ref` — instance _(class: `Socket`)_"
 msgstr "`ref` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1052 src/api/reference.md:2281
+#: src/api/reference.md:1090 src/api/reference.md:2319
 msgid "`remoteAddress` — instance _(class: `Socket`)_"
 msgstr "`remoteAddress` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1053 src/api/reference.md:2286
+#: src/api/reference.md:1091 src/api/reference.md:2324
 msgid "`removeListener` — instance _(class: `Socket`)_"
 msgstr "`removeListener` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1054
+#: src/api/reference.md:1092
 msgid "`send` — instance _(class: `Socket`)_"
 msgstr "`send` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1055
+#: src/api/reference.md:1093
 msgid "`sendto` — instance _(class: `Socket`)_"
 msgstr "`sendto` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:1056
+#: src/api/reference.md:1094
 msgid "`setBroadcast` — instance _(class: `Socket`)_"
 msgstr "`setBroadcast` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1057
+#: src/api/reference.md:1095
 msgid "`setMulticastInterface` — instance _(class: `Socket`)_"
 msgstr "`setMulticastInterface` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1058
+#: src/api/reference.md:1096
 msgid "`setMulticastLoopback` — instance _(class: `Socket`)_"
 msgstr "`setMulticastLoopback` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1059
+#: src/api/reference.md:1097
 msgid "`setMulticastTTL` — instance _(class: `Socket`)_"
 msgstr "`setMulticastTTL` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1060
+#: src/api/reference.md:1098
 msgid "`setRecvBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setRecvBufferSize` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1061
+#: src/api/reference.md:1099
 msgid "`setSendBufferSize` — instance _(class: `Socket`)_"
 msgstr "`setSendBufferSize` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1062
+#: src/api/reference.md:1100
 msgid "`setTTL` — instance _(class: `Socket`)_"
 msgstr "`setTTL` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1063 src/api/reference.md:2304
+#: src/api/reference.md:1101 src/api/reference.md:2342
 msgid "`unref` — instance _(class: `Socket`)_"
 msgstr "`unref` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:1069
+#: src/api/reference.md:1107
 msgid "`diagnostics_channel`"
 msgstr "`diagnostics_channel`"
 
-#: src/api/reference.md:1073
+#: src/api/reference.md:1111
 msgid "`BoundedChannel`"
 msgstr "`BoundedChannel`"
 
-#: src/api/reference.md:1074
+#: src/api/reference.md:1112
 msgid "`Channel`"
 msgstr "`Channel`"
 
-#: src/api/reference.md:1078
+#: src/api/reference.md:1116
 msgid "`boundedChannel` — module"
 msgstr "`boundedChannel` — 模块"
 
-#: src/api/reference.md:1079
+#: src/api/reference.md:1117
 msgid "`channel` — module"
 msgstr "`channel` — 模块"
 
-#: src/api/reference.md:1080
+#: src/api/reference.md:1118
 msgid "`hasSubscribers` — module"
 msgstr "`hasSubscribers` — 模块"
 
-#: src/api/reference.md:1082
+#: src/api/reference.md:1120
 msgid "`tracingChannel` — module"
 msgstr "`tracingChannel` — 模块"
 
-#: src/api/reference.md:1089
+#: src/api/reference.md:1127
 msgid "`dns`"
 msgstr "`dns`"
 
-#: src/api/reference.md:1093 src/api/reference.md:1202
+#: src/api/reference.md:1131 src/api/reference.md:1240
 msgid "`Resolver`"
 msgstr "`Resolver`"
 
-#: src/api/reference.md:1097 src/api/reference.md:1206
+#: src/api/reference.md:1135 src/api/reference.md:1244
 msgid "`Resolver` — module"
 msgstr "`Resolver` — 模块"
 
-#: src/api/reference.md:1098 src/api/reference.md:1207
+#: src/api/reference.md:1136 src/api/reference.md:1245
 msgid "`cancel` — instance _(class: `Resolver`)_"
 msgstr "`cancel` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1099 src/api/reference.md:1208
+#: src/api/reference.md:1137 src/api/reference.md:1246
 msgid "`getDefaultResultOrder` — module"
 msgstr "`getDefaultResultOrder` — 模块"
 
-#: src/api/reference.md:1100 src/api/reference.md:1209
+#: src/api/reference.md:1138 src/api/reference.md:1247
 msgid "`getServers` — module"
 msgstr "`getServers` — 模块"
 
-#: src/api/reference.md:1101 src/api/reference.md:1210
+#: src/api/reference.md:1139 src/api/reference.md:1248
 msgid "`getServers` — instance _(class: `Resolver`)_"
 msgstr "`getServers` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1102 src/api/reference.md:1211
+#: src/api/reference.md:1140 src/api/reference.md:1249
 msgid "`lookup` — module"
 msgstr "`lookup` — 模块"
 
-#: src/api/reference.md:1103 src/api/reference.md:1212
+#: src/api/reference.md:1141 src/api/reference.md:1250
 msgid "`lookupService` — module"
 msgstr "`lookupService` — 模块"
 
-#: src/api/reference.md:1104 src/api/reference.md:1213
-#: src/api/reference.md:2411 src/api/reference.md:2437
-#: src/api/reference.md:2463 src/api/reference.md:3805
+#: src/api/reference.md:1142 src/api/reference.md:1251
+#: src/api/reference.md:2449 src/api/reference.md:2475
+#: src/api/reference.md:2501 src/api/reference.md:3843
 msgid "`resolve` — module"
 msgstr "`resolve` — 模块"
 
-#: src/api/reference.md:1105 src/api/reference.md:1214
+#: src/api/reference.md:1143 src/api/reference.md:1252
 msgid "`resolve` — instance _(class: `Resolver`)_"
 msgstr "`resolve` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1106 src/api/reference.md:1215
+#: src/api/reference.md:1144 src/api/reference.md:1253
 msgid "`resolve4` — module"
 msgstr "`resolve4` — 模块"
 
-#: src/api/reference.md:1107 src/api/reference.md:1216
+#: src/api/reference.md:1145 src/api/reference.md:1254
 msgid "`resolve4` — instance _(class: `Resolver`)_"
 msgstr "`resolve4` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1108 src/api/reference.md:1217
+#: src/api/reference.md:1146 src/api/reference.md:1255
 msgid "`resolve6` — module"
 msgstr "`resolve6` — 模块"
 
-#: src/api/reference.md:1109 src/api/reference.md:1218
+#: src/api/reference.md:1147 src/api/reference.md:1256
 msgid "`resolve6` — instance _(class: `Resolver`)_"
 msgstr "`resolve6` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1110 src/api/reference.md:1219
+#: src/api/reference.md:1148 src/api/reference.md:1257
 msgid "`resolveAny` — module"
 msgstr "`resolveAny` — 模块"
 
-#: src/api/reference.md:1111 src/api/reference.md:1220
+#: src/api/reference.md:1149 src/api/reference.md:1258
 msgid "`resolveAny` — instance _(class: `Resolver`)_"
 msgstr "`resolveAny` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1112 src/api/reference.md:1221
+#: src/api/reference.md:1150 src/api/reference.md:1259
 msgid "`resolveCaa` — module"
 msgstr "`resolveCaa` — 模块"
 
-#: src/api/reference.md:1113 src/api/reference.md:1222
+#: src/api/reference.md:1151 src/api/reference.md:1260
 msgid "`resolveCaa` — instance _(class: `Resolver`)_"
 msgstr "`resolveCaa` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1114 src/api/reference.md:1223
+#: src/api/reference.md:1152 src/api/reference.md:1261
 msgid "`resolveCname` — module"
 msgstr "`resolveCname` — 模块"
 
-#: src/api/reference.md:1115 src/api/reference.md:1224
+#: src/api/reference.md:1153 src/api/reference.md:1262
 msgid "`resolveCname` — instance _(class: `Resolver`)_"
 msgstr "`resolveCname` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1116 src/api/reference.md:1225
+#: src/api/reference.md:1154 src/api/reference.md:1263
 msgid "`resolveMx` — module"
 msgstr "`resolveMx` — 模块"
 
-#: src/api/reference.md:1117 src/api/reference.md:1226
+#: src/api/reference.md:1155 src/api/reference.md:1264
 msgid "`resolveMx` — instance _(class: `Resolver`)_"
 msgstr "`resolveMx` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1118 src/api/reference.md:1227
+#: src/api/reference.md:1156 src/api/reference.md:1265
 msgid "`resolveNaptr` — module"
 msgstr "`resolveNaptr` — 模块"
 
-#: src/api/reference.md:1119 src/api/reference.md:1228
+#: src/api/reference.md:1157 src/api/reference.md:1266
 msgid "`resolveNaptr` — instance _(class: `Resolver`)_"
 msgstr "`resolveNaptr` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1120 src/api/reference.md:1229
+#: src/api/reference.md:1158 src/api/reference.md:1267
 msgid "`resolveNs` — module"
 msgstr "`resolveNs` — 模块"
 
-#: src/api/reference.md:1121 src/api/reference.md:1230
+#: src/api/reference.md:1159 src/api/reference.md:1268
 msgid "`resolveNs` — instance _(class: `Resolver`)_"
 msgstr "`resolveNs` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1122 src/api/reference.md:1231
+#: src/api/reference.md:1160 src/api/reference.md:1269
 msgid "`resolvePtr` — module"
 msgstr "`resolvePtr` — 模块"
 
-#: src/api/reference.md:1123 src/api/reference.md:1232
+#: src/api/reference.md:1161 src/api/reference.md:1270
 msgid "`resolvePtr` — instance _(class: `Resolver`)_"
 msgstr "`resolvePtr` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1124 src/api/reference.md:1233
+#: src/api/reference.md:1162 src/api/reference.md:1271
 msgid "`resolveSoa` — module"
 msgstr "`resolveSoa` — 模块"
 
-#: src/api/reference.md:1125 src/api/reference.md:1234
+#: src/api/reference.md:1163 src/api/reference.md:1272
 msgid "`resolveSoa` — instance _(class: `Resolver`)_"
 msgstr "`resolveSoa` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1126 src/api/reference.md:1235
+#: src/api/reference.md:1164 src/api/reference.md:1273
 msgid "`resolveSrv` — module"
 msgstr "`resolveSrv` — 模块"
 
-#: src/api/reference.md:1127 src/api/reference.md:1236
+#: src/api/reference.md:1165 src/api/reference.md:1274
 msgid "`resolveSrv` — instance _(class: `Resolver`)_"
 msgstr "`resolveSrv` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1128 src/api/reference.md:1237
+#: src/api/reference.md:1166 src/api/reference.md:1275
 msgid "`resolveTlsa` — module"
 msgstr "`resolveTlsa` — 模块"
 
-#: src/api/reference.md:1129 src/api/reference.md:1238
+#: src/api/reference.md:1167 src/api/reference.md:1276
 msgid "`resolveTlsa` — instance _(class: `Resolver`)_"
 msgstr "`resolveTlsa` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1130 src/api/reference.md:1239
+#: src/api/reference.md:1168 src/api/reference.md:1277
 msgid "`resolveTxt` — module"
 msgstr "`resolveTxt` — 模块"
 
-#: src/api/reference.md:1131 src/api/reference.md:1240
+#: src/api/reference.md:1169 src/api/reference.md:1278
 msgid "`resolveTxt` — instance _(class: `Resolver`)_"
 msgstr "`resolveTxt` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1132 src/api/reference.md:1241
-#: src/api/reference.md:2015
+#: src/api/reference.md:1170 src/api/reference.md:1279
+#: src/api/reference.md:2053
 msgid "`reverse` — module"
 msgstr "`reverse` — 模块"
 
-#: src/api/reference.md:1133 src/api/reference.md:1242
+#: src/api/reference.md:1171 src/api/reference.md:1280
 msgid "`reverse` — instance _(class: `Resolver`)_"
 msgstr "`reverse` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1134 src/api/reference.md:1243
+#: src/api/reference.md:1172 src/api/reference.md:1281
 msgid "`setDefaultResultOrder` — module"
 msgstr "`setDefaultResultOrder` — 模块"
 
-#: src/api/reference.md:1135 src/api/reference.md:1244
+#: src/api/reference.md:1173 src/api/reference.md:1282
 msgid "`setLocalAddress` — instance _(class: `Resolver`)_"
 msgstr "`setLocalAddress` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1136 src/api/reference.md:1245
+#: src/api/reference.md:1174 src/api/reference.md:1283
 msgid "`setServers` — module"
 msgstr "`setServers` — 模块"
 
-#: src/api/reference.md:1137 src/api/reference.md:1246
+#: src/api/reference.md:1175 src/api/reference.md:1284
 msgid "`setServers` — instance _(class: `Resolver`)_"
 msgstr "`setServers` — 实例 _(类：`Resolver`)_"
 
-#: src/api/reference.md:1141 src/api/reference.md:1142
+#: src/api/reference.md:1179 src/api/reference.md:1180
 msgid "`ADDRCONFIG`"
 msgstr "`ADDRCONFIG`"
 
-#: src/api/reference.md:1143 src/api/reference.md:1144
-#: src/api/reference.md:1250
+#: src/api/reference.md:1181 src/api/reference.md:1182
+#: src/api/reference.md:1288
 msgid "`ADDRGETNETWORKPARAMS`"
 msgstr "`ADDRGETNETWORKPARAMS`"
 
-#: src/api/reference.md:1145 src/api/reference.md:1146
+#: src/api/reference.md:1183 src/api/reference.md:1184
 msgid "`ALL`"
 msgstr "`ALL`"
 
-#: src/api/reference.md:1147 src/api/reference.md:1148
-#: src/api/reference.md:1251
+#: src/api/reference.md:1185 src/api/reference.md:1186
+#: src/api/reference.md:1289
 msgid "`BADFAMILY`"
 msgstr "`BADFAMILY`"
 
-#: src/api/reference.md:1149 src/api/reference.md:1150
-#: src/api/reference.md:1252
+#: src/api/reference.md:1187 src/api/reference.md:1188
+#: src/api/reference.md:1290
 msgid "`BADFLAGS`"
 msgstr "`BADFLAGS`"
 
-#: src/api/reference.md:1151 src/api/reference.md:1152
-#: src/api/reference.md:1253
+#: src/api/reference.md:1189 src/api/reference.md:1190
+#: src/api/reference.md:1291
 msgid "`BADHINTS`"
 msgstr "`BADHINTS`"
 
-#: src/api/reference.md:1153 src/api/reference.md:1154
-#: src/api/reference.md:1254
+#: src/api/reference.md:1191 src/api/reference.md:1192
+#: src/api/reference.md:1292
 msgid "`BADNAME`"
 msgstr "`BADNAME`"
 
-#: src/api/reference.md:1155 src/api/reference.md:1156
-#: src/api/reference.md:1255
+#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1293
 msgid "`BADQUERY`"
 msgstr "`BADQUERY`"
 
-#: src/api/reference.md:1157 src/api/reference.md:1158
-#: src/api/reference.md:1256
+#: src/api/reference.md:1195 src/api/reference.md:1196
+#: src/api/reference.md:1294
 msgid "`BADRESP`"
 msgstr "`BADRESP`"
 
-#: src/api/reference.md:1159 src/api/reference.md:1160
-#: src/api/reference.md:1257
+#: src/api/reference.md:1197 src/api/reference.md:1198
+#: src/api/reference.md:1295
 msgid "`BADSTR`"
 msgstr "`BADSTR`"
 
-#: src/api/reference.md:1161 src/api/reference.md:1162
-#: src/api/reference.md:1258
+#: src/api/reference.md:1199 src/api/reference.md:1200
+#: src/api/reference.md:1296
 msgid "`CANCELLED`"
 msgstr "`CANCELLED`"
 
-#: src/api/reference.md:1163 src/api/reference.md:1164
-#: src/api/reference.md:1259
+#: src/api/reference.md:1201 src/api/reference.md:1202
+#: src/api/reference.md:1297
 msgid "`CONNREFUSED`"
 msgstr "`CONNREFUSED`"
 
-#: src/api/reference.md:1165 src/api/reference.md:1166
-#: src/api/reference.md:1260
+#: src/api/reference.md:1203 src/api/reference.md:1204
+#: src/api/reference.md:1298
 msgid "`DESTRUCTION`"
 msgstr "`DESTRUCTION`"
 
-#: src/api/reference.md:1167 src/api/reference.md:1168
-#: src/api/reference.md:1261
+#: src/api/reference.md:1205 src/api/reference.md:1206
+#: src/api/reference.md:1299
 msgid "`EOF`"
 msgstr "`EOF`"
 
-#: src/api/reference.md:1169 src/api/reference.md:1170
-#: src/api/reference.md:1262
+#: src/api/reference.md:1207 src/api/reference.md:1208
+#: src/api/reference.md:1300
 msgid "`FILE`"
 msgstr "`FILE`"
 
-#: src/api/reference.md:1171 src/api/reference.md:1172
-#: src/api/reference.md:1263
+#: src/api/reference.md:1209 src/api/reference.md:1210
+#: src/api/reference.md:1301
 msgid "`FORMERR`"
 msgstr "`FORMERR`"
 
-#: src/api/reference.md:1173 src/api/reference.md:1174
-#: src/api/reference.md:1264
+#: src/api/reference.md:1211 src/api/reference.md:1212
+#: src/api/reference.md:1302
 msgid "`LOADIPHLPAPI`"
 msgstr "`LOADIPHLPAPI`"
 
-#: src/api/reference.md:1175 src/api/reference.md:1176
-#: src/api/reference.md:1265
+#: src/api/reference.md:1213 src/api/reference.md:1214
+#: src/api/reference.md:1303
 msgid "`NODATA`"
 msgstr "`NODATA`"
 
-#: src/api/reference.md:1177 src/api/reference.md:1178
-#: src/api/reference.md:1266
+#: src/api/reference.md:1215 src/api/reference.md:1216
+#: src/api/reference.md:1304
 msgid "`NOMEM`"
 msgstr "`NOMEM`"
 
-#: src/api/reference.md:1179 src/api/reference.md:1180
-#: src/api/reference.md:1267
+#: src/api/reference.md:1217 src/api/reference.md:1218
+#: src/api/reference.md:1305
 msgid "`NONAME`"
 msgstr "`NONAME`"
 
-#: src/api/reference.md:1181 src/api/reference.md:1182
-#: src/api/reference.md:1268
+#: src/api/reference.md:1219 src/api/reference.md:1220
+#: src/api/reference.md:1306
 msgid "`NOTFOUND`"
 msgstr "`NOTFOUND`"
 
-#: src/api/reference.md:1183 src/api/reference.md:1184
-#: src/api/reference.md:1269
+#: src/api/reference.md:1221 src/api/reference.md:1222
+#: src/api/reference.md:1307
 msgid "`NOTIMP`"
 msgstr "`NOTIMP`"
 
-#: src/api/reference.md:1185 src/api/reference.md:1186
-#: src/api/reference.md:1270
+#: src/api/reference.md:1223 src/api/reference.md:1224
+#: src/api/reference.md:1308
 msgid "`NOTINITIALIZED`"
 msgstr "`NOTINITIALIZED`"
 
-#: src/api/reference.md:1187 src/api/reference.md:1188
-#: src/api/reference.md:1271
+#: src/api/reference.md:1225 src/api/reference.md:1226
+#: src/api/reference.md:1309
 msgid "`REFUSED`"
 msgstr "`REFUSED`"
 
-#: src/api/reference.md:1189 src/api/reference.md:1190
-#: src/api/reference.md:1272
+#: src/api/reference.md:1227 src/api/reference.md:1228
+#: src/api/reference.md:1310
 msgid "`SERVFAIL`"
 msgstr "`SERVFAIL`"
 
-#: src/api/reference.md:1191 src/api/reference.md:1192
-#: src/api/reference.md:1273
+#: src/api/reference.md:1229 src/api/reference.md:1230
+#: src/api/reference.md:1311
 msgid "`TIMEOUT`"
 msgstr "`TIMEOUT`"
 
-#: src/api/reference.md:1193 src/api/reference.md:1194
+#: src/api/reference.md:1231 src/api/reference.md:1232
 msgid "`V4MAPPED`"
 msgstr "`V4MAPPED`"
 
-#: src/api/reference.md:1196 src/api/reference.md:1559
-#: src/api/reference.md:3462 src/api/reference.md:3463
-#: src/api/reference.md:3652
+#: src/api/reference.md:1234 src/api/reference.md:1597
+#: src/api/reference.md:3500 src/api/reference.md:3501
+#: src/api/reference.md:3690
 msgid "`promises`"
 msgstr "`promises`"
 
-#: src/api/reference.md:1198
+#: src/api/reference.md:1236
 msgid "`dns/promises`"
 msgstr "`dns/promises`"
 
-#: src/api/reference.md:1276 src/api/reference.md:3126
+#: src/api/reference.md:1314 src/api/reference.md:3164
 msgid "`domain`"
 msgstr "`domain`"
 
-#: src/api/reference.md:1280
+#: src/api/reference.md:1318
 msgid "`Domain`"
 msgstr "`Domain`"
 
-#: src/api/reference.md:1284
+#: src/api/reference.md:1322
 msgid "`Domain` — module"
 msgstr "`Domain` — 模块"
 
-#: src/api/reference.md:1286 src/api/reference.md:1334
-#: src/api/reference.md:3397
+#: src/api/reference.md:1324 src/api/reference.md:1372
+#: src/api/reference.md:3435
 msgid "`addListener` — instance"
 msgstr "`addListener` — 实例"
 
-#: src/api/reference.md:1287
+#: src/api/reference.md:1325
 msgid "`bind` — instance"
 msgstr "`bind` — 实例"
 
-#: src/api/reference.md:1289
+#: src/api/reference.md:1327
 msgid "`createDomain` — module"
 msgstr "`createDomain` — 模块"
 
-#: src/api/reference.md:1290 src/api/reference.md:1338
-#: src/api/reference.md:3406
+#: src/api/reference.md:1328 src/api/reference.md:1376
+#: src/api/reference.md:3444 src/api/reference.md:4148
 msgid "`emit` — instance"
 msgstr "`emit` — 实例"
 
-#: src/api/reference.md:1291
+#: src/api/reference.md:1329
 msgid "`enter` — instance"
 msgstr "`enter` — 实例"
 
-#: src/api/reference.md:1293
+#: src/api/reference.md:1331
 msgid "`intercept` — instance"
 msgstr "`intercept` — 实例"
 
-#: src/api/reference.md:1294 src/api/reference.md:1349
-#: src/api/reference.md:1396 src/api/reference.md:3215
-#: src/api/reference.md:3422 src/api/reference.md:4109
+#: src/api/reference.md:1332 src/api/reference.md:1387
+#: src/api/reference.md:1434 src/api/reference.md:3253
+#: src/api/reference.md:3460 src/api/reference.md:4150
 msgid "`on` — instance"
 msgstr "`on` — 实例"
 
-#: src/api/reference.md:1295
+#: src/api/reference.md:1333
 msgid "`remove` — instance"
 msgstr "`remove` — 实例"
 
-#: src/api/reference.md:1300
+#: src/api/reference.md:1338
 msgid "`_stack`"
 msgstr "`_stack`"
 
-#: src/api/reference.md:1301
+#: src/api/reference.md:1339
 msgid "`active`"
 msgstr "`active`"
 
-#: src/api/reference.md:1302
+#: src/api/reference.md:1340
 msgid "`members`"
 msgstr "`members`"
 
-#: src/api/reference.md:1308 src/api/reference.md:2566
-#: src/api/reference.md:2608
+#: src/api/reference.md:1346 src/api/reference.md:2604
+#: src/api/reference.md:2646
 msgid "`config` — module"
 msgstr "`config` — 模块"
 
-#: src/api/reference.md:1309 src/api/reference.md:2409
-#: src/api/reference.md:2435 src/api/reference.md:2461
-#: src/api/reference.md:3165 src/api/reference.md:3175
-#: src/api/reference.md:3803
+#: src/api/reference.md:1347 src/api/reference.md:2447
+#: src/api/reference.md:2473 src/api/reference.md:2499
+#: src/api/reference.md:3203 src/api/reference.md:3213
+#: src/api/reference.md:3841
 msgid "`parse` — module"
 msgstr "`parse` — 模块"
 
-#: src/api/reference.md:1315
+#: src/api/reference.md:1353
 msgid "`createRandom` — module _(class: `Wallet`)_"
 msgstr "`createRandom` — 模块 _(类:`Wallet`)_"
 
-#: src/api/reference.md:1316
+#: src/api/reference.md:1354
 msgid "`formatEther` — module"
 msgstr "`formatEther` — 模块"
 
-#: src/api/reference.md:1317
+#: src/api/reference.md:1355
 msgid "`formatUnits` — module"
 msgstr "`formatUnits` — 模块"
 
-#: src/api/reference.md:1318
+#: src/api/reference.md:1356
 msgid "`getAddress` — module"
 msgstr "`getAddress` — 模块"
 
-#: src/api/reference.md:1319
+#: src/api/reference.md:1357
 msgid "`parseEther` — module"
 msgstr "`parseEther` — 模块"
 
-#: src/api/reference.md:1320
+#: src/api/reference.md:1358
 msgid "`parseUnits` — module"
 msgstr "`parseUnits` — 模块"
 
-#: src/api/reference.md:1326
+#: src/api/reference.md:1364
 msgid "`EventEmitter`"
 msgstr "`EventEmitter`"
 
-#: src/api/reference.md:1327
+#: src/api/reference.md:1365
 msgid "`EventEmitterAsyncResource`"
 msgstr "`EventEmitterAsyncResource`"
 
-#: src/api/reference.md:1331
+#: src/api/reference.md:1369
 msgid "`EventEmitter` — module"
 msgstr "`EventEmitter` — 模块"
 
-#: src/api/reference.md:1332
+#: src/api/reference.md:1370
 msgid "`EventEmitterAsyncResource` — module"
 msgstr "`EventEmitterAsyncResource` — 模块"
 
-#: src/api/reference.md:1333
+#: src/api/reference.md:1371
 msgid "`addAbortListener` — module"
 msgstr "`addAbortListener` — 模块"
 
-#: src/api/reference.md:1335
+#: src/api/reference.md:1373
 msgid "`asyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncId` — 实例 _(类：`EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1336
+#: src/api/reference.md:1374
 msgid "`asyncResource` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`asyncResource` — 实例 _(类：`EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1337
+#: src/api/reference.md:1375
 msgid "`domain` — instance"
 msgstr "`domain` — 实例"
 
-#: src/api/reference.md:1339
+#: src/api/reference.md:1377
 msgid "`emitDestroy` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`emitDestroy` — 实例 _(类：`EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1340 src/api/reference.md:3409
+#: src/api/reference.md:1378 src/api/reference.md:3447
 msgid "`eventNames` — instance"
 msgstr "`eventNames` — 实例"
 
-#: src/api/reference.md:1341
+#: src/api/reference.md:1379
 msgid "`getEventListeners` — module"
 msgstr "`getEventListeners` — 模块"
 
-#: src/api/reference.md:1342 src/api/reference.md:3412
+#: src/api/reference.md:1380 src/api/reference.md:3450
 msgid "`getMaxListeners` — instance"
 msgstr "`getMaxListeners` — 实例"
 
-#: src/api/reference.md:1343
+#: src/api/reference.md:1381
 msgid "`getMaxListeners` — module"
 msgstr "`getMaxListeners` — 模块"
 
-#: src/api/reference.md:1344
+#: src/api/reference.md:1382
 msgid "`init` — module"
 msgstr "`init` — 模块"
 
-#: src/api/reference.md:1345 src/api/reference.md:3419
+#: src/api/reference.md:1383 src/api/reference.md:3457
 msgid "`listenerCount` — instance"
 msgstr "`listenerCount` — 实例"
 
-#: src/api/reference.md:1346
+#: src/api/reference.md:1384
 msgid "`listenerCount` — module"
 msgstr "`listenerCount` — 模块"
 
-#: src/api/reference.md:1347 src/api/reference.md:3420
+#: src/api/reference.md:1385 src/api/reference.md:3458
 msgid "`listeners` — instance"
 msgstr "`listeners` — 实例"
 
-#: src/api/reference.md:1348 src/api/reference.md:3421
+#: src/api/reference.md:1386 src/api/reference.md:3459
 msgid "`off` — instance"
 msgstr "`off` — 实例"
 
-#: src/api/reference.md:1350
+#: src/api/reference.md:1388
 msgid "`on` — module"
 msgstr "`on` — 模块"
 
-#: src/api/reference.md:1351 src/api/reference.md:3423
+#: src/api/reference.md:1389 src/api/reference.md:3461
 msgid "`once` — instance"
 msgstr "`once` — 实例"
 
-#: src/api/reference.md:1352
+#: src/api/reference.md:1390
 msgid "`once` — module"
 msgstr "`once` — 模块"
 
-#: src/api/reference.md:1353 src/api/reference.md:3427
+#: src/api/reference.md:1391 src/api/reference.md:3465
 msgid "`prependListener` — instance"
 msgstr "`prependListener` — 实例"
 
-#: src/api/reference.md:1354 src/api/reference.md:3428
+#: src/api/reference.md:1392 src/api/reference.md:3466
 msgid "`prependOnceListener` — instance"
 msgstr "`prependOnceListener` — 实例"
 
-#: src/api/reference.md:1355 src/api/reference.md:3430
+#: src/api/reference.md:1393 src/api/reference.md:3468
 msgid "`rawListeners` — instance"
 msgstr "`rawListeners` — 实例"
 
-#: src/api/reference.md:1356 src/api/reference.md:3441
+#: src/api/reference.md:1394 src/api/reference.md:3479
 msgid "`removeAllListeners` — instance"
 msgstr "`removeAllListeners` — 实例"
 
-#: src/api/reference.md:1357 src/api/reference.md:3442
+#: src/api/reference.md:1395 src/api/reference.md:3480
 msgid "`removeListener` — instance"
 msgstr "`removeListener` — 实例"
 
-#: src/api/reference.md:1358 src/api/reference.md:3446
+#: src/api/reference.md:1396 src/api/reference.md:3484
 msgid "`setMaxListeners` — instance"
 msgstr "`setMaxListeners` — 实例"
 
-#: src/api/reference.md:1359
+#: src/api/reference.md:1397
 msgid "`setMaxListeners` — module"
 msgstr "`setMaxListeners` — 模块"
 
-#: src/api/reference.md:1360
+#: src/api/reference.md:1398
 msgid "`triggerAsyncId` — instance _(class: `EventEmitterAsyncResource`)_"
 msgstr "`triggerAsyncId` — 实例 _(类：`EventEmitterAsyncResource`)_"
 
-#: src/api/reference.md:1364
+#: src/api/reference.md:1402
 msgid "`captureRejectionSymbol`"
 msgstr "`captureRejectionSymbol`"
 
-#: src/api/reference.md:1365
+#: src/api/reference.md:1403
 msgid "`captureRejections`"
 msgstr "`captureRejections`"
 
-#: src/api/reference.md:1367
+#: src/api/reference.md:1405
 msgid "`defaultMaxListeners`"
 msgstr "`defaultMaxListeners`"
 
-#: src/api/reference.md:1368
+#: src/api/reference.md:1406
 msgid "`errorMonitor`"
 msgstr "`errorMonitor`"
 
-#: src/api/reference.md:1369
+#: src/api/reference.md:1407
 msgid "`usingDomains`"
 msgstr "`usingDomains`"
 
-#: src/api/reference.md:1375
+#: src/api/reference.md:1413
 msgid "`backOff` — module"
 msgstr "`backOff` — 模块"
 
-#: src/api/reference.md:1381
+#: src/api/reference.md:1419
 msgid "`addHook` — instance"
 msgstr "`addHook` — 实例"
 
-#: src/api/reference.md:1383
+#: src/api/reference.md:1421
 msgid "`body` — instance"
 msgstr "`body` — 实例"
 
-#: src/api/reference.md:1385
+#: src/api/reference.md:1423
 msgid "`code` — instance"
 msgstr "`code` — 实例"
 
-#: src/api/reference.md:1387 src/api/reference.md:2031
-#: src/api/reference.md:3195
+#: src/api/reference.md:1425 src/api/reference.md:2069
+#: src/api/reference.md:3233
 msgid "`delete` — instance"
 msgstr "`delete` — 实例"
 
-#: src/api/reference.md:1389
+#: src/api/reference.md:1427
 msgid "`head` — instance"
 msgstr "`head` — 实例"
 
-#: src/api/reference.md:1390
+#: src/api/reference.md:1428
 msgid "`header` — instance"
 msgstr "`header` — 实例"
 
-#: src/api/reference.md:1391
+#: src/api/reference.md:1429
 msgid "`headers` — instance"
 msgstr "`headers` — 实例"
 
-#: src/api/reference.md:1393
+#: src/api/reference.md:1431
 msgid "`json` — instance"
 msgstr "`json` — 实例"
 
-#: src/api/reference.md:1394
+#: src/api/reference.md:1432
 msgid "`listen` — instance"
 msgstr "`listen` — 实例"
 
-#: src/api/reference.md:1395
+#: src/api/reference.md:1433
 msgid "`method` — instance"
 msgstr "`method` — 实例"
 
-#: src/api/reference.md:1397
+#: src/api/reference.md:1435
 msgid "`options` — instance"
 msgstr "`options` — 实例"
 
-#: src/api/reference.md:1398
+#: src/api/reference.md:1436
 msgid "`param` — instance"
 msgstr "`param` — 实例"
 
-#: src/api/reference.md:1399
+#: src/api/reference.md:1437
 msgid "`params` — instance"
 msgstr "`params` — 实例"
 
-#: src/api/reference.md:1400
+#: src/api/reference.md:1438
 msgid "`patch` — instance"
 msgstr "`patch` — 实例"
 
-#: src/api/reference.md:1401
+#: src/api/reference.md:1439
 msgid "`post` — instance"
 msgstr "`post` — 实例"
 
-#: src/api/reference.md:1402
+#: src/api/reference.md:1440
 msgid "`put` — instance"
 msgstr "`put` — 实例"
 
-#: src/api/reference.md:1403 src/api/reference.md:2153
-#: src/api/reference.md:2177 src/api/reference.md:3050
+#: src/api/reference.md:1441 src/api/reference.md:2191
+#: src/api/reference.md:2215 src/api/reference.md:3088
 msgid "`query` — instance"
 msgstr "`query` — 实例"
 
-#: src/api/reference.md:1404
+#: src/api/reference.md:1442
 msgid "`rawBody` — instance"
 msgstr "`rawBody` — 实例"
 
-#: src/api/reference.md:1405
+#: src/api/reference.md:1443
 msgid "`redirect` — instance"
 msgstr "`redirect` — 实例"
 
-#: src/api/reference.md:1406
+#: src/api/reference.md:1444
 msgid "`register` — instance"
 msgstr "`register` — 实例"
 
-#: src/api/reference.md:1407
+#: src/api/reference.md:1445
 msgid "`route` — instance"
 msgstr "`route` — 实例"
 
-#: src/api/reference.md:1408 src/api/reference.md:4112
+#: src/api/reference.md:1446 src/api/reference.md:4153
 msgid "`send` — instance"
 msgstr "`send` — 实例"
 
-#: src/api/reference.md:1409
+#: src/api/reference.md:1447
 msgid "`server` — instance"
 msgstr "`server` — 实例"
 
-#: src/api/reference.md:1410
+#: src/api/reference.md:1448
 msgid "`setErrorHandler` — instance"
 msgstr "`setErrorHandler` — 实例"
 
-#: src/api/reference.md:1411 src/api/reference.md:4019
+#: src/api/reference.md:1449 src/api/reference.md:4057
 msgid "`status` — instance"
 msgstr "`status` — 实例"
 
-#: src/api/reference.md:1413
+#: src/api/reference.md:1451
 msgid "`type` — instance"
 msgstr "`type` — 实例"
 
-#: src/api/reference.md:1414
+#: src/api/reference.md:1452
 msgid "`url` — instance"
 msgstr "`url` — 实例"
 
-#: src/api/reference.md:1415
+#: src/api/reference.md:1453
 msgid "`user` — instance"
 msgstr "`user` — 实例"
 
-#: src/api/reference.md:1417
+#: src/api/reference.md:1455
 msgid "`fetch`"
 msgstr "`fetch`"
 
-#: src/api/reference.md:1422 src/api/reference.md:2320
+#: src/api/reference.md:1460 src/api/reference.md:2358
 msgid "`FormData`"
 msgstr "`FormData`"
 
-#: src/api/reference.md:1423 src/api/reference.md:2321
+#: src/api/reference.md:1461 src/api/reference.md:2359
 msgid "`Headers`"
 msgstr "`Headers`"
 
-#: src/api/reference.md:1424 src/api/reference.md:2322
+#: src/api/reference.md:1462 src/api/reference.md:2360
 msgid "`Request`"
 msgstr "`Request`"
 
-#: src/api/reference.md:1425 src/api/reference.md:2323
+#: src/api/reference.md:1463 src/api/reference.md:2361
 msgid "`Response`"
 msgstr "`Response`"
 
-#: src/api/reference.md:1431
+#: src/api/reference.md:1469
 msgid "`ffi`"
 msgstr "`ffi`"
 
-#: src/api/reference.md:1436
+#: src/api/reference.md:1474
 msgid "`getRawPointer` — module"
 msgstr "模块 `getRawPointer`"
 
-#: src/api/reference.md:1439
+#: src/api/reference.md:1477
 msgid "`toString` — module"
 msgstr "模块 `toString`"
 
-#: src/api/reference.md:1445
+#: src/api/reference.md:1483
 msgid "`fs`"
 msgstr "`fs`"
 
-#: src/api/reference.md:1449
+#: src/api/reference.md:1487
 msgid "`Dir`"
 msgstr "`Dir`"
 
-#: src/api/reference.md:1450
+#: src/api/reference.md:1488
 msgid "`Dirent`"
 msgstr "`Dirent`"
 
-#: src/api/reference.md:1451
+#: src/api/reference.md:1489
 msgid "`FileReadStream`"
 msgstr "`FileReadStream`"
 
-#: src/api/reference.md:1452
+#: src/api/reference.md:1490
 msgid "`FileWriteStream`"
 msgstr "`FileWriteStream`"
 
-#: src/api/reference.md:1453 src/api/reference.md:3715
+#: src/api/reference.md:1491 src/api/reference.md:3753
 msgid "`ReadStream`"
 msgstr "`ReadStream`"
 
-#: src/api/reference.md:1454
+#: src/api/reference.md:1492
 msgid "`Stats`"
 msgstr "`Stats`"
 
-#: src/api/reference.md:1455
+#: src/api/reference.md:1493
 msgid "`Utf8Stream`"
 msgstr "`Utf8Stream`"
 
-#: src/api/reference.md:1456 src/api/reference.md:3716
+#: src/api/reference.md:1494 src/api/reference.md:3754
 msgid "`WriteStream`"
 msgstr "`WriteStream`"
 
-#: src/api/reference.md:1460 src/api/reference.md:1461
+#: src/api/reference.md:1498 src/api/reference.md:1499
 msgid "`_toUnixTimestamp` — module"
 msgstr "`_toUnixTimestamp` — 模块"
 
-#: src/api/reference.md:1462 src/api/reference.md:1565
+#: src/api/reference.md:1500 src/api/reference.md:1603
 msgid "`access` — module"
 msgstr "`access` — 模块"
 
-#: src/api/reference.md:1463
+#: src/api/reference.md:1501
 msgid "`accessSync` — module"
 msgstr "`accessSync` — 模块"
 
-#: src/api/reference.md:1464 src/api/reference.md:1566
+#: src/api/reference.md:1502 src/api/reference.md:1604
 msgid "`appendFile` — module"
 msgstr "`appendFile` — 模块"
 
-#: src/api/reference.md:1465
+#: src/api/reference.md:1503
 msgid "`appendFileSync` — module"
 msgstr "`appendFileSync` — 模块"
 
-#: src/api/reference.md:1466 src/api/reference.md:1567
+#: src/api/reference.md:1504 src/api/reference.md:1605
 msgid "`chmod` — module"
 msgstr "`chmod` — 模块"
 
-#: src/api/reference.md:1467
+#: src/api/reference.md:1505
 msgid "`chmodSync` — module"
 msgstr "`chmodSync` — 模块"
 
-#: src/api/reference.md:1468 src/api/reference.md:1568
+#: src/api/reference.md:1506 src/api/reference.md:1606
 msgid "`chown` — module"
 msgstr "`chown` — 模块"
 
-#: src/api/reference.md:1469
+#: src/api/reference.md:1507
 msgid "`chownSync` — module"
 msgstr "`chownSync` — 模块"
 
-#: src/api/reference.md:1470 src/api/reference.md:1895
+#: src/api/reference.md:1508 src/api/reference.md:1933
 msgid "`close` — module"
 msgstr "`close` — 模块"
 
-#: src/api/reference.md:1471
+#: src/api/reference.md:1509
 msgid "`closeSync` — module"
 msgstr "`closeSync` — 模块"
 
-#: src/api/reference.md:1472 src/api/reference.md:1569
+#: src/api/reference.md:1510 src/api/reference.md:1607
 msgid "`copyFile` — module"
 msgstr "`copyFile` — 模块"
 
-#: src/api/reference.md:1473
+#: src/api/reference.md:1511
 msgid "`copyFileSync` — module"
 msgstr "`copyFileSync` — 模块"
 
-#: src/api/reference.md:1474 src/api/reference.md:1570
+#: src/api/reference.md:1512 src/api/reference.md:1608
 msgid "`cp` — module"
 msgstr "`cp` — 模块"
 
-#: src/api/reference.md:1475
+#: src/api/reference.md:1513
 msgid "`cpSync` — module"
 msgstr "`cpSync` — 模块"
 
-#: src/api/reference.md:1476
+#: src/api/reference.md:1514
 msgid "`createReadStream` — module"
 msgstr "`createReadStream` — 模块"
 
-#: src/api/reference.md:1477
+#: src/api/reference.md:1515
 msgid "`createWriteStream` — module"
 msgstr "`createWriteStream` — 模块"
 
-#: src/api/reference.md:1478
+#: src/api/reference.md:1516
 msgid "`exists` — module"
 msgstr "`exists` — 模块"
 
-#: src/api/reference.md:1479
+#: src/api/reference.md:1517
 msgid "`existsSync` — module"
 msgstr "`existsSync` — 模块"
 
-#: src/api/reference.md:1480
+#: src/api/reference.md:1518
 msgid "`fchmod` — module"
 msgstr "`fchmod` — 模块"
 
-#: src/api/reference.md:1481
+#: src/api/reference.md:1519
 msgid "`fchmodSync` — module"
 msgstr "`fchmodSync` — 模块"
 
-#: src/api/reference.md:1482
+#: src/api/reference.md:1520
 msgid "`fchown` — module"
 msgstr "`fchown` — 模块"
 
-#: src/api/reference.md:1483
+#: src/api/reference.md:1521
 msgid "`fchownSync` — module"
 msgstr "`fchownSync` — 模块"
 
-#: src/api/reference.md:1484
+#: src/api/reference.md:1522
 msgid "`fdatasync` — module"
 msgstr "`fdatasync` — 模块"
 
-#: src/api/reference.md:1485
+#: src/api/reference.md:1523
 msgid "`fdatasyncSync` — module"
 msgstr "`fdatasyncSync` — 模块"
 
-#: src/api/reference.md:1486
+#: src/api/reference.md:1524
 msgid "`fstat` — module"
 msgstr "`fstat` — 模块"
 
-#: src/api/reference.md:1487
+#: src/api/reference.md:1525
 msgid "`fstatSync` — module"
 msgstr "`fstatSync` — 模块"
 
-#: src/api/reference.md:1488
+#: src/api/reference.md:1526
 msgid "`fsync` — module"
 msgstr "`fsync` — 模块"
 
-#: src/api/reference.md:1489
+#: src/api/reference.md:1527
 msgid "`fsyncSync` — module"
 msgstr "`fsyncSync` — 模块"
 
-#: src/api/reference.md:1490
+#: src/api/reference.md:1528
 msgid "`ftruncate` — module"
 msgstr "`ftruncate` — 模块"
 
-#: src/api/reference.md:1491
+#: src/api/reference.md:1529
 msgid "`ftruncateSync` — module"
 msgstr "`ftruncateSync` — 模块"
 
-#: src/api/reference.md:1492
+#: src/api/reference.md:1530
 msgid "`futimes` — module"
 msgstr "`futimes` — 模块"
 
-#: src/api/reference.md:1493
+#: src/api/reference.md:1531
 msgid "`futimesSync` — module"
 msgstr "`futimesSync` — 模块"
 
-#: src/api/reference.md:1494 src/api/reference.md:1571
+#: src/api/reference.md:1532 src/api/reference.md:1609
 msgid "`glob` — module"
 msgstr "`glob` — 模块"
 
-#: src/api/reference.md:1495
+#: src/api/reference.md:1533
 msgid "`globSync` — module"
 msgstr "`globSync` — 模块"
 
-#: src/api/reference.md:1496 src/api/reference.md:1572
+#: src/api/reference.md:1534 src/api/reference.md:1610
 msgid "`lchmod` — module"
 msgstr "`lchmod` — 模块"
 
-#: src/api/reference.md:1497
+#: src/api/reference.md:1535
 msgid "`lchmodSync` — module"
 msgstr "`lchmodSync` — 模块"
 
-#: src/api/reference.md:1498 src/api/reference.md:1573
+#: src/api/reference.md:1536 src/api/reference.md:1611
 msgid "`lchown` — module"
 msgstr "`lchown` — 模块"
 
-#: src/api/reference.md:1499
+#: src/api/reference.md:1537
 msgid "`lchownSync` — module"
 msgstr "`lchownSync` — 模块"
 
-#: src/api/reference.md:1500 src/api/reference.md:1574
+#: src/api/reference.md:1538 src/api/reference.md:1612
 msgid "`link` — module"
 msgstr "`link` — 模块"
 
-#: src/api/reference.md:1501
+#: src/api/reference.md:1539
 msgid "`linkSync` — module"
 msgstr "`linkSync` — 模块"
 
-#: src/api/reference.md:1502 src/api/reference.md:1575
+#: src/api/reference.md:1540 src/api/reference.md:1613
 msgid "`lstat` — module"
 msgstr "`lstat` — 模块"
 
-#: src/api/reference.md:1503
+#: src/api/reference.md:1541
 msgid "`lstatSync` — module"
 msgstr "`lstatSync` — 模块"
 
-#: src/api/reference.md:1504 src/api/reference.md:1576
+#: src/api/reference.md:1542 src/api/reference.md:1614
 msgid "`lutimes` — module"
 msgstr "`lutimes` — 模块"
 
-#: src/api/reference.md:1505
+#: src/api/reference.md:1543
 msgid "`lutimesSync` — module"
 msgstr "`lutimesSync` — 模块"
 
-#: src/api/reference.md:1506 src/api/reference.md:1577
+#: src/api/reference.md:1544 src/api/reference.md:1615
 msgid "`mkdir` — module"
 msgstr "`mkdir` — 模块"
 
-#: src/api/reference.md:1507
+#: src/api/reference.md:1545
 msgid "`mkdirSync` — module"
 msgstr "`mkdirSync` — 模块"
 
-#: src/api/reference.md:1508 src/api/reference.md:1578
+#: src/api/reference.md:1546 src/api/reference.md:1616
 msgid "`mkdtemp` — module"
 msgstr "`mkdtemp` — 模块"
 
-#: src/api/reference.md:1509
+#: src/api/reference.md:1547
 msgid "`mkdtempDisposableSync` — module"
 msgstr "`mkdtempDisposableSync` — 模块"
 
-#: src/api/reference.md:1510
+#: src/api/reference.md:1548
 msgid "`mkdtempSync` — module"
 msgstr "`mkdtempSync` — 模块"
 
-#: src/api/reference.md:1511 src/api/reference.md:1580
-#: src/api/reference.md:3748
+#: src/api/reference.md:1549 src/api/reference.md:1618
+#: src/api/reference.md:3786
 msgid "`open` — module"
 msgstr "`open` — 模块"
 
-#: src/api/reference.md:1512
+#: src/api/reference.md:1550
 msgid "`openAsBlob` — module"
 msgstr "`openAsBlob` — 模块"
 
-#: src/api/reference.md:1513
+#: src/api/reference.md:1551
 msgid "`openSync` — module"
 msgstr "`openSync` — 模块"
 
-#: src/api/reference.md:1514 src/api/reference.md:1581
+#: src/api/reference.md:1552 src/api/reference.md:1619
 msgid "`opendir` — module"
 msgstr "`opendir` — 模块"
 
-#: src/api/reference.md:1515
+#: src/api/reference.md:1553
 msgid "`opendirSync` — module"
 msgstr "`opendirSync` — 模块"
 
-#: src/api/reference.md:1516
+#: src/api/reference.md:1554
 msgid "`read` — module"
 msgstr "`read` — 模块"
 
-#: src/api/reference.md:1517 src/api/reference.md:1584
+#: src/api/reference.md:1555 src/api/reference.md:1622
 msgid "`readFile` — module"
 msgstr "`readFile` — 模块"
 
-#: src/api/reference.md:1518
+#: src/api/reference.md:1556
 msgid "`readFileSync` — module"
 msgstr "`readFileSync` — 模块"
 
-#: src/api/reference.md:1519
+#: src/api/reference.md:1557
 msgid "`readSync` — module"
 msgstr "`readSync` — 模块"
 
-#: src/api/reference.md:1520 src/api/reference.md:1585
+#: src/api/reference.md:1558 src/api/reference.md:1623
 msgid "`readdir` — module"
 msgstr "`readdir` — 模块"
 
-#: src/api/reference.md:1521
+#: src/api/reference.md:1559
 msgid "`readdirSync` — module"
 msgstr "`readdirSync` — 模块"
 
-#: src/api/reference.md:1522 src/api/reference.md:1586
+#: src/api/reference.md:1560 src/api/reference.md:1624
 msgid "`readlink` — module"
 msgstr "`readlink` — 模块"
 
-#: src/api/reference.md:1523
+#: src/api/reference.md:1561
 msgid "`readlinkSync` — module"
 msgstr "`readlinkSync` — 模块"
 
-#: src/api/reference.md:1524
+#: src/api/reference.md:1562
 msgid "`readv` — module"
 msgstr "`readv` — 模块"
 
-#: src/api/reference.md:1525
+#: src/api/reference.md:1563
 msgid "`readvSync` — module"
 msgstr "`readvSync` — 模块"
 
-#: src/api/reference.md:1526 src/api/reference.md:1587
+#: src/api/reference.md:1564 src/api/reference.md:1625
 msgid "`realpath` — module"
 msgstr "`realpath` — 模块"
 
-#: src/api/reference.md:1527
+#: src/api/reference.md:1565
 msgid "`realpathSync` — module"
 msgstr "`realpathSync` — 模块"
 
-#: src/api/reference.md:1528 src/api/reference.md:1588
+#: src/api/reference.md:1566 src/api/reference.md:1626
 msgid "`rename` — module"
 msgstr "`rename` — 模块"
 
-#: src/api/reference.md:1529
+#: src/api/reference.md:1567
 msgid "`renameSync` — module"
 msgstr "`renameSync` — 模块"
 
-#: src/api/reference.md:1530 src/api/reference.md:1589
+#: src/api/reference.md:1568 src/api/reference.md:1627
 msgid "`rm` — module"
 msgstr "`rm` — 模块"
 
-#: src/api/reference.md:1531
+#: src/api/reference.md:1569
 msgid "`rmSync` — module"
 msgstr "`rmSync` — 模块"
 
-#: src/api/reference.md:1532 src/api/reference.md:1590
+#: src/api/reference.md:1570 src/api/reference.md:1628
 msgid "`rmdir` — module"
 msgstr "`rmdir` — 模块"
 
-#: src/api/reference.md:1533
+#: src/api/reference.md:1571
 msgid "`rmdirSync` — module"
 msgstr "`rmdirSync` — 模块"
 
-#: src/api/reference.md:1534 src/api/reference.md:1591
+#: src/api/reference.md:1572 src/api/reference.md:1629
 msgid "`stat` — module"
 msgstr "`stat` — 模块"
 
-#: src/api/reference.md:1535
+#: src/api/reference.md:1573
 msgid "`statSync` — module"
 msgstr "`statSync` — 模块"
 
-#: src/api/reference.md:1536 src/api/reference.md:1592
+#: src/api/reference.md:1574 src/api/reference.md:1630
 msgid "`statfs` — module"
 msgstr "`statfs` — 模块"
 
-#: src/api/reference.md:1537
+#: src/api/reference.md:1575
 msgid "`statfsSync` — module"
 msgstr "`statfsSync` — 模块"
 
-#: src/api/reference.md:1538 src/api/reference.md:1593
+#: src/api/reference.md:1576 src/api/reference.md:1631
 msgid "`symlink` — module"
 msgstr "`symlink` — 模块"
 
-#: src/api/reference.md:1539
+#: src/api/reference.md:1577
 msgid "`symlinkSync` — module"
 msgstr "`symlinkSync` — 模块"
 
-#: src/api/reference.md:1540 src/api/reference.md:1594
+#: src/api/reference.md:1578 src/api/reference.md:1632
 msgid "`truncate` — module"
 msgstr "`truncate` — 模块"
 
-#: src/api/reference.md:1541
+#: src/api/reference.md:1579
 msgid "`truncateSync` — module"
 msgstr "`truncateSync` — 模块"
 
-#: src/api/reference.md:1542 src/api/reference.md:1595
+#: src/api/reference.md:1580 src/api/reference.md:1633
 msgid "`unlink` — module"
 msgstr "`unlink` — 模块"
 
-#: src/api/reference.md:1543
+#: src/api/reference.md:1581
 msgid "`unlinkSync` — module"
 msgstr "`unlinkSync` — 模块"
 
-#: src/api/reference.md:1544
+#: src/api/reference.md:1582
 msgid "`unwatchFile` — module"
 msgstr "`unwatchFile` — 模块"
 
-#: src/api/reference.md:1545 src/api/reference.md:1596
+#: src/api/reference.md:1583 src/api/reference.md:1634
 msgid "`utimes` — module"
 msgstr "`utimes` — 模块"
 
-#: src/api/reference.md:1546
+#: src/api/reference.md:1584
 msgid "`utimesSync` — module"
 msgstr "`utimesSync` — 模块"
 
-#: src/api/reference.md:1547 src/api/reference.md:1597
+#: src/api/reference.md:1585 src/api/reference.md:1635
 msgid "`watch` — module"
 msgstr "`watch` — 模块"
 
-#: src/api/reference.md:1548
+#: src/api/reference.md:1586
 msgid "`watchFile` — module"
 msgstr "`watchFile` — 模块"
 
-#: src/api/reference.md:1550 src/api/reference.md:1598
+#: src/api/reference.md:1588 src/api/reference.md:1636
 msgid "`writeFile` — module"
 msgstr "`writeFile` — 模块"
 
-#: src/api/reference.md:1551
+#: src/api/reference.md:1589
 msgid "`writeFileSync` — module"
 msgstr "`writeFileSync` — 模块"
 
-#: src/api/reference.md:1552
+#: src/api/reference.md:1590
 msgid "`writeSync` — module"
 msgstr "`writeSync` — 模块"
 
-#: src/api/reference.md:1553
+#: src/api/reference.md:1591
 msgid "`writev` — module"
 msgstr "`writev` — 模块"
 
-#: src/api/reference.md:1554
+#: src/api/reference.md:1592
 msgid "`writevSync` — module"
 msgstr "`writevSync` — 模块"
 
-#: src/api/reference.md:1561
+#: src/api/reference.md:1599
 msgid "`fs/promises`"
 msgstr "`fs/promises`"
 
-#: src/api/reference.md:1579
+#: src/api/reference.md:1617
 msgid "`mkdtempDisposable` — module"
 msgstr "`mkdtempDisposable` — 模块"
 
-#: src/api/reference.md:1582
+#: src/api/reference.md:1620
 msgid "`pull` — instance _(class: `FileHandle`)_"
 msgstr "`pull` — 实例 _(类：`FileHandle`)_"
 
-#: src/api/reference.md:1583
+#: src/api/reference.md:1621
 msgid "`pullSync` — instance _(class: `FileHandle`)_"
 msgstr "`pullSync` — 实例 _(类：`FileHandle`)_"
 
-#: src/api/reference.md:1599
+#: src/api/reference.md:1637
 msgid "`writer` — instance _(class: `FileHandle`)_"
 msgstr "`writer` — 实例 _(类：`FileHandle`)_"
 
-#: src/api/reference.md:1606
+#: src/api/reference.md:1644
 msgid "`http`"
 msgstr "`http`"
 
-#: src/api/reference.md:1610 src/api/reference.md:1836
-#: src/api/reference.md:3769
+#: src/api/reference.md:1648 src/api/reference.md:1874
+#: src/api/reference.md:3807
 msgid "`Agent`"
 msgstr "`Agent`"
 
-#: src/api/reference.md:1611
+#: src/api/reference.md:1649
 msgid "`ClientRequest`"
 msgstr "`ClientRequest`"
 
-#: src/api/reference.md:1612 src/api/reference.md:1613
+#: src/api/reference.md:1650 src/api/reference.md:1651
 msgid "`IncomingMessage`"
 msgstr "`IncomingMessage`"
 
-#: src/api/reference.md:1614 src/api/reference.md:1615
+#: src/api/reference.md:1652 src/api/reference.md:1653
 msgid "`OutgoingMessage`"
 msgstr "`OutgoingMessage`"
 
-#: src/api/reference.md:1616 src/api/reference.md:1617
-#: src/api/reference.md:1837 src/api/reference.md:1838
-#: src/api/reference.md:2192
+#: src/api/reference.md:1654 src/api/reference.md:1655
+#: src/api/reference.md:1875 src/api/reference.md:1876
+#: src/api/reference.md:2230
 msgid "`Server`"
 msgstr "`Server`"
 
-#: src/api/reference.md:1618 src/api/reference.md:1619
+#: src/api/reference.md:1656 src/api/reference.md:1657
 msgid "`ServerResponse`"
 msgstr "`ServerResponse`"
 
-#: src/api/reference.md:1620 src/api/reference.md:4097
+#: src/api/reference.md:1658 src/api/reference.md:4135
 msgid "`WebSocket`"
 msgstr "`WebSocket`"
 
-#: src/api/reference.md:1624 src/api/reference.md:1842
-#: src/api/reference.md:3774
+#: src/api/reference.md:1662 src/api/reference.md:1880
+#: src/api/reference.md:3812
 msgid "`Agent` — module"
 msgstr "`Agent` — 模块"
 
-#: src/api/reference.md:1625 src/api/reference.md:1843
-#: src/api/reference.md:2200 src/api/reference.md:3675
-#: src/api/reference.md:4102
+#: src/api/reference.md:1663 src/api/reference.md:1881
+#: src/api/reference.md:2238 src/api/reference.md:3713
+#: src/api/reference.md:4140
 msgid "`Server` — module"
 msgstr "`Server` — 模块"
 
-#: src/api/reference.md:1626
+#: src/api/reference.md:1664
 msgid "`__get_aborted` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_aborted` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1627
+#: src/api/reference.md:1665
 msgid "`__get_aborted` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_aborted` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1628
+#: src/api/reference.md:1666
 msgid "`__get_complete` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_complete` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1629
+#: src/api/reference.md:1667
 msgid "`__get_connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_connection` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1630
+#: src/api/reference.md:1668
 msgid "`__get_connection` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_connection` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1631
+#: src/api/reference.md:1669
 msgid "`__get_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__get_createConnection` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1632
+#: src/api/reference.md:1670
 msgid "`__get_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__get_createSocket` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1633
+#: src/api/reference.md:1671
 msgid "`__get_defaultPort` — instance _(class: `Agent`)_"
 msgstr "`__get_defaultPort` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1634
+#: src/api/reference.md:1672
 msgid "`__get_destroyed` — instance _(class: `Agent`)_"
 msgstr "`__get_destroyed` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1635
+#: src/api/reference.md:1673
 msgid "`__get_destroyed` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_destroyed` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1636
+#: src/api/reference.md:1674
 msgid "`__get_destroyed` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_destroyed` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1637
+#: src/api/reference.md:1675
 msgid "`__get_finished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_finished` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1638
+#: src/api/reference.md:1676
 msgid "`__get_freeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_freeSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1639
+#: src/api/reference.md:1677
 msgid "`__get_headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_headers` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1640
+#: src/api/reference.md:1678
 msgid "`__get_headersSent` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_headersSent` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1641
+#: src/api/reference.md:1679
 msgid "`__get_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_headersTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1642
+#: src/api/reference.md:1680
 msgid "`__get_host` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_host` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1643
+#: src/api/reference.md:1681
 msgid "`__get_httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersion` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1644
+#: src/api/reference.md:1682
 msgid "`__get_httpVersionMajor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMajor` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1645
+#: src/api/reference.md:1683
 msgid "`__get_httpVersionMinor` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_httpVersionMinor` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1646
+#: src/api/reference.md:1684
 msgid "`__get_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAlive` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1647
+#: src/api/reference.md:1685
 msgid "`__get_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__get_keepAliveMsecs` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1648
+#: src/api/reference.md:1686
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1649
+#: src/api/reference.md:1687
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1650
+#: src/api/reference.md:1688
 msgid "`__get_listening` — instance _(class: `HttpServer`)_"
 msgstr "`__get_listening` 实例 _ ((类:`HttpServer`)"
 
-#: src/api/reference.md:1651
+#: src/api/reference.md:1689
 msgid "`__get_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxFreeSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1652
+#: src/api/reference.md:1690
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxHeadersCount` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1653
+#: src/api/reference.md:1691
 msgid "`__get_maxHeadersCount` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_maxHeadersCount` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1654
+#: src/api/reference.md:1692
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1655
+#: src/api/reference.md:1693
 msgid "`__get_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1656
+#: src/api/reference.md:1694
 msgid "`__get_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__get_maxTotalSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1657
+#: src/api/reference.md:1695
 msgid "`__get_method` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_method` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1658
+#: src/api/reference.md:1696
 msgid "`__get_method` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_method` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1659
+#: src/api/reference.md:1697
 msgid "`__get_path` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_path` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1660
+#: src/api/reference.md:1698
 msgid "`__get_protocol` — instance _(class: `Agent`)_"
 msgstr "`__get_protocol` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1661
+#: src/api/reference.md:1699
 msgid "`__get_protocol` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_protocol` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1662
+#: src/api/reference.md:1700
 msgid "`__get_req` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_req` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1663
+#: src/api/reference.md:1701
 msgid "`__get_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_requestTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1664
+#: src/api/reference.md:1702
 msgid "`__get_requests` — instance _(class: `Agent`)_"
 msgstr "`__get_requests` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1665
+#: src/api/reference.md:1703
 msgid "`__get_reusedSocket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_reusedSocket` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1666
+#: src/api/reference.md:1704
 msgid "`__get_socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_socket` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1667
+#: src/api/reference.md:1705
 msgid "`__get_socket` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_socket` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1668
+#: src/api/reference.md:1706
 msgid "`__get_sockets` — instance _(class: `Agent`)_"
 msgstr "`__get_sockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1669
+#: src/api/reference.md:1707
 msgid "`__get_statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusCode` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1670
+#: src/api/reference.md:1708
 msgid "`__get_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_statusCode` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1671
+#: src/api/reference.md:1709
 msgid "`__get_statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_statusMessage` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1672
+#: src/api/reference.md:1710
 msgid "`__get_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__get_timeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1673
+#: src/api/reference.md:1711
 msgid "`__get_trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_trailers` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1674
+#: src/api/reference.md:1712
 msgid "`__get_url` — instance _(class: `IncomingMessage`)_"
 msgstr "`__get_url` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1675
+#: src/api/reference.md:1713
 msgid "`__get_writableEnded` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableEnded` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1676
+#: src/api/reference.md:1714
 msgid "`__get_writableEnded` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableEnded` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1677
+#: src/api/reference.md:1715
 msgid "`__get_writableFinished` — instance _(class: `ClientRequest`)_"
 msgstr "`__get_writableFinished` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1678
+#: src/api/reference.md:1716
 msgid "`__get_writableFinished` — instance _(class: `ServerResponse`)_"
 msgstr "`__get_writableFinished` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1679
+#: src/api/reference.md:1717
 msgid "`__set_createConnection` — instance _(class: `Agent`)_"
 msgstr "`__set_createConnection` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1680
+#: src/api/reference.md:1718
 msgid "`__set_createSocket` — instance _(class: `Agent`)_"
 msgstr "`__set_createSocket` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1681
+#: src/api/reference.md:1719
 msgid "`__set_headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_headersTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1682
+#: src/api/reference.md:1720
 msgid "`__set_keepAlive` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAlive` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1683
+#: src/api/reference.md:1721
 msgid "`__set_keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`__set_keepAliveMsecs` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1684
+#: src/api/reference.md:1722
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1685
+#: src/api/reference.md:1723
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1686
+#: src/api/reference.md:1724
 msgid "`__set_maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxFreeSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1687
+#: src/api/reference.md:1725
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxHeadersCount` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1688
+#: src/api/reference.md:1726
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1689
+#: src/api/reference.md:1727
 msgid "`__set_maxSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1690
+#: src/api/reference.md:1728
 msgid "`__set_maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`__set_maxTotalSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1691
+#: src/api/reference.md:1729
 msgid "`__set_protocol` — instance _(class: `Agent`)_"
 msgstr "`__set_protocol` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1692
+#: src/api/reference.md:1730
 msgid "`__set_requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_requestTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1693
+#: src/api/reference.md:1731
 msgid "`__set_sendDate` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_sendDate` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1694
+#: src/api/reference.md:1732
 msgid "`__set_statusCode` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusCode` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1695
+#: src/api/reference.md:1733
 msgid "`__set_statusMessage` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_statusMessage` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1696
+#: src/api/reference.md:1734
 msgid "`__set_strictContentLength` — instance _(class: `ServerResponse`)_"
 msgstr "`__set_strictContentLength` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1697
+#: src/api/reference.md:1735
 msgid "`__set_timeout` — instance _(class: `HttpServer`)_"
 msgstr "`__set_timeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1698
+#: src/api/reference.md:1736
 msgid "`_connectionListener` — module"
 msgstr "`_connectionListener` — 模块"
 
-#: src/api/reference.md:1699
+#: src/api/reference.md:1737
 msgid "`abort` — instance _(class: `ClientRequest`)_"
 msgstr "`abort` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1700
+#: src/api/reference.md:1738
 msgid "`addListener` — instance _(class: `HttpServer`)_"
 msgstr "`addListener` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1701
+#: src/api/reference.md:1739
 msgid "`addListener` — instance _(class: `IncomingMessage`)_"
 msgstr "`addListener` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1702
+#: src/api/reference.md:1740
 msgid "`addListener` — instance _(class: `ServerResponse`)_"
 msgstr "`addListener` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1703
+#: src/api/reference.md:1741
 msgid "`addTrailers` — instance _(class: `ServerResponse`)_"
 msgstr "`addTrailers` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1704
+#: src/api/reference.md:1742
 msgid "`address` — instance _(class: `HttpServer`)_"
 msgstr "`address` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1705
+#: src/api/reference.md:1743
 msgid "`appendHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`appendHeader` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1706 src/api/reference.md:3777
+#: src/api/reference.md:1744 src/api/reference.md:3815
 msgid "`close` — instance _(class: `Agent`)_"
 msgstr "`close` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1707
+#: src/api/reference.md:1745
 msgid "`close` — instance _(class: `HttpServer`)_"
 msgstr "`close` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1708
+#: src/api/reference.md:1746
 msgid "`closeAllConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeAllConnections` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1709
+#: src/api/reference.md:1747
 msgid "`closeIdleConnections` — instance _(class: `HttpServer`)_"
 msgstr "`closeIdleConnections` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1710
+#: src/api/reference.md:1748
 msgid "`connection` — instance _(class: `IncomingMessage`)_"
 msgstr "`connection` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1711
+#: src/api/reference.md:1749
 msgid "`cork` — instance _(class: `ClientRequest`)_"
 msgstr "`cork` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1712
+#: src/api/reference.md:1750
 msgid "`cork` — instance _(class: `ServerResponse`)_"
 msgstr "`cork` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1713 src/api/reference.md:1714
-#: src/api/reference.md:1820 src/api/reference.md:1864
-#: src/api/reference.md:1865 src/api/reference.md:2227
-#: src/api/reference.md:3684
+#: src/api/reference.md:1751 src/api/reference.md:1752
+#: src/api/reference.md:1858 src/api/reference.md:1902
+#: src/api/reference.md:1903 src/api/reference.md:2265
+#: src/api/reference.md:3722
 msgid "`createServer` — module"
 msgstr "`createServer` — 模块"
 
-#: src/api/reference.md:1715
+#: src/api/reference.md:1753
 msgid "`defaultPort` — instance _(class: `Agent`)_"
 msgstr "`defaultPort` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1716 src/api/reference.md:3779
+#: src/api/reference.md:1754 src/api/reference.md:3817
 msgid "`destroy` — instance _(class: `Agent`)_"
 msgstr "`destroy` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1717
+#: src/api/reference.md:1755
 msgid "`destroy` — instance _(class: `IncomingMessage`)_"
 msgstr "`destroy` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1718
+#: src/api/reference.md:1756
 msgid "`destroy` — instance _(class: `ClientRequest`)_"
 msgstr "`destroy` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1719
+#: src/api/reference.md:1757
 msgid "`destroyed` — instance _(class: `Agent`)_"
 msgstr "`destroyed` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1720
+#: src/api/reference.md:1758
 msgid "`end` — instance _(class: `ServerResponse`)_"
 msgstr "`end` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1721
+#: src/api/reference.md:1759
 msgid "`flushHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`flushHeaders` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1722
+#: src/api/reference.md:1760
 msgid "`flushHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`flushHeaders` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1723
+#: src/api/reference.md:1761
 msgid "`freeSockets` — instance _(class: `Agent`)_"
 msgstr "`freeSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1725
+#: src/api/reference.md:1763
 msgid "`getHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeader` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1726
+#: src/api/reference.md:1764
 msgid "`getHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeader` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1727
+#: src/api/reference.md:1765
 msgid "`getHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaderNames` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1728
+#: src/api/reference.md:1766
 msgid "`getHeaderNames` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaderNames` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1729
+#: src/api/reference.md:1767
 msgid "`getHeaders` — instance _(class: `ClientRequest`)_"
 msgstr "`getHeaders` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1730
+#: src/api/reference.md:1768
 msgid "`getHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`getHeaders` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1731
+#: src/api/reference.md:1769
 msgid "`getName` — instance _(class: `Agent`)_"
 msgstr "`getName` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1732
+#: src/api/reference.md:1770
 msgid "`getRawHeaderNames` — instance _(class: `ClientRequest`)_"
 msgstr "`getRawHeaderNames` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1733
+#: src/api/reference.md:1771
 msgid "`getStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`getStatus` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1734
+#: src/api/reference.md:1772
 msgid "`hasHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`hasHeader` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1735
+#: src/api/reference.md:1773
 msgid "`hasHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`hasHeader` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1736
+#: src/api/reference.md:1774
 msgid "`headers` — instance _(class: `IncomingMessage`)_"
 msgstr "`headers` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1737
+#: src/api/reference.md:1775
 msgid "`headersTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`headersTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1738
+#: src/api/reference.md:1776
 msgid "`httpVersion` — instance _(class: `IncomingMessage`)_"
 msgstr "`httpVersion` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1739
+#: src/api/reference.md:1777
 msgid "`keepAlive` — instance _(class: `Agent`)_"
 msgstr "`keepAlive` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1740
+#: src/api/reference.md:1778
 msgid "`keepAliveMsecs` — instance _(class: `Agent`)_"
 msgstr "`keepAliveMsecs` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1741
+#: src/api/reference.md:1779
 msgid "`keepAliveTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1742
+#: src/api/reference.md:1780
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1743
+#: src/api/reference.md:1781
 msgid ""
 "`keepSocketAlive` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns "
 "the keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -38986,103 +39304,103 @@ msgstr ""
 "`keepSocketAlive` 实例 _ ((类: `Agent`) _ **一个小块** reqwest拥有保持活力"
 "池; 每个插座的子是无操作,警告一次 (#4917)"
 
-#: src/api/reference.md:1744
+#: src/api/reference.md:1782
 msgid "`listen` — instance _(class: `HttpServer`)_"
 msgstr "`listen` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1745
+#: src/api/reference.md:1783
 msgid "`listenerCount` — instance _(class: `ClientRequest`)_"
 msgstr "`listenerCount` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1746
+#: src/api/reference.md:1784
 msgid "`listening` — instance _(class: `HttpServer`)_"
 msgstr "`listening` 实例 _ ((类:`HttpServer`)"
 
-#: src/api/reference.md:1747
+#: src/api/reference.md:1785
 msgid "`maxFreeSockets` — instance _(class: `Agent`)_"
 msgstr "`maxFreeSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1748
+#: src/api/reference.md:1786
 msgid "`maxHeadersCount` — instance _(class: `HttpServer`)_"
 msgstr "`maxHeadersCount` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1749
+#: src/api/reference.md:1787
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpServer`)_"
 msgstr "`maxRequestsPerSocket` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1750
+#: src/api/reference.md:1788
 msgid "`maxSockets` — instance _(class: `Agent`)_"
 msgstr "`maxSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1751
+#: src/api/reference.md:1789
 msgid "`maxTotalSockets` — instance _(class: `Agent`)_"
 msgstr "`maxTotalSockets` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1752
+#: src/api/reference.md:1790
 msgid "`method` — instance _(class: `IncomingMessage`)_"
 msgstr "`method` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1753
+#: src/api/reference.md:1791
 msgid "`on` — instance _(class: `HttpServer`)_"
 msgstr "`on` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1754
+#: src/api/reference.md:1792
 msgid "`on` — instance _(class: `IncomingMessage`)_"
 msgstr "`on` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1755
+#: src/api/reference.md:1793
 msgid "`on` — instance _(class: `ServerResponse`)_"
 msgstr "`on` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1756
+#: src/api/reference.md:1794
 msgid "`once` — instance _(class: `IncomingMessage`)_"
 msgstr "`once` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1757
+#: src/api/reference.md:1795
 msgid "`once` — instance _(class: `ClientRequest`)_"
 msgstr "`once` 实例 _ ((类:`ClientRequest`)"
 
-#: src/api/reference.md:1758
+#: src/api/reference.md:1796
 msgid "`pause` — instance _(class: `IncomingMessage`)_"
 msgstr "`pause` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1759
+#: src/api/reference.md:1797
 msgid "`protocol` — instance _(class: `Agent`)_"
 msgstr "`protocol` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1760
+#: src/api/reference.md:1798
 msgid "`read` — instance _(class: `IncomingMessage`)_"
 msgstr "`read` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1761
+#: src/api/reference.md:1799
 msgid "`ref` — instance _(class: `HttpServer`)_"
 msgstr "`ref` 实例 _ ((类:`HttpServer`)"
 
-#: src/api/reference.md:1762
+#: src/api/reference.md:1800
 msgid "`removeHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`removeHeader` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1763
+#: src/api/reference.md:1801
 msgid "`removeHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`removeHeader` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1764
+#: src/api/reference.md:1802
 msgid "`req` — instance _(class: `IncomingMessage`)_"
 msgstr "`req` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1766
+#: src/api/reference.md:1804
 msgid "`requestTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`requestTimeout` — 实例 _(类：`HttpServer`)_"
 
-#: src/api/reference.md:1767
+#: src/api/reference.md:1805
 msgid "`requests` — instance _(class: `Agent`)_"
 msgstr "`requests` — 实例 _(类：`Agent`)_"
 
-#: src/api/reference.md:1768
+#: src/api/reference.md:1806
 msgid "`resume` — instance _(class: `IncomingMessage`)_"
 msgstr "`resume` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1769
+#: src/api/reference.md:1807
 msgid ""
 "`reuseSocket` — instance _(class: `Agent`)_ ⚠ **stub** — reqwest owns the "
 "keep-alive pool; per-socket hooks are no-ops, warns once (#4917)"
@@ -39090,375 +39408,369 @@ msgstr ""
 "`reuseSocket` 实例 _ ((类: `Agent`) _ **一个小块** reqwest拥有保持活力池; 每"
 "个插座的子是无操作,警告一次 (#4917)"
 
-#: src/api/reference.md:1770
+#: src/api/reference.md:1808
 msgid "`setEncoding` — instance _(class: `IncomingMessage`)_"
 msgstr "`setEncoding` — 实例 _(类：`IncomingMessage`)_"
 
-#: src/api/reference.md:1771
+#: src/api/reference.md:1809
 msgid "`setGlobalProxyFromEnv` — module"
 msgstr "`setGlobalProxyFromEnv` — 模块"
 
-#: src/api/reference.md:1772
+#: src/api/reference.md:1810
 msgid "`setHeader` — instance _(class: `ClientRequest`)_"
 msgstr "`setHeader` — 实例 _(类：`ClientRequest`)_"
 
-#: src/api/reference.md:1773
+#: src/api/reference.md:1811
 msgid "`setHeader` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeader` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1774
+#: src/api/reference.md:1812
 msgid "`setHeaders` — instance _(class: `ServerResponse`)_"
 msgstr "`setHeaders` — 实例 _(类：`ServerResponse`)_"
 
-#: src/api/reference.md:1775
+#: src/api/reference.md:1813
 msgid "`setMaxIdleHTTPParsers` — module"
 msgstr "`setMaxIdleHTTPParsers` — 模块"
 
-#: src/api/reference.md:1776
+#: src/api/reference.md:1814
 msgid "`setNoDelay` — instance _(class: `ClientRequest`)_"
 msgstr "`setNoDelay` — 实例 _(类: `ClientRequest`)_"
 
-#: src/api/reference.md:1777
+#: src/api/reference.md:1815
 msgid "`setSocketKeepAlive` — instance _(class: `ClientRequest`)_"
 msgstr "`setSocketKeepAlive` — 实例 _(类: `ClientRequest`)_"
 
-#: src/api/reference.md:1778
+#: src/api/reference.md:1816
 msgid "`setStatus` — instance _(class: `ServerResponse`)_"
 msgstr "`setStatus` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1779
+#: src/api/reference.md:1817
 msgid "`setTimeout` — instance _(class: `HttpServer`)_"
 msgstr "`setTimeout` — 实例 _(类: `HttpServer`)_"
 
-#: src/api/reference.md:1780
+#: src/api/reference.md:1818
 msgid "`setTimeout` — instance _(class: `IncomingMessage`)_"
 msgstr "`setTimeout` — 实例 _(类: `IncomingMessage`)_"
 
-#: src/api/reference.md:1781
+#: src/api/reference.md:1819
 msgid "`setTimeout` — instance _(class: `ClientRequest`)_"
 msgstr "`setTimeout` — 实例 _(类: `ClientRequest`)_"
 
-#: src/api/reference.md:1782
+#: src/api/reference.md:1820
 msgid "`setTimeout` — instance _(class: `ServerResponse`)_"
 msgstr "`setTimeout` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1783
+#: src/api/reference.md:1821
 msgid "`socket` — instance _(class: `IncomingMessage`)_"
 msgstr "`socket` 实例 _ ((类:`IncomingMessage`)"
 
-#: src/api/reference.md:1784
+#: src/api/reference.md:1822
 msgid "`sockets` — instance _(class: `Agent`)_"
 msgstr "`sockets` — 实例 _(类: `Agent`)_"
 
-#: src/api/reference.md:1785
+#: src/api/reference.md:1823
 msgid "`statusCode` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusCode` — 实例 _(类: `IncomingMessage`)_"
 
-#: src/api/reference.md:1786
+#: src/api/reference.md:1824
 msgid "`statusMessage` — instance _(class: `IncomingMessage`)_"
 msgstr "`statusMessage` — 实例 _(类: `IncomingMessage`)_"
 
-#: src/api/reference.md:1787
+#: src/api/reference.md:1825
 msgid "`timeout` — instance _(class: `HttpServer`)_"
 msgstr "`timeout` — 实例 _(类: `HttpServer`)_"
 
-#: src/api/reference.md:1788
+#: src/api/reference.md:1826
 msgid "`trailers` — instance _(class: `IncomingMessage`)_"
 msgstr "`trailers` — 实例 _(类: `IncomingMessage`)_"
 
-#: src/api/reference.md:1789
+#: src/api/reference.md:1827
 msgid "`uncork` — instance _(class: `ClientRequest`)_"
 msgstr "`uncork` — 实例 _(类: `ClientRequest`)_"
 
-#: src/api/reference.md:1790
+#: src/api/reference.md:1828
 msgid "`uncork` — instance _(class: `ServerResponse`)_"
 msgstr "`uncork` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1791
+#: src/api/reference.md:1829
 msgid "`unref` — instance _(class: `HttpServer`)_"
 msgstr "`unref` 实例 _ ((类:`HttpServer`)"
 
-#: src/api/reference.md:1792
+#: src/api/reference.md:1830
 msgid "`url` — instance _(class: `IncomingMessage`)_"
 msgstr "`url` — 实例 _(类: `IncomingMessage`)_"
 
-#: src/api/reference.md:1793
+#: src/api/reference.md:1831
 msgid "`validateHeaderName` — module"
 msgstr "`validateHeaderName` — 模块"
 
-#: src/api/reference.md:1794
+#: src/api/reference.md:1832
 msgid "`validateHeaderValue` — module"
 msgstr "`validateHeaderValue` — 模块"
 
-#: src/api/reference.md:1795
+#: src/api/reference.md:1833
 msgid "`write` — instance _(class: `ServerResponse`)_"
 msgstr "`write` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1796
+#: src/api/reference.md:1834
 msgid "`writeContinue` — instance _(class: `ServerResponse`)_"
 msgstr "`writeContinue` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1797
+#: src/api/reference.md:1835
 msgid "`writeEarlyHints` — instance _(class: `ServerResponse`)_"
 msgstr "`writeEarlyHints` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1798
+#: src/api/reference.md:1836
 msgid "`writeHead` — instance _(class: `ServerResponse`)_"
 msgstr "`writeHead` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1799
+#: src/api/reference.md:1837
 msgid "`writeProcessing` — instance _(class: `ServerResponse`)_"
 msgstr "`writeProcessing` — 实例 _(类: `ServerResponse`)_"
 
-#: src/api/reference.md:1803
+#: src/api/reference.md:1841
 msgid "`METHODS`"
 msgstr "`METHODS`"
 
-#: src/api/reference.md:1804
+#: src/api/reference.md:1842
 msgid "`STATUS_CODES`"
 msgstr "`STATUS_CODES`"
 
-#: src/api/reference.md:1805 src/api/reference.md:1884
+#: src/api/reference.md:1843 src/api/reference.md:1922
 msgid "`globalAgent`"
 msgstr "`globalAgent`"
 
-#: src/api/reference.md:1806
+#: src/api/reference.md:1844
 msgid "`kConnectionsCheckingInterval`"
 msgstr "`kConnectionsCheckingInterval`"
 
-#: src/api/reference.md:1807
+#: src/api/reference.md:1845
 msgid "`maxHeaderSize`"
 msgstr "`maxHeaderSize`"
 
-#: src/api/reference.md:1809
+#: src/api/reference.md:1847
 msgid "`http2`"
 msgstr "`http2`"
 
-#: src/api/reference.md:1813
+#: src/api/reference.md:1851
 msgid "`Http2ServerRequest`"
 msgstr "`Http2ServerRequest`"
 
-#: src/api/reference.md:1814
+#: src/api/reference.md:1852
 msgid "`Http2ServerResponse`"
 msgstr "`Http2ServerResponse`"
 
-#: src/api/reference.md:1818 src/api/reference.md:2120
-#: src/api/reference.md:2222 src/api/reference.md:3045
-#: src/api/reference.md:3681
-msgid "`connect` — module"
-msgstr "`connect` — 模块"
-
-#: src/api/reference.md:1819
+#: src/api/reference.md:1857
 msgid "`createSecureServer` — module"
 msgstr "`createSecureServer` — 模块"
 
-#: src/api/reference.md:1821
+#: src/api/reference.md:1859
 msgid "`getDefaultSettings` — module"
 msgstr "`getDefaultSettings` — 模块"
 
-#: src/api/reference.md:1822
+#: src/api/reference.md:1860
 msgid "`getPackedSettings` — module"
 msgstr "`getPackedSettings` — 模块"
 
-#: src/api/reference.md:1823
+#: src/api/reference.md:1861
 msgid "`getUnpackedSettings` — module"
 msgstr "`getUnpackedSettings` — 模块"
 
-#: src/api/reference.md:1824
+#: src/api/reference.md:1862
 msgid "`performServerHandshake` — module"
 msgstr "`performServerHandshake` — 模块"
 
-#: src/api/reference.md:1830
+#: src/api/reference.md:1868
 msgid "`sensitiveHeaders`"
 msgstr "`sensitiveHeaders`"
 
-#: src/api/reference.md:1832
+#: src/api/reference.md:1870
 msgid "`https`"
 msgstr "`https`"
 
-#: src/api/reference.md:1844
+#: src/api/reference.md:1882
 msgid "`__get_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_headersTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1845
+#: src/api/reference.md:1883
 msgid "`__get_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1846
+#: src/api/reference.md:1884
 msgid "`__get_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_keepAliveTimeoutBuffer` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1847
+#: src/api/reference.md:1885
 msgid "`__get_listening` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_listening` 实例 _ ((类:`HttpsServer`)"
 
-#: src/api/reference.md:1848
+#: src/api/reference.md:1886
 msgid "`__get_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxHeadersCount` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1849
+#: src/api/reference.md:1887
 msgid "`__get_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_maxRequestsPerSocket` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1850
+#: src/api/reference.md:1888
 msgid "`__get_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_requestTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1851
+#: src/api/reference.md:1889
 msgid "`__get_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__get_timeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1852
+#: src/api/reference.md:1890
 msgid "`__set_headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_headersTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1853
+#: src/api/reference.md:1891
 msgid "`__set_keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1854
+#: src/api/reference.md:1892
 msgid "`__set_keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_keepAliveTimeoutBuffer` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1855
+#: src/api/reference.md:1893
 msgid "`__set_maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxHeadersCount` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1856
+#: src/api/reference.md:1894
 msgid "`__set_maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_maxRequestsPerSocket` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1857
+#: src/api/reference.md:1895
 msgid "`__set_requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_requestTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1858
+#: src/api/reference.md:1896
 msgid "`__set_timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`__set_timeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1859
+#: src/api/reference.md:1897
 msgid "`addListener` — instance _(class: `HttpsServer`)_"
 msgstr "`addListener` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1860
+#: src/api/reference.md:1898
 msgid "`address` — instance _(class: `HttpsServer`)_"
 msgstr "`address` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1861
+#: src/api/reference.md:1899
 msgid "`close` — instance _(class: `HttpsServer`)_"
 msgstr "`close` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1862
+#: src/api/reference.md:1900
 msgid "`closeAllConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeAllConnections` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1863
+#: src/api/reference.md:1901
 msgid "`closeIdleConnections` — instance _(class: `HttpsServer`)_"
 msgstr "`closeIdleConnections` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1867
+#: src/api/reference.md:1905
 msgid "`headersTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`headersTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1868
+#: src/api/reference.md:1906
 msgid "`keepAliveTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1869
+#: src/api/reference.md:1907
 msgid "`keepAliveTimeoutBuffer` — instance _(class: `HttpsServer`)_"
 msgstr "`keepAliveTimeoutBuffer` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1870
+#: src/api/reference.md:1908
 msgid "`listen` — instance _(class: `HttpsServer`)_"
 msgstr "`listen` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1871
+#: src/api/reference.md:1909
 msgid "`listening` — instance _(class: `HttpsServer`)_"
 msgstr "`listening` 实例 _ ((类:`HttpsServer`)"
 
-#: src/api/reference.md:1872
+#: src/api/reference.md:1910
 msgid "`maxHeadersCount` — instance _(class: `HttpsServer`)_"
 msgstr "`maxHeadersCount` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1873
+#: src/api/reference.md:1911
 msgid "`maxRequestsPerSocket` — instance _(class: `HttpsServer`)_"
 msgstr "`maxRequestsPerSocket` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1874
+#: src/api/reference.md:1912
 msgid "`on` — instance _(class: `HttpsServer`)_"
 msgstr "`on` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1875
+#: src/api/reference.md:1913
 msgid "`ref` — instance _(class: `HttpsServer`)_"
 msgstr "`ref` 实例 _ ((类:`HttpsServer`)"
 
-#: src/api/reference.md:1877
+#: src/api/reference.md:1915
 msgid "`requestTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`requestTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1878
+#: src/api/reference.md:1916
 msgid "`setTimeout` — instance _(class: `HttpsServer`)_"
 msgstr "`setTimeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1879
+#: src/api/reference.md:1917
 msgid "`timeout` — instance _(class: `HttpsServer`)_"
 msgstr "`timeout` — 实例 _(类: `HttpsServer`)_"
 
-#: src/api/reference.md:1880
+#: src/api/reference.md:1918
 msgid "`unref` — instance _(class: `HttpsServer`)_"
 msgstr "`unref` 实例 _ ((类:`HttpsServer`)"
 
-#: src/api/reference.md:1886
+#: src/api/reference.md:1924
 msgid "`inspector`"
 msgstr "`inspector`"
 
-#: src/api/reference.md:1890 src/api/reference.md:1921
-#: src/api/reference.md:3324
+#: src/api/reference.md:1928 src/api/reference.md:1959
+#: src/api/reference.md:3362
 msgid "`Session`"
 msgstr "`Session`"
 
-#: src/api/reference.md:1894 src/api/reference.md:1925
-#: src/api/reference.md:3331
+#: src/api/reference.md:1932 src/api/reference.md:1963
+#: src/api/reference.md:3369
 msgid "`Session` — module"
 msgstr "`Session` — 模块"
 
-#: src/api/reference.md:1896 src/api/reference.md:1926
+#: src/api/reference.md:1934 src/api/reference.md:1964
 msgid "`connect` — instance _(class: `Session`)_"
 msgstr "`connect` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1897 src/api/reference.md:1927
+#: src/api/reference.md:1935 src/api/reference.md:1965
 msgid "`connectToMainThread` — instance _(class: `Session`)_"
 msgstr "`connectToMainThread` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1898
+#: src/api/reference.md:1936
 msgid "`debug` — module _(class: `console`)_"
 msgstr "`debug` 模块 _ ((类:`console`)"
 
-#: src/api/reference.md:1899 src/api/reference.md:1928
+#: src/api/reference.md:1937 src/api/reference.md:1966
 msgid "`disconnect` — instance _(class: `Session`)_"
 msgstr "`disconnect` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1900
+#: src/api/reference.md:1938
 msgid "`error` — module _(class: `console`)_"
 msgstr "`error` 模块 _ ((类:`console`)"
 
-#: src/api/reference.md:1901
+#: src/api/reference.md:1939
 msgid "`info` — module _(class: `console`)_"
 msgstr "`info` 模块 _ ((类:`console`)"
 
-#: src/api/reference.md:1902
+#: src/api/reference.md:1940
 msgid "`log` — module _(class: `console`)_"
 msgstr "`log` 模块 _ ((类:`console`)"
 
-#: src/api/reference.md:1903 src/api/reference.md:1929
+#: src/api/reference.md:1941 src/api/reference.md:1967
 msgid "`on` — instance _(class: `Session`)_"
 msgstr "`on` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1904 src/api/reference.md:1930
+#: src/api/reference.md:1942 src/api/reference.md:1968
 msgid "`once` — instance _(class: `Session`)_"
 msgstr "`once` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1905
+#: src/api/reference.md:1943
 msgid ""
 "`open` — module ⚠ **stub** — accepts port/host but binds no real WebSocket "
 "inspector endpoint; sessions are in-process fakes (#4916)"
@@ -39466,7 +39778,7 @@ msgstr ""
 "`open`  模块 **一个小块** 接受 port/host 但没有真正的 WebSocket 检查员终点; "
 "会议是正在进行中的假冒 (#4916)"
 
-#: src/api/reference.md:1906
+#: src/api/reference.md:1944
 msgid ""
 "`post` — instance _(class: `Session`)_ ⚠ **stub** — only Runtime.enable and "
 "a canned Runtime.evaluate subset respond; every other protocol method throws "
@@ -39475,7 +39787,7 @@ msgstr ""
 "`post` 实例 _ ((类: `Session`) _ **一个小块** 只有Runtime.enable和一个装的"
 "Runtime.evaluate子集响应;其他任何协议方法都会抛出检查员错误 -32601 (#4916)"
 
-#: src/api/reference.md:1907
+#: src/api/reference.md:1945
 msgid ""
 "`url` — module ⚠ **stub** — always undefined: Perry never exposes a real "
 "inspector endpoint (#4916)"
@@ -39483,3292 +39795,3283 @@ msgstr ""
 "`url`  模块 **一个小块** 始终未定义:Perry 永远不会暴露真正的检查器终点 "
 "(#4916)"
 
-#: src/api/reference.md:1908
+#: src/api/reference.md:1946
 msgid ""
 "`waitForDebugger` — module ⚠ **stub** — returns immediately after open(); "
 "there is no debugger to wait for (#4916)"
 msgstr ""
 "`waitForDebugger`  模块 **一个小块** 返回 open后立即();没有调试器等待 (#4916)"
 
-#: src/api/reference.md:1909
+#: src/api/reference.md:1947
 msgid "`warn` — module _(class: `console`)_"
 msgstr "`warn` 模块 _ ((类:`console`)"
 
-#: src/api/reference.md:1913
+#: src/api/reference.md:1951
 msgid "`Network`"
 msgstr "`Network`"
 
-#: src/api/reference.md:1917
+#: src/api/reference.md:1955
 msgid "`inspector/promises`"
 msgstr "`inspector/promises`"
 
-#: src/api/reference.md:1931
+#: src/api/reference.md:1969
 msgid "`post` — instance _(class: `Session`)_"
 msgstr "`post` — 实例 _(类: `Session`)_"
 
-#: src/api/reference.md:1937
+#: src/api/reference.md:1975
 msgid "`ioredis`"
 msgstr "`ioredis`"
 
-#: src/api/reference.md:1941 src/api/reference.md:1961
-#: src/api/reference.md:3241
+#: src/api/reference.md:1979 src/api/reference.md:1999
+#: src/api/reference.md:3279
 msgid "`Redis`"
 msgstr "`Redis`"
 
-#: src/api/reference.md:1945 src/api/reference.md:1976
-#: src/api/reference.md:2121
+#: src/api/reference.md:1983 src/api/reference.md:2014
+#: src/api/reference.md:2159
 msgid "`connect` — instance"
 msgstr "`connect` — 实例"
 
-#: src/api/reference.md:1946 src/api/reference.md:1965
-#: src/api/reference.md:3245
+#: src/api/reference.md:1984 src/api/reference.md:2003
+#: src/api/reference.md:3283
 msgid "`createClient` — module"
 msgstr "`createClient` — 模块"
 
-#: src/api/reference.md:1947
+#: src/api/reference.md:1985
 msgid "`decr` — instance"
 msgstr "`decr` — 实例"
 
-#: src/api/reference.md:1948
+#: src/api/reference.md:1986
 msgid "`del` — instance"
 msgstr "`del` — 实例"
 
-#: src/api/reference.md:1949
+#: src/api/reference.md:1987
 msgid "`disconnect` — instance"
 msgstr "`disconnect` — 实例"
 
-#: src/api/reference.md:1950
+#: src/api/reference.md:1988
 msgid "`exists` — instance"
 msgstr "`exists` — 实例"
 
-#: src/api/reference.md:1951
+#: src/api/reference.md:1989
 msgid "`expire` — instance"
 msgstr "`expire` — 实例"
 
-#: src/api/reference.md:1953
+#: src/api/reference.md:1991
 msgid "`incr` — instance"
 msgstr "`incr` — 实例"
 
-#: src/api/reference.md:1954
+#: src/api/reference.md:1992
 msgid "`quit` — instance"
 msgstr "`quit` — 实例"
 
-#: src/api/reference.md:1955 src/api/reference.md:2035
+#: src/api/reference.md:1993 src/api/reference.md:2073
 msgid "`set` — instance"
 msgstr "`set` — 实例"
 
-#: src/api/reference.md:1957
+#: src/api/reference.md:1995
 msgid "`iovalkey`"
 msgstr "`iovalkey`"
 
-#: src/api/reference.md:1967
+#: src/api/reference.md:2005
 msgid "`iroh`"
 msgstr "`iroh`"
 
-#: src/api/reference.md:1971
+#: src/api/reference.md:2009
 msgid "`acceptBi` — instance"
 msgstr "`acceptBi` — 实例"
 
-#: src/api/reference.md:1972
+#: src/api/reference.md:2010
 msgid "`acceptOne` — instance"
 msgstr "`acceptOne` — 实例"
 
-#: src/api/reference.md:1973
+#: src/api/reference.md:2011
 msgid "`bind` — module"
 msgstr "`bind` — 模块"
 
-#: src/api/reference.md:1975
+#: src/api/reference.md:2013
 msgid "`connClose` — instance"
 msgstr "`connClose` — 实例"
 
-#: src/api/reference.md:1977
+#: src/api/reference.md:2015
 msgid "`nodeId` — instance"
 msgstr "`nodeId` — 实例"
 
-#: src/api/reference.md:1978
+#: src/api/reference.md:2016
 msgid "`openBi` — instance"
 msgstr "`openBi` — 实例"
 
-#: src/api/reference.md:1979
+#: src/api/reference.md:2017
 msgid "`streamFinish` — instance"
 msgstr "`streamFinish` — 实例"
 
-#: src/api/reference.md:1980
+#: src/api/reference.md:2018
 msgid "`streamReadToEnd` — instance"
 msgstr "`streamReadToEnd` — 实例"
 
-#: src/api/reference.md:1981
+#: src/api/reference.md:2019
 msgid "`streamWrite` — instance"
 msgstr "`streamWrite` — 实例"
 
-#: src/api/reference.md:1987 src/api/reference.md:3150
-#: src/api/reference.md:3172
+#: src/api/reference.md:2025 src/api/reference.md:3188
+#: src/api/reference.md:3210
 msgid "`decode` — module"
 msgstr "`decode` — 模块"
 
-#: src/api/reference.md:1991
+#: src/api/reference.md:2029
 msgid "`lodash`"
 msgstr "`lodash`"
 
-#: src/api/reference.md:1995
+#: src/api/reference.md:2033
 msgid "`camelCase` — module"
 msgstr "`camelCase` — 模块"
 
-#: src/api/reference.md:1996
+#: src/api/reference.md:2034
 msgid "`chunk` — module"
 msgstr "`chunk` — 模块"
 
-#: src/api/reference.md:1997 src/api/reference.md:1998
+#: src/api/reference.md:2035 src/api/reference.md:2036
 msgid "`clamp` — module"
 msgstr "`clamp` — 模块"
 
-#: src/api/reference.md:1999
+#: src/api/reference.md:2037
 msgid "`compact` — module"
 msgstr "`compact` — 模块"
 
-#: src/api/reference.md:2000
+#: src/api/reference.md:2038
 msgid "`drop` — module"
 msgstr "`drop` — 模块"
 
-#: src/api/reference.md:2001
+#: src/api/reference.md:2039
 msgid "`first` — module"
 msgstr "`first` — 模块"
 
-#: src/api/reference.md:2002
+#: src/api/reference.md:2040
 msgid "`flatten` — module"
 msgstr "`flatten` — 模块"
 
-#: src/api/reference.md:2004
+#: src/api/reference.md:2042
 msgid "`inRange` — module"
 msgstr "`inRange` — 模块"
 
-#: src/api/reference.md:2005
+#: src/api/reference.md:2043
 msgid "`kebabCase` — module"
 msgstr "`kebabCase` — 模块"
 
-#: src/api/reference.md:2006
+#: src/api/reference.md:2044
 msgid "`last` — module"
 msgstr "`last` — 模块"
 
-#: src/api/reference.md:2007
+#: src/api/reference.md:2045
 msgid "`max` — module"
 msgstr "`max` — 模块"
 
-#: src/api/reference.md:2008
+#: src/api/reference.md:2046
 msgid "`maxBy` — module"
 msgstr "`maxBy` — 模块"
 
-#: src/api/reference.md:2009
+#: src/api/reference.md:2047
 msgid "`mean` — module"
 msgstr "`mean` — 模块"
 
-#: src/api/reference.md:2010
+#: src/api/reference.md:2048
 msgid "`meanBy` — module"
 msgstr "`meanBy` — 模块"
 
-#: src/api/reference.md:2011
+#: src/api/reference.md:2049
 msgid "`min` — module"
 msgstr "`min` — 模块"
 
-#: src/api/reference.md:2012
+#: src/api/reference.md:2050
 msgid "`minBy` — module"
 msgstr "`minBy` — 模块"
 
-#: src/api/reference.md:2013
+#: src/api/reference.md:2051
 msgid "`random` — module"
 msgstr "`random` — 模块"
 
-#: src/api/reference.md:2014
+#: src/api/reference.md:2052
 msgid "`range` — module"
 msgstr "`range` — 模块"
 
-#: src/api/reference.md:2016
+#: src/api/reference.md:2054
 msgid "`size` — module"
 msgstr "`size` — 模块"
 
-#: src/api/reference.md:2017
+#: src/api/reference.md:2055
 msgid "`snakeCase` — module"
 msgstr "`snakeCase` — 模块"
 
-#: src/api/reference.md:2018
+#: src/api/reference.md:2056
 msgid "`sum` — module"
 msgstr "`sum` — 模块"
 
-#: src/api/reference.md:2019
+#: src/api/reference.md:2057
 msgid "`sumBy` — module"
 msgstr "`sumBy` — 模块"
 
-#: src/api/reference.md:2020
+#: src/api/reference.md:2058
 msgid "`tail` — module"
 msgstr "`tail` — 模块"
 
-#: src/api/reference.md:2021
+#: src/api/reference.md:2059
 msgid "`take` — module"
 msgstr "`take` — 模块"
 
-#: src/api/reference.md:2022
+#: src/api/reference.md:2060
 msgid "`times` — module"
 msgstr "`times` — 模块"
 
-#: src/api/reference.md:2023
+#: src/api/reference.md:2061
 msgid "`uniq` — module"
 msgstr "`uniq` — 模块"
 
-#: src/api/reference.md:2029
+#: src/api/reference.md:2067
 msgid "`clear` — instance"
 msgstr "`clear` — 实例"
 
-#: src/api/reference.md:2033
+#: src/api/reference.md:2071
 msgid "`has` — instance"
 msgstr "`has` — 实例"
 
-#: src/api/reference.md:2034
+#: src/api/reference.md:2072
 msgid "`peek` — instance"
 msgstr "`peek` 实例"
 
-#: src/api/reference.md:2036
+#: src/api/reference.md:2074
 msgid "`size` — instance"
 msgstr "`size` — 实例"
 
-#: src/api/reference.md:2038
+#: src/api/reference.md:2076
 msgid "`module`"
 msgstr "`module`"
 
-#: src/api/reference.md:2042 src/api/reference.md:2073
+#: src/api/reference.md:2080 src/api/reference.md:2111
 msgid "`Module`"
 msgstr "`Module`"
 
-#: src/api/reference.md:2043
+#: src/api/reference.md:2081
 msgid "`SourceMap`"
 msgstr "`SourceMap`"
 
-#: src/api/reference.md:2047
+#: src/api/reference.md:2085
 msgid "`Module` — module"
 msgstr "`Module` — 模块"
 
-#: src/api/reference.md:2048
+#: src/api/reference.md:2086
 msgid "`SourceMap` — module"
 msgstr "`SourceMap` — 模块"
 
-#: src/api/reference.md:2049
+#: src/api/reference.md:2087
 msgid "`_findPath` — module"
 msgstr "`_findPath` — 模块"
 
-#: src/api/reference.md:2050
+#: src/api/reference.md:2088
 msgid "`_initPaths` — module"
 msgstr "`_initPaths` — 模块"
 
-#: src/api/reference.md:2051
+#: src/api/reference.md:2089
 msgid "`_load` — module"
 msgstr "`_load` — 模块"
 
-#: src/api/reference.md:2052
+#: src/api/reference.md:2090
 msgid "`_nodeModulePaths` — module"
 msgstr "`_nodeModulePaths` — 模块"
 
-#: src/api/reference.md:2053
+#: src/api/reference.md:2091
 msgid "`_preloadModules` — module"
 msgstr "`_preloadModules` — 模块"
 
-#: src/api/reference.md:2054
+#: src/api/reference.md:2092
 msgid "`_resolveFilename` — module"
 msgstr "`_resolveFilename` — 模块"
 
-#: src/api/reference.md:2055
+#: src/api/reference.md:2093
 msgid "`_resolveLookupPaths` — module"
 msgstr "`_resolveLookupPaths` — 模块"
 
-#: src/api/reference.md:2056
+#: src/api/reference.md:2094
 msgid "`createRequire` — module"
 msgstr "`createRequire` — 模块"
 
-#: src/api/reference.md:2057
+#: src/api/reference.md:2095
 msgid "`enableCompileCache` — module"
 msgstr "`enableCompileCache` — 模块"
 
-#: src/api/reference.md:2058
+#: src/api/reference.md:2096
 msgid "`findPackageJSON` — module"
 msgstr "`findPackageJSON` — 模块"
 
-#: src/api/reference.md:2059
+#: src/api/reference.md:2097
 msgid "`findSourceMap` — module"
 msgstr "`findSourceMap` — 模块"
 
-#: src/api/reference.md:2060
+#: src/api/reference.md:2098
 msgid "`flushCompileCache` — module"
 msgstr "`flushCompileCache` — 模块"
 
-#: src/api/reference.md:2061
+#: src/api/reference.md:2099
 msgid "`getCompileCacheDir` — module"
 msgstr "`getCompileCacheDir` — 模块"
 
-#: src/api/reference.md:2062
+#: src/api/reference.md:2100
 msgid "`getSourceMapsSupport` — module"
 msgstr "`getSourceMapsSupport` — 模块"
 
-#: src/api/reference.md:2063
+#: src/api/reference.md:2101
 msgid "`isBuiltin` — module"
 msgstr "`isBuiltin` — 模块"
 
-#: src/api/reference.md:2064
+#: src/api/reference.md:2102
 msgid "`register` — module"
 msgstr "`register` — 模块"
 
-#: src/api/reference.md:2065
+#: src/api/reference.md:2103
 msgid "`registerHooks` — module"
 msgstr "`registerHooks` — 模块"
 
-#: src/api/reference.md:2066
+#: src/api/reference.md:2104
 msgid "`runMain` — module"
 msgstr "`runMain` — 模块"
 
-#: src/api/reference.md:2067
+#: src/api/reference.md:2105
 msgid "`setSourceMapsSupport` — module"
 msgstr "`setSourceMapsSupport` — 模块"
 
-#: src/api/reference.md:2068
+#: src/api/reference.md:2106
 msgid "`stripTypeScriptTypes` — module"
 msgstr "`stripTypeScriptTypes` — 模块"
 
-#: src/api/reference.md:2069
+#: src/api/reference.md:2107
 msgid "`syncBuiltinESMExports` — module"
 msgstr "`syncBuiltinESMExports` — 模块"
 
-#: src/api/reference.md:2074
+#: src/api/reference.md:2112
 msgid "`_cache`"
 msgstr "`_cache`"
 
-#: src/api/reference.md:2075
+#: src/api/reference.md:2113
 msgid "`_extensions`"
 msgstr "`_extensions`"
 
-#: src/api/reference.md:2076
+#: src/api/reference.md:2114
 msgid "`_pathCache`"
 msgstr "`_pathCache`"
 
-#: src/api/reference.md:2077 src/api/reference.md:3273
+#: src/api/reference.md:2115 src/api/reference.md:3311
 msgid "`builtinModules`"
 msgstr "`builtinModules`"
 
-#: src/api/reference.md:2080
+#: src/api/reference.md:2118
 msgid "`globalPaths`"
 msgstr "`globalPaths`"
 
-#: src/api/reference.md:2094
+#: src/api/reference.md:2132
 msgid "`fromNow` — instance"
 msgstr "`fromNow` 实例"
 
-#: src/api/reference.md:2098
+#: src/api/reference.md:2136
 msgid "`isBetween` — instance"
 msgstr "`isBetween` 实例"
 
-#: src/api/reference.md:2103
+#: src/api/reference.md:2141
 msgid "`moment` — module"
 msgstr "`moment` — 模块"
 
-#: src/api/reference.md:2108
+#: src/api/reference.md:2146
 msgid "`toDate` — instance"
 msgstr "`toDate` 实例"
 
-#: src/api/reference.md:2119
+#: src/api/reference.md:2157
 msgid "`collection` — instance"
 msgstr "`collection` — 实例"
 
-#: src/api/reference.md:2122
+#: src/api/reference.md:2160
 msgid "`countDocuments` — instance"
 msgstr "`countDocuments` — 实例"
 
-#: src/api/reference.md:2123
+#: src/api/reference.md:2161
 msgid "`db` — instance"
 msgstr "`db` — 实例"
 
-#: src/api/reference.md:2124
+#: src/api/reference.md:2162
 msgid "`deleteMany` — instance"
 msgstr "`deleteMany` — 实例"
 
-#: src/api/reference.md:2125
+#: src/api/reference.md:2163
 msgid "`deleteOne` — instance"
 msgstr "`deleteOne` — 实例"
 
-#: src/api/reference.md:2127
+#: src/api/reference.md:2165
 msgid "`findOne` — instance"
 msgstr "`findOne` — 实例"
 
-#: src/api/reference.md:2128
+#: src/api/reference.md:2166
 msgid "`insertMany` — instance"
 msgstr "`insertMany` — 实例"
 
-#: src/api/reference.md:2129
+#: src/api/reference.md:2167
 msgid "`insertOne` — instance"
 msgstr "`insertOne` — 实例"
 
-#: src/api/reference.md:2130
+#: src/api/reference.md:2168
 msgid "`updateMany` — instance"
 msgstr "`updateMany` — 实例"
 
-#: src/api/reference.md:2131
+#: src/api/reference.md:2169
 msgid "`updateOne` — instance"
 msgstr "`updateOne` — 实例"
 
-#: src/api/reference.md:2133
+#: src/api/reference.md:2171
 msgid "`mysql2`"
 msgstr "`mysql2`"
 
-#: src/api/reference.md:2137 src/api/reference.md:2161
-#: src/api/reference.md:3040
+#: src/api/reference.md:2175 src/api/reference.md:2199
+#: src/api/reference.md:3078
 msgid "`Pool`"
 msgstr "`Pool`"
 
-#: src/api/reference.md:2141 src/api/reference.md:2165
+#: src/api/reference.md:2179 src/api/reference.md:2203
 msgid "`beginTransaction` — instance"
 msgstr "`beginTransaction` — 实例"
 
-#: src/api/reference.md:2142 src/api/reference.md:2166
+#: src/api/reference.md:2180 src/api/reference.md:2204
 msgid "`commit` — instance"
 msgstr "`commit` — 实例"
 
-#: src/api/reference.md:2143 src/api/reference.md:2167
-#: src/api/reference.md:2226
+#: src/api/reference.md:2181 src/api/reference.md:2205
+#: src/api/reference.md:2264
 msgid "`createConnection` — module"
 msgstr "`createConnection` — 模块"
 
-#: src/api/reference.md:2144 src/api/reference.md:2168
+#: src/api/reference.md:2182 src/api/reference.md:2206
 msgid "`createPool` — module"
 msgstr "`createPool` — 模块"
 
-#: src/api/reference.md:2145 src/api/reference.md:2169
-#: src/api/reference.md:3047
+#: src/api/reference.md:2183 src/api/reference.md:2207
+#: src/api/reference.md:3085
 msgid "`end` — instance _(class: `Pool`)_"
 msgstr "`end` — 实例 _(类:`Pool`)_"
 
-#: src/api/reference.md:2146 src/api/reference.md:2170
-#: src/api/reference.md:3048 src/api/reference.md:3407
+#: src/api/reference.md:2184 src/api/reference.md:2208
+#: src/api/reference.md:3086 src/api/reference.md:3445
 msgid "`end` — instance"
 msgstr "`end` — 实例"
 
-#: src/api/reference.md:2147 src/api/reference.md:2171
+#: src/api/reference.md:2185 src/api/reference.md:2209
 msgid "`execute` — instance _(class: `Pool`)_"
 msgstr "`execute` — 实例 _(类:`Pool`)_"
 
-#: src/api/reference.md:2148 src/api/reference.md:2172
+#: src/api/reference.md:2186 src/api/reference.md:2210
 msgid "`execute` — instance _(class: `PoolConnection`)_"
 msgstr "`execute` — 实例 _(类:`PoolConnection`)_"
 
-#: src/api/reference.md:2149 src/api/reference.md:2173
+#: src/api/reference.md:2187 src/api/reference.md:2211
 msgid "`execute` — instance"
 msgstr "`execute` — 实例"
 
-#: src/api/reference.md:2150 src/api/reference.md:2174
+#: src/api/reference.md:2188 src/api/reference.md:2212
 msgid "`getConnection` — instance"
 msgstr "`getConnection` — 实例"
 
-#: src/api/reference.md:2151 src/api/reference.md:2175
-#: src/api/reference.md:3049
+#: src/api/reference.md:2189 src/api/reference.md:2213
+#: src/api/reference.md:3087
 msgid "`query` — instance _(class: `Pool`)_"
 msgstr "`query` — 实例 _(类:`Pool`)_"
 
-#: src/api/reference.md:2152 src/api/reference.md:2176
+#: src/api/reference.md:2190 src/api/reference.md:2214
 msgid "`query` — instance _(class: `PoolConnection`)_"
 msgstr "`query` — 实例 _(类:`PoolConnection`)_"
 
-#: src/api/reference.md:2154 src/api/reference.md:2178
+#: src/api/reference.md:2192 src/api/reference.md:2216
 msgid "`release` — instance"
 msgstr "`release` — 实例"
 
-#: src/api/reference.md:2155 src/api/reference.md:2179
+#: src/api/reference.md:2193 src/api/reference.md:2217
 msgid "`rollback` — instance"
 msgstr "`rollback` — 实例"
 
-#: src/api/reference.md:2157
+#: src/api/reference.md:2195
 msgid "`mysql2/promise`"
 msgstr "`mysql2/promise`"
 
-#: src/api/reference.md:2185
+#: src/api/reference.md:2223
 msgid "`nanoid` — module"
 msgstr "`nanoid` — 模块"
 
-#: src/api/reference.md:2191
+#: src/api/reference.md:2229
 msgid "`BlockList`"
 msgstr "`BlockList`"
 
-#: src/api/reference.md:2194
+#: src/api/reference.md:2232
 msgid "`SocketAddress`"
 msgstr "`SocketAddress`"
 
-#: src/api/reference.md:2195 src/api/reference.md:3387
+#: src/api/reference.md:2233 src/api/reference.md:3425
 msgid "`Stream`"
 msgstr "`Stream`"
 
-#: src/api/reference.md:2199
+#: src/api/reference.md:2237
 msgid "`BlockList` — module"
 msgstr "`BlockList` — 模块"
 
-#: src/api/reference.md:2202
+#: src/api/reference.md:2240
 msgid "`SocketAddress` — module"
 msgstr "`SocketAddress` — 模块"
 
-#: src/api/reference.md:2203
+#: src/api/reference.md:2241
 msgid "`Stream` — module"
 msgstr "`Stream` — 模块"
 
-#: src/api/reference.md:2204
+#: src/api/reference.md:2242
 msgid "`__set_dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`__set_dropMaxConnection` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2205
+#: src/api/reference.md:2243
 msgid "`__set_maxConnections` — instance _(class: `Server`)_"
 msgstr "`__set_maxConnections` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2206
+#: src/api/reference.md:2244
 msgid "`_createServerHandle` — module"
 msgstr "`_createServerHandle` — 模块"
 
-#: src/api/reference.md:2207
+#: src/api/reference.md:2245
 msgid "`_normalizeArgs` — module"
 msgstr "`_normalizeArgs` — 模块"
 
-#: src/api/reference.md:2208
+#: src/api/reference.md:2246
 msgid "`addAddress` — instance _(class: `BlockList`)_"
 msgstr "`addAddress` — 实例 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2210 src/api/reference.md:3677
+#: src/api/reference.md:2248 src/api/reference.md:3715
 msgid "`addListener` — instance _(class: `Server`)_"
 msgstr "`addListener` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2211
+#: src/api/reference.md:2249
 msgid "`addRange` — instance _(class: `BlockList`)_"
 msgstr "`addRange` — 实例 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2212
+#: src/api/reference.md:2250
 msgid "`addSubnet` — instance _(class: `BlockList`)_"
 msgstr "`addSubnet` — 实例 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2214
+#: src/api/reference.md:2252
 msgid "`address` — instance _(class: `SocketAddress`)_"
 msgstr "`address` — 实例 _(类: `SocketAddress`)_"
 
-#: src/api/reference.md:2215 src/api/reference.md:3678
+#: src/api/reference.md:2253 src/api/reference.md:3716
 msgid "`address` — instance _(class: `Server`)_"
 msgstr "`address` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2216
+#: src/api/reference.md:2254
 msgid "`autoSelectFamilyAttemptedAddresses` — instance _(class: `Socket`)_"
 msgstr "`autoSelectFamilyAttemptedAddresses` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2217
+#: src/api/reference.md:2255
 msgid "`bufferSize` — instance _(class: `Socket`)_"
 msgstr "`bufferSize` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2218
+#: src/api/reference.md:2256
 msgid "`bytesRead` — instance _(class: `Socket`)_"
 msgstr "`bytesRead` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2219
+#: src/api/reference.md:2257
 msgid "`bytesWritten` — instance _(class: `Socket`)_"
 msgstr "`bytesWritten` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2220
+#: src/api/reference.md:2258
 msgid "`check` — instance _(class: `BlockList`)_"
 msgstr "`check` — 实例 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2221 src/api/reference.md:3680
+#: src/api/reference.md:2259 src/api/reference.md:3718
 msgid "`close` — instance _(class: `Server`)_"
 msgstr "`close` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2224
+#: src/api/reference.md:2262
 msgid "`connecting` — instance _(class: `Socket`)_"
 msgstr "`connecting` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2225
+#: src/api/reference.md:2263
 msgid "`cork` — instance _(class: `Socket`)_"
 msgstr "`cork` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2228
+#: src/api/reference.md:2266
 msgid "`destroy` — instance _(class: `Socket`)_"
 msgstr "`destroy` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:2229
+#: src/api/reference.md:2267
 msgid "`destroyed` — instance _(class: `Socket`)_"
 msgstr "`destroyed` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2230
+#: src/api/reference.md:2268
 msgid "`dropMaxConnection` — instance _(class: `Server`)_"
 msgstr "`dropMaxConnection` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2231
+#: src/api/reference.md:2269
 msgid "`end` — instance _(class: `Socket`)_"
 msgstr "`end` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:2233 src/api/reference.md:3685
+#: src/api/reference.md:2271 src/api/reference.md:3723
 msgid "`eventNames` — instance _(class: `Server`)_"
 msgstr "`eventNames` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2234
+#: src/api/reference.md:2272
 msgid "`exportKeyingMaterial` — instance _(class: `Socket`)_"
 msgstr "`exportKeyingMaterial` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2235
+#: src/api/reference.md:2273
 msgid "`family` — instance _(class: `SocketAddress`)_"
 msgstr "`family` — 实例 _(类: `SocketAddress`)_"
 
-#: src/api/reference.md:2236
+#: src/api/reference.md:2274
 msgid "`flowlabel` — instance _(class: `SocketAddress`)_"
 msgstr "`flowlabel` — 实例 _(类: `SocketAddress`)_"
 
-#: src/api/reference.md:2237
+#: src/api/reference.md:2275
 msgid "`fromJSON` — instance _(class: `BlockList`)_"
 msgstr "`fromJSON` — 实例 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2238
+#: src/api/reference.md:2276
 msgid "`getCertificate` — instance _(class: `Socket`)_"
 msgstr "`getCertificate` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2239
+#: src/api/reference.md:2277
 msgid "`getCipher` — instance _(class: `Socket`)_"
 msgstr "`getCipher` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2240
+#: src/api/reference.md:2278
 msgid "`getConnections` — instance _(class: `Server`)_"
 msgstr "`getConnections` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2241
+#: src/api/reference.md:2279
 msgid "`getDefaultAutoSelectFamily` — module"
 msgstr "`getDefaultAutoSelectFamily` — 模块"
 
-#: src/api/reference.md:2242
+#: src/api/reference.md:2280
 msgid "`getDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`getDefaultAutoSelectFamilyAttemptTimeout` — 模块"
 
-#: src/api/reference.md:2243
+#: src/api/reference.md:2281
 msgid "`getEphemeralKeyInfo` — instance _(class: `Socket`)_"
 msgstr "`getEphemeralKeyInfo` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2244
+#: src/api/reference.md:2282
 msgid "`getFinished` — instance _(class: `Socket`)_"
 msgstr "`getFinished` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2245
+#: src/api/reference.md:2283
 msgid "`getPeerCertificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerCertificate` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2246
+#: src/api/reference.md:2284
 msgid "`getPeerFinished` — instance _(class: `Socket`)_"
 msgstr "`getPeerFinished` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2247
+#: src/api/reference.md:2285
 msgid "`getPeerX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getPeerX509Certificate` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2248
+#: src/api/reference.md:2286
 msgid "`getProtocol` — instance _(class: `Socket`)_"
 msgstr "`getProtocol` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2249
+#: src/api/reference.md:2287
 msgid "`getSession` — instance _(class: `Socket`)_"
 msgstr "`getSession` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2250
+#: src/api/reference.md:2288
 msgid "`getSharedSigalgs` — instance _(class: `Socket`)_"
 msgstr "`getSharedSigalgs` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2251
+#: src/api/reference.md:2289
 msgid "`getTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`getTypeOfService` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2252
+#: src/api/reference.md:2290
 msgid "`getX509Certificate` — instance _(class: `Socket`)_"
 msgstr "`getX509Certificate` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2253
+#: src/api/reference.md:2291
 msgid "`isBlockList` — module _(class: `BlockList`)_"
 msgstr "`isBlockList` — 模块 _(类: `BlockList`)_"
 
-#: src/api/reference.md:2254
+#: src/api/reference.md:2292
 msgid "`isIP` — module"
 msgstr "`isIP` — 模块"
 
-#: src/api/reference.md:2255
+#: src/api/reference.md:2293
 msgid "`isIPv4` — module"
 msgstr "`isIPv4` — 模块"
 
-#: src/api/reference.md:2256
+#: src/api/reference.md:2294
 msgid "`isIPv6` — module"
 msgstr "`isIPv6` — 模块"
 
-#: src/api/reference.md:2257
+#: src/api/reference.md:2295
 msgid "`isSessionReused` — instance _(class: `Socket`)_"
 msgstr "`isSessionReused` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2258 src/api/reference.md:3690
+#: src/api/reference.md:2296 src/api/reference.md:3728
 msgid "`listen` — instance _(class: `Server`)_"
 msgstr "`listen` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2260 src/api/reference.md:3691
+#: src/api/reference.md:2298 src/api/reference.md:3729
 msgid "`listenerCount` — instance _(class: `Server`)_"
 msgstr "`listenerCount` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2261
+#: src/api/reference.md:2299
 msgid "`listeners` — instance _(class: `Socket`)_"
 msgstr "`listeners` — 实例 _(类: `Socket`)_"
 
-#: src/api/reference.md:2262
+#: src/api/reference.md:2300
 msgid "`listeners` — instance _(class: `Server`)_"
 msgstr "`listeners` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2263
+#: src/api/reference.md:2301
 msgid "`listening` — instance _(class: `Server`)_"
 msgstr "`listening` — 实例 _(类: `Server`)_"
 
-#: src/api/reference.md:2264
+#: src/api/reference.md:2302
 msgid "`localAddress` — instance _(class: `Socket`)_"
 msgstr "`localAddress` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2265
+#: src/api/reference.md:2303
 msgid "`localFamily` — instance _(class: `Socket`)_"
 msgstr "`localFamily` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2266
+#: src/api/reference.md:2304
 msgid "`localPort` — instance _(class: `Socket`)_"
 msgstr "`localPort` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2267
+#: src/api/reference.md:2305
 msgid "`maxConnections` — instance _(class: `Server`)_"
 msgstr "`maxConnections` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2269 src/api/reference.md:3692
+#: src/api/reference.md:2307 src/api/reference.md:3730
 msgid "`off` — instance _(class: `Server`)_"
 msgstr "`off` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2272 src/api/reference.md:3694
+#: src/api/reference.md:2310 src/api/reference.md:3732
 msgid "`once` — instance _(class: `Server`)_"
 msgstr "`once` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2273
+#: src/api/reference.md:2311
 msgid "`parse` — module _(class: `SocketAddress`)_"
 msgstr "`parse` — 模块 _(类：`SocketAddress`)_"
 
-#: src/api/reference.md:2274
+#: src/api/reference.md:2312
 msgid "`pause` — instance _(class: `Socket`)_"
 msgstr "`pause` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2275
+#: src/api/reference.md:2313
 msgid "`pending` — instance _(class: `Socket`)_"
 msgstr "`pending` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2276
+#: src/api/reference.md:2314
 msgid "`port` — instance _(class: `SocketAddress`)_"
 msgstr "`port` — 实例 _(类：`SocketAddress`)_"
 
-#: src/api/reference.md:2277
+#: src/api/reference.md:2315
 msgid "`rawListeners` — instance _(class: `Socket`)_"
 msgstr "`rawListeners` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2278
+#: src/api/reference.md:2316
 msgid "`rawListeners` — instance _(class: `Server`)_"
 msgstr "`rawListeners` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2279
+#: src/api/reference.md:2317
 msgid "`readyState` — instance _(class: `Socket`)_"
 msgstr "`readyState` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2282
+#: src/api/reference.md:2320
 msgid "`remoteFamily` — instance _(class: `Socket`)_"
 msgstr "`remoteFamily` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2283
+#: src/api/reference.md:2321
 msgid "`remotePort` — instance _(class: `Socket`)_"
 msgstr "`remotePort` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2284
+#: src/api/reference.md:2322
 msgid "`removeAllListeners` — instance _(class: `Socket`)_"
 msgstr "`removeAllListeners` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2285 src/api/reference.md:3695
+#: src/api/reference.md:2323 src/api/reference.md:3733
 msgid "`removeAllListeners` — instance _(class: `Server`)_"
 msgstr "`removeAllListeners` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2287 src/api/reference.md:3696
+#: src/api/reference.md:2325 src/api/reference.md:3734
 msgid "`removeListener` — instance _(class: `Server`)_"
 msgstr "`removeListener` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:2288
+#: src/api/reference.md:2326
 msgid "`resetAndDestroy` — instance _(class: `Socket`)_"
 msgstr "`resetAndDestroy` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2289
+#: src/api/reference.md:2327
 msgid "`resume` — instance _(class: `Socket`)_"
 msgstr "`resume` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2290
+#: src/api/reference.md:2328
 msgid "`rules` — instance _(class: `BlockList`)_"
 msgstr "`rules` — 实例 _(类：`BlockList`)_"
 
-#: src/api/reference.md:2291
+#: src/api/reference.md:2329
 msgid "`setDefaultAutoSelectFamily` — module"
 msgstr "`setDefaultAutoSelectFamily` — 模块"
 
-#: src/api/reference.md:2292
+#: src/api/reference.md:2330
 msgid "`setDefaultAutoSelectFamilyAttemptTimeout` — module"
 msgstr "`setDefaultAutoSelectFamilyAttemptTimeout` — 模块"
 
-#: src/api/reference.md:2293
+#: src/api/reference.md:2331
 msgid "`setDefaultEncoding` — instance _(class: `Socket`)_"
 msgstr "`setDefaultEncoding` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2294
+#: src/api/reference.md:2332
 msgid "`setEncoding` — instance _(class: `Socket`)_"
 msgstr "`setEncoding` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2295
+#: src/api/reference.md:2333
 msgid "`setKeepAlive` — instance _(class: `Socket`)_"
 msgstr "`setKeepAlive` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2296
+#: src/api/reference.md:2334
 msgid "`setKeyCert` — instance _(class: `Socket`)_"
 msgstr "`setKeyCert` 实例 _ ((类:`Socket`)"
 
-#: src/api/reference.md:2297
+#: src/api/reference.md:2335
 msgid "`setMaxSendFragment` — instance _(class: `Socket`)_"
 msgstr "`setMaxSendFragment` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2298
+#: src/api/reference.md:2336
 msgid "`setNoDelay` — instance _(class: `Socket`)_"
 msgstr "`setNoDelay` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2299
+#: src/api/reference.md:2337
 msgid "`setTimeout` — instance _(class: `Socket`)_"
 msgstr "`setTimeout` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2300
+#: src/api/reference.md:2338
 msgid "`setTypeOfService` — instance _(class: `Socket`)_"
 msgstr "`setTypeOfService` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2301
+#: src/api/reference.md:2339
 msgid "`timeout` — instance _(class: `Socket`)_"
 msgstr "`timeout` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2302
+#: src/api/reference.md:2340
 msgid "`toJSON` — instance _(class: `BlockList`)_"
 msgstr "`toJSON` — 实例 _(类：`BlockList`)_"
 
-#: src/api/reference.md:2303
+#: src/api/reference.md:2341
 msgid "`uncork` — instance _(class: `Socket`)_"
 msgstr "`uncork` — 实例 _(类：`Socket`)_"
 
-#: src/api/reference.md:2305
+#: src/api/reference.md:2343
 msgid "`upgradeToTLS` — instance _(class: `Socket`)_"
 msgstr "`upgradeToTLS` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:2306
+#: src/api/reference.md:2344
 msgid "`write` — instance _(class: `Socket`)_"
 msgstr "`write` — 实例 _(类:`Socket`)_"
 
-#: src/api/reference.md:2308
+#: src/api/reference.md:2346
 msgid "`node-cron`"
 msgstr "`node-cron`"
 
-#: src/api/reference.md:2315
+#: src/api/reference.md:2353
 msgid "`node-fetch`"
 msgstr "`node-fetch`"
 
-#: src/api/reference.md:2333
+#: src/api/reference.md:2371
 msgid "`certificateFromPem` — module"
 msgstr "模块 `certificateFromPem`"
 
-#: src/api/reference.md:2334
+#: src/api/reference.md:2372
 msgid "`certificateToPem` — module"
 msgstr "模块 `certificateToPem`"
 
-#: src/api/reference.md:2336
+#: src/api/reference.md:2374
 msgid "`createCertificate` — module"
 msgstr "模块 `createCertificate`"
 
-#: src/api/reference.md:2338
+#: src/api/reference.md:2376
 msgid "`privateKeyFromPem` — module"
 msgstr "模块 `privateKeyFromPem`"
 
-#: src/api/reference.md:2339
+#: src/api/reference.md:2377
 msgid "`privateKeyToPem` — module"
 msgstr "模块 `privateKeyToPem`"
 
-#: src/api/reference.md:2340
+#: src/api/reference.md:2378
 msgid "`publicKeyToPem` — module"
 msgstr "模块 `publicKeyToPem`"
 
-#: src/api/reference.md:2341
+#: src/api/reference.md:2379
 msgid "`setExtensions` — instance _(class: `Certificate`)_"
 msgstr "`setExtensions` 实例 _ ((类:`Certificate`)"
 
-#: src/api/reference.md:2342
+#: src/api/reference.md:2380
 msgid "`setIssuer` — instance _(class: `Certificate`)_"
 msgstr "`setIssuer` 实例 _ ((类:`Certificate`)"
 
-#: src/api/reference.md:2343
+#: src/api/reference.md:2381
 msgid "`setSubject` — instance _(class: `Certificate`)_"
 msgstr "`setSubject` 实例 _ ((类:`Certificate`)"
 
-#: src/api/reference.md:2344
+#: src/api/reference.md:2382
 msgid "`sign` — instance _(class: `Certificate`)_"
 msgstr "`sign` 实例 _ ((类:`Certificate`)"
 
-#: src/api/reference.md:2346
+#: src/api/reference.md:2384
 msgid "`node-pty`"
 msgstr "`node-pty`"
 
-#: src/api/reference.md:2360
+#: src/api/reference.md:2398
 msgid "`createTransport` — module"
 msgstr "`createTransport` — 模块"
 
-#: src/api/reference.md:2361
+#: src/api/reference.md:2399
 msgid "`sendMail` — instance"
 msgstr "`sendMail` — 实例"
 
-#: src/api/reference.md:2362
+#: src/api/reference.md:2400
 msgid "`verify` — instance"
 msgstr "`verify` — 实例"
 
-#: src/api/reference.md:2364
+#: src/api/reference.md:2402
 msgid "`os`"
 msgstr "`os`"
 
-#: src/api/reference.md:2368
+#: src/api/reference.md:2406
 msgid "`arch` — module"
 msgstr "`arch` — 模块"
 
-#: src/api/reference.md:2369
+#: src/api/reference.md:2407
 msgid "`availableParallelism` — module"
 msgstr "`availableParallelism` — 模块"
 
-#: src/api/reference.md:2370
+#: src/api/reference.md:2408
 msgid "`cpus` — module"
 msgstr "`cpus` — 模块"
 
-#: src/api/reference.md:2371
+#: src/api/reference.md:2409
 msgid "`endianness` — module"
 msgstr "`endianness` — 模块"
 
-#: src/api/reference.md:2372
+#: src/api/reference.md:2410
 msgid "`freemem` — module"
 msgstr "`freemem` — 模块"
 
-#: src/api/reference.md:2373
+#: src/api/reference.md:2411
 msgid "`getPriority` — module"
 msgstr "`getPriority` — 模块"
 
-#: src/api/reference.md:2374
+#: src/api/reference.md:2412
 msgid "`homedir` — module"
 msgstr "`homedir` — 模块"
 
-#: src/api/reference.md:2375
+#: src/api/reference.md:2413
 msgid "`hostname` — module"
 msgstr "`hostname` — 模块"
 
-#: src/api/reference.md:2376
+#: src/api/reference.md:2414
 msgid "`loadavg` — module"
 msgstr "`loadavg` — 模块"
 
-#: src/api/reference.md:2377
+#: src/api/reference.md:2415
 msgid "`machine` — module"
 msgstr "`machine` — 模块"
 
-#: src/api/reference.md:2378
+#: src/api/reference.md:2416
 msgid "`networkInterfaces` — module"
 msgstr "`networkInterfaces` — 模块"
 
-#: src/api/reference.md:2379
+#: src/api/reference.md:2417
 msgid "`platform` — module"
 msgstr "`platform` — 模块"
 
-#: src/api/reference.md:2380
+#: src/api/reference.md:2418
 msgid "`release` — module"
 msgstr "`release` — 模块"
 
-#: src/api/reference.md:2381
+#: src/api/reference.md:2419
 msgid "`setPriority` — module"
 msgstr "`setPriority` — 模块"
 
-#: src/api/reference.md:2382
+#: src/api/reference.md:2420
 msgid "`tmpdir` — module"
 msgstr "`tmpdir` — 模块"
 
-#: src/api/reference.md:2383
+#: src/api/reference.md:2421
 msgid "`totalmem` — module"
 msgstr "`totalmem` — 模块"
 
-#: src/api/reference.md:2384
+#: src/api/reference.md:2422
 msgid "`type` — module"
 msgstr "`type` — 模块"
 
-#: src/api/reference.md:2385 src/api/reference.md:3110
+#: src/api/reference.md:2423 src/api/reference.md:3148
 msgid "`uptime` — module"
 msgstr "`uptime` — 模块"
 
-#: src/api/reference.md:2386
+#: src/api/reference.md:2424
 msgid "`userInfo` — module"
 msgstr "`userInfo` — 模块"
 
-#: src/api/reference.md:2387 src/api/reference.md:3920
+#: src/api/reference.md:2425 src/api/reference.md:3958
 msgid "`version` — module"
 msgstr "`version` — 模块"
 
-#: src/api/reference.md:2391
+#: src/api/reference.md:2429
 msgid "`EOL`"
 msgstr "`EOL`"
 
-#: src/api/reference.md:2394
+#: src/api/reference.md:2432
 msgid "`devNull`"
 msgstr "`devNull`"
 
-#: src/api/reference.md:2396
+#: src/api/reference.md:2434
 msgid "`path`"
 msgstr "`path`"
 
-#: src/api/reference.md:2400 src/api/reference.md:2426
-#: src/api/reference.md:2452
+#: src/api/reference.md:2438 src/api/reference.md:2464
+#: src/api/reference.md:2490
 msgid "`_makeLong` — module"
 msgstr "`_makeLong` — 模块"
 
-#: src/api/reference.md:2401 src/api/reference.md:2427
-#: src/api/reference.md:2453
+#: src/api/reference.md:2439 src/api/reference.md:2465
+#: src/api/reference.md:2491
 msgid "`basename` — module"
 msgstr "`basename` — 模块"
 
-#: src/api/reference.md:2402 src/api/reference.md:2428
-#: src/api/reference.md:2454
+#: src/api/reference.md:2440 src/api/reference.md:2466
+#: src/api/reference.md:2492
 msgid "`dirname` — module"
 msgstr "`dirname` — 模块"
 
-#: src/api/reference.md:2403 src/api/reference.md:2429
-#: src/api/reference.md:2455
+#: src/api/reference.md:2441 src/api/reference.md:2467
+#: src/api/reference.md:2493
 msgid "`extname` — module"
 msgstr "`extname` — 模块"
 
-#: src/api/reference.md:2405 src/api/reference.md:2431
-#: src/api/reference.md:2457
+#: src/api/reference.md:2443 src/api/reference.md:2469
+#: src/api/reference.md:2495
 msgid "`isAbsolute` — module"
 msgstr "`isAbsolute` — 模块"
 
-#: src/api/reference.md:2406 src/api/reference.md:2432
-#: src/api/reference.md:2458
+#: src/api/reference.md:2444 src/api/reference.md:2470
+#: src/api/reference.md:2496
 msgid "`join` — module"
 msgstr "`join` — 模块"
 
-#: src/api/reference.md:2407 src/api/reference.md:2433
-#: src/api/reference.md:2459
+#: src/api/reference.md:2445 src/api/reference.md:2471
+#: src/api/reference.md:2497
 msgid "`matchesGlob` — module"
 msgstr "`matchesGlob` — 模块"
 
-#: src/api/reference.md:2408 src/api/reference.md:2434
-#: src/api/reference.md:2460
+#: src/api/reference.md:2446 src/api/reference.md:2472
+#: src/api/reference.md:2498
 msgid "`normalize` — module"
 msgstr "`normalize` — 模块"
 
-#: src/api/reference.md:2410 src/api/reference.md:2436
-#: src/api/reference.md:2462
+#: src/api/reference.md:2448 src/api/reference.md:2474
+#: src/api/reference.md:2500
 msgid "`relative` — module"
 msgstr "`relative` — 模块"
 
-#: src/api/reference.md:2412 src/api/reference.md:2438
-#: src/api/reference.md:2464
+#: src/api/reference.md:2450 src/api/reference.md:2476
+#: src/api/reference.md:2502
 msgid "`toNamespacedPath` — module"
 msgstr "`toNamespacedPath` — 模块"
 
-#: src/api/reference.md:2417 src/api/reference.md:2443
-#: src/api/reference.md:2469
+#: src/api/reference.md:2455 src/api/reference.md:2481
+#: src/api/reference.md:2507
 msgid "`delimiter`"
 msgstr "`delimiter`"
 
-#: src/api/reference.md:2418 src/api/reference.md:2444
-#: src/api/reference.md:2470
+#: src/api/reference.md:2456 src/api/reference.md:2482
+#: src/api/reference.md:2508
 msgid "`posix`"
 msgstr "`posix`"
 
-#: src/api/reference.md:2419 src/api/reference.md:2445
-#: src/api/reference.md:2471
+#: src/api/reference.md:2457 src/api/reference.md:2483
+#: src/api/reference.md:2509
 msgid "`sep`"
 msgstr "`sep`"
 
-#: src/api/reference.md:2420 src/api/reference.md:2446
-#: src/api/reference.md:2472
+#: src/api/reference.md:2458 src/api/reference.md:2484
+#: src/api/reference.md:2510
 msgid "`win32`"
 msgstr "`win32`"
 
-#: src/api/reference.md:2422
+#: src/api/reference.md:2460
 msgid "`path/posix`"
 msgstr "`path/posix`"
 
-#: src/api/reference.md:2448
+#: src/api/reference.md:2486
 msgid "`path/win32`"
 msgstr "`path/win32`"
 
-#: src/api/reference.md:2474
+#: src/api/reference.md:2512
 msgid "`perf_hooks`"
 msgstr "`perf_hooks`"
 
-#: src/api/reference.md:2478
+#: src/api/reference.md:2516
 msgid "`Performance`"
 msgstr "`Performance`"
 
-#: src/api/reference.md:2479
+#: src/api/reference.md:2517
 msgid "`PerformanceEntry`"
 msgstr "`PerformanceEntry`"
 
-#: src/api/reference.md:2480
+#: src/api/reference.md:2518
 msgid "`PerformanceMark`"
 msgstr "`PerformanceMark`"
 
-#: src/api/reference.md:2481
+#: src/api/reference.md:2519
 msgid "`PerformanceMeasure`"
 msgstr "`PerformanceMeasure`"
 
-#: src/api/reference.md:2482
+#: src/api/reference.md:2520
 msgid "`PerformanceObserver`"
 msgstr "`PerformanceObserver`"
 
-#: src/api/reference.md:2483
+#: src/api/reference.md:2521
 msgid "`PerformanceObserverEntryList`"
 msgstr "`PerformanceObserverEntryList`"
 
-#: src/api/reference.md:2484
+#: src/api/reference.md:2522
 msgid "`PerformanceResourceTiming`"
 msgstr "`PerformanceResourceTiming`"
 
-#: src/api/reference.md:2488
+#: src/api/reference.md:2526
 msgid "`createHistogram` — module"
 msgstr "`createHistogram` — 模块"
 
-#: src/api/reference.md:2489
+#: src/api/reference.md:2527
 msgid "`disconnect` — instance _(class: `PerformanceObserver`)_"
 msgstr "`disconnect` — 实例 _(类：`PerformanceObserver`)_"
 
-#: src/api/reference.md:2490
+#: src/api/reference.md:2528
 msgid "`eventLoopUtilization` — module"
 msgstr "模块 `eventLoopUtilization`"
 
-#: src/api/reference.md:2491
+#: src/api/reference.md:2529
 msgid "`monitorEventLoopDelay` — module"
 msgstr "`monitorEventLoopDelay` — 模块"
 
-#: src/api/reference.md:2492
+#: src/api/reference.md:2530
 msgid "`observe` — instance _(class: `PerformanceObserver`)_"
 msgstr "`observe` — 实例 _(类：`PerformanceObserver`)_"
 
-#: src/api/reference.md:2493
+#: src/api/reference.md:2531
 msgid "`takeRecords` — instance _(class: `PerformanceObserver`)_"
 msgstr "`takeRecords` — 实例 _(类：`PerformanceObserver`)_"
 
-#: src/api/reference.md:2494
+#: src/api/reference.md:2532
 msgid "`timerify` — module"
 msgstr "`timerify` — 模块"
 
-#: src/api/reference.md:2500
+#: src/api/reference.md:2538
 msgid "`performance`"
 msgstr "`performance`"
 
-#: src/api/reference.md:2502 src/contributing/architecture.md:26
+#: src/api/reference.md:2540 src/contributing/architecture.md:26
 msgid "`perry`"
 msgstr "`perry`"
 
-#: src/api/reference.md:2506
+#: src/api/reference.md:2544
 msgid "`embeddedFiles` — module"
 msgstr "模块 `embeddedFiles`"
 
-#: src/api/reference.md:2507
+#: src/api/reference.md:2545
 msgid "`readEmbedded` — module"
 msgstr "模块 `readEmbedded`"
 
-#: src/api/reference.md:2511
-msgid "`isStandaloneExecutable`"
-msgstr "`isStandaloneExecutable`"
-
-#: src/api/reference.md:2517
+#: src/api/reference.md:2555
 msgid "`js_ads_banner_create` — module"
 msgstr "`js_ads_banner_create` — 模块"
 
-#: src/api/reference.md:2518
+#: src/api/reference.md:2556
 msgid "`js_ads_banner_destroy` — module"
 msgstr "`js_ads_banner_destroy` — 模块"
 
-#: src/api/reference.md:2519
+#: src/api/reference.md:2557
 msgid "`js_ads_interstitial_load` — module"
 msgstr "`js_ads_interstitial_load` — 模块"
 
-#: src/api/reference.md:2520
+#: src/api/reference.md:2558
 msgid "`js_ads_interstitial_show` — module"
 msgstr "`js_ads_interstitial_show` — 模块"
 
-#: src/api/reference.md:2521
+#: src/api/reference.md:2559
 msgid "`js_ads_request_consent` — module"
 msgstr "模块 `js_ads_request_consent`"
 
-#: src/api/reference.md:2522
+#: src/api/reference.md:2560
 msgid "`js_ads_rewarded_load` — module"
 msgstr "`js_ads_rewarded_load` — 模块"
 
-#: src/api/reference.md:2523
+#: src/api/reference.md:2561
 msgid "`js_ads_rewarded_show` — module"
 msgstr "`js_ads_rewarded_show` — 模块"
 
-#: src/api/reference.md:2525
+#: src/api/reference.md:2563
 msgid "`perry/audio`"
 msgstr "`perry/audio`"
 
-#: src/api/reference.md:2529
+#: src/api/reference.md:2567
 msgid "`createBus` — module"
 msgstr "`createBus` — 模块"
 
-#: src/api/reference.md:2530
+#: src/api/reference.md:2568
 msgid "`crossfade` — module"
 msgstr "`crossfade` — 模块"
 
-#: src/api/reference.md:2531
+#: src/api/reference.md:2569
 msgid "`destroyBus` — module"
 msgstr "`destroyBus` — 模块"
 
-#: src/api/reference.md:2532
+#: src/api/reference.md:2570
 msgid "`fadeIn` — module"
 msgstr "`fadeIn` — 模块"
 
-#: src/api/reference.md:2533
+#: src/api/reference.md:2571
 msgid "`fadeOut` — module"
 msgstr "`fadeOut` — 模块"
 
-#: src/api/reference.md:2534 src/api/reference.md:2658
+#: src/api/reference.md:2572 src/api/reference.md:2696
 msgid "`getDuration` — module"
 msgstr "`getDuration` — 模块"
 
-#: src/api/reference.md:2535
+#: src/api/reference.md:2573
 msgid "`getPosition` — module"
 msgstr "`getPosition` — 模块"
 
-#: src/api/reference.md:2536 src/api/reference.md:2660
+#: src/api/reference.md:2574 src/api/reference.md:2698
 msgid "`isPlaying` — module"
 msgstr "`isPlaying` — 模块"
 
-#: src/api/reference.md:2537
+#: src/api/reference.md:2575
 msgid "`loadSound` — module"
 msgstr "`loadSound` — 模块"
 
-#: src/api/reference.md:2538
+#: src/api/reference.md:2576
 msgid "`muteBus` — module"
 msgstr "`muteBus` — 模块"
 
-#: src/api/reference.md:2539
+#: src/api/reference.md:2577
 msgid "`onEnded` — module"
 msgstr "`onEnded` — 模块"
 
-#: src/api/reference.md:2540
+#: src/api/reference.md:2578
 msgid "`onLoaded` — module"
 msgstr "`onLoaded` — 模块"
 
-#: src/api/reference.md:2541 src/api/reference.md:2663
+#: src/api/reference.md:2579 src/api/reference.md:2701
 msgid "`pause` — module"
 msgstr "`pause` — 模块"
 
-#: src/api/reference.md:2542 src/api/reference.md:2664
+#: src/api/reference.md:2580 src/api/reference.md:2702
 msgid "`play` — module"
 msgstr "`play` — 模块"
 
-#: src/api/reference.md:2543
+#: src/api/reference.md:2581
 msgid "`resume` — module"
 msgstr "`resume` — 模块"
 
-#: src/api/reference.md:2544
+#: src/api/reference.md:2582
 msgid "`resumeAll` — module"
 msgstr "`resumeAll` — 模块"
 
-#: src/api/reference.md:2545
+#: src/api/reference.md:2583
 msgid "`setMasterVolume` — module"
 msgstr "`setMasterVolume` — 模块"
 
-#: src/api/reference.md:2546
+#: src/api/reference.md:2584
 msgid "`setPan` — module"
 msgstr "`setPan` — 模块"
 
-#: src/api/reference.md:2547 src/api/reference.md:2667
+#: src/api/reference.md:2585 src/api/reference.md:2705
 msgid "`setRate` — module"
 msgstr "`setRate` — 模块"
 
-#: src/api/reference.md:2548 src/api/reference.md:2668
+#: src/api/reference.md:2586 src/api/reference.md:2706
 msgid "`setVolume` — module"
 msgstr "`setVolume` — 模块"
 
-#: src/api/reference.md:2549
+#: src/api/reference.md:2587
 msgid "`soloBus` — module"
 msgstr "`soloBus` — 模块"
 
-#: src/api/reference.md:2550 src/api/reference.md:2573
-#: src/api/reference.md:2602 src/api/reference.md:2615
-#: src/api/reference.md:2669
+#: src/api/reference.md:2588 src/api/reference.md:2611
+#: src/api/reference.md:2640 src/api/reference.md:2653
+#: src/api/reference.md:2707
 msgid "`stop` — module"
 msgstr "`stop` — 模块"
 
-#: src/api/reference.md:2551
+#: src/api/reference.md:2589
 msgid "`suspend` — module"
 msgstr "`suspend` — 模块"
 
-#: src/api/reference.md:2552
+#: src/api/reference.md:2590
 msgid "`unload` — module"
 msgstr "`unload` — 模块"
 
-#: src/api/reference.md:2554
+#: src/api/reference.md:2592
 msgid "`perry/background`"
 msgstr "`perry/background`"
 
-#: src/api/reference.md:2558
+#: src/api/reference.md:2596
 msgid "`cancel` — module"
 msgstr "`cancel` — 模块"
 
-#: src/api/reference.md:2559
+#: src/api/reference.md:2597
 msgid "`registerTask` — module"
 msgstr "`registerTask` — 模块"
 
-#: src/api/reference.md:2562
+#: src/api/reference.md:2600
 msgid "`perry/compose`"
 msgstr "`perry/compose`"
 
-#: src/api/reference.md:2567 src/api/reference.md:2609
+#: src/api/reference.md:2605 src/api/reference.md:2647
 msgid "`down` — module"
 msgstr "`down` — 模块"
 
-#: src/api/reference.md:2569 src/api/reference.md:2592
-#: src/api/reference.md:2611
+#: src/api/reference.md:2607 src/api/reference.md:2630
+#: src/api/reference.md:2649
 msgid "`logs` — module"
 msgstr "`logs` — 模块"
 
-#: src/api/reference.md:2570 src/api/reference.md:2612
+#: src/api/reference.md:2608 src/api/reference.md:2650
 msgid "`ps` — module"
 msgstr "`ps` — 模块"
 
-#: src/api/reference.md:2571 src/api/reference.md:2613
+#: src/api/reference.md:2609 src/api/reference.md:2651
 msgid "`restart` — module"
 msgstr "`restart` — 模块"
 
-#: src/api/reference.md:2572 src/api/reference.md:2601
-#: src/api/reference.md:2614
+#: src/api/reference.md:2610 src/api/reference.md:2639
+#: src/api/reference.md:2652
 msgid "`start` — module"
 msgstr "`start` — 模块"
 
-#: src/api/reference.md:2574 src/api/reference.md:2616
+#: src/api/reference.md:2612 src/api/reference.md:2654
 msgid "`up` — module"
 msgstr "`up` — 模块"
 
-#: src/api/reference.md:2576
+#: src/api/reference.md:2614
 msgid "`perry/container`"
 msgstr "`perry/container`"
 
-#: src/api/reference.md:2580
+#: src/api/reference.md:2618
 msgid "`composeUp` — module"
 msgstr "`composeUp` — 模块"
 
-#: src/api/reference.md:2582
+#: src/api/reference.md:2620
 msgid "`detectBackend` — module"
 msgstr "`detectBackend` — 模块"
 
-#: src/api/reference.md:2583
+#: src/api/reference.md:2621
 msgid "`downAll` — module"
 msgstr "`downAll` — 模块"
 
-#: src/api/reference.md:2584
+#: src/api/reference.md:2622
 msgid "`downByProject` — module"
 msgstr "`downByProject` — 模块"
 
-#: src/api/reference.md:2586
+#: src/api/reference.md:2624
 msgid "`getAvailableBackends` — module"
 msgstr "`getAvailableBackends` — 模块"
 
-#: src/api/reference.md:2587
+#: src/api/reference.md:2625
 msgid "`getBackend` — module"
 msgstr "`getBackend` — 模块"
 
-#: src/api/reference.md:2588
+#: src/api/reference.md:2626
 msgid "`getBackendPriority` — module"
 msgstr "`getBackendPriority` — 模块"
 
-#: src/api/reference.md:2589 src/api/reference.md:3569
-#: src/api/reference.md:3844
+#: src/api/reference.md:2627 src/api/reference.md:3607
+#: src/api/reference.md:3882
 msgid "`inspect` — module"
 msgstr "`inspect` — 模块"
 
-#: src/api/reference.md:2590
+#: src/api/reference.md:2628
 msgid "`list` — module"
 msgstr "`list` — 模块"
 
-#: src/api/reference.md:2591
+#: src/api/reference.md:2629
 msgid "`listImages` — module"
 msgstr "`listImages` — 模块"
 
-#: src/api/reference.md:2593
+#: src/api/reference.md:2631
 msgid "`pullImage` — module"
 msgstr "`pullImage` — 模块"
 
-#: src/api/reference.md:2594
+#: src/api/reference.md:2632
 msgid "`remove` — module"
 msgstr "`remove` — 模块"
 
-#: src/api/reference.md:2595
+#: src/api/reference.md:2633
 msgid "`removeIfExists` — module"
 msgstr "`removeIfExists` — 模块"
 
-#: src/api/reference.md:2596
+#: src/api/reference.md:2634
 msgid "`removeImage` — module"
 msgstr "`removeImage` — 模块"
 
-#: src/api/reference.md:2597 src/api/reference.md:2824
-#: src/api/reference.md:3607
+#: src/api/reference.md:2635 src/api/reference.md:2862
+#: src/api/reference.md:3645
 msgid "`run` — module"
 msgstr "`run` — 模块"
 
-#: src/api/reference.md:2598
+#: src/api/reference.md:2636
 msgid "`selectBackendFor` — module"
 msgstr "`selectBackendFor` — 模块"
 
-#: src/api/reference.md:2599
+#: src/api/reference.md:2637
 msgid "`setBackend` — module"
 msgstr "`setBackend` — 模块"
 
-#: src/api/reference.md:2600
+#: src/api/reference.md:2638
 msgid "`setBackends` — module"
 msgstr "`setBackends` — 模块"
 
-#: src/api/reference.md:2604
+#: src/api/reference.md:2642
 msgid "`perry/container-compose`"
 msgstr "`perry/container-compose`"
 
-#: src/api/reference.md:2618
+#: src/api/reference.md:2656
 msgid "`perry/gc`"
 msgstr "`perry/gc`"
 
-#: src/api/reference.md:2622
+#: src/api/reference.md:2660
 msgid "`collect` — module"
 msgstr "模块 `collect`"
 
-#: src/api/reference.md:2623
+#: src/api/reference.md:2661
 msgid "`idleHint` — module"
 msgstr "模块 `idleHint`"
 
-#: src/api/reference.md:2624
+#: src/api/reference.md:2662
 msgid "`minor` — module"
 msgstr "模块 `minor`"
 
-#: src/api/reference.md:2626
+#: src/api/reference.md:2664
 msgid "`perry/i18n`"
 msgstr "`perry/i18n`"
 
-#: src/api/reference.md:2630
+#: src/api/reference.md:2668
 msgid "`Currency` — module"
 msgstr "`Currency` — 模块"
 
-#: src/api/reference.md:2631
+#: src/api/reference.md:2669
 msgid "`FormatNumber` — module"
 msgstr "`FormatNumber` — 模块"
 
-#: src/api/reference.md:2632
+#: src/api/reference.md:2670
 msgid "`FormatTime` — module"
 msgstr "`FormatTime` — 模块"
 
-#: src/api/reference.md:2633
+#: src/api/reference.md:2671
 msgid "`LongDate` — module"
 msgstr "`LongDate` — 模块"
 
-#: src/api/reference.md:2634
+#: src/api/reference.md:2672
 msgid "`Percent` — module"
 msgstr "`Percent` — 模块"
 
-#: src/api/reference.md:2635
+#: src/api/reference.md:2673
 msgid "`Raw` — module"
 msgstr "`Raw` — 模块"
 
-#: src/api/reference.md:2636
+#: src/api/reference.md:2674
 msgid "`ShortDate` — module"
 msgstr "`ShortDate` — 模块"
 
-#: src/api/reference.md:2637
+#: src/api/reference.md:2675
 msgid "`t` — module"
 msgstr "`t` — 模块"
 
-#: src/api/reference.md:2639
+#: src/api/reference.md:2677
 msgid "`perry/ios`"
 msgstr "`perry/ios`"
 
-#: src/api/reference.md:2643
+#: src/api/reference.md:2681
 msgid "`createLanguageModelSession` — module"
 msgstr "模块 `createLanguageModelSession`"
 
-#: src/api/reference.md:2644
+#: src/api/reference.md:2682
 msgid "`destroyLanguageModelSession` — module"
 msgstr "模块 `destroyLanguageModelSession`"
 
-#: src/api/reference.md:2645
+#: src/api/reference.md:2683
 msgid "`foundationModelAvailability` — module"
 msgstr "模块 `foundationModelAvailability`"
 
-#: src/api/reference.md:2646
+#: src/api/reference.md:2684
 msgid "`getLayoutEnvironment` — module"
 msgstr "模块 `getLayoutEnvironment`"
 
-#: src/api/reference.md:2647
+#: src/api/reference.md:2685
 msgid "`offLayoutChange` — module"
 msgstr "模块 `offLayoutChange`"
 
-#: src/api/reference.md:2648
+#: src/api/reference.md:2686
 msgid "`onLayoutChange` — module"
 msgstr "模块 `onLayoutChange`"
 
-#: src/api/reference.md:2649
+#: src/api/reference.md:2687
 msgid "`respond` — module"
 msgstr "模块 `respond`"
 
-#: src/api/reference.md:2651
+#: src/api/reference.md:2689
 msgid "`perry/media`"
 msgstr "`perry/media`"
 
-#: src/api/reference.md:2655
+#: src/api/reference.md:2693
 msgid "`createPlayer` — module"
 msgstr "`createPlayer` — 模块"
 
-#: src/api/reference.md:2656
+#: src/api/reference.md:2694
 msgid "`destroy` — module"
 msgstr "`destroy` — 模块"
 
-#: src/api/reference.md:2657
+#: src/api/reference.md:2695
 msgid "`getCurrentTime` — module"
 msgstr "`getCurrentTime` — 模块"
 
-#: src/api/reference.md:2659
+#: src/api/reference.md:2697
 msgid "`getState` — module"
 msgstr "`getState` — 模块"
 
-#: src/api/reference.md:2661
+#: src/api/reference.md:2699
 msgid "`onStateChange` — module"
 msgstr "`onStateChange` — 模块"
 
-#: src/api/reference.md:2662
+#: src/api/reference.md:2700
 msgid "`onTimeUpdate` — module"
 msgstr "`onTimeUpdate` — 模块"
 
-#: src/api/reference.md:2665
+#: src/api/reference.md:2703
 msgid "`seek` — module"
 msgstr "`seek` — 模块"
 
-#: src/api/reference.md:2666
+#: src/api/reference.md:2704
 msgid "`setNowPlaying` — module"
 msgstr "`setNowPlaying` — 模块"
 
-#: src/api/reference.md:2671
+#: src/api/reference.md:2709
 msgid "`perry/native`"
 msgstr "`perry/native`"
 
-#: src/api/reference.md:2675
+#: src/api/reference.md:2713
 msgid "`alignof` — module _(intrinsic)_"
 msgstr "`alignof` 模块 _ ((内在)"
 
-#: src/api/reference.md:2676
+#: src/api/reference.md:2714
 msgid "`f32` — module"
 msgstr "模块 `f32`"
 
-#: src/api/reference.md:2677
+#: src/api/reference.md:2715
 msgid "`f64` — module"
 msgstr "模块 `f64`"
 
-#: src/api/reference.md:2678
+#: src/api/reference.md:2716
 msgid "`i16` — module"
 msgstr "模块 `i16`"
 
-#: src/api/reference.md:2679
+#: src/api/reference.md:2717
 msgid "`i32` — module"
 msgstr "模块 `i32`"
 
-#: src/api/reference.md:2680
+#: src/api/reference.md:2718
 msgid "`i64` — module"
 msgstr "模块 `i64`"
 
-#: src/api/reference.md:2681
+#: src/api/reference.md:2719
 msgid "`i8` — module"
 msgstr "模块 `i8`"
 
-#: src/api/reference.md:2682
+#: src/api/reference.md:2720
 msgid "`isize` — module"
 msgstr "模块 `isize`"
 
-#: src/api/reference.md:2683
+#: src/api/reference.md:2721
 msgid "`offsetof` — module _(intrinsic)_"
 msgstr "`offsetof` 模块 _ ((内在)"
 
-#: src/api/reference.md:2684
+#: src/api/reference.md:2722
 msgid "`sizeof` — module _(intrinsic)_"
 msgstr "`sizeof` 模块 _ ((内在)"
 
-#: src/api/reference.md:2685
+#: src/api/reference.md:2723
 msgid "`u16` — module"
 msgstr "模块 `u16`"
 
-#: src/api/reference.md:2686
+#: src/api/reference.md:2724
 msgid "`u32` — module"
 msgstr "模块 `u32`"
 
-#: src/api/reference.md:2687
+#: src/api/reference.md:2725
 msgid "`u64` — module"
 msgstr "模块 `u64`"
 
-#: src/api/reference.md:2688
+#: src/api/reference.md:2726
 msgid "`u8` — module"
 msgstr "模块 `u8`"
 
-#: src/api/reference.md:2689
+#: src/api/reference.md:2727
 msgid "`usize` — module"
 msgstr "模块 `usize`"
 
-#: src/api/reference.md:2693
+#: src/api/reference.md:2731
 msgid "`NativeArena`"
 msgstr "`NativeArena`"
 
-#: src/api/reference.md:2695
+#: src/api/reference.md:2733
 msgid "`perry/plugin`"
 msgstr "`perry/plugin`"
 
-#: src/api/reference.md:2699
+#: src/api/reference.md:2737
 msgid "`PluginApi`"
 msgstr "`PluginApi`"
 
-#: src/api/reference.md:2703
+#: src/api/reference.md:2741
 msgid "`discoverPlugins` — module"
 msgstr "`discoverPlugins` — 模块"
 
-#: src/api/reference.md:2704
+#: src/api/reference.md:2742
 msgid "`emitEvent` — module"
 msgstr "`emitEvent` — 模块"
 
-#: src/api/reference.md:2705
+#: src/api/reference.md:2743
 msgid "`emitHook` — module"
 msgstr "`emitHook` — 模块"
 
-#: src/api/reference.md:2706
+#: src/api/reference.md:2744
 msgid "`initPlugins` — module"
 msgstr "`initPlugins` — 模块"
 
-#: src/api/reference.md:2707
+#: src/api/reference.md:2745
 msgid "`invokeTool` — module"
 msgstr "`invokeTool` — 模块"
 
-#: src/api/reference.md:2708
+#: src/api/reference.md:2746
 msgid "`listHooks` — module"
 msgstr "`listHooks` — 模块"
 
-#: src/api/reference.md:2709
+#: src/api/reference.md:2747
 msgid "`listPlugins` — module"
 msgstr "`listPlugins` — 模块"
 
-#: src/api/reference.md:2710
+#: src/api/reference.md:2748
 msgid "`listTools` — module"
 msgstr "`listTools` — 模块"
 
-#: src/api/reference.md:2711
+#: src/api/reference.md:2749
 msgid "`loadPlugin` — module"
 msgstr "`loadPlugin` — 模块"
 
-#: src/api/reference.md:2712
+#: src/api/reference.md:2750
 msgid "`pluginCount` — module"
 msgstr "`pluginCount` — 模块"
 
-#: src/api/reference.md:2713
+#: src/api/reference.md:2751
 msgid "`setPluginConfig` — module"
 msgstr "`setPluginConfig` — 模块"
 
-#: src/api/reference.md:2714
+#: src/api/reference.md:2752
 msgid "`unloadPlugin` — module"
 msgstr "`unloadPlugin` — 模块"
 
-#: src/api/reference.md:2716
+#: src/api/reference.md:2754
 msgid "`perry/system`"
 msgstr "`perry/system`"
 
-#: src/api/reference.md:2720
+#: src/api/reference.md:2758
 msgid "`appGetLaunchUrl` — module"
 msgstr "`appGetLaunchUrl` — 模块"
 
-#: src/api/reference.md:2721
+#: src/api/reference.md:2759
 msgid "`appGroupDelete` — module"
 msgstr "`appGroupDelete` — 模块"
 
-#: src/api/reference.md:2722
+#: src/api/reference.md:2760
 msgid "`appGroupGet` — module"
 msgstr "`appGroupGet` — 模块"
 
-#: src/api/reference.md:2723
+#: src/api/reference.md:2761
 msgid "`appGroupSet` — module"
 msgstr "`appGroupSet` — 模块"
 
-#: src/api/reference.md:2724
+#: src/api/reference.md:2762
 msgid "`appOnOpenUrl` — module"
 msgstr "`appOnOpenUrl` — 模块"
 
-#: src/api/reference.md:2725
+#: src/api/reference.md:2763
 msgid "`audioGetLevel` — module"
 msgstr "`audioGetLevel` — 模块"
 
-#: src/api/reference.md:2726
+#: src/api/reference.md:2764
 msgid "`audioGetPeak` — module"
 msgstr "`audioGetPeak` — 模块"
 
-#: src/api/reference.md:2727
+#: src/api/reference.md:2765
 msgid "`audioGetWaveform` — module"
 msgstr "`audioGetWaveform` — 模块"
 
-#: src/api/reference.md:2728
+#: src/api/reference.md:2766
 msgid "`audioRegisterCallback` — module"
 msgstr "`audioRegisterCallback` — 模块"
 
-#: src/api/reference.md:2729
+#: src/api/reference.md:2767
 msgid "`audioSetOutputFilename` — module"
 msgstr "`audioSetOutputFilename` — 模块"
 
-#: src/api/reference.md:2730
+#: src/api/reference.md:2768
 msgid "`audioStart` — module"
 msgstr "`audioStart` — 模块"
 
-#: src/api/reference.md:2731
+#: src/api/reference.md:2769
 msgid "`audioStartRecording` — module"
 msgstr "`audioStartRecording` — 模块"
 
-#: src/api/reference.md:2732
+#: src/api/reference.md:2770
 msgid "`audioStop` — module"
 msgstr "`audioStop` — 模块"
 
-#: src/api/reference.md:2733
+#: src/api/reference.md:2771
 msgid "`audioStopRecording` — module"
 msgstr "`audioStopRecording` — 模块"
 
-#: src/api/reference.md:2734
+#: src/api/reference.md:2772
 msgid "`audioUnregisterCallback` — module"
 msgstr "`audioUnregisterCallback` — 模块"
 
-#: src/api/reference.md:2735
+#: src/api/reference.md:2773
 msgid "`geolocationGetCurrent` — module"
 msgstr "`geolocationGetCurrent` — 模块"
 
-#: src/api/reference.md:2736
+#: src/api/reference.md:2774
 msgid "`geolocationRequestPermission` — module"
 msgstr "`geolocationRequestPermission` — 模块"
 
-#: src/api/reference.md:2737
+#: src/api/reference.md:2775
 msgid "`geolocationStopWatch` — module"
 msgstr "`geolocationStopWatch` — 模块"
 
-#: src/api/reference.md:2738
+#: src/api/reference.md:2776
 msgid "`geolocationWatch` — module"
 msgstr "`geolocationWatch` — 模块"
 
-#: src/api/reference.md:2739
+#: src/api/reference.md:2777
 msgid "`getAppBuildNumber` — module"
 msgstr "`getAppBuildNumber` — 模块"
 
-#: src/api/reference.md:2740
+#: src/api/reference.md:2778
 msgid "`getAppIcon` — module"
 msgstr "`getAppIcon` — 模块"
 
-#: src/api/reference.md:2741
+#: src/api/reference.md:2779
 msgid "`getAppVersion` — module"
 msgstr "`getAppVersion` — 模块"
 
-#: src/api/reference.md:2742
+#: src/api/reference.md:2780
 msgid "`getBundleId` — module"
 msgstr "`getBundleId` — 模块"
 
-#: src/api/reference.md:2743
+#: src/api/reference.md:2781
 msgid "`getDeviceIdiom` — module"
 msgstr "`getDeviceIdiom` — 模块"
 
-#: src/api/reference.md:2744
+#: src/api/reference.md:2782
 msgid "`getDeviceModel` — module"
 msgstr "`getDeviceModel` — 模块"
 
-#: src/api/reference.md:2745
+#: src/api/reference.md:2783
 msgid "`getLocale` — module"
 msgstr "`getLocale` — 模块"
 
-#: src/api/reference.md:2746
+#: src/api/reference.md:2784
 msgid "`getOSVersion` — module"
 msgstr "`getOSVersion` — 模块"
 
-#: src/api/reference.md:2747
+#: src/api/reference.md:2785
 msgid "`getSafeAreaInsets` — module"
 msgstr "`getSafeAreaInsets` — 模块"
 
-#: src/api/reference.md:2748
+#: src/api/reference.md:2786
 msgid "`hapticPlay` — module"
 msgstr "模块 `hapticPlay`"
 
-#: src/api/reference.md:2749
+#: src/api/reference.md:2787
 msgid "`imagePickerPick` — module"
 msgstr "`imagePickerPick` — 模块"
 
-#: src/api/reference.md:2750
+#: src/api/reference.md:2788
 msgid "`isDarkMode` — module"
 msgstr "`isDarkMode` — 模块"
 
-#: src/api/reference.md:2751
+#: src/api/reference.md:2789
 msgid "`keychainDelete` — module"
 msgstr "`keychainDelete` — 模块"
 
-#: src/api/reference.md:2752
+#: src/api/reference.md:2790
 msgid "`keychainGet` — module"
 msgstr "`keychainGet` — 模块"
 
-#: src/api/reference.md:2753
+#: src/api/reference.md:2791
 msgid "`keychainSave` — module"
 msgstr "`keychainSave` — 模块"
 
-#: src/api/reference.md:2754
+#: src/api/reference.md:2792
 msgid "`networkGetStatus` — module"
 msgstr "`networkGetStatus` — 模块"
 
-#: src/api/reference.md:2755
+#: src/api/reference.md:2793
 msgid "`networkOnChange` — module"
 msgstr "`networkOnChange` — 模块"
 
-#: src/api/reference.md:2756
+#: src/api/reference.md:2794
 msgid "`networkStopOnChange` — module"
 msgstr "`networkStopOnChange` — 模块"
 
-#: src/api/reference.md:2757
+#: src/api/reference.md:2795
 msgid "`notificationCancel` — module"
 msgstr "`notificationCancel` — 模块"
 
-#: src/api/reference.md:2758
+#: src/api/reference.md:2796
 msgid "`notificationOnBackgroundReceive` — module"
 msgstr "`notificationOnBackgroundReceive` — 模块"
 
-#: src/api/reference.md:2759
+#: src/api/reference.md:2797
 msgid "`notificationOnReceive` — module"
 msgstr "`notificationOnReceive` — 模块"
 
-#: src/api/reference.md:2760
+#: src/api/reference.md:2798
 msgid "`notificationOnTap` — module"
 msgstr "`notificationOnTap` — 模块"
 
-#: src/api/reference.md:2761
+#: src/api/reference.md:2799
 msgid "`notificationRegisterRemote` — module"
 msgstr "`notificationRegisterRemote` — 模块"
 
-#: src/api/reference.md:2762
+#: src/api/reference.md:2800
 msgid "`notificationSend` — module"
 msgstr "`notificationSend` — 模块"
 
-#: src/api/reference.md:2763
+#: src/api/reference.md:2801
 msgid "`openURL` — module"
 msgstr "`openURL` — 模块"
 
-#: src/api/reference.md:2764
+#: src/api/reference.md:2802
 msgid "`preferencesGet` — module"
 msgstr "`preferencesGet` — 模块"
 
-#: src/api/reference.md:2765
+#: src/api/reference.md:2803
 msgid "`preferencesSet` — module"
 msgstr "`preferencesSet` — 模块"
 
-#: src/api/reference.md:2766
+#: src/api/reference.md:2804
 msgid "`shareText` — module"
 msgstr "`shareText` — 模块"
 
-#: src/api/reference.md:2767
+#: src/api/reference.md:2805
 msgid "`shareUrl` — module"
 msgstr "`shareUrl` — 模块"
 
-#: src/api/reference.md:2768
+#: src/api/reference.md:2806
 msgid "`takeScreenshot` — module"
 msgstr "`takeScreenshot` — 模块"
 
-#: src/api/reference.md:2770
+#: src/api/reference.md:2808
 msgid "`perry/thread`"
 msgstr "`perry/thread`"
 
-#: src/api/reference.md:2774
+#: src/api/reference.md:2812
 msgid "`parallelFilter` — module"
 msgstr "`parallelFilter` — 模块"
 
-#: src/api/reference.md:2775
+#: src/api/reference.md:2813
 msgid "`parallelMap` — module"
 msgstr "`parallelMap` — 模块"
 
-#: src/api/reference.md:2782
+#: src/api/reference.md:2820
 msgid "`AnimatedSpinner` — module"
 msgstr "`AnimatedSpinner` — 模块"
 
-#: src/api/reference.md:2783
+#: src/api/reference.md:2821
 msgid "`Box` — module"
 msgstr "`Box` — 模块"
 
-#: src/api/reference.md:2784
+#: src/api/reference.md:2822
 msgid "`Input` — module"
 msgstr "`Input` — 模块"
 
-#: src/api/reference.md:2785
+#: src/api/reference.md:2823
 msgid "`InputAt` — module"
 msgstr "`InputAt` — 模块"
 
-#: src/api/reference.md:2786
+#: src/api/reference.md:2824
 msgid "`List` — module"
 msgstr "`List` — 模块"
 
-#: src/api/reference.md:2787
+#: src/api/reference.md:2825
 msgid "`ProgressBar` — module"
 msgstr "`ProgressBar` — 模块"
 
-#: src/api/reference.md:2788
+#: src/api/reference.md:2826
 msgid "`Select` — module"
 msgstr "`Select` — 模块"
 
-#: src/api/reference.md:2789 src/api/reference.md:2870
+#: src/api/reference.md:2827 src/api/reference.md:2908
 msgid "`Spacer` — module"
 msgstr "`Spacer` — 模块"
 
-#: src/api/reference.md:2790
+#: src/api/reference.md:2828
 msgid "`Spinner` — module"
 msgstr "`Spinner` — 模块"
 
-#: src/api/reference.md:2791 src/api/reference.md:2874
+#: src/api/reference.md:2829 src/api/reference.md:2912
 msgid "`Table` — module"
 msgstr "`Table` — 模块"
 
-#: src/api/reference.md:2792
+#: src/api/reference.md:2830
 msgid "`Tabs` — module"
 msgstr "`Tabs` — 模块"
 
-#: src/api/reference.md:2793 src/api/reference.md:2875
+#: src/api/reference.md:2831 src/api/reference.md:2913
 msgid "`Text` — module"
 msgstr "`Text` — 模块"
 
-#: src/api/reference.md:2794 src/api/reference.md:2876
+#: src/api/reference.md:2832 src/api/reference.md:2914
 msgid "`TextArea` — module"
 msgstr "`TextArea` — 模块"
 
-#: src/api/reference.md:2795
+#: src/api/reference.md:2833
 msgid "`TextStyled` — module"
 msgstr "`TextStyled` — 模块"
 
-#: src/api/reference.md:2796
+#: src/api/reference.md:2834
 msgid "`boxSetAlignItems` — module"
 msgstr "`boxSetAlignItems` — 模块"
 
-#: src/api/reference.md:2797
+#: src/api/reference.md:2835
 msgid "`boxSetFlexBasis` — module"
 msgstr "`boxSetFlexBasis` — 模块"
 
-#: src/api/reference.md:2798
+#: src/api/reference.md:2836
 msgid "`boxSetFlexBasisPct` — module"
 msgstr "`boxSetFlexBasisPct` — 模块"
 
-#: src/api/reference.md:2799
+#: src/api/reference.md:2837
 msgid "`boxSetFlexDirection` — module"
 msgstr "`boxSetFlexDirection` — 模块"
 
-#: src/api/reference.md:2800
+#: src/api/reference.md:2838
 msgid "`boxSetFlexGrow` — module"
 msgstr "`boxSetFlexGrow` — 模块"
 
-#: src/api/reference.md:2801
+#: src/api/reference.md:2839
 msgid "`boxSetFlexShrink` — module"
 msgstr "`boxSetFlexShrink` — 模块"
 
-#: src/api/reference.md:2802
+#: src/api/reference.md:2840
 msgid "`boxSetGap` — module"
 msgstr "`boxSetGap` — 模块"
 
-#: src/api/reference.md:2803
+#: src/api/reference.md:2841
 msgid "`boxSetHeight` — module"
 msgstr "`boxSetHeight` — 模块"
 
-#: src/api/reference.md:2804
+#: src/api/reference.md:2842
 msgid "`boxSetHeightPct` — module"
 msgstr "`boxSetHeightPct` — 模块"
 
-#: src/api/reference.md:2805
+#: src/api/reference.md:2843
 msgid "`boxSetJustifyContent` — module"
 msgstr "`boxSetJustifyContent` — 模块"
 
-#: src/api/reference.md:2806
+#: src/api/reference.md:2844
 msgid "`boxSetPadding` — module"
 msgstr "`boxSetPadding` — 模块"
 
-#: src/api/reference.md:2807
+#: src/api/reference.md:2845
 msgid "`boxSetPaddingEach` — module"
 msgstr "`boxSetPaddingEach` — 模块"
 
-#: src/api/reference.md:2808
+#: src/api/reference.md:2846
 msgid "`boxSetWidth` — module"
 msgstr "`boxSetWidth` — 模块"
 
-#: src/api/reference.md:2809
+#: src/api/reference.md:2847
 msgid "`boxSetWidthPct` — module"
 msgstr "`boxSetWidthPct` — 模块"
 
-#: src/api/reference.md:2810
+#: src/api/reference.md:2848
 msgid "`columns` — instance _(class: `TuiStdout`)_"
 msgstr "`columns` — 实例 _(类：`TuiStdout`)_"
 
-#: src/api/reference.md:2811
+#: src/api/reference.md:2849
 msgid "`enter` — module"
 msgstr "`enter` — 模块"
 
-#: src/api/reference.md:2812 src/api/reference.md:3078
+#: src/api/reference.md:2850 src/api/reference.md:3116
 msgid "`exit` — module"
 msgstr "`exit` — 模块"
 
-#: src/api/reference.md:2813
+#: src/api/reference.md:2851
 msgid "`exit` — instance _(class: `TuiApp`)_"
 msgstr "`exit` — 实例 _(类：`TuiApp`)_"
 
-#: src/api/reference.md:2814 src/api/reference.md:2914
+#: src/api/reference.md:2852 src/api/reference.md:2952
 msgid "`focus` — module"
 msgstr "`focus` — 模块"
 
-#: src/api/reference.md:2815
+#: src/api/reference.md:2853
 msgid "`focus` — instance _(class: `FocusManager`)_"
 msgstr "`focus` — 实例 _(类：`FocusManager`)_"
 
-#: src/api/reference.md:2816
+#: src/api/reference.md:2854
 msgid "`focusNext` — module"
 msgstr "`focusNext` — 模块"
 
-#: src/api/reference.md:2817
+#: src/api/reference.md:2855
 msgid "`focusNext` — instance _(class: `FocusManager`)_"
 msgstr "`focusNext` — 实例 _(类：`FocusManager`)_"
 
-#: src/api/reference.md:2818
+#: src/api/reference.md:2856
 msgid "`focusPrevious` — module"
 msgstr "`focusPrevious` — 模块"
 
-#: src/api/reference.md:2819
+#: src/api/reference.md:2857
 msgid "`focusPrevious` — instance _(class: `FocusManager`)_"
 msgstr "`focusPrevious` — 实例 _(类：`FocusManager`)_"
 
-#: src/api/reference.md:2820
+#: src/api/reference.md:2858
 msgid "`get` — instance _(class: `State`)_"
 msgstr "`get` — 实例 _(类:`State`)_"
 
-#: src/api/reference.md:2821
+#: src/api/reference.md:2859
 msgid "`get` — instance _(class: `RefBox`)_"
 msgstr "`get` — 实例 _(类：`RefBox`)_"
 
-#: src/api/reference.md:2822
+#: src/api/reference.md:2860
 msgid "`render` — module"
 msgstr "`render` — 模块"
 
-#: src/api/reference.md:2823
+#: src/api/reference.md:2861
 msgid "`rows` — instance _(class: `TuiStdout`)_"
 msgstr "`rows` — 实例 _(类：`TuiStdout`)_"
 
-#: src/api/reference.md:2825
+#: src/api/reference.md:2863
 msgid "`set` — instance _(class: `State`)_"
 msgstr "`set` — 实例 _(类:`State`)_"
 
-#: src/api/reference.md:2826
+#: src/api/reference.md:2864
 msgid "`set` — instance _(class: `RefBox`)_"
 msgstr "`set` — 实例 _(类：`RefBox`)_"
 
-#: src/api/reference.md:2827
+#: src/api/reference.md:2865
 msgid "`state` — module"
 msgstr "`state` — 模块"
 
-#: src/api/reference.md:2828
+#: src/api/reference.md:2866
 msgid "`useApp` — module"
 msgstr "`useApp` — 模块"
 
-#: src/api/reference.md:2829
+#: src/api/reference.md:2867
 msgid "`useEffect` — module"
 msgstr "`useEffect` — 模块"
 
-#: src/api/reference.md:2830
+#: src/api/reference.md:2868
 msgid "`useFocus` — module"
 msgstr "`useFocus` — 模块"
 
-#: src/api/reference.md:2831
+#: src/api/reference.md:2869
 msgid "`useFocusManager` — module"
 msgstr "`useFocusManager` — 模块"
 
-#: src/api/reference.md:2832
+#: src/api/reference.md:2870
 msgid "`useInput` — module"
 msgstr "`useInput` — 模块"
 
-#: src/api/reference.md:2833
+#: src/api/reference.md:2871
 msgid "`useMemo` — module"
 msgstr "`useMemo` — 模块"
 
-#: src/api/reference.md:2834
+#: src/api/reference.md:2872
 msgid "`useRef` — module"
 msgstr "`useRef` — 模块"
 
-#: src/api/reference.md:2835
+#: src/api/reference.md:2873
 msgid "`useState` — module"
 msgstr "`useState` — 模块"
 
-#: src/api/reference.md:2836
+#: src/api/reference.md:2874
 msgid "`useStateSet` — module"
 msgstr "`useStateSet` — 模块"
 
-#: src/api/reference.md:2837
+#: src/api/reference.md:2875
 msgid "`useStateTuple` — module"
 msgstr "`useStateTuple` — 模块"
 
-#: src/api/reference.md:2838
+#: src/api/reference.md:2876
 msgid "`useStdout` — module"
 msgstr "`useStdout` — 模块"
 
-#: src/api/reference.md:2839
+#: src/api/reference.md:2877
 msgid "`waitUntilExit` — module"
 msgstr "`waitUntilExit` — 模块"
 
-#: src/api/reference.md:2840
+#: src/api/reference.md:2878
 msgid "`waitUntilExit` — instance _(class: `TuiApp`)_"
 msgstr "`waitUntilExit` — 实例 _(类：`TuiApp`)_"
 
-#: src/api/reference.md:2841
+#: src/api/reference.md:2879
 msgid "`write` — instance _(class: `TuiStdout`)_"
 msgstr "`write` — 实例 _(类：`TuiStdout`)_"
 
-#: src/api/reference.md:2843
+#: src/api/reference.md:2881
 msgid "`perry/ui`"
 msgstr "`perry/ui`"
 
-#: src/api/reference.md:2847
+#: src/api/reference.md:2885
 msgid "`App` — module"
 msgstr "`App` — 模块"
 
-#: src/api/reference.md:2848
+#: src/api/reference.md:2886
 msgid "`AttributedText` — module"
 msgstr "`AttributedText` — 模块"
 
-#: src/api/reference.md:2849
+#: src/api/reference.md:2887
 msgid "`BloomView` — module"
 msgstr "模块 `BloomView`"
 
-#: src/api/reference.md:2850
+#: src/api/reference.md:2888
 msgid "`BottomNavigation` — module"
 msgstr "`BottomNavigation` — 模块"
 
-#: src/api/reference.md:2851
+#: src/api/reference.md:2889
 msgid "`Button` — module"
 msgstr "`Button` — 模块"
 
-#: src/api/reference.md:2852
+#: src/api/reference.md:2890
 msgid "`CameraView` — module"
 msgstr "`CameraView` — 模块"
 
-#: src/api/reference.md:2853
+#: src/api/reference.md:2891
 msgid "`Canvas` — module"
 msgstr "`Canvas` — 模块"
 
-#: src/api/reference.md:2854
+#: src/api/reference.md:2892
 msgid "`Divider` — module"
 msgstr "`Divider` — 模块"
 
-#: src/api/reference.md:2855
+#: src/api/reference.md:2893
 msgid "`ForEach` — module"
 msgstr "`ForEach` — 模块"
 
-#: src/api/reference.md:2856
+#: src/api/reference.md:2894
 msgid "`HStack` — module"
 msgstr "`HStack` — 模块"
 
-#: src/api/reference.md:2857
+#: src/api/reference.md:2895
 msgid "`HStackWithInsets` — module"
 msgstr "`HStackWithInsets` — 模块"
 
-#: src/api/reference.md:2858
+#: src/api/reference.md:2896
 msgid "`Image` — module"
 msgstr "`Image` — 模块"
 
-#: src/api/reference.md:2859
+#: src/api/reference.md:2897
 msgid "`ImageFile` — module"
 msgstr "`ImageFile` — 模块"
 
-#: src/api/reference.md:2860
+#: src/api/reference.md:2898
 msgid "`ImageGallery` — module"
 msgstr "`ImageGallery` — 模块"
 
-#: src/api/reference.md:2861
+#: src/api/reference.md:2899
 msgid "`ImageSymbol` — module"
 msgstr "`ImageSymbol` — 模块"
 
-#: src/api/reference.md:2862
+#: src/api/reference.md:2900
 msgid "`LazyVStack` — module"
 msgstr "`LazyVStack` — 模块"
 
-#: src/api/reference.md:2863
+#: src/api/reference.md:2901
 msgid "`NavStack` — module"
 msgstr "`NavStack` — 模块"
 
-#: src/api/reference.md:2864
+#: src/api/reference.md:2902
 msgid "`Picker` — module"
 msgstr "`Picker` — 模块"
 
-#: src/api/reference.md:2865
+#: src/api/reference.md:2903
 msgid "`ProgressView` — module"
 msgstr "`ProgressView` — 模块"
 
-#: src/api/reference.md:2866
+#: src/api/reference.md:2904
 msgid "`ScrollView` — module"
 msgstr "`ScrollView` — 模块"
 
-#: src/api/reference.md:2867
+#: src/api/reference.md:2905
 msgid "`Section` — module"
 msgstr "`Section` — 模块"
 
-#: src/api/reference.md:2868
+#: src/api/reference.md:2906
 msgid "`SecureField` — module"
 msgstr "`SecureField` — 模块"
 
-#: src/api/reference.md:2869
+#: src/api/reference.md:2907
 msgid "`Slider` — module"
 msgstr "`Slider` — 模块"
 
-#: src/api/reference.md:2871
+#: src/api/reference.md:2909
 msgid "`SplitView` — module"
 msgstr "`SplitView` — 模块"
 
-#: src/api/reference.md:2872
+#: src/api/reference.md:2910
 msgid "`State` — module"
 msgstr "`State` — 模块"
 
-#: src/api/reference.md:2873
+#: src/api/reference.md:2911
 msgid "`TabBar` — module"
 msgstr "`TabBar` — 模块"
 
-#: src/api/reference.md:2877
+#: src/api/reference.md:2915
 msgid "`TextField` — module"
 msgstr "`TextField` — 模块"
 
-#: src/api/reference.md:2878
+#: src/api/reference.md:2916
 msgid "`Toggle` — module"
 msgstr "`Toggle` — 模块"
 
-#: src/api/reference.md:2879
+#: src/api/reference.md:2917
 msgid "`VStack` — module"
 msgstr "`VStack` — 模块"
 
-#: src/api/reference.md:2880
+#: src/api/reference.md:2918
 msgid "`VStackWithInsets` — module"
 msgstr "`VStackWithInsets` — 模块"
 
-#: src/api/reference.md:2881
+#: src/api/reference.md:2919
 msgid "`WebView` — module"
 msgstr "`WebView` — 模块"
 
-#: src/api/reference.md:2882
+#: src/api/reference.md:2920
 msgid "`WheelPicker` — module"
 msgstr "模块 `WheelPicker`"
 
-#: src/api/reference.md:2883
+#: src/api/reference.md:2921
 msgid "`Window` — module"
 msgstr "`Window` — 模块"
 
-#: src/api/reference.md:2884
+#: src/api/reference.md:2922
 msgid "`ZStack` — module"
 msgstr "`ZStack` — 模块"
 
-#: src/api/reference.md:2885
+#: src/api/reference.md:2923
 msgid "`addKeyboardShortcut` — module"
 msgstr "`addKeyboardShortcut` — 模块"
 
-#: src/api/reference.md:2886
+#: src/api/reference.md:2924
 msgid "`alert` — module"
 msgstr "`alert` — 模块"
 
-#: src/api/reference.md:2887
+#: src/api/reference.md:2925
 msgid "`alertWithButtons` — module"
 msgstr "`alertWithButtons` — 模块"
 
-#: src/api/reference.md:2888
+#: src/api/reference.md:2926
 msgid "`appSetActivationPolicy` — module"
 msgstr "模块 `appSetActivationPolicy`"
 
-#: src/api/reference.md:2889
+#: src/api/reference.md:2927
 msgid "`appSetMaxSize` — module"
 msgstr "`appSetMaxSize` — 模块"
 
-#: src/api/reference.md:2890
+#: src/api/reference.md:2928
 msgid "`appSetMinSize` — module"
 msgstr "`appSetMinSize` — 模块"
 
-#: src/api/reference.md:2891
+#: src/api/reference.md:2929
 msgid "`appSetTimer` — module"
 msgstr "`appSetTimer` — 模块"
 
-#: src/api/reference.md:2892
+#: src/api/reference.md:2930
 msgid "`attributedTextAppend` — module"
 msgstr "`attributedTextAppend` — 模块"
 
-#: src/api/reference.md:2893
+#: src/api/reference.md:2931
 msgid "`attributedTextClear` — module"
 msgstr "`attributedTextClear` — 模块"
 
-#: src/api/reference.md:2894
+#: src/api/reference.md:2932
 msgid "`bloomViewGetHwnd` — module"
 msgstr "模块 `bloomViewGetHwnd`"
 
-#: src/api/reference.md:2895
+#: src/api/reference.md:2933
 msgid "`bloomViewGetNativeHandle` — module"
 msgstr "模块 `bloomViewGetNativeHandle`"
 
-#: src/api/reference.md:2896
+#: src/api/reference.md:2934
 msgid "`blur` — module"
 msgstr "`blur` — 模块"
 
-#: src/api/reference.md:2897
+#: src/api/reference.md:2935
 msgid "`bottomNavAddItem` — module"
 msgstr "`bottomNavAddItem` — 模块"
 
-#: src/api/reference.md:2898
+#: src/api/reference.md:2936
 msgid "`bottomNavSetBadge` — module"
 msgstr "`bottomNavSetBadge` — 模块"
 
-#: src/api/reference.md:2899
+#: src/api/reference.md:2937
 msgid "`bottomNavSetSelected` — module"
 msgstr "`bottomNavSetSelected` — 模块"
 
-#: src/api/reference.md:2900
+#: src/api/reference.md:2938
 msgid "`bottomNavSetTintColor` — module"
 msgstr "`bottomNavSetTintColor` — 模块"
 
-#: src/api/reference.md:2901
+#: src/api/reference.md:2939
 msgid "`bottomNavSetUnselectedTintColor` — module"
 msgstr "`bottomNavSetUnselectedTintColor` — 模块"
 
-#: src/api/reference.md:2902
+#: src/api/reference.md:2940
 msgid "`cameraFreeze` — module"
 msgstr "`cameraFreeze` — 模块"
 
-#: src/api/reference.md:2903
+#: src/api/reference.md:2941
 msgid "`cameraRegisterFrameCallback` — module"
 msgstr "`cameraRegisterFrameCallback` — 模块"
 
-#: src/api/reference.md:2904
+#: src/api/reference.md:2942
 msgid "`cameraSampleColor` — module"
 msgstr "`cameraSampleColor` — 模块"
 
-#: src/api/reference.md:2905
+#: src/api/reference.md:2943
 msgid "`cameraSetOnTap` — module"
 msgstr "`cameraSetOnTap` — 模块"
 
-#: src/api/reference.md:2906
+#: src/api/reference.md:2944
 msgid "`cameraStart` — module"
 msgstr "`cameraStart` — 模块"
 
-#: src/api/reference.md:2907
+#: src/api/reference.md:2945
 msgid "`cameraStop` — module"
 msgstr "`cameraStop` — 模块"
 
-#: src/api/reference.md:2908
+#: src/api/reference.md:2946
 msgid "`cameraUnfreeze` — module"
 msgstr "`cameraUnfreeze` — 模块"
 
-#: src/api/reference.md:2909
+#: src/api/reference.md:2947
 msgid "`cameraUnregisterFrameCallback` — module"
 msgstr "`cameraUnregisterFrameCallback` — 模块"
 
-#: src/api/reference.md:2910
+#: src/api/reference.md:2948
 msgid "`clipboardRead` — module"
 msgstr "`clipboardRead` — 模块"
 
-#: src/api/reference.md:2911
+#: src/api/reference.md:2949
 msgid "`clipboardWrite` — module"
 msgstr "`clipboardWrite` — 模块"
 
-#: src/api/reference.md:2912
+#: src/api/reference.md:2950
 msgid "`currentModifiers` — module"
 msgstr "`currentModifiers` — 模块"
 
-#: src/api/reference.md:2913
+#: src/api/reference.md:2951
 msgid "`embedNSView` — module"
 msgstr "`embedNSView` — 模块"
 
-#: src/api/reference.md:2915
+#: src/api/reference.md:2953
 msgid "`frameSplitAddChild` — module"
 msgstr "`frameSplitAddChild` — 模块"
 
-#: src/api/reference.md:2916
+#: src/api/reference.md:2954
 msgid "`frameSplitCreate` — module"
 msgstr "`frameSplitCreate` — 模块"
 
-#: src/api/reference.md:2917
+#: src/api/reference.md:2955
 msgid "`imageGalleryAddImage` — module"
 msgstr "`imageGalleryAddImage` — 模块"
 
-#: src/api/reference.md:2918
+#: src/api/reference.md:2956
 msgid "`imageGallerySetIndex` — module"
 msgstr "`imageGallerySetIndex` — 模块"
 
-#: src/api/reference.md:2919
+#: src/api/reference.md:2957
 msgid "`isKeyDown` — module"
 msgstr "`isKeyDown` — 模块"
 
-#: src/api/reference.md:2920
+#: src/api/reference.md:2958
 msgid "`lazyvstackEndRefreshing` — module"
 msgstr "`lazyvstackEndRefreshing` — 模块"
 
-#: src/api/reference.md:2921
+#: src/api/reference.md:2959
 msgid "`lazyvstackSetRefreshControl` — module"
 msgstr "`lazyvstackSetRefreshControl` — 模块"
 
-#: src/api/reference.md:2922
+#: src/api/reference.md:2960
 msgid "`lazyvstackSetScrollEndCallback` — module"
 msgstr "`lazyvstackSetScrollEndCallback` — 模块"
 
-#: src/api/reference.md:2923
+#: src/api/reference.md:2961
 msgid "`loadImage` — module"
 msgstr "`loadImage` — 模块"
 
-#: src/api/reference.md:2924
+#: src/api/reference.md:2962
 msgid "`menuAddItem` — module"
 msgstr "`menuAddItem` — 模块"
 
-#: src/api/reference.md:2925
+#: src/api/reference.md:2963
 msgid "`menuAddItemWithShortcut` — module"
 msgstr "`menuAddItemWithShortcut` — 模块"
 
-#: src/api/reference.md:2926
+#: src/api/reference.md:2964
 msgid "`menuAddSeparator` — module"
 msgstr "`menuAddSeparator` — 模块"
 
-#: src/api/reference.md:2927
+#: src/api/reference.md:2965
 msgid "`menuAddStandardAction` — module"
 msgstr "`menuAddStandardAction` — 模块"
 
-#: src/api/reference.md:2928
+#: src/api/reference.md:2966
 msgid "`menuAddSubmenu` — module"
 msgstr "`menuAddSubmenu` — 模块"
 
-#: src/api/reference.md:2929
+#: src/api/reference.md:2967
 msgid "`menuBarAddMenu` — module"
 msgstr "`menuBarAddMenu` — 模块"
 
-#: src/api/reference.md:2930
+#: src/api/reference.md:2968
 msgid "`menuBarAttach` — module"
 msgstr "`menuBarAttach` — 模块"
 
-#: src/api/reference.md:2931
+#: src/api/reference.md:2969
 msgid "`menuBarCreate` — module"
 msgstr "`menuBarCreate` — 模块"
 
-#: src/api/reference.md:2932
+#: src/api/reference.md:2970
 msgid "`menuClear` — module"
 msgstr "`menuClear` — 模块"
 
-#: src/api/reference.md:2933
+#: src/api/reference.md:2971
 msgid "`menuCreate` — module"
 msgstr "`menuCreate` — 模块"
 
-#: src/api/reference.md:2934
+#: src/api/reference.md:2972
 msgid "`onActivate` — module"
 msgstr "`onActivate` — 模块"
 
-#: src/api/reference.md:2935
+#: src/api/reference.md:2973
 msgid "`onAppKeyDown` — module"
 msgstr "`onAppKeyDown` — 模块"
 
-#: src/api/reference.md:2936
+#: src/api/reference.md:2974
 msgid "`onAppKeyUp` — module"
 msgstr "`onAppKeyUp` — 模块"
 
-#: src/api/reference.md:2937
+#: src/api/reference.md:2975
 msgid "`onKeyDown` — module"
 msgstr "`onKeyDown` — 模块"
 
-#: src/api/reference.md:2938
+#: src/api/reference.md:2976
 msgid "`onKeyUp` — module"
 msgstr "`onKeyUp` — 模块"
 
-#: src/api/reference.md:2939
+#: src/api/reference.md:2977
 msgid "`onTerminate` — module"
 msgstr "`onTerminate` — 模块"
 
-#: src/api/reference.md:2940
+#: src/api/reference.md:2978
 msgid "`openFileDialog` — module"
 msgstr "`openFileDialog` — 模块"
 
-#: src/api/reference.md:2941
+#: src/api/reference.md:2979
 msgid "`openFolderDialog` — module"
 msgstr "`openFolderDialog` — 模块"
 
-#: src/api/reference.md:2942
+#: src/api/reference.md:2980
 msgid "`pollOpenFile` — module"
 msgstr "`pollOpenFile` — 模块"
 
-#: src/api/reference.md:2943
+#: src/api/reference.md:2981
 msgid "`registerGlobalHotkey` — module"
 msgstr "`registerGlobalHotkey` — 模块"
 
-#: src/api/reference.md:2944
+#: src/api/reference.md:2982
 msgid "`saveFileDialog` — module"
 msgstr "`saveFileDialog` — 模块"
 
-#: src/api/reference.md:2945
+#: src/api/reference.md:2983
 msgid "`scrollViewSetScrollEndCallback` — module"
 msgstr "`scrollViewSetScrollEndCallback` — 模块"
 
-#: src/api/reference.md:2946
+#: src/api/reference.md:2984
 msgid "`scrollviewSetScrollEndCallback` — module"
 msgstr "`scrollviewSetScrollEndCallback` — 模块"
 
-#: src/api/reference.md:2947
+#: src/api/reference.md:2985
 msgid "`setText` — module"
 msgstr "`setText` — 模块"
 
-#: src/api/reference.md:2948
+#: src/api/reference.md:2986
 msgid "`sheetCreate` — module"
 msgstr "`sheetCreate` — 模块"
 
-#: src/api/reference.md:2949
+#: src/api/reference.md:2987
 msgid "`sheetDismiss` — module"
 msgstr "`sheetDismiss` — 模块"
 
-#: src/api/reference.md:2950
+#: src/api/reference.md:2988
 msgid "`sheetPresent` — module"
 msgstr "`sheetPresent` — 模块"
 
-#: src/api/reference.md:2951
+#: src/api/reference.md:2989
 msgid "`showToast` — module"
 msgstr "`showToast` — 模块"
 
-#: src/api/reference.md:2952
+#: src/api/reference.md:2990
 msgid "`toolbarAddItem` — module"
 msgstr "`toolbarAddItem` — 模块"
 
-#: src/api/reference.md:2953
+#: src/api/reference.md:2991
 msgid "`toolbarAttach` — module"
 msgstr "`toolbarAttach` — 模块"
 
-#: src/api/reference.md:2954
+#: src/api/reference.md:2992
 msgid "`toolbarCreate` — module"
 msgstr "`toolbarCreate` — 模块"
 
-#: src/api/reference.md:2955
+#: src/api/reference.md:2993
 msgid "`trayAttachMenu` — module"
 msgstr "`trayAttachMenu` — 模块"
 
-#: src/api/reference.md:2956
+#: src/api/reference.md:2994
 msgid "`trayCreate` — module"
 msgstr "`trayCreate` — 模块"
 
-#: src/api/reference.md:2957
+#: src/api/reference.md:2995
 msgid "`trayDestroy` — module"
 msgstr "`trayDestroy` — 模块"
 
-#: src/api/reference.md:2958
+#: src/api/reference.md:2996
 msgid "`trayOnClick` — module"
 msgstr "`trayOnClick` — 模块"
 
-#: src/api/reference.md:2959
+#: src/api/reference.md:2997
 msgid "`traySetIcon` — module"
 msgstr "`traySetIcon` — 模块"
 
-#: src/api/reference.md:2960
+#: src/api/reference.md:2998
 msgid "`traySetTooltip` — module"
 msgstr "`traySetTooltip` — 模块"
 
-#: src/api/reference.md:2961
+#: src/api/reference.md:2999
 msgid "`webviewCanGoBack` — module"
 msgstr "`webviewCanGoBack` — 模块"
 
-#: src/api/reference.md:2962
+#: src/api/reference.md:3000
 msgid "`webviewClearCookies` — module"
 msgstr "`webviewClearCookies` — 模块"
 
-#: src/api/reference.md:2963
+#: src/api/reference.md:3001
 msgid "`webviewEvaluateJs` — module"
 msgstr "`webviewEvaluateJs` — 模块"
 
-#: src/api/reference.md:2964
+#: src/api/reference.md:3002
 msgid "`webviewGoBack` — module"
 msgstr "`webviewGoBack` — 模块"
 
-#: src/api/reference.md:2965
+#: src/api/reference.md:3003
 msgid "`webviewGoForward` — module"
 msgstr "`webviewGoForward` — 模块"
 
-#: src/api/reference.md:2966
+#: src/api/reference.md:3004
 msgid "`webviewLoadUrl` — module"
 msgstr "`webviewLoadUrl` — 模块"
 
-#: src/api/reference.md:2967
+#: src/api/reference.md:3005
 msgid "`webviewReload` — module"
 msgstr "`webviewReload` — 模块"
 
-#: src/api/reference.md:2968
+#: src/api/reference.md:3006
 msgid "`wheelPickerAddItem` — module"
 msgstr "模块 `wheelPickerAddItem`"
 
-#: src/api/reference.md:2969
+#: src/api/reference.md:3007
 msgid "`wheelPickerGetSelected` — module"
 msgstr "模块 `wheelPickerGetSelected`"
 
-#: src/api/reference.md:2970
+#: src/api/reference.md:3008
 msgid "`wheelPickerSetSelected` — module"
 msgstr "模块 `wheelPickerSetSelected`"
 
-#: src/api/reference.md:2972
+#: src/api/reference.md:3010
 msgid "`perry/updater`"
 msgstr "`perry/updater`"
 
-#: src/api/reference.md:2976
+#: src/api/reference.md:3014
 msgid "`clearSentinel` — module"
 msgstr "`clearSentinel` — 模块"
 
-#: src/api/reference.md:2977
+#: src/api/reference.md:3015
 msgid "`compareVersions` — module"
 msgstr "`compareVersions` — 模块"
 
-#: src/api/reference.md:2978
+#: src/api/reference.md:3016
 msgid "`computeFileSha256` — module"
 msgstr "`computeFileSha256` — 模块"
 
-#: src/api/reference.md:2979
+#: src/api/reference.md:3017
 msgid "`embeddedCheckHeaders` — module"
 msgstr "模块 `embeddedCheckHeaders`"
 
-#: src/api/reference.md:2980
+#: src/api/reference.md:3018
 msgid "`embeddedCheckUrl` — module"
 msgstr "模块 `embeddedCheckUrl`"
 
-#: src/api/reference.md:2981
+#: src/api/reference.md:3019
 msgid "`embeddedRefreshDue` — module"
 msgstr "模块 `embeddedRefreshDue`"
 
-#: src/api/reference.md:2982
+#: src/api/reference.md:3020
 msgid "`getBackupPath` — module"
 msgstr "`getBackupPath` — 模块"
 
-#: src/api/reference.md:2983
+#: src/api/reference.md:3021
 msgid "`getEmbeddedConfig` — module"
 msgstr "模块 `getEmbeddedConfig`"
 
-#: src/api/reference.md:2984
+#: src/api/reference.md:3022
 msgid "`getExePath` — module"
 msgstr "`getExePath` — 模块"
 
-#: src/api/reference.md:2985
+#: src/api/reference.md:3023
 msgid "`getSentinelPath` — module"
 msgstr "`getSentinelPath` — 模块"
 
-#: src/api/reference.md:2986
+#: src/api/reference.md:3024
 msgid "`installUpdate` — module"
 msgstr "`installUpdate` — 模块"
 
-#: src/api/reference.md:2987
+#: src/api/reference.md:3025
 msgid "`performRollback` — module"
 msgstr "`performRollback` — 模块"
 
-#: src/api/reference.md:2988
+#: src/api/reference.md:3026
 msgid "`readSentinel` — module"
 msgstr "`readSentinel` — 模块"
 
-#: src/api/reference.md:2989
+#: src/api/reference.md:3027
 msgid "`recordEmbeddedResponse` — module"
 msgstr "模块 `recordEmbeddedResponse`"
 
-#: src/api/reference.md:2990
+#: src/api/reference.md:3028
 msgid "`relaunch` — module"
 msgstr "`relaunch` — 模块"
 
-#: src/api/reference.md:2991
+#: src/api/reference.md:3029
 msgid "`verifyHash` — module"
 msgstr "`verifyHash` — 模块"
 
-#: src/api/reference.md:2992
+#: src/api/reference.md:3030
 msgid "`verifySignature` — module"
 msgstr "`verifySignature` — 模块"
 
-#: src/api/reference.md:2993
+#: src/api/reference.md:3031
 msgid "`verifySignatureV2` — module"
 msgstr "`verifySignatureV2` — 模块"
 
-#: src/api/reference.md:2994
+#: src/api/reference.md:3032
 msgid "`writeSentinel` — module"
 msgstr "`writeSentinel` — 模块"
 
-#: src/api/reference.md:2996
+#: src/api/reference.md:3034
 msgid "`perry/widget`"
 msgstr "`perry/widget`"
 
-#: src/api/reference.md:3000
+#: src/api/reference.md:3038
 msgid "`Widget` — module"
 msgstr "`Widget` — 模块"
 
-#: src/api/reference.md:3002
+#: src/api/reference.md:3040
 msgid "`perry/workloads`"
 msgstr "`perry/workloads`"
 
-#: src/api/reference.md:3006
+#: src/api/reference.md:3044
 msgid "`graph` — module"
 msgstr "`graph` — 模块"
 
-#: src/api/reference.md:3007
+#: src/api/reference.md:3045
 msgid "`inspectGraph` — module"
 msgstr "`inspectGraph` — 模块"
 
-#: src/api/reference.md:3008
+#: src/api/reference.md:3046
 msgid "`node` — module"
 msgstr "`node` — 模块"
 
-#: src/api/reference.md:3009
+#: src/api/reference.md:3047
 msgid "`runGraph` — module"
 msgstr "`runGraph` — 模块"
 
-#: src/api/reference.md:3013
+#: src/api/reference.md:3051
 msgid "`policy`"
 msgstr "`policy`"
 
-#: src/api/reference.md:3014
+#: src/api/reference.md:3052
 msgid "`runtime`"
 msgstr "`runtime`"
 
-#: src/api/reference.md:3016
+#: src/api/reference.md:3054
 msgid "`perry/yoga`"
 msgstr "`perry/yoga`"
 
-#: src/api/reference.md:3020
+#: src/api/reference.md:3058
 msgid "`calculateLayout` — module"
 msgstr "模块 `calculateLayout`"
 
-#: src/api/reference.md:3021
+#: src/api/reference.md:3059
 msgid "`childCount` — module"
 msgstr "模块 `childCount`"
 
-#: src/api/reference.md:3022
+#: src/api/reference.md:3060
 msgid "`getComputed` — module"
 msgstr "模块 `getComputed`"
 
-#: src/api/reference.md:3023
+#: src/api/reference.md:3061
 msgid "`getComputedEdge` — module"
 msgstr "模块 `getComputedEdge`"
 
-#: src/api/reference.md:3024
+#: src/api/reference.md:3062
 msgid "`insertChild` — module"
 msgstr "模块 `insertChild`"
 
-#: src/api/reference.md:3025
+#: src/api/reference.md:3063
 msgid "`nodeFree` — module"
 msgstr "模块 `nodeFree`"
 
-#: src/api/reference.md:3026
+#: src/api/reference.md:3064
 msgid "`nodeNew` — module"
 msgstr "模块 `nodeNew`"
 
-#: src/api/reference.md:3027
+#: src/api/reference.md:3065
 msgid "`removeChild` — module"
 msgstr "模块 `removeChild`"
 
-#: src/api/reference.md:3028
+#: src/api/reference.md:3066
 msgid "`setEdge` — module"
 msgstr "模块 `setEdge`"
 
-#: src/api/reference.md:3029
+#: src/api/reference.md:3067
 msgid "`setEnum` — module"
 msgstr "模块 `setEnum`"
 
-#: src/api/reference.md:3030
+#: src/api/reference.md:3068
 msgid "`setGap` — module"
 msgstr "模块 `setGap`"
 
-#: src/api/reference.md:3031
+#: src/api/reference.md:3069
 msgid "`setMeasureFunc` — module"
 msgstr "模块 `setMeasureFunc`"
 
-#: src/api/reference.md:3032
+#: src/api/reference.md:3070
 msgid "`setNumber` — module"
 msgstr "模块 `setNumber`"
 
-#: src/api/reference.md:3033
+#: src/api/reference.md:3071
 msgid "`unsetMeasureFunc` — module"
 msgstr "模块 `unsetMeasureFunc`"
 
-#: src/api/reference.md:3039 src/api/reference.md:4096
+#: src/api/reference.md:3077 src/api/reference.md:4134
 msgid "`Client`"
 msgstr "`Client`"
 
-#: src/api/reference.md:3044
+#: src/api/reference.md:3082
 msgid "`Pool` — module"
 msgstr "`Pool` — 模块"
 
-#: src/api/reference.md:3046
+#: src/api/reference.md:3084
 msgid "`connect` — instance _(class: `Client`)_"
 msgstr "`connect` — 实例 _(类:`Client`)_"
 
-#: src/api/reference.md:3052
+#: src/api/reference.md:3090
 msgid "`process`"
 msgstr "`process`"
 
-#: src/api/reference.md:3056
+#: src/api/reference.md:3094
 msgid "`_debugEnd` — module"
 msgstr "`_debugEnd` — 模块"
 
-#: src/api/reference.md:3057
+#: src/api/reference.md:3095
 msgid "`_debugProcess` — module"
 msgstr "`_debugProcess` — 模块"
 
-#: src/api/reference.md:3058
+#: src/api/reference.md:3096
 msgid "`_fatalException` — module"
 msgstr "`_fatalException` — 模块"
 
-#: src/api/reference.md:3059
+#: src/api/reference.md:3097
 msgid "`_getActiveHandles` — module"
 msgstr "`_getActiveHandles` — 模块"
 
-#: src/api/reference.md:3060
+#: src/api/reference.md:3098
 msgid "`_getActiveRequests` — module"
 msgstr "`_getActiveRequests` — 模块"
 
-#: src/api/reference.md:3061
+#: src/api/reference.md:3099
 msgid "`_kill` — module"
 msgstr "`_kill` — 模块"
 
-#: src/api/reference.md:3062
+#: src/api/reference.md:3100
 msgid "`_linkedBinding` — module"
 msgstr "`_linkedBinding` — 模块"
 
-#: src/api/reference.md:3063
+#: src/api/reference.md:3101
 msgid "`_rawDebug` — module"
 msgstr "`_rawDebug` — 模块"
 
-#: src/api/reference.md:3064
+#: src/api/reference.md:3102
 msgid "`_startProfilerIdleNotifier` — module"
 msgstr "`_startProfilerIdleNotifier` — 模块"
 
-#: src/api/reference.md:3065
+#: src/api/reference.md:3103
 msgid "`_stopProfilerIdleNotifier` — module"
 msgstr "`_stopProfilerIdleNotifier` — 模块"
 
-#: src/api/reference.md:3066
+#: src/api/reference.md:3104
 msgid "`_tickCallback` — module"
 msgstr "`_tickCallback` — 模块"
 
-#: src/api/reference.md:3067
+#: src/api/reference.md:3105
 msgid "`abort` — module"
 msgstr "`abort` — 模块"
 
-#: src/api/reference.md:3068
+#: src/api/reference.md:3106
 msgid "`addUncaughtExceptionCaptureCallback` — module"
 msgstr "`addUncaughtExceptionCaptureCallback` — 模块"
 
-#: src/api/reference.md:3069
+#: src/api/reference.md:3107
 msgid "`availableMemory` — module"
 msgstr "`availableMemory` — 模块"
 
-#: src/api/reference.md:3070
+#: src/api/reference.md:3108
 msgid "`binding` — module"
 msgstr "`binding` — 模块"
 
-#: src/api/reference.md:3071
+#: src/api/reference.md:3109
 msgid "`chdir` — module"
 msgstr "`chdir` — 模块"
 
-#: src/api/reference.md:3072
+#: src/api/reference.md:3110
 msgid "`constrainedMemory` — module"
 msgstr "`constrainedMemory` — 模块"
 
-#: src/api/reference.md:3073
+#: src/api/reference.md:3111
 msgid "`cpuUsage` — module"
 msgstr "`cpuUsage` — 模块"
 
-#: src/api/reference.md:3074
+#: src/api/reference.md:3112
 msgid "`cwd` — module"
 msgstr "`cwd` — 模块"
 
-#: src/api/reference.md:3076
+#: src/api/reference.md:3114
 msgid "`emitWarning` — module"
 msgstr "`emitWarning` — 模块"
 
-#: src/api/reference.md:3077
+#: src/api/reference.md:3115
 msgid "`execve` — module"
 msgstr "`execve` — 模块"
 
-#: src/api/reference.md:3079
+#: src/api/reference.md:3117
 msgid "`getActiveResourcesInfo` — module"
 msgstr "`getActiveResourcesInfo` — 模块"
 
-#: src/api/reference.md:3080
+#: src/api/reference.md:3118
 msgid "`getBuiltinModule` — module"
 msgstr "`getBuiltinModule` — 模块"
 
-#: src/api/reference.md:3081
+#: src/api/reference.md:3119
 msgid "`getegid` — module"
 msgstr "`getegid` — 模块"
 
-#: src/api/reference.md:3082
+#: src/api/reference.md:3120
 msgid "`geteuid` — module"
 msgstr "`geteuid` — 模块"
 
-#: src/api/reference.md:3083
+#: src/api/reference.md:3121
 msgid "`getgid` — module"
 msgstr "`getgid` — 模块"
 
-#: src/api/reference.md:3084
+#: src/api/reference.md:3122
 msgid "`getgroups` — module"
 msgstr "`getgroups` — 模块"
 
-#: src/api/reference.md:3085
+#: src/api/reference.md:3123
 msgid "`getuid` — module"
 msgstr "`getuid` — 模块"
 
-#: src/api/reference.md:3086
+#: src/api/reference.md:3124
 msgid "`hasUncaughtExceptionCaptureCallback` — module"
 msgstr "`hasUncaughtExceptionCaptureCallback` — 模块"
 
-#: src/api/reference.md:3087
+#: src/api/reference.md:3125
 msgid "`hrtime` — module"
 msgstr "`hrtime` — 模块"
 
-#: src/api/reference.md:3088
+#: src/api/reference.md:3126
 msgid "`initgroups` — module"
 msgstr "`initgroups` — 模块"
 
-#: src/api/reference.md:3089
+#: src/api/reference.md:3127
 msgid "`kill` — module"
 msgstr "`kill` — 模块"
 
-#: src/api/reference.md:3090
+#: src/api/reference.md:3128
 msgid "`loadEnvFile` — module"
 msgstr "`loadEnvFile` — 模块"
 
-#: src/api/reference.md:3091
+#: src/api/reference.md:3129
 msgid "`memoryUsage` — module"
 msgstr "`memoryUsage` — 模块"
 
-#: src/api/reference.md:3092
+#: src/api/reference.md:3130
 msgid "`nextTick` — module"
 msgstr "`nextTick` — 模块"
 
-#: src/api/reference.md:3093
+#: src/api/reference.md:3131
 msgid "`openStdin` — module"
 msgstr "`openStdin` — 模块"
 
-#: src/api/reference.md:3094
+#: src/api/reference.md:3132
 msgid "`reallyExit` — module"
 msgstr "`reallyExit` — 模块"
 
-#: src/api/reference.md:3095
+#: src/api/reference.md:3133
 msgid "`ref` — module"
 msgstr "`ref` — 模块"
 
-#: src/api/reference.md:3096
+#: src/api/reference.md:3134
 msgid "`resourceUsage` — module"
 msgstr "`resourceUsage` — 模块"
 
-#: src/api/reference.md:3097 src/api/reference.md:3098
+#: src/api/reference.md:3135 src/api/reference.md:3136
 msgid "`setSourceMapsEnabled` — module"
 msgstr "`setSourceMapsEnabled` — 模块"
 
-#: src/api/reference.md:3099
+#: src/api/reference.md:3137
 msgid "`setUncaughtExceptionCaptureCallback` — module"
 msgstr "`setUncaughtExceptionCaptureCallback` — 模块"
 
-#: src/api/reference.md:3100
+#: src/api/reference.md:3138
 msgid "`setegid` — module"
 msgstr "`setegid` — 模块"
 
-#: src/api/reference.md:3101
+#: src/api/reference.md:3139
 msgid "`seteuid` — module"
 msgstr "`seteuid` — 模块"
 
-#: src/api/reference.md:3102
+#: src/api/reference.md:3140
 msgid "`setgid` — module"
 msgstr "`setgid` — 模块"
 
-#: src/api/reference.md:3103
+#: src/api/reference.md:3141
 msgid "`setgroups` — module"
 msgstr "`setgroups` — 模块"
 
-#: src/api/reference.md:3104
+#: src/api/reference.md:3142
 msgid "`setuid` — module"
 msgstr "`setuid` — 模块"
 
-#: src/api/reference.md:3105 src/api/reference.md:3106
+#: src/api/reference.md:3143 src/api/reference.md:3144
 msgid "`sourceMapsEnabled` — module"
 msgstr "`sourceMapsEnabled` — 模块"
 
-#: src/api/reference.md:3107
+#: src/api/reference.md:3145
 msgid "`threadCpuUsage` — module"
 msgstr "`threadCpuUsage` — 模块"
 
-#: src/api/reference.md:3108
+#: src/api/reference.md:3146
 msgid "`umask` — module"
 msgstr "`umask` — 模块"
 
-#: src/api/reference.md:3109
+#: src/api/reference.md:3147
 msgid "`unref` — module"
 msgstr "`unref` — 模块"
 
-#: src/api/reference.md:3114
+#: src/api/reference.md:3152
 msgid "`_eval`"
 msgstr "`_eval`"
 
-#: src/api/reference.md:3115
+#: src/api/reference.md:3153
 msgid "`_events`"
 msgstr "`_events`"
 
-#: src/api/reference.md:3116
+#: src/api/reference.md:3154
 msgid "`_eventsCount`"
 msgstr "`_eventsCount`"
 
-#: src/api/reference.md:3117
+#: src/api/reference.md:3155
 msgid "`_exiting`"
 msgstr "`_exiting`"
 
-#: src/api/reference.md:3118
+#: src/api/reference.md:3156
 msgid "`_maxListeners`"
 msgstr "`_maxListeners`"
 
-#: src/api/reference.md:3119
+#: src/api/reference.md:3157
 msgid "`_preload_modules`"
 msgstr "`_preload_modules`"
 
-#: src/api/reference.md:3120
+#: src/api/reference.md:3158
 msgid "`allowedNodeEnvironmentFlags`"
 msgstr "`allowedNodeEnvironmentFlags`"
 
-#: src/api/reference.md:3121
+#: src/api/reference.md:3159
 msgid "`arch`"
 msgstr "`arch`"
 
-#: src/api/reference.md:3122
+#: src/api/reference.md:3160
 msgid "`argv`"
 msgstr "`argv`"
 
-#: src/api/reference.md:3123
+#: src/api/reference.md:3161
 msgid "`argv0`"
 msgstr "`argv0`"
 
-#: src/api/reference.md:3124 src/widgets/creating-widgets.md:55
+#: src/api/reference.md:3162 src/widgets/creating-widgets.md:55
 msgid "`config`"
 msgstr "`config`"
 
-#: src/api/reference.md:3125
+#: src/api/reference.md:3163
 msgid "`debugPort`"
 msgstr "`debugPort`"
 
-#: src/api/reference.md:3127 src/container/containers.md:49
+#: src/api/reference.md:3165 src/container/containers.md:49
 msgid "`env`"
 msgstr "`env`"
 
-#: src/api/reference.md:3128
+#: src/api/reference.md:3166
 msgid "`execArgv`"
 msgstr "`execArgv`"
 
-#: src/api/reference.md:3129
+#: src/api/reference.md:3167
 msgid "`execPath`"
 msgstr "`execPath`"
 
-#: src/api/reference.md:3130
+#: src/api/reference.md:3168
 msgid "`features`"
 msgstr "`features`"
 
-#: src/api/reference.md:3131
+#: src/api/reference.md:3169
 msgid "`finalization`"
 msgstr "`finalization`"
 
-#: src/api/reference.md:3132
+#: src/api/reference.md:3170
 msgid "`moduleLoadList`"
 msgstr "`moduleLoadList`"
 
-#: src/api/reference.md:3133
+#: src/api/reference.md:3171
 msgid "`permission`"
 msgstr "`permission`"
 
-#: src/api/reference.md:3134
+#: src/api/reference.md:3172
 msgid "`pid`"
 msgstr "`pid`"
 
-#: src/api/reference.md:3135
+#: src/api/reference.md:3173
 msgid "`platform`"
 msgstr "`platform`"
 
-#: src/api/reference.md:3136
+#: src/api/reference.md:3174
 msgid "`ppid`"
 msgstr "`ppid`"
 
-#: src/api/reference.md:3137 src/contributing/building.md:52
+#: src/api/reference.md:3175 src/contributing/building.md:52
 msgid "`release`"
 msgstr "`release`"
 
-#: src/api/reference.md:3138
+#: src/api/reference.md:3176
 msgid "`report`"
 msgstr "`report`"
 
-#: src/api/reference.md:3143 src/api/reference.md:3159
-#: src/updater/overview.md:109 src/cli/perry-toml.md:120
-msgid "`version`"
-msgstr "`version`"
-
-#: src/api/reference.md:3144
+#: src/api/reference.md:3182
 msgid "`versions`"
 msgstr "`versions`"
 
-#: src/api/reference.md:3146
+#: src/api/reference.md:3184
 msgid "`punycode`"
 msgstr "`punycode`"
 
-#: src/api/reference.md:3151 src/api/reference.md:3173
+#: src/api/reference.md:3189 src/api/reference.md:3211
 msgid "`encode` — module"
 msgstr "`encode` — 模块"
 
-#: src/api/reference.md:3152
+#: src/api/reference.md:3190
 msgid "`toASCII` — module"
 msgstr "`toASCII` — 模块"
 
-#: src/api/reference.md:3153
+#: src/api/reference.md:3191
 msgid "`toUnicode` — module"
 msgstr "`toUnicode` — 模块"
 
-#: src/api/reference.md:3158
+#: src/api/reference.md:3196
 msgid "`ucs2`"
 msgstr "`ucs2`"
 
-#: src/api/reference.md:3166 src/api/reference.md:3176
+#: src/api/reference.md:3204 src/api/reference.md:3214
 msgid "`stringify` — module"
 msgstr "`stringify` — 模块"
 
-#: src/api/reference.md:3168
+#: src/api/reference.md:3206
 msgid "`querystring`"
 msgstr "`querystring`"
 
-#: src/api/reference.md:3174
+#: src/api/reference.md:3212
 msgid "`escape` — module"
 msgstr "`escape` — 模块"
 
-#: src/api/reference.md:3177
+#: src/api/reference.md:3215
 msgid "`unescape` — module"
 msgstr "`unescape` — 模块"
 
-#: src/api/reference.md:3178
+#: src/api/reference.md:3216
 msgid "`unescapeBuffer` — module"
 msgstr "`unescapeBuffer` — 模块"
 
-#: src/api/reference.md:3188
+#: src/api/reference.md:3226
 msgid "`RateLimiterAbstract`"
 msgstr "`RateLimiterAbstract`"
 
-#: src/api/reference.md:3189
+#: src/api/reference.md:3227
 msgid "`RateLimiterMemory`"
 msgstr "`RateLimiterMemory`"
 
-#: src/api/reference.md:3193
+#: src/api/reference.md:3231
 msgid "`block` — instance"
 msgstr "`block` 实例"
 
-#: src/api/reference.md:3194
+#: src/api/reference.md:3232
 msgid "`consume` — instance"
 msgstr "`consume` 实例"
 
-#: src/api/reference.md:3197
+#: src/api/reference.md:3235
 msgid "`penalty` — instance"
 msgstr "`penalty` 实例"
 
-#: src/api/reference.md:3198
+#: src/api/reference.md:3236
 msgid "`reward` — instance"
 msgstr "`reward` 实例"
 
-#: src/api/reference.md:3200
+#: src/api/reference.md:3238
 msgid "`readline`"
 msgstr "`readline`"
 
-#: src/api/reference.md:3204
+#: src/api/reference.md:3242
 msgid "`clearLine` — module"
 msgstr "`clearLine` — 模块"
 
-#: src/api/reference.md:3205
+#: src/api/reference.md:3243
 msgid "`clearScreenDown` — module"
 msgstr "`clearScreenDown` — 模块"
 
-#: src/api/reference.md:3207 src/api/reference.md:3234
+#: src/api/reference.md:3245 src/api/reference.md:3272
 msgid "`createInterface` — module"
 msgstr "`createInterface` — 模块"
 
-#: src/api/reference.md:3208
+#: src/api/reference.md:3246
 msgid "`cursorTo` — module"
 msgstr "`cursorTo` — 模块"
 
-#: src/api/reference.md:3209
+#: src/api/reference.md:3247
 msgid "`emitKeypressEvents` — module"
 msgstr "`emitKeypressEvents` — 模块"
 
-#: src/api/reference.md:3210
+#: src/api/reference.md:3248
 msgid "`getCursorPos` — instance"
 msgstr "`getCursorPos` — 实例"
 
-#: src/api/reference.md:3211
+#: src/api/reference.md:3249
 msgid "`getPrompt` — instance"
 msgstr "`getPrompt` — 实例"
 
-#: src/api/reference.md:3212
+#: src/api/reference.md:3250
 msgid "`iterator` — instance"
 msgstr "`iterator` — 实例"
 
-#: src/api/reference.md:3213
+#: src/api/reference.md:3251
 msgid "`line` — instance"
 msgstr "`line` — 实例"
 
-#: src/api/reference.md:3214
+#: src/api/reference.md:3252
 msgid "`moveCursor` — module"
 msgstr "`moveCursor` — 模块"
 
-#: src/api/reference.md:3216 src/api/reference.md:3424
+#: src/api/reference.md:3254 src/api/reference.md:3462
 msgid "`pause` — instance"
 msgstr "`pause` — 实例"
 
-#: src/api/reference.md:3217
+#: src/api/reference.md:3255
 msgid "`prompt` — instance"
 msgstr "`prompt` — 实例"
 
-#: src/api/reference.md:3218 src/api/reference.md:3235
+#: src/api/reference.md:3256 src/api/reference.md:3273
 msgid "`question` — instance"
 msgstr "`question` — 实例"
 
-#: src/api/reference.md:3219 src/api/reference.md:3443
+#: src/api/reference.md:3257 src/api/reference.md:3481
 msgid "`resume` — instance"
 msgstr "`resume` — 实例"
 
-#: src/api/reference.md:3220
+#: src/api/reference.md:3258
 msgid "`setPrompt` — instance"
 msgstr "`setPrompt` — 实例"
 
-#: src/api/reference.md:3221
+#: src/api/reference.md:3259
 msgid "`terminal` — instance"
 msgstr "`terminal` — 实例"
 
-#: src/api/reference.md:3222 src/api/reference.md:3458
+#: src/api/reference.md:3260 src/api/reference.md:3496
 msgid "`write` — instance"
 msgstr "`write` — 实例"
 
-#: src/api/reference.md:3224
+#: src/api/reference.md:3262
 msgid "`readline/promises`"
 msgstr "`readline/promises`"
 
-#: src/api/reference.md:3228
+#: src/api/reference.md:3266
 msgid "`Interface`"
 msgstr "`Interface`"
 
-#: src/api/reference.md:3229
+#: src/api/reference.md:3267
 msgid "`Readline`"
 msgstr "`Readline`"
 
-#: src/api/reference.md:3237
+#: src/api/reference.md:3275
 msgid "`redis`"
 msgstr "`redis`"
 
-#: src/api/reference.md:3247
+#: src/api/reference.md:3285
 msgid "`repl`"
 msgstr "`repl`"
 
-#: src/api/reference.md:3251
+#: src/api/reference.md:3289
 msgid "`REPLServer`"
 msgstr "`REPLServer`"
 
-#: src/api/reference.md:3252
+#: src/api/reference.md:3290
 msgid "`Recoverable`"
 msgstr "`Recoverable`"
 
-#: src/api/reference.md:3256
+#: src/api/reference.md:3294
 msgid ""
 "`REPLServer` — module ⚠ **stub** — REPLServer shape only: never reads the "
 "input stream, and .write() evaluates just numeric literals, context lookups, "
@@ -42777,43 +43080,43 @@ msgstr ""
 "`REPLServer`  模块 **一个小块** REPLServer 只有形状:从来没有读取输入流,并"
 "且.write() 仅评估数字字母,上下文查询和单个'+';没有真正的JS eval循环 (#4916)"
 
-#: src/api/reference.md:3257
+#: src/api/reference.md:3295
 msgid "`Recoverable` — module"
 msgstr "`Recoverable` — 模块"
 
-#: src/api/reference.md:3258
+#: src/api/reference.md:3296
 msgid "`addListener` — instance _(class: `REPLServer`)_"
 msgstr "`addListener` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3259
+#: src/api/reference.md:3297
 msgid "`clearBufferedCommand` — instance _(class: `REPLServer`)_"
 msgstr "`clearBufferedCommand` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3260
+#: src/api/reference.md:3298
 msgid "`defineCommand` — instance _(class: `REPLServer`)_"
 msgstr "`defineCommand` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3261
+#: src/api/reference.md:3299
 msgid "`displayPrompt` — instance _(class: `REPLServer`)_"
 msgstr "`displayPrompt` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3262
+#: src/api/reference.md:3300
 msgid "`emit` — instance _(class: `REPLServer`)_"
 msgstr "`emit` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3263
+#: src/api/reference.md:3301
 msgid "`on` — instance _(class: `REPLServer`)_"
 msgstr "`on` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3264
+#: src/api/reference.md:3302
 msgid "`once` — instance _(class: `REPLServer`)_"
 msgstr "`once` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3265
+#: src/api/reference.md:3303
 msgid "`setupHistory` — instance _(class: `REPLServer`)_"
 msgstr "`setupHistory` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3266
+#: src/api/reference.md:3304
 msgid ""
 "`start` — module ⚠ **stub** — REPLServer shape only: never reads the input "
 "stream, and .write() evaluates just numeric literals, context lookups, and a "
@@ -42822,1459 +43125,1459 @@ msgstr ""
 "`start`  模块 **一个小块** REPLServer 只有形状:从来没有读取输入流,并"
 "且.write() 仅评估数字字母,上下文查询和单个'+';没有真正的JS eval循环 (#4916)"
 
-#: src/api/reference.md:3267
+#: src/api/reference.md:3305
 msgid "`write` — instance _(class: `REPLServer`)_"
 msgstr "`write` — 实例 _(类：`REPLServer`)_"
 
-#: src/api/reference.md:3271
+#: src/api/reference.md:3309
 msgid "`REPL_MODE_SLOPPY`"
 msgstr "`REPL_MODE_SLOPPY`"
 
-#: src/api/reference.md:3272
+#: src/api/reference.md:3310
 msgid "`REPL_MODE_STRICT`"
 msgstr "`REPL_MODE_STRICT`"
 
-#: src/api/reference.md:3276
+#: src/api/reference.md:3314
 msgid "`sea`"
 msgstr "`sea`"
 
-#: src/api/reference.md:3280
+#: src/api/reference.md:3318
 msgid "`getAsset` — module"
 msgstr "`getAsset` — 模块"
 
-#: src/api/reference.md:3281
+#: src/api/reference.md:3319
 msgid "`getAssetAsBlob` — module"
 msgstr "`getAssetAsBlob` — 模块"
 
-#: src/api/reference.md:3282
+#: src/api/reference.md:3320
 msgid "`getAssetKeys` — module"
 msgstr "`getAssetKeys` — 模块"
 
-#: src/api/reference.md:3283
+#: src/api/reference.md:3321
 msgid "`getRawAsset` — module"
 msgstr "`getRawAsset` — 模块"
 
-#: src/api/reference.md:3284
+#: src/api/reference.md:3322
 msgid "`isSea` — module"
 msgstr "`isSea` — 模块"
 
-#: src/api/reference.md:3294
+#: src/api/reference.md:3332
 msgid "`autoOrient` — instance"
 msgstr "`autoOrient` 实例"
 
-#: src/api/reference.md:3295
+#: src/api/reference.md:3333
 msgid "`avif` — instance"
 msgstr "`avif` 实例"
 
-#: src/api/reference.md:3296
+#: src/api/reference.md:3334
 msgid "`blur` — instance"
 msgstr "`blur` — 实例"
 
-#: src/api/reference.md:3297
+#: src/api/reference.md:3335
 msgid "`composite` — instance"
 msgstr "`composite` 实例"
 
-#: src/api/reference.md:3299
+#: src/api/reference.md:3337
 msgid "`extend` — instance"
 msgstr "`extend` 实例"
 
-#: src/api/reference.md:3300
+#: src/api/reference.md:3338
 msgid "`extract` — instance"
 msgstr "`extract` 实例"
 
-#: src/api/reference.md:3301
+#: src/api/reference.md:3339
 msgid "`flip` — instance"
 msgstr "`flip` — 实例"
 
-#: src/api/reference.md:3302
+#: src/api/reference.md:3340
 msgid "`flop` — instance"
 msgstr "`flop` — 实例"
 
-#: src/api/reference.md:3303
+#: src/api/reference.md:3341
 msgid "`grayscale` — instance"
 msgstr "`grayscale` — 实例"
 
-#: src/api/reference.md:3304
+#: src/api/reference.md:3342
 msgid "`height` — instance"
 msgstr "`height` — 实例"
 
-#: src/api/reference.md:3305
+#: src/api/reference.md:3343
 msgid "`jpeg` — instance"
 msgstr "`jpeg` — 实例"
 
-#: src/api/reference.md:3306
+#: src/api/reference.md:3344
 msgid "`metadata` — instance"
 msgstr "`metadata` — 实例"
 
-#: src/api/reference.md:3307
+#: src/api/reference.md:3345
 msgid "`png` — instance"
 msgstr "`png` — 实例"
 
-#: src/api/reference.md:3308
+#: src/api/reference.md:3346
 msgid "`resize` — instance"
 msgstr "`resize` — 实例"
 
-#: src/api/reference.md:3309
+#: src/api/reference.md:3347
 msgid "`rotate` — instance"
 msgstr "`rotate` — 实例"
 
-#: src/api/reference.md:3310
+#: src/api/reference.md:3348
 msgid "`sharp` — module"
 msgstr "`sharp` — 模块"
 
-#: src/api/reference.md:3311
+#: src/api/reference.md:3349
 msgid "`sharpen` — instance"
 msgstr "`sharpen` 实例"
 
-#: src/api/reference.md:3312
+#: src/api/reference.md:3350
 msgid "`toBuffer` — instance"
 msgstr "`toBuffer` — 实例"
 
-#: src/api/reference.md:3313
+#: src/api/reference.md:3351
 msgid "`toFile` — instance"
 msgstr "`toFile` — 实例"
 
-#: src/api/reference.md:3314
+#: src/api/reference.md:3352
 msgid "`trim` — instance"
 msgstr "`trim` 实例"
 
-#: src/api/reference.md:3315
+#: src/api/reference.md:3353
 msgid "`webp` — instance"
 msgstr "`webp` — 实例"
 
-#: src/api/reference.md:3316
+#: src/api/reference.md:3354
 msgid "`width` — instance"
 msgstr "`width` — 实例"
 
-#: src/api/reference.md:3318
+#: src/api/reference.md:3356
 msgid "`sqlite`"
 msgstr "`sqlite`"
 
-#: src/api/reference.md:3322
+#: src/api/reference.md:3360
 msgid "`DatabaseSync`"
 msgstr "`DatabaseSync`"
 
-#: src/api/reference.md:3323
+#: src/api/reference.md:3361
 msgid "`SQLTagStore`"
 msgstr "`SQLTagStore`"
 
-#: src/api/reference.md:3325
+#: src/api/reference.md:3363
 msgid "`StatementSync`"
 msgstr "`StatementSync`"
 
-#: src/api/reference.md:3329
+#: src/api/reference.md:3367
 msgid "`@@__perry_wk_dispose` — instance"
 msgstr "`@@__perry_wk_dispose` — 实例"
 
-#: src/api/reference.md:3330
+#: src/api/reference.md:3368
 msgid "`DatabaseSync` — module"
 msgstr "`DatabaseSync` — 模块"
 
-#: src/api/reference.md:3332
+#: src/api/reference.md:3370
 msgid "`StatementSync` — module"
 msgstr "`StatementSync` — 模块"
 
-#: src/api/reference.md:3333
+#: src/api/reference.md:3371
 msgid "`__perry_dispose__` — instance"
 msgstr "`__perry_dispose__` — 实例"
 
-#: src/api/reference.md:3334
+#: src/api/reference.md:3372
 msgid "`aggregate` — instance _(class: `DatabaseSync`)_"
 msgstr "`aggregate` — 实例 _(类：`DatabaseSync`)_"
 
-#: src/api/reference.md:3335
+#: src/api/reference.md:3373
 msgid "`all` — instance _(class: `SQLTagStore`)_"
 msgstr "`all` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3337
+#: src/api/reference.md:3375
 msgid "`applyChangeset` — instance"
 msgstr "`applyChangeset` — 实例"
 
-#: src/api/reference.md:3338
+#: src/api/reference.md:3376
 msgid "`backup` — module"
 msgstr "`backup` — 模块"
 
-#: src/api/reference.md:3339
+#: src/api/reference.md:3377
 msgid "`capacity` — instance _(class: `SQLTagStore`)_"
 msgstr "`capacity` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3340
+#: src/api/reference.md:3378
 msgid "`changeset` — instance"
 msgstr "`changeset` — 实例"
 
-#: src/api/reference.md:3341
+#: src/api/reference.md:3379
 msgid "`clear` — instance _(class: `SQLTagStore`)_"
 msgstr "`clear` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3344
+#: src/api/reference.md:3382
 msgid "`createSession` — instance"
 msgstr "`createSession` — 实例"
 
-#: src/api/reference.md:3345
+#: src/api/reference.md:3383
 msgid "`createTagStore` — instance _(class: `DatabaseSync`)_"
 msgstr "`createTagStore` — 实例 _(类：`DatabaseSync`)_"
 
-#: src/api/reference.md:3346
+#: src/api/reference.md:3384
 msgid "`db` — instance _(class: `SQLTagStore`)_"
 msgstr "`db` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3347
+#: src/api/reference.md:3385
 msgid "`deserialize` — instance"
 msgstr "`deserialize` 实例"
 
-#: src/api/reference.md:3348
+#: src/api/reference.md:3386
 msgid "`enableDefensive` — instance _(class: `DatabaseSync`)_"
 msgstr "`enableDefensive` — 实例 _(类：`DatabaseSync`)_"
 
-#: src/api/reference.md:3349
+#: src/api/reference.md:3387
 msgid "`enableLoadExtension` — instance"
 msgstr "`enableLoadExtension` — 实例"
 
-#: src/api/reference.md:3351
+#: src/api/reference.md:3389
 msgid "`expandedSQL` — instance"
 msgstr "`expandedSQL` — 实例"
 
-#: src/api/reference.md:3352
+#: src/api/reference.md:3390
 msgid "`function` — instance _(class: `DatabaseSync`)_"
 msgstr "`function` — 实例 _(类：`DatabaseSync`)_"
 
-#: src/api/reference.md:3353
+#: src/api/reference.md:3391
 msgid "`get` — instance _(class: `SQLTagStore`)_"
 msgstr "`get` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3355
+#: src/api/reference.md:3393
 msgid "`isOpen` — instance"
 msgstr "`isOpen` — 实例"
 
-#: src/api/reference.md:3356
+#: src/api/reference.md:3394
 msgid "`isTransaction` — instance"
 msgstr "`isTransaction` — 实例"
 
-#: src/api/reference.md:3357
+#: src/api/reference.md:3395
 msgid "`iterate` — instance _(class: `SQLTagStore`)_"
 msgstr "`iterate` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3359
+#: src/api/reference.md:3397
 msgid "`limits` — instance"
 msgstr "`limits` — 实例"
 
-#: src/api/reference.md:3360
+#: src/api/reference.md:3398
 msgid "`loadExtension` — instance"
 msgstr "`loadExtension` — 实例"
 
-#: src/api/reference.md:3361
+#: src/api/reference.md:3399
 msgid "`location` — instance"
 msgstr "`location` — 实例"
 
-#: src/api/reference.md:3362
+#: src/api/reference.md:3400
 msgid "`open` — instance"
 msgstr "`open` — 实例"
 
-#: src/api/reference.md:3363
+#: src/api/reference.md:3401
 msgid "`patchset` — instance"
 msgstr "`patchset` — 实例"
 
-#: src/api/reference.md:3365
+#: src/api/reference.md:3403
 msgid "`run` — instance _(class: `SQLTagStore`)_"
 msgstr "`run` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3367
+#: src/api/reference.md:3405
 msgid "`serialize` — instance"
 msgstr "`serialize` 实例"
 
-#: src/api/reference.md:3368
+#: src/api/reference.md:3406
 msgid "`setAllowBareNamedParameters` — instance"
 msgstr "`setAllowBareNamedParameters` — 实例"
 
-#: src/api/reference.md:3369
+#: src/api/reference.md:3407
 msgid "`setAllowUnknownNamedParameters` — instance"
 msgstr "`setAllowUnknownNamedParameters` — 实例"
 
-#: src/api/reference.md:3370
+#: src/api/reference.md:3408
 msgid "`setAuthorizer` — instance _(class: `DatabaseSync`)_"
 msgstr "`setAuthorizer` — 实例 _(类：`DatabaseSync`)_"
 
-#: src/api/reference.md:3371
+#: src/api/reference.md:3409
 msgid "`setReadBigInts` — instance"
 msgstr "`setReadBigInts` — 实例"
 
-#: src/api/reference.md:3372
+#: src/api/reference.md:3410
 msgid "`setReturnArrays` — instance"
 msgstr "`setReturnArrays` — 实例"
 
-#: src/api/reference.md:3373
+#: src/api/reference.md:3411
 msgid "`size` — instance _(class: `SQLTagStore`)_"
 msgstr "`size` — 实例 _(类：`SQLTagStore`)_"
 
-#: src/api/reference.md:3374
+#: src/api/reference.md:3412
 msgid "`sourceSQL` — instance"
 msgstr "`sourceSQL` — 实例"
 
-#: src/api/reference.md:3380
+#: src/api/reference.md:3418
 msgid "`stream`"
 msgstr "`stream`"
 
-#: src/api/reference.md:3384
+#: src/api/reference.md:3422
 msgid "`Duplex`"
 msgstr "`Duplex`"
 
-#: src/api/reference.md:3385
+#: src/api/reference.md:3423
 msgid "`PassThrough`"
 msgstr "`PassThrough`"
 
-#: src/api/reference.md:3386
+#: src/api/reference.md:3424
 msgid "`Readable`"
 msgstr "`Readable`"
 
-#: src/api/reference.md:3388
+#: src/api/reference.md:3426
 msgid "`Transform`"
 msgstr "`Transform`"
 
-#: src/api/reference.md:3389
+#: src/api/reference.md:3427
 msgid "`Writable`"
 msgstr "`Writable`"
 
-#: src/api/reference.md:3393
+#: src/api/reference.md:3431
 msgid "`_isArrayBufferView` — module"
 msgstr "`_isArrayBufferView` — 模块"
 
-#: src/api/reference.md:3394
+#: src/api/reference.md:3432
 msgid "`_isUint8Array` — module"
 msgstr "`_isUint8Array` — 模块"
 
-#: src/api/reference.md:3395
+#: src/api/reference.md:3433
 msgid "`_uint8ArrayToBuffer` — module"
 msgstr "`_uint8ArrayToBuffer` — 模块"
 
-#: src/api/reference.md:3396
+#: src/api/reference.md:3434
 msgid "`addAbortSignal` — module"
 msgstr "`addAbortSignal` — 模块"
 
-#: src/api/reference.md:3398
+#: src/api/reference.md:3436
 msgid "`allowHalfOpen` — instance"
 msgstr "`allowHalfOpen` — 实例"
 
-#: src/api/reference.md:3399
+#: src/api/reference.md:3437
 msgid "`closed` — instance"
 msgstr "`closed` — 实例"
 
-#: src/api/reference.md:3400
+#: src/api/reference.md:3438
 msgid "`compose` — module"
 msgstr "`compose` — 模块"
 
-#: src/api/reference.md:3401
+#: src/api/reference.md:3439
 msgid "`cork` — instance"
 msgstr "`cork` — 实例"
 
-#: src/api/reference.md:3403
+#: src/api/reference.md:3441
 msgid "`destroy` — instance"
 msgstr "`destroy` — 实例"
 
-#: src/api/reference.md:3404
+#: src/api/reference.md:3442
 msgid "`destroyed` — instance"
 msgstr "`destroyed` — 实例"
 
-#: src/api/reference.md:3405
+#: src/api/reference.md:3443
 msgid "`duplexPair` — module"
 msgstr "`duplexPair` — 模块"
 
-#: src/api/reference.md:3408
+#: src/api/reference.md:3446
 msgid "`errored` — instance"
 msgstr "`errored` — 实例"
 
-#: src/api/reference.md:3410 src/api/reference.md:3484
-#: src/api/reference.md:3485
+#: src/api/reference.md:3448 src/api/reference.md:3522
+#: src/api/reference.md:3523
 msgid "`finished` — module"
 msgstr "`finished` — 模块"
 
-#: src/api/reference.md:3411
+#: src/api/reference.md:3449
 msgid "`getDefaultHighWaterMark` — module"
 msgstr "`getDefaultHighWaterMark` — 模块"
 
-#: src/api/reference.md:3413
+#: src/api/reference.md:3451
 msgid "`isDestroyed` — module"
 msgstr "`isDestroyed` — 模块"
 
-#: src/api/reference.md:3414
+#: src/api/reference.md:3452
 msgid "`isDisturbed` — module"
 msgstr "`isDisturbed` — 模块"
 
-#: src/api/reference.md:3415
+#: src/api/reference.md:3453
 msgid "`isErrored` — module"
 msgstr "`isErrored` — 模块"
 
-#: src/api/reference.md:3416
+#: src/api/reference.md:3454
 msgid "`isPaused` — instance"
 msgstr "`isPaused` — 实例"
 
-#: src/api/reference.md:3417
+#: src/api/reference.md:3455
 msgid "`isReadable` — module"
 msgstr "`isReadable` — 模块"
 
-#: src/api/reference.md:3418
+#: src/api/reference.md:3456
 msgid "`isWritable` — module"
 msgstr "`isWritable` — 模块"
 
-#: src/api/reference.md:3425
+#: src/api/reference.md:3463
 msgid "`pipe` — instance"
 msgstr "`pipe` — 实例"
 
-#: src/api/reference.md:3426 src/api/reference.md:3486
-#: src/api/reference.md:3487
+#: src/api/reference.md:3464 src/api/reference.md:3524
+#: src/api/reference.md:3525
 msgid "`pipeline` — module"
 msgstr "`pipeline` — 模块"
 
-#: src/api/reference.md:3429
+#: src/api/reference.md:3467
 msgid "`push` — instance"
 msgstr "`push` — 实例"
 
-#: src/api/reference.md:3431
+#: src/api/reference.md:3469
 msgid "`read` — instance"
 msgstr "`read` — 实例"
 
-#: src/api/reference.md:3432
+#: src/api/reference.md:3470
 msgid "`readable` — instance"
 msgstr "`readable` — 实例"
 
-#: src/api/reference.md:3433
+#: src/api/reference.md:3471
 msgid "`readableAborted` — instance"
 msgstr "`readableAborted` — 实例"
 
-#: src/api/reference.md:3434
+#: src/api/reference.md:3472
 msgid "`readableDidRead` — instance"
 msgstr "`readableDidRead` — 实例"
 
-#: src/api/reference.md:3435
+#: src/api/reference.md:3473
 msgid "`readableEncoding` — instance"
 msgstr "`readableEncoding` — 实例"
 
-#: src/api/reference.md:3436
+#: src/api/reference.md:3474
 msgid "`readableEnded` — instance"
 msgstr "`readableEnded` — 实例"
 
-#: src/api/reference.md:3437
+#: src/api/reference.md:3475
 msgid "`readableFlowing` — instance"
 msgstr "`readableFlowing` — 实例"
 
-#: src/api/reference.md:3438
+#: src/api/reference.md:3476
 msgid "`readableHighWaterMark` — instance"
 msgstr "`readableHighWaterMark` — 实例"
 
-#: src/api/reference.md:3439
+#: src/api/reference.md:3477
 msgid "`readableLength` — instance"
 msgstr "`readableLength` — 实例"
 
-#: src/api/reference.md:3440
+#: src/api/reference.md:3478
 msgid "`readableObjectMode` — instance"
 msgstr "`readableObjectMode` — 实例"
 
-#: src/api/reference.md:3444
+#: src/api/reference.md:3482
 msgid "`setDefaultHighWaterMark` — module"
 msgstr "`setDefaultHighWaterMark` — 模块"
 
-#: src/api/reference.md:3445
+#: src/api/reference.md:3483
 msgid "`setEncoding` — instance"
 msgstr "`setEncoding` — 实例"
 
-#: src/api/reference.md:3447
+#: src/api/reference.md:3485
 msgid "`uncork` — instance"
 msgstr "`uncork` — 实例"
 
-#: src/api/reference.md:3448
+#: src/api/reference.md:3486
 msgid "`unpipe` — instance"
 msgstr "`unpipe` — 实例"
 
-#: src/api/reference.md:3449
+#: src/api/reference.md:3487
 msgid "`unshift` — instance"
 msgstr "`unshift` — 实例"
 
-#: src/api/reference.md:3450
+#: src/api/reference.md:3488
 msgid "`writable` — instance"
 msgstr "`writable` — 实例"
 
-#: src/api/reference.md:3451
+#: src/api/reference.md:3489
 msgid "`writableCorked` — instance"
 msgstr "`writableCorked` — 实例"
 
-#: src/api/reference.md:3452
+#: src/api/reference.md:3490
 msgid "`writableEnded` — instance"
 msgstr "`writableEnded` — 实例"
 
-#: src/api/reference.md:3453
+#: src/api/reference.md:3491
 msgid "`writableFinished` — instance"
 msgstr "`writableFinished` — 实例"
 
-#: src/api/reference.md:3454
+#: src/api/reference.md:3492
 msgid "`writableHighWaterMark` — instance"
 msgstr "`writableHighWaterMark` — 实例"
 
-#: src/api/reference.md:3455
+#: src/api/reference.md:3493
 msgid "`writableLength` — instance"
 msgstr "`writableLength` — 实例"
 
-#: src/api/reference.md:3456
+#: src/api/reference.md:3494
 msgid "`writableNeedDrain` — instance"
 msgstr "`writableNeedDrain` — 实例"
 
-#: src/api/reference.md:3457
+#: src/api/reference.md:3495
 msgid "`writableObjectMode` — instance"
 msgstr "`writableObjectMode` — 实例"
 
-#: src/api/reference.md:3465
+#: src/api/reference.md:3503
 msgid "`stream/consumers`"
 msgstr "`stream/consumers`"
 
-#: src/api/reference.md:3469
+#: src/api/reference.md:3507
 msgid "`arrayBuffer` — module"
 msgstr "`arrayBuffer` — 模块"
 
-#: src/api/reference.md:3470
+#: src/api/reference.md:3508
 msgid "`blob` — module"
 msgstr "`blob` — 模块"
 
-#: src/api/reference.md:3471
+#: src/api/reference.md:3509
 msgid "`buffer` — module"
 msgstr "`buffer` — 模块"
 
-#: src/api/reference.md:3472
+#: src/api/reference.md:3510
 msgid "`bytes` — module"
 msgstr "`bytes` — 模块"
 
-#: src/api/reference.md:3473
+#: src/api/reference.md:3511
 msgid "`json` — module"
 msgstr "`json` — 模块"
 
-#: src/api/reference.md:3474
+#: src/api/reference.md:3512
 msgid "`text` — module"
 msgstr "`text` — 模块"
 
-#: src/api/reference.md:3480
+#: src/api/reference.md:3518
 msgid "`stream/promises`"
 msgstr "`stream/promises`"
 
-#: src/api/reference.md:3489
+#: src/api/reference.md:3527
 msgid "`stream/web`"
 msgstr "`stream/web`"
 
-#: src/api/reference.md:3493 src/api/reference.md:3519
+#: src/api/reference.md:3531 src/api/reference.md:3557
 msgid "`ByteLengthQueuingStrategy`"
 msgstr "`ByteLengthQueuingStrategy`"
 
-#: src/api/reference.md:3494
+#: src/api/reference.md:3532
 msgid "`CompressionStream`"
 msgstr "`CompressionStream`"
 
-#: src/api/reference.md:3495 src/api/reference.md:3520
+#: src/api/reference.md:3533 src/api/reference.md:3558
 msgid "`CountQueuingStrategy`"
 msgstr "`CountQueuingStrategy`"
 
-#: src/api/reference.md:3496 src/api/reference.md:3521
+#: src/api/reference.md:3534 src/api/reference.md:3559
 msgid "`DecompressionStream`"
 msgstr "`DecompressionStream`"
 
-#: src/api/reference.md:3497
+#: src/api/reference.md:3535
 msgid "`ReadableByteStreamController`"
 msgstr "`ReadableByteStreamController`"
 
-#: src/api/reference.md:3498 src/api/reference.md:3522
+#: src/api/reference.md:3536 src/api/reference.md:3560
 msgid "`ReadableStream`"
 msgstr "`ReadableStream`"
 
-#: src/api/reference.md:3499
+#: src/api/reference.md:3537
 msgid "`ReadableStreamBYOBReader`"
 msgstr "`ReadableStreamBYOBReader`"
 
-#: src/api/reference.md:3500
+#: src/api/reference.md:3538
 msgid "`ReadableStreamBYOBRequest`"
 msgstr "`ReadableStreamBYOBRequest`"
 
-#: src/api/reference.md:3501
+#: src/api/reference.md:3539
 msgid "`ReadableStreamDefaultController`"
 msgstr "`ReadableStreamDefaultController`"
 
-#: src/api/reference.md:3502
+#: src/api/reference.md:3540
 msgid "`ReadableStreamDefaultReader`"
 msgstr "`ReadableStreamDefaultReader`"
 
-#: src/api/reference.md:3503
+#: src/api/reference.md:3541
 msgid "`TextDecoderStream`"
 msgstr "`TextDecoderStream`"
 
-#: src/api/reference.md:3504
+#: src/api/reference.md:3542
 msgid "`TextEncoderStream`"
 msgstr "`TextEncoderStream`"
 
-#: src/api/reference.md:3505 src/api/reference.md:3525
+#: src/api/reference.md:3543 src/api/reference.md:3563
 msgid "`TransformStream`"
 msgstr "`TransformStream`"
 
-#: src/api/reference.md:3506
+#: src/api/reference.md:3544
 msgid "`TransformStreamDefaultController`"
 msgstr "`TransformStreamDefaultController`"
 
-#: src/api/reference.md:3507 src/api/reference.md:3526
+#: src/api/reference.md:3545 src/api/reference.md:3564
 msgid "`WritableStream`"
 msgstr "`WritableStream`"
 
-#: src/api/reference.md:3508
+#: src/api/reference.md:3546
 msgid "`WritableStreamDefaultController`"
 msgstr "`WritableStreamDefaultController`"
 
-#: src/api/reference.md:3509
+#: src/api/reference.md:3547
 msgid "`WritableStreamDefaultWriter`"
 msgstr "`WritableStreamDefaultWriter`"
 
-#: src/api/reference.md:3523 src/api/reference.md:3545
-#: src/api/reference.md:3820
+#: src/api/reference.md:3561 src/api/reference.md:3583
+#: src/api/reference.md:3858
 msgid "`TextDecoder`"
 msgstr "`TextDecoder`"
 
-#: src/api/reference.md:3524 src/api/reference.md:3546
-#: src/api/reference.md:3821
+#: src/api/reference.md:3562 src/api/reference.md:3584
+#: src/api/reference.md:3859
 msgid "`TextEncoder`"
 msgstr "`TextEncoder`"
 
-#: src/api/reference.md:3528
+#: src/api/reference.md:3566
 msgid "`string_decoder`"
 msgstr "`string_decoder`"
 
-#: src/api/reference.md:3532
+#: src/api/reference.md:3570
 msgid "`StringDecoder`"
 msgstr "`StringDecoder`"
 
-#: src/api/reference.md:3536
+#: src/api/reference.md:3574
 msgid "`end` — instance _(class: `StringDecoder`)_"
 msgstr "`end` — 实例 _(类：`StringDecoder`)_"
 
-#: src/api/reference.md:3537
+#: src/api/reference.md:3575
 msgid "`write` — instance _(class: `StringDecoder`)_"
 msgstr "`write` — 实例 _(类：`StringDecoder`)_"
 
-#: src/api/reference.md:3539
+#: src/api/reference.md:3577
 msgid "`sys`"
 msgstr "`sys`"
 
-#: src/api/reference.md:3543 src/api/reference.md:3818
+#: src/api/reference.md:3581 src/api/reference.md:3856
 msgid "`MIMEParams`"
 msgstr "`MIMEParams`"
 
-#: src/api/reference.md:3544 src/api/reference.md:3819
+#: src/api/reference.md:3582 src/api/reference.md:3857
 msgid "`MIMEType`"
 msgstr "`MIMEType`"
 
-#: src/api/reference.md:3550 src/api/reference.md:3825
+#: src/api/reference.md:3588 src/api/reference.md:3863
 msgid "`MIMEParams` — module"
 msgstr "`MIMEParams` — 模块"
 
-#: src/api/reference.md:3551 src/api/reference.md:3826
+#: src/api/reference.md:3589 src/api/reference.md:3864
 msgid "`MIMEType` — module"
 msgstr "`MIMEType` — 模块"
 
-#: src/api/reference.md:3552 src/api/reference.md:3827
+#: src/api/reference.md:3590 src/api/reference.md:3865
 msgid "`_errnoException` — module"
 msgstr "`_errnoException` — 模块"
 
-#: src/api/reference.md:3553 src/api/reference.md:3828
+#: src/api/reference.md:3591 src/api/reference.md:3866
 msgid "`_exceptionWithHostPort` — module"
 msgstr "`_exceptionWithHostPort` — 模块"
 
-#: src/api/reference.md:3554 src/api/reference.md:3829
+#: src/api/reference.md:3592 src/api/reference.md:3867
 msgid "`_extend` — module"
 msgstr "`_extend` — 模块"
 
-#: src/api/reference.md:3555 src/api/reference.md:3830
+#: src/api/reference.md:3593 src/api/reference.md:3868
 msgid "`aborted` — module"
 msgstr "`aborted` — 模块"
 
-#: src/api/reference.md:3556 src/api/reference.md:3831
+#: src/api/reference.md:3594 src/api/reference.md:3869
 msgid "`callbackify` — module"
 msgstr "`callbackify` — 模块"
 
-#: src/api/reference.md:3557 src/api/reference.md:3832
+#: src/api/reference.md:3595 src/api/reference.md:3870
 msgid "`convertProcessSignalToExitCode` — module"
 msgstr "`convertProcessSignalToExitCode` — 模块"
 
-#: src/api/reference.md:3559 src/api/reference.md:3834
+#: src/api/reference.md:3597 src/api/reference.md:3872
 msgid "`debuglog` — module"
 msgstr "`debuglog` — 模块"
 
-#: src/api/reference.md:3560 src/api/reference.md:3835
+#: src/api/reference.md:3598 src/api/reference.md:3873
 msgid "`deprecate` — module"
 msgstr "`deprecate` — 模块"
 
-#: src/api/reference.md:3561 src/api/reference.md:3836
+#: src/api/reference.md:3599 src/api/reference.md:3874
 msgid "`diff` — module"
 msgstr "`diff` — 模块"
 
-#: src/api/reference.md:3563 src/api/reference.md:3838
+#: src/api/reference.md:3601 src/api/reference.md:3876
 msgid "`formatWithOptions` — module"
 msgstr "`formatWithOptions` — 模块"
 
-#: src/api/reference.md:3564 src/api/reference.md:3839
+#: src/api/reference.md:3602 src/api/reference.md:3877
 msgid "`getCallSites` — module"
 msgstr "`getCallSites` — 模块"
 
-#: src/api/reference.md:3565 src/api/reference.md:3840
+#: src/api/reference.md:3603 src/api/reference.md:3878
 msgid "`getSystemErrorMap` — module"
 msgstr "`getSystemErrorMap` — 模块"
 
-#: src/api/reference.md:3566 src/api/reference.md:3841
+#: src/api/reference.md:3604 src/api/reference.md:3879
 msgid "`getSystemErrorMessage` — module"
 msgstr "`getSystemErrorMessage` — 模块"
 
-#: src/api/reference.md:3567 src/api/reference.md:3842
+#: src/api/reference.md:3605 src/api/reference.md:3880
 msgid "`getSystemErrorName` — module"
 msgstr "`getSystemErrorName` — 模块"
 
-#: src/api/reference.md:3568 src/api/reference.md:3843
+#: src/api/reference.md:3606 src/api/reference.md:3881
 msgid "`inherits` — module"
 msgstr "`inherits` — 模块"
 
-#: src/api/reference.md:3570 src/api/reference.md:3845
+#: src/api/reference.md:3608 src/api/reference.md:3883
 msgid "`isArray` — module"
 msgstr "`isArray` — 模块"
 
-#: src/api/reference.md:3571 src/api/reference.md:3846
+#: src/api/reference.md:3609 src/api/reference.md:3884
 msgid "`isDeepStrictEqual` — module"
 msgstr "`isDeepStrictEqual` — 模块"
 
-#: src/api/reference.md:3572 src/api/reference.md:3847
+#: src/api/reference.md:3610 src/api/reference.md:3885
 msgid "`parseArgs` — module"
 msgstr "`parseArgs` — 模块"
 
-#: src/api/reference.md:3573 src/api/reference.md:3848
+#: src/api/reference.md:3611 src/api/reference.md:3886
 msgid "`parseEnv` — module"
 msgstr "`parseEnv` — 模块"
 
-#: src/api/reference.md:3574 src/api/reference.md:3849
+#: src/api/reference.md:3612 src/api/reference.md:3887
 msgid "`promisify` — module"
 msgstr "`promisify` — 模块"
 
-#: src/api/reference.md:3575 src/api/reference.md:3850
+#: src/api/reference.md:3613 src/api/reference.md:3888
 msgid "`setTraceSigInt` — module"
 msgstr "`setTraceSigInt` — 模块"
 
-#: src/api/reference.md:3576 src/api/reference.md:3851
+#: src/api/reference.md:3614 src/api/reference.md:3889
 msgid "`stripVTControlCharacters` — module"
 msgstr "`stripVTControlCharacters` — 模块"
 
-#: src/api/reference.md:3577 src/api/reference.md:3852
+#: src/api/reference.md:3615 src/api/reference.md:3890
 msgid "`styleText` — module"
 msgstr "`styleText` — 模块"
 
-#: src/api/reference.md:3578 src/api/reference.md:3853
+#: src/api/reference.md:3616 src/api/reference.md:3891
 msgid "`toUSVString` — module"
 msgstr "`toUSVString` — 模块"
 
-#: src/api/reference.md:3579 src/api/reference.md:3854
+#: src/api/reference.md:3617 src/api/reference.md:3892
 msgid "`transferableAbortController` — module"
 msgstr "`transferableAbortController` — 模块"
 
-#: src/api/reference.md:3580 src/api/reference.md:3855
+#: src/api/reference.md:3618 src/api/reference.md:3893
 msgid "`transferableAbortSignal` — module"
 msgstr "`transferableAbortSignal` — 模块"
 
-#: src/api/reference.md:3585 src/api/reference.md:3860 src/cli/commands.md:26
+#: src/api/reference.md:3623 src/api/reference.md:3898 src/cli/commands.md:26
 msgid "`types`"
 msgstr "`types`"
 
-#: src/api/reference.md:3587
+#: src/api/reference.md:3625
 msgid "`test`"
 msgstr "`test`"
 
-#: src/api/reference.md:3591
+#: src/api/reference.md:3629
 msgid "`after` — module"
 msgstr "`after` — 模块"
 
-#: src/api/reference.md:3592
+#: src/api/reference.md:3630
 msgid "`afterEach` — module"
 msgstr "`afterEach` — 模块"
 
-#: src/api/reference.md:3593
+#: src/api/reference.md:3631
 msgid "`before` — module"
 msgstr "`before` — 模块"
 
-#: src/api/reference.md:3594
+#: src/api/reference.md:3632
 msgid "`beforeEach` — module"
 msgstr "`beforeEach` — 模块"
 
-#: src/api/reference.md:3597
+#: src/api/reference.md:3635
 msgid "`enable` — module _(class: `timers`)_"
 msgstr "`enable` — 模块 _(类：`timers`)_"
 
-#: src/api/reference.md:3598
+#: src/api/reference.md:3636
 msgid "`expectFailure` — module"
 msgstr "`expectFailure` — 模块"
 
-#: src/api/reference.md:3599
+#: src/api/reference.md:3637
 msgid "`fn` — module _(class: `mock`)_"
 msgstr "`fn` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3600
+#: src/api/reference.md:3638
 msgid "`getter` — module _(class: `mock`)_"
 msgstr "`getter` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3601
+#: src/api/reference.md:3639
 msgid "`it` — module"
 msgstr "`it` — 模块"
 
-#: src/api/reference.md:3602
+#: src/api/reference.md:3640
 msgid "`method` — module _(class: `mock`)_"
 msgstr "`method` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3603
+#: src/api/reference.md:3641
 msgid "`only` — module"
 msgstr "`only` — 模块"
 
-#: src/api/reference.md:3604
+#: src/api/reference.md:3642
 msgid "`property` — module _(class: `mock`)_"
 msgstr "`property` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3605
+#: src/api/reference.md:3643
 msgid "`reset` — module _(class: `mock`)_"
 msgstr "`reset` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3606
+#: src/api/reference.md:3644
 msgid "`restoreAll` — module _(class: `mock`)_"
 msgstr "`restoreAll` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3608
+#: src/api/reference.md:3646
 msgid "`runAll` — module _(class: `timers`)_"
 msgstr "`runAll` — 模块 _(类：`timers`)_"
 
-#: src/api/reference.md:3609
+#: src/api/reference.md:3647
 msgid "`setDefaultSnapshotSerializers` — module _(class: `snapshot`)_"
 msgstr "`setDefaultSnapshotSerializers` — 模块 _(类：`snapshot`)_"
 
-#: src/api/reference.md:3610
+#: src/api/reference.md:3648
 msgid "`setResolveSnapshotPath` — module _(class: `snapshot`)_"
 msgstr "`setResolveSnapshotPath` — 模块 _(类：`snapshot`)_"
 
-#: src/api/reference.md:3611
+#: src/api/reference.md:3649
 msgid "`setTime` — module _(class: `timers`)_"
 msgstr "`setTime` — 模块 _(类：`timers`)_"
 
-#: src/api/reference.md:3612
+#: src/api/reference.md:3650
 msgid "`setter` — module _(class: `mock`)_"
 msgstr "`setter` — 模块 _(类：`mock`)_"
 
-#: src/api/reference.md:3613
+#: src/api/reference.md:3651
 msgid "`skip` — module"
 msgstr "`skip` — 模块"
 
-#: src/api/reference.md:3614
+#: src/api/reference.md:3652
 msgid "`suite` — module"
 msgstr "`suite` — 模块"
 
-#: src/api/reference.md:3615
+#: src/api/reference.md:3653
 msgid "`test` — module"
 msgstr "`test` — 模块"
 
-#: src/api/reference.md:3616
+#: src/api/reference.md:3654
 msgid "`tick` — module _(class: `timers`)_"
 msgstr "`tick` — 模块 _(类：`timers`)_"
 
-#: src/api/reference.md:3617
+#: src/api/reference.md:3655
 msgid "`todo` — module"
 msgstr "`todo` — 模块"
 
-#: src/api/reference.md:3622
+#: src/api/reference.md:3660
 msgid "`mock`"
 msgstr "`mock`"
 
-#: src/api/reference.md:3623
+#: src/api/reference.md:3661
 msgid "`snapshot`"
 msgstr "`snapshot`"
 
-#: src/api/reference.md:3625
+#: src/api/reference.md:3663
 msgid "`test/reporters`"
 msgstr "`test/reporters`"
 
-#: src/api/reference.md:3629
+#: src/api/reference.md:3667
 msgid "`dot` — module"
 msgstr "`dot` — 模块"
 
-#: src/api/reference.md:3630
+#: src/api/reference.md:3668
 msgid "`junit` — module"
 msgstr "`junit` — 模块"
 
-#: src/api/reference.md:3631
+#: src/api/reference.md:3669
 msgid "`lcov` — module"
 msgstr "`lcov` — 模块"
 
-#: src/api/reference.md:3632
+#: src/api/reference.md:3670
 msgid "`spec` — module"
 msgstr "`spec` — 模块"
 
-#: src/api/reference.md:3633
+#: src/api/reference.md:3671
 msgid "`tap` — module"
 msgstr "`tap` — 模块"
 
-#: src/api/reference.md:3639
+#: src/api/reference.md:3677
 msgid "`timers`"
 msgstr "`timers`"
 
-#: src/api/reference.md:3643
+#: src/api/reference.md:3681
 msgid "`clearImmediate` — module"
 msgstr "`clearImmediate` — 模块"
 
-#: src/api/reference.md:3644
+#: src/api/reference.md:3682
 msgid "`clearInterval` — module"
 msgstr "`clearInterval` — 模块"
 
-#: src/api/reference.md:3645
+#: src/api/reference.md:3683
 msgid "`clearTimeout` — module"
 msgstr "`clearTimeout` — 模块"
 
-#: src/api/reference.md:3646 src/api/reference.md:3658
+#: src/api/reference.md:3684 src/api/reference.md:3696
 msgid "`setImmediate` — module"
 msgstr "`setImmediate` — 模块"
 
-#: src/api/reference.md:3647 src/api/reference.md:3659
+#: src/api/reference.md:3685 src/api/reference.md:3697
 msgid "`setInterval` — module"
 msgstr "`setInterval` — 模块"
 
-#: src/api/reference.md:3648 src/api/reference.md:3660
+#: src/api/reference.md:3686 src/api/reference.md:3698
 msgid "`setTimeout` — module"
 msgstr "`setTimeout` — 模块"
 
-#: src/api/reference.md:3654
+#: src/api/reference.md:3692
 msgid "`timers/promises`"
 msgstr "`timers/promises`"
 
-#: src/api/reference.md:3664
+#: src/api/reference.md:3702
 msgid "`scheduler`"
 msgstr "`scheduler`"
 
-#: src/api/reference.md:3666
+#: src/api/reference.md:3704
 msgid "`tls`"
 msgstr "`tls`"
 
-#: src/api/reference.md:3670
+#: src/api/reference.md:3708
 msgid "`SecureContext`"
 msgstr "`SecureContext`"
 
-#: src/api/reference.md:3674
+#: src/api/reference.md:3712
 msgid "`SecureContext` — module"
 msgstr "`SecureContext` — 模块"
 
-#: src/api/reference.md:3676
+#: src/api/reference.md:3714
 msgid "`TLSSocket` — module"
 msgstr "`TLSSocket` — 模块"
 
-#: src/api/reference.md:3679
+#: src/api/reference.md:3717
 msgid "`checkServerIdentity` — module"
 msgstr "`checkServerIdentity` — 模块"
 
-#: src/api/reference.md:3682
+#: src/api/reference.md:3720
 msgid "`convertALPNProtocols` — module"
 msgstr "模块 `convertALPNProtocols`"
 
-#: src/api/reference.md:3683
+#: src/api/reference.md:3721
 msgid "`createSecureContext` — module"
 msgstr "`createSecureContext` — 模块"
 
-#: src/api/reference.md:3686
+#: src/api/reference.md:3724
 msgid "`getCACertificates` — module"
 msgstr "`getCACertificates` — 模块"
 
-#: src/api/reference.md:3687
+#: src/api/reference.md:3725
 msgid "`getCertificateCompressionAlgorithms` — module"
 msgstr "模块 `getCertificateCompressionAlgorithms`"
 
-#: src/api/reference.md:3689
+#: src/api/reference.md:3727
 msgid "`getTicketKeys` — instance _(class: `Server`)_"
 msgstr "`getTicketKeys` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:3693
+#: src/api/reference.md:3731
 msgid "`on` — instance _(class: `Server`)_"
 msgstr "`on` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:3697
+#: src/api/reference.md:3735
 msgid "`setDefaultCACertificates` — module"
 msgstr "`setDefaultCACertificates` — 模块"
 
-#: src/api/reference.md:3698
+#: src/api/reference.md:3736
 msgid "`setSecureContext` — instance _(class: `Server`)_"
 msgstr "`setSecureContext` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:3699
+#: src/api/reference.md:3737
 msgid "`setTicketKeys` — instance _(class: `Server`)_"
 msgstr "`setTicketKeys` — 实例 _(类：`Server`)_"
 
-#: src/api/reference.md:3703
+#: src/api/reference.md:3741
 msgid "`CLIENT_RENEG_LIMIT`"
 msgstr "`CLIENT_RENEG_LIMIT`"
 
-#: src/api/reference.md:3704
+#: src/api/reference.md:3742
 msgid "`CLIENT_RENEG_WINDOW`"
 msgstr "`CLIENT_RENEG_WINDOW`"
 
-#: src/api/reference.md:3705
+#: src/api/reference.md:3743
 msgid "`DEFAULT_CIPHERS`"
 msgstr "`DEFAULT_CIPHERS`"
 
-#: src/api/reference.md:3706
+#: src/api/reference.md:3744
 msgid "`DEFAULT_ECDH_CURVE`"
 msgstr "`DEFAULT_ECDH_CURVE`"
 
-#: src/api/reference.md:3707
+#: src/api/reference.md:3745
 msgid "`DEFAULT_MAX_VERSION`"
 msgstr "`DEFAULT_MAX_VERSION`"
 
-#: src/api/reference.md:3708
+#: src/api/reference.md:3746
 msgid "`DEFAULT_MIN_VERSION`"
 msgstr "`DEFAULT_MIN_VERSION`"
 
-#: src/api/reference.md:3709
+#: src/api/reference.md:3747
 msgid "`rootCertificates`"
 msgstr "`rootCertificates`"
 
-#: src/api/reference.md:3711
+#: src/api/reference.md:3749
 msgid "`tty`"
 msgstr "`tty`"
 
-#: src/api/reference.md:3720
+#: src/api/reference.md:3758
 msgid "`ReadStream` — module"
 msgstr "`ReadStream` — 模块"
 
-#: src/api/reference.md:3721
+#: src/api/reference.md:3759
 msgid "`WriteStream` — module"
 msgstr "`WriteStream` — 模块"
 
-#: src/api/reference.md:3722
+#: src/api/reference.md:3760
 msgid "`_refreshSize` — instance _(class: `WriteStream`)_"
 msgstr "`_refreshSize` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3723
+#: src/api/reference.md:3761
 msgid "`addListener` — instance _(class: `WriteStream`)_"
 msgstr "`addListener` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3724
+#: src/api/reference.md:3762
 msgid "`clearLine` — instance _(class: `WriteStream`)_"
 msgstr "`clearLine` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3725
+#: src/api/reference.md:3763
 msgid "`clearScreenDown` — instance _(class: `WriteStream`)_"
 msgstr "`clearScreenDown` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3726
+#: src/api/reference.md:3764
 msgid "`cursorTo` — instance _(class: `WriteStream`)_"
 msgstr "`cursorTo` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3727
+#: src/api/reference.md:3765
 msgid "`getColorDepth` — instance _(class: `WriteStream`)_"
 msgstr "`getColorDepth` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3728
+#: src/api/reference.md:3766
 msgid "`getWindowSize` — instance _(class: `WriteStream`)_"
 msgstr "`getWindowSize` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3729
+#: src/api/reference.md:3767
 msgid "`hasColors` — instance _(class: `WriteStream`)_"
 msgstr "`hasColors` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3730
+#: src/api/reference.md:3768
 msgid "`isatty` — module"
 msgstr "`isatty` — 模块"
 
-#: src/api/reference.md:3731
+#: src/api/reference.md:3769
 msgid "`moveCursor` — instance _(class: `WriteStream`)_"
 msgstr "`moveCursor` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3732
+#: src/api/reference.md:3770
 msgid "`off` — instance _(class: `WriteStream`)_"
 msgstr "`off` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3733
+#: src/api/reference.md:3771
 msgid "`on` — instance _(class: `WriteStream`)_"
 msgstr "`on` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3734
+#: src/api/reference.md:3772
 msgid "`once` — instance _(class: `WriteStream`)_"
 msgstr "`once` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3735
+#: src/api/reference.md:3773
 msgid "`removeAllListeners` — instance _(class: `WriteStream`)_"
 msgstr "`removeAllListeners` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3736
+#: src/api/reference.md:3774
 msgid "`removeListener` — instance _(class: `WriteStream`)_"
 msgstr "`removeListener` — 实例 _(类：`WriteStream`)_"
 
-#: src/api/reference.md:3737
+#: src/api/reference.md:3775
 msgid "`setRawMode` — instance _(class: `ReadStream`)_"
 msgstr "`setRawMode` — 实例 _(类：`ReadStream`)_"
 
-#: src/api/reference.md:3739
+#: src/api/reference.md:3777
 msgid "`tursodb`"
 msgstr "`tursodb`"
 
-#: src/api/reference.md:3745
+#: src/api/reference.md:3783
 msgid "`execBatch` — instance"
 msgstr "`execBatch` — 实例"
 
-#: src/api/reference.md:3746
+#: src/api/reference.md:3784
 msgid "`isAutocommit` — instance"
 msgstr "`isAutocommit` — 实例"
 
-#: src/api/reference.md:3747
+#: src/api/reference.md:3785
 msgid "`lastInsertRowid` — instance"
 msgstr "`lastInsertRowid` — 实例"
 
-#: src/api/reference.md:3749
+#: src/api/reference.md:3787
 msgid "`queryAll` — instance"
 msgstr "`queryAll` — 实例"
 
-#: src/api/reference.md:3750
+#: src/api/reference.md:3788
 msgid "`queryOne` — instance"
 msgstr "`queryOne` — 实例"
 
-#: src/api/reference.md:3756
+#: src/api/reference.md:3794
 msgid "`flattenDiagnosticMessageText` — module"
 msgstr "模块 `flattenDiagnosticMessageText`"
 
-#: src/api/reference.md:3757
+#: src/api/reference.md:3795
 msgid "`transpileModule` — module"
 msgstr "模块 `transpileModule`"
 
-#: src/api/reference.md:3761
+#: src/api/reference.md:3799
 msgid "`DiagnosticCategory`"
 msgstr "`DiagnosticCategory`"
 
-#: src/api/reference.md:3762
+#: src/api/reference.md:3800
 msgid "`ModuleKind`"
 msgstr "`ModuleKind`"
 
-#: src/api/reference.md:3763
+#: src/api/reference.md:3801
 msgid "`ScriptTarget`"
 msgstr "`ScriptTarget`"
 
-#: src/api/reference.md:3770
+#: src/api/reference.md:3808
 msgid "`ProxyAgent`"
 msgstr "`ProxyAgent`"
 
-#: src/api/reference.md:3775
+#: src/api/reference.md:3813
 msgid "`ProxyAgent` — module"
 msgstr "模块 `ProxyAgent`"
 
-#: src/api/reference.md:3776
+#: src/api/reference.md:3814
 msgid "`close` — instance _(class: `ProxyAgent`)_"
 msgstr "`close` 实例 _ ((类:`ProxyAgent`)"
 
-#: src/api/reference.md:3778
+#: src/api/reference.md:3816
 msgid "`destroy` — instance _(class: `ProxyAgent`)_"
 msgstr "`destroy` 实例 _ ((类:`ProxyAgent`)"
 
-#: src/api/reference.md:3780
+#: src/api/reference.md:3818
 msgid "`fetch` — module"
 msgstr "模块 `fetch`"
 
-#: src/api/reference.md:3781
+#: src/api/reference.md:3819
 msgid "`getGlobalDispatcher` — module"
 msgstr "模块 `getGlobalDispatcher`"
 
-#: src/api/reference.md:3783
+#: src/api/reference.md:3821
 msgid "`setGlobalDispatcher` — module"
 msgstr "模块 `setGlobalDispatcher`"
 
-#: src/api/reference.md:3789
+#: src/api/reference.md:3827
 msgid "`URL`"
 msgstr "`URL`"
 
-#: src/api/reference.md:3790
+#: src/api/reference.md:3828
 msgid "`URLPattern`"
 msgstr "`URLPattern`"
 
-#: src/api/reference.md:3791
+#: src/api/reference.md:3829
 msgid "`URLSearchParams`"
 msgstr "`URLSearchParams`"
 
-#: src/api/reference.md:3792
+#: src/api/reference.md:3830
 msgid "`Url`"
 msgstr "`Url`"
 
-#: src/api/reference.md:3796
+#: src/api/reference.md:3834
 msgid "`Url` — module"
 msgstr "`Url` — 模块"
 
-#: src/api/reference.md:3797
+#: src/api/reference.md:3835
 msgid "`domainToASCII` — module"
 msgstr "`domainToASCII` — 模块"
 
-#: src/api/reference.md:3798
+#: src/api/reference.md:3836
 msgid "`domainToUnicode` — module"
 msgstr "`domainToUnicode` — 模块"
 
-#: src/api/reference.md:3799
+#: src/api/reference.md:3837
 msgid "`exec` — instance _(class: `URLPattern`)_"
 msgstr "`exec` — 实例 _(类：`URLPattern`)_"
 
-#: src/api/reference.md:3801
+#: src/api/reference.md:3839
 msgid "`fileURLToPathBuffer` — module"
 msgstr "`fileURLToPathBuffer` — 模块"
 
-#: src/api/reference.md:3806
+#: src/api/reference.md:3844
 msgid "`resolveObject` — module"
 msgstr "`resolveObject` — 模块"
 
-#: src/api/reference.md:3807
+#: src/api/reference.md:3845
 msgid "`test` — instance _(class: `URLPattern`)_"
 msgstr "`test` — 实例 _(类：`URLPattern`)_"
 
-#: src/api/reference.md:3808
+#: src/api/reference.md:3846
 msgid "`urlToHttpOptions` — module"
 msgstr "`urlToHttpOptions` — 模块"
 
-#: src/api/reference.md:3814
+#: src/api/reference.md:3852
 msgid "`util`"
 msgstr "`util`"
 
-#: src/api/reference.md:3862
+#: src/api/reference.md:3900
 msgid "`util/types`"
 msgstr "`util/types`"
 
-#: src/api/reference.md:3866
+#: src/api/reference.md:3904
 msgid "`isAnyArrayBuffer` — module"
 msgstr "`isAnyArrayBuffer` — 模块"
 
-#: src/api/reference.md:3867
+#: src/api/reference.md:3905
 msgid "`isArgumentsObject` — module"
 msgstr "`isArgumentsObject` — 模块"
 
-#: src/api/reference.md:3868
+#: src/api/reference.md:3906
 msgid "`isArrayBuffer` — module"
 msgstr "`isArrayBuffer` — 模块"
 
-#: src/api/reference.md:3869
+#: src/api/reference.md:3907
 msgid "`isArrayBufferView` — module"
 msgstr "`isArrayBufferView` — 模块"
 
-#: src/api/reference.md:3870
+#: src/api/reference.md:3908
 msgid "`isAsyncFunction` — module"
 msgstr "`isAsyncFunction` — 模块"
 
-#: src/api/reference.md:3871
+#: src/api/reference.md:3909
 msgid "`isBigInt64Array` — module"
 msgstr "`isBigInt64Array` — 模块"
 
-#: src/api/reference.md:3872
+#: src/api/reference.md:3910
 msgid "`isBigIntObject` — module"
 msgstr "`isBigIntObject` — 模块"
 
-#: src/api/reference.md:3873
+#: src/api/reference.md:3911
 msgid "`isBigUint64Array` — module"
 msgstr "`isBigUint64Array` — 模块"
 
-#: src/api/reference.md:3874
+#: src/api/reference.md:3912
 msgid "`isBooleanObject` — module"
 msgstr "`isBooleanObject` — 模块"
 
-#: src/api/reference.md:3875
+#: src/api/reference.md:3913
 msgid "`isBoxedPrimitive` — module"
 msgstr "`isBoxedPrimitive` — 模块"
 
-#: src/api/reference.md:3876
+#: src/api/reference.md:3914
 msgid "`isCryptoKey` — module"
 msgstr "`isCryptoKey` — 模块"
 
-#: src/api/reference.md:3877
+#: src/api/reference.md:3915
 msgid "`isDataView` — module"
 msgstr "`isDataView` — 模块"
 
-#: src/api/reference.md:3878
+#: src/api/reference.md:3916
 msgid "`isDate` — module"
 msgstr "`isDate` — 模块"
 
-#: src/api/reference.md:3879
+#: src/api/reference.md:3917
 msgid "`isExternal` — module"
 msgstr "`isExternal` — 模块"
 
-#: src/api/reference.md:3880
+#: src/api/reference.md:3918
 msgid "`isFloat16Array` — module"
 msgstr "`isFloat16Array` — 模块"
 
-#: src/api/reference.md:3881
+#: src/api/reference.md:3919
 msgid "`isFloat32Array` — module"
 msgstr "`isFloat32Array` — 模块"
 
-#: src/api/reference.md:3882
+#: src/api/reference.md:3920
 msgid "`isFloat64Array` — module"
 msgstr "`isFloat64Array` — 模块"
 
-#: src/api/reference.md:3883
+#: src/api/reference.md:3921
 msgid "`isGeneratorFunction` — module"
 msgstr "`isGeneratorFunction` — 模块"
 
-#: src/api/reference.md:3884
+#: src/api/reference.md:3922
 msgid "`isGeneratorObject` — module"
 msgstr "`isGeneratorObject` — 模块"
 
-#: src/api/reference.md:3885
+#: src/api/reference.md:3923
 msgid "`isInt16Array` — module"
 msgstr "`isInt16Array` — 模块"
 
-#: src/api/reference.md:3886
+#: src/api/reference.md:3924
 msgid "`isInt32Array` — module"
 msgstr "`isInt32Array` — 模块"
 
-#: src/api/reference.md:3887
+#: src/api/reference.md:3925
 msgid "`isInt8Array` — module"
 msgstr "`isInt8Array` — 模块"
 
-#: src/api/reference.md:3888
+#: src/api/reference.md:3926
 msgid "`isKeyObject` — module"
 msgstr "`isKeyObject` — 模块"
 
-#: src/api/reference.md:3889
+#: src/api/reference.md:3927
 msgid "`isMap` — module"
 msgstr "`isMap` — 模块"
 
-#: src/api/reference.md:3890
+#: src/api/reference.md:3928
 msgid "`isMapIterator` — module"
 msgstr "`isMapIterator` — 模块"
 
-#: src/api/reference.md:3891
+#: src/api/reference.md:3929
 msgid "`isModuleNamespaceObject` — module"
 msgstr "`isModuleNamespaceObject` — 模块"
 
-#: src/api/reference.md:3892
+#: src/api/reference.md:3930
 msgid "`isNativeError` — module"
 msgstr "`isNativeError` — 模块"
 
-#: src/api/reference.md:3893
+#: src/api/reference.md:3931
 msgid "`isNumberObject` — module"
 msgstr "`isNumberObject` — 模块"
 
-#: src/api/reference.md:3894
+#: src/api/reference.md:3932
 msgid "`isPromise` — module"
 msgstr "`isPromise` — 模块"
 
-#: src/api/reference.md:3895
+#: src/api/reference.md:3933
 msgid "`isProxy` — module"
 msgstr "`isProxy` — 模块"
 
-#: src/api/reference.md:3896
+#: src/api/reference.md:3934
 msgid "`isRegExp` — module"
 msgstr "`isRegExp` — 模块"
 
-#: src/api/reference.md:3897
+#: src/api/reference.md:3935
 msgid "`isSet` — module"
 msgstr "`isSet` — 模块"
 
-#: src/api/reference.md:3898
+#: src/api/reference.md:3936
 msgid "`isSetIterator` — module"
 msgstr "`isSetIterator` — 模块"
 
-#: src/api/reference.md:3899
+#: src/api/reference.md:3937
 msgid "`isSharedArrayBuffer` — module"
 msgstr "`isSharedArrayBuffer` — 模块"
 
-#: src/api/reference.md:3900
+#: src/api/reference.md:3938
 msgid "`isStringObject` — module"
 msgstr "`isStringObject` — 模块"
 
-#: src/api/reference.md:3901
+#: src/api/reference.md:3939
 msgid "`isSymbolObject` — module"
 msgstr "`isSymbolObject` — 模块"
 
-#: src/api/reference.md:3902
+#: src/api/reference.md:3940
 msgid "`isTypedArray` — module"
 msgstr "`isTypedArray` — 模块"
 
-#: src/api/reference.md:3903
+#: src/api/reference.md:3941
 msgid "`isUint16Array` — module"
 msgstr "`isUint16Array` — 模块"
 
-#: src/api/reference.md:3904
+#: src/api/reference.md:3942
 msgid "`isUint32Array` — module"
 msgstr "`isUint32Array` — 模块"
 
-#: src/api/reference.md:3905
+#: src/api/reference.md:3943
 msgid "`isUint8Array` — module"
 msgstr "`isUint8Array` — 模块"
 
-#: src/api/reference.md:3906
+#: src/api/reference.md:3944
 msgid "`isUint8ClampedArray` — module"
 msgstr "`isUint8ClampedArray` — 模块"
 
-#: src/api/reference.md:3907
+#: src/api/reference.md:3945
 msgid "`isWeakMap` — module"
 msgstr "`isWeakMap` — 模块"
 
-#: src/api/reference.md:3908
+#: src/api/reference.md:3946
 msgid "`isWeakSet` — module"
 msgstr "`isWeakSet` — 模块"
 
-#: src/api/reference.md:3914
+#: src/api/reference.md:3952
 msgid "`v1` — module"
 msgstr "`v1` — 模块"
 
-#: src/api/reference.md:3915
+#: src/api/reference.md:3953
 msgid "`v3` — module"
 msgstr "模块 `v3`"
 
-#: src/api/reference.md:3916
+#: src/api/reference.md:3954
 msgid "`v4` — module"
 msgstr "`v4` — 模块"
 
-#: src/api/reference.md:3917
+#: src/api/reference.md:3955
 msgid "`v5` — module"
 msgstr "模块 `v5`"
 
-#: src/api/reference.md:3918
+#: src/api/reference.md:3956
 msgid "`v7` — module"
 msgstr "`v7` — 模块"
 
-#: src/api/reference.md:3922
+#: src/api/reference.md:3960
 msgid "`v8`"
 msgstr "`v8`"
 
-#: src/api/reference.md:3926
+#: src/api/reference.md:3964
 msgid "`DefaultDeserializer`"
 msgstr "`DefaultDeserializer`"
 
-#: src/api/reference.md:3927
+#: src/api/reference.md:3965
 msgid "`DefaultSerializer`"
 msgstr "`DefaultSerializer`"
 
-#: src/api/reference.md:3928
+#: src/api/reference.md:3966
 msgid "`Deserializer`"
 msgstr "`Deserializer`"
 
-#: src/api/reference.md:3929
+#: src/api/reference.md:3967
 msgid "`GCProfiler`"
 msgstr "`GCProfiler`"
 
-#: src/api/reference.md:3930
+#: src/api/reference.md:3968
 msgid "`Serializer`"
 msgstr "`Serializer`"
 
-#: src/api/reference.md:3934
+#: src/api/reference.md:3972
 msgid "`addDeserializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addDeserializeCallback` — 实例 _(类：`startupSnapshot`)_"
 
-#: src/api/reference.md:3935
+#: src/api/reference.md:3973
 msgid "`addSerializeCallback` — instance _(class: `startupSnapshot`)_"
 msgstr "`addSerializeCallback` — 实例 _(类：`startupSnapshot`)_"
 
-#: src/api/reference.md:3936
+#: src/api/reference.md:3974
 msgid "`cachedDataVersionTag` — module"
 msgstr "`cachedDataVersionTag` — 模块"
 
-#: src/api/reference.md:3937
+#: src/api/reference.md:3975
 msgid "`createHook` — instance _(class: `promiseHooks`)_"
 msgstr "`createHook` — 实例 _(类：`promiseHooks`)_"
 
-#: src/api/reference.md:3938
+#: src/api/reference.md:3976
 msgid "`deserialize` — module"
 msgstr "`deserialize` — 模块"
 
-#: src/api/reference.md:3939
+#: src/api/reference.md:3977
 msgid "`getCppHeapStatistics` — module"
 msgstr "`getCppHeapStatistics` — 模块"
 
-#: src/api/reference.md:3940
+#: src/api/reference.md:3978
 msgid ""
 "`getHeapCodeStatistics` — module ⚠ **stub** — all fields 0; Perry compiles "
 "AOT, there is no JIT code heap (#4916)"
@@ -44282,11 +44585,11 @@ msgstr ""
 "`getHeapCodeStatistics`  模块 **一个小块** 所有字段0; Perry编译AOT,没有JIT代"
 "码堆 (#4916)"
 
-#: src/api/reference.md:3941
+#: src/api/reference.md:3979
 msgid "`getHeapSnapshot` — module"
 msgstr "`getHeapSnapshot` — 模块"
 
-#: src/api/reference.md:3942
+#: src/api/reference.md:3980
 msgid ""
 "`getHeapSpaceStatistics` — module ⚠ **stub** — Node space names with all "
 "live usage attributed to old_space from Perry arenas; other spaces report 0 "
@@ -44295,7 +44598,7 @@ msgstr ""
 "`getHeapSpaceStatistics`  模块 **一个小块** 节点空间名称,所有现场使用都归因"
 "于 old_space 从 Perry 舞台;其他空间报告 0 (#4916)"
 
-#: src/api/reference.md:3943
+#: src/api/reference.md:3981
 msgid ""
 "`getHeapStatistics` — module ⚠ **stub** — Node shape, Perry numbers: "
 "total_heap_size/used_heap_size/malloced_memory/total_allocated_bytes from "
@@ -44308,87 +44611,87 @@ msgstr ""
 "地,total_physical_size=RSS,heap_size_limit固定 ~2GB (不执行);\\*\\_可执"
 "行,external_memory,全球处理器和zap字段为0 (#4916)"
 
-#: src/api/reference.md:3944
+#: src/api/reference.md:3982
 msgid "`isBuildingSnapshot` — instance _(class: `startupSnapshot`)_"
 msgstr "`isBuildingSnapshot` — 实例 _(类：`startupSnapshot`)_"
 
-#: src/api/reference.md:3945
+#: src/api/reference.md:3983
 msgid "`isStringOneByteRepresentation` — module"
 msgstr "`isStringOneByteRepresentation` — 模块"
 
-#: src/api/reference.md:3946
+#: src/api/reference.md:3984
 msgid "`onAfter` — instance _(class: `promiseHooks`)_"
 msgstr "`onAfter` — 实例 _(类：`promiseHooks`)_"
 
-#: src/api/reference.md:3947
+#: src/api/reference.md:3985
 msgid "`onBefore` — instance _(class: `promiseHooks`)_"
 msgstr "`onBefore` — 实例 _(类：`promiseHooks`)_"
 
-#: src/api/reference.md:3948
+#: src/api/reference.md:3986
 msgid "`onInit` — instance _(class: `promiseHooks`)_"
 msgstr "`onInit` — 实例 _(类：`promiseHooks`)_"
 
-#: src/api/reference.md:3949
+#: src/api/reference.md:3987
 msgid "`onSettled` — instance _(class: `promiseHooks`)_"
 msgstr "`onSettled` — 实例 _(类：`promiseHooks`)_"
 
-#: src/api/reference.md:3950
+#: src/api/reference.md:3988
 msgid "`queryObjects` — module"
 msgstr "`queryObjects` — 模块"
 
-#: src/api/reference.md:3951
+#: src/api/reference.md:3989
 msgid "`readDouble` — instance _(class: `Deserializer`)_"
 msgstr "`readDouble` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3952
+#: src/api/reference.md:3990
 msgid "`readHeader` — instance _(class: `Deserializer`)_"
 msgstr "`readHeader` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3953
+#: src/api/reference.md:3991
 msgid "`readRawBytes` — instance _(class: `Deserializer`)_"
 msgstr "`readRawBytes` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3954
+#: src/api/reference.md:3992
 msgid "`readUint32` — instance _(class: `Deserializer`)_"
 msgstr "`readUint32` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3955
+#: src/api/reference.md:3993
 msgid "`readUint64` — instance _(class: `Deserializer`)_"
 msgstr "`readUint64` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3956
+#: src/api/reference.md:3994
 msgid "`readValue` — instance _(class: `Deserializer`)_"
 msgstr "`readValue` — 实例 _(类：`Deserializer`)_"
 
-#: src/api/reference.md:3957
+#: src/api/reference.md:3995
 msgid "`releaseBuffer` — instance _(class: `Serializer`)_"
 msgstr "`releaseBuffer` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3958
+#: src/api/reference.md:3996
 msgid "`serialize` — module"
 msgstr "`serialize` — 模块"
 
-#: src/api/reference.md:3959
+#: src/api/reference.md:3997
 msgid "`setDeserializeMainFunction` — instance _(class: `startupSnapshot`)_"
 msgstr "`setDeserializeMainFunction` — 实例 _(类：`startupSnapshot`)_"
 
-#: src/api/reference.md:3960
+#: src/api/reference.md:3998
 msgid "`setFlagsFromString` — module"
 msgstr "`setFlagsFromString` — 模块"
 
-#: src/api/reference.md:3961
+#: src/api/reference.md:3999
 msgid "`setHeapSnapshotNearHeapLimit` — module"
 msgstr "`setHeapSnapshotNearHeapLimit` — 模块"
 
-#: src/api/reference.md:3962
+#: src/api/reference.md:4000
 msgid "`start` — instance _(class: `GCProfiler`)_"
 msgstr "`start` — 实例 _(类：`GCProfiler`)_"
 
-#: src/api/reference.md:3963
+#: src/api/reference.md:4001
 msgid "`startCpuProfile` — module"
 msgstr "`startCpuProfile` — 模块"
 
-#: src/api/reference.md:3964
+#: src/api/reference.md:4002
 msgid ""
 "`stop` — instance _(class: `GCProfiler`)_ ⚠ **stub** — report has the Node "
 "shape but the statistics array is always empty (#4916)"
@@ -44396,459 +44699,469 @@ msgstr ""
 "`stop` 实例 _ ((类: `GCProfiler`) _ **一个小块** 报告有节点形状,但统计数组总"
 "是空的 (#4916)"
 
-#: src/api/reference.md:3965
+#: src/api/reference.md:4003
 msgid "`stopCoverage` — module"
 msgstr "`stopCoverage` — 模块"
 
-#: src/api/reference.md:3966
+#: src/api/reference.md:4004
 msgid "`takeCoverage` — module"
 msgstr "`takeCoverage` — 模块"
 
-#: src/api/reference.md:3967
+#: src/api/reference.md:4005
 msgid "`writeDouble` — instance _(class: `Serializer`)_"
 msgstr "`writeDouble` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3968
+#: src/api/reference.md:4006
 msgid "`writeHeader` — instance _(class: `Serializer`)_"
 msgstr "`writeHeader` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3969
+#: src/api/reference.md:4007
 msgid "`writeHeapSnapshot` — module"
 msgstr "`writeHeapSnapshot` — 模块"
 
-#: src/api/reference.md:3970
+#: src/api/reference.md:4008
 msgid "`writeRawBytes` — instance _(class: `Serializer`)_"
 msgstr "`writeRawBytes` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3971
+#: src/api/reference.md:4009
 msgid "`writeUint32` — instance _(class: `Serializer`)_"
 msgstr "`writeUint32` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3972
+#: src/api/reference.md:4010
 msgid "`writeUint64` — instance _(class: `Serializer`)_"
 msgstr "`writeUint64` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3973
+#: src/api/reference.md:4011
 msgid "`writeValue` — instance _(class: `Serializer`)_"
 msgstr "`writeValue` — 实例 _(类：`Serializer`)_"
 
-#: src/api/reference.md:3977
+#: src/api/reference.md:4015
 msgid "`promiseHooks`"
 msgstr "`promiseHooks`"
 
-#: src/api/reference.md:3978
+#: src/api/reference.md:4016
 msgid "`startupSnapshot`"
 msgstr "`startupSnapshot`"
 
-#: src/api/reference.md:3984
+#: src/api/reference.md:4022
 msgid "`isEmail` — module"
 msgstr "`isEmail` — 模块"
 
-#: src/api/reference.md:3985
+#: src/api/reference.md:4023
 msgid "`isEmpty` — module"
 msgstr "`isEmpty` — 模块"
 
-#: src/api/reference.md:3986
+#: src/api/reference.md:4024
 msgid "`isJSON` — module"
 msgstr "`isJSON` — 模块"
 
-#: src/api/reference.md:3987
+#: src/api/reference.md:4025
 msgid "`isURL` — module"
 msgstr "`isURL` — 模块"
 
-#: src/api/reference.md:3988
+#: src/api/reference.md:4026
 msgid "`isUUID` — module"
 msgstr "`isUUID` — 模块"
 
-#: src/api/reference.md:3990
+#: src/api/reference.md:4028
 msgid "`vm`"
 msgstr "`vm`"
 
-#: src/api/reference.md:3994
+#: src/api/reference.md:4032
 msgid "`Script`"
 msgstr "`Script`"
 
-#: src/api/reference.md:3998
+#: src/api/reference.md:4036
 msgid "`compileFunction` — module"
 msgstr "`compileFunction` — 模块"
 
-#: src/api/reference.md:3999
+#: src/api/reference.md:4037
 msgid "`createCachedData` — instance"
 msgstr "`createCachedData` — 实例"
 
-#: src/api/reference.md:4000
+#: src/api/reference.md:4038
 msgid "`createContext` — module"
 msgstr "`createContext` — 模块"
 
-#: src/api/reference.md:4001
+#: src/api/reference.md:4039
 msgid "`createScript` — module"
 msgstr "`createScript` — 模块"
 
-#: src/api/reference.md:4002
+#: src/api/reference.md:4040
 msgid "`dependencySpecifiers` — instance"
 msgstr "`dependencySpecifiers` — 实例"
 
-#: src/api/reference.md:4003
+#: src/api/reference.md:4041
 msgid "`error` — instance"
 msgstr "`error` — 实例"
 
-#: src/api/reference.md:4004
+#: src/api/reference.md:4042
 msgid "`evaluate` — instance"
 msgstr "`evaluate` — 实例"
 
-#: src/api/reference.md:4005
+#: src/api/reference.md:4043
 msgid "`hasAsyncGraph` — instance"
 msgstr "`hasAsyncGraph` — 实例"
 
-#: src/api/reference.md:4006
+#: src/api/reference.md:4044
 msgid "`hasTopLevelAwait` — instance"
 msgstr "`hasTopLevelAwait` — 实例"
 
-#: src/api/reference.md:4007
+#: src/api/reference.md:4045
 msgid "`identifier` — instance"
 msgstr "`identifier` — 实例"
 
-#: src/api/reference.md:4008
+#: src/api/reference.md:4046
 msgid "`instantiate` — instance"
 msgstr "`instantiate` — 实例"
 
-#: src/api/reference.md:4009
+#: src/api/reference.md:4047
 msgid "`isContext` — module"
 msgstr "`isContext` — 模块"
 
-#: src/api/reference.md:4010
+#: src/api/reference.md:4048
 msgid "`link` — instance"
 msgstr "`link` — 实例"
 
-#: src/api/reference.md:4011
+#: src/api/reference.md:4049
 msgid "`linkRequests` — instance"
 msgstr "`linkRequests` — 实例"
 
-#: src/api/reference.md:4012
+#: src/api/reference.md:4050
 msgid "`measureMemory` — module"
 msgstr "`measureMemory` — 模块"
 
-#: src/api/reference.md:4013
+#: src/api/reference.md:4051
 msgid "`moduleRequests` — instance"
 msgstr "`moduleRequests` — 实例"
 
-#: src/api/reference.md:4014
+#: src/api/reference.md:4052
 msgid "`namespace` — instance"
 msgstr "`namespace` — 实例"
 
-#: src/api/reference.md:4015
+#: src/api/reference.md:4053
 msgid "`runInContext` — module"
 msgstr "`runInContext` — 模块"
 
-#: src/api/reference.md:4016
+#: src/api/reference.md:4054
 msgid "`runInNewContext` — module"
 msgstr "`runInNewContext` — 模块"
 
-#: src/api/reference.md:4017
+#: src/api/reference.md:4055
 msgid "`runInThisContext` — module"
 msgstr "`runInThisContext` — 模块"
 
-#: src/api/reference.md:4018
+#: src/api/reference.md:4056
 msgid "`setExport` — instance"
 msgstr "`setExport` — 实例"
 
-#: src/api/reference.md:4026
+#: src/api/reference.md:4064
 msgid "`wasi`"
 msgstr "`wasi`"
 
-#: src/api/reference.md:4030
+#: src/api/reference.md:4068
 msgid "`WASI`"
 msgstr "`WASI`"
 
-#: src/api/reference.md:4034
+#: src/api/reference.md:4072
 msgid "`WASI` — module"
 msgstr "`WASI` — 模块"
 
-#: src/api/reference.md:4035
+#: src/api/reference.md:4073
 msgid "`finalizeBindings` — instance _(class: `WASI`)_"
 msgstr "`finalizeBindings` — 实例 _(类：`WASI`)_"
 
-#: src/api/reference.md:4036
+#: src/api/reference.md:4074
 msgid "`getImportObject` — instance _(class: `WASI`)_"
 msgstr "`getImportObject` — 实例 _(类: `WASI`)_"
 
-#: src/api/reference.md:4037
+#: src/api/reference.md:4075
 msgid "`initialize` — instance _(class: `WASI`)_"
 msgstr "`initialize` — 实例 _(类: `WASI`)_"
 
-#: src/api/reference.md:4038
+#: src/api/reference.md:4076
 msgid "`start` — instance _(class: `WASI`)_"
 msgstr "`start` — 实例 _(类: `WASI`)_"
 
-#: src/api/reference.md:4042
+#: src/api/reference.md:4080
 msgid "`wasiImport`"
 msgstr "`wasiImport`"
 
-#: src/api/reference.md:4048
+#: src/api/reference.md:4086
 msgid "`BroadcastChannel`"
 msgstr "`BroadcastChannel`"
 
-#: src/api/reference.md:4049
+#: src/api/reference.md:4087
 msgid "`MessageChannel`"
 msgstr "`MessageChannel`"
 
-#: src/api/reference.md:4050
+#: src/api/reference.md:4088
 msgid "`MessagePort`"
 msgstr "`MessagePort`"
 
-#: src/api/reference.md:4055
+#: src/api/reference.md:4093
 msgid "`BroadcastChannel` — module"
 msgstr "`BroadcastChannel` — 模块"
 
-#: src/api/reference.md:4056
+#: src/api/reference.md:4094
 msgid "`MessageChannel` — module"
 msgstr "`MessageChannel` — 模块"
 
-#: src/api/reference.md:4057
+#: src/api/reference.md:4095
 msgid "`addEventListener` — instance"
 msgstr "`addEventListener` 实例"
 
-#: src/api/reference.md:4058
+#: src/api/reference.md:4096
 msgid "`cpuUsage` — instance _(class: `Worker`)_"
 msgstr "`cpuUsage` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4059
+#: src/api/reference.md:4097
 msgid "`getEnvironmentData` — module"
 msgstr "`getEnvironmentData` — 模块"
 
-#: src/api/reference.md:4060
+#: src/api/reference.md:4098
 msgid "`getHeapSnapshot` — instance _(class: `Worker`)_"
 msgstr "`getHeapSnapshot` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4061
+#: src/api/reference.md:4099
 msgid "`getHeapStatistics` — instance _(class: `Worker`)_"
 msgstr "`getHeapStatistics` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4062
+#: src/api/reference.md:4100
 msgid "`isMarkedAsUntransferable` — module"
 msgstr "`isMarkedAsUntransferable` — 模块"
 
-#: src/api/reference.md:4063
+#: src/api/reference.md:4101
 msgid "`markAsUncloneable` — module"
 msgstr "`markAsUncloneable` — 模块"
 
-#: src/api/reference.md:4064
+#: src/api/reference.md:4102
 msgid "`markAsUntransferable` — module"
 msgstr "`markAsUntransferable` — 模块"
 
-#: src/api/reference.md:4065
+#: src/api/reference.md:4103
 msgid "`moveMessagePortToContext` — module"
 msgstr "`moveMessagePortToContext` — 模块"
 
-#: src/api/reference.md:4066
+#: src/api/reference.md:4104
 msgid "`off` — instance _(class: `Worker`)_"
 msgstr "`off` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4067
+#: src/api/reference.md:4105
 msgid "`on` — instance _(class: `Worker`)_"
 msgstr "`on` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4068
+#: src/api/reference.md:4106
 msgid "`once` — instance _(class: `Worker`)_"
 msgstr "`once` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4069
+#: src/api/reference.md:4107
 msgid "`postMessageToThread` — module"
 msgstr "`postMessageToThread` — 模块"
 
-#: src/api/reference.md:4070
+#: src/api/reference.md:4108
 msgid "`receiveMessageOnPort` — module"
 msgstr "`receiveMessageOnPort` — 模块"
 
-#: src/api/reference.md:4071
+#: src/api/reference.md:4109
 msgid "`ref` — instance _(class: `Worker`)_"
 msgstr "`ref` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4072
+#: src/api/reference.md:4110
 msgid "`reload` — instance _(class: `Worker`)_"
 msgstr "`reload` 实例 _ ((类:`Worker`)"
 
-#: src/api/reference.md:4073
+#: src/api/reference.md:4111
 msgid "`removeEventListener` — instance"
 msgstr "`removeEventListener` 实例"
 
-#: src/api/reference.md:4074
+#: src/api/reference.md:4112
 msgid "`setEnvironmentData` — module"
 msgstr "`setEnvironmentData` — 模块"
 
-#: src/api/reference.md:4075
+#: src/api/reference.md:4113
 msgid "`startCpuProfile` — instance _(class: `Worker`)_"
 msgstr "`startCpuProfile` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4076
+#: src/api/reference.md:4114
 msgid "`startHeapProfile` — instance _(class: `Worker`)_"
 msgstr "`startHeapProfile` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4077
+#: src/api/reference.md:4115
 msgid "`terminate` — instance _(class: `Worker`)_"
 msgstr "`terminate` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4078
+#: src/api/reference.md:4116
 msgid "`unref` — instance _(class: `Worker`)_"
 msgstr "`unref` — 实例 _(类: `Worker`)_"
 
-#: src/api/reference.md:4082
+#: src/api/reference.md:4120
 msgid "`SHARE_ENV`"
 msgstr "`SHARE_ENV`"
 
-#: src/api/reference.md:4083
+#: src/api/reference.md:4121
 msgid "`isInternalThread`"
 msgstr "`isInternalThread`"
 
-#: src/api/reference.md:4084
+#: src/api/reference.md:4122
 msgid "`isMainThread`"
 msgstr "`isMainThread`"
 
-#: src/api/reference.md:4085
+#: src/api/reference.md:4123
 msgid "`locks`"
 msgstr "`locks`"
 
-#: src/api/reference.md:4086
+#: src/api/reference.md:4124
 msgid "`parentPort`"
 msgstr "`parentPort`"
 
-#: src/api/reference.md:4087
+#: src/api/reference.md:4125
 msgid "`resourceLimits`"
 msgstr "`resourceLimits`"
 
-#: src/api/reference.md:4088
+#: src/api/reference.md:4126
 msgid "`threadId`"
 msgstr "`threadId`"
 
-#: src/api/reference.md:4089
+#: src/api/reference.md:4127
 msgid "`threadName`"
 msgstr "`threadName`"
 
-#: src/api/reference.md:4090
+#: src/api/reference.md:4128
 msgid "`workerData`"
 msgstr "`workerData`"
 
-#: src/api/reference.md:4098
+#: src/api/reference.md:4136
 msgid "`WebSocketServer`"
 msgstr "`WebSocketServer`"
 
-#: src/api/reference.md:4103
+#: src/api/reference.md:4141
 msgid "`WebSocket` — module"
 msgstr "`WebSocket` — 模块"
 
-#: src/api/reference.md:4104
+#: src/api/reference.md:4142
 msgid "`addListener` — instance _(class: `Client`)_"
 msgstr "`addListener` — 实例 _(类: `Client`)_"
 
-#: src/api/reference.md:4106
+#: src/api/reference.md:4143
+#, fuzzy
+msgid "`address` — instance"
+msgstr "`add` — 实例"
+
+#: src/api/reference.md:4144
+#, fuzzy
+msgid "`clients` — instance"
+msgstr "`limits` — 实例"
+
+#: src/api/reference.md:4146
 msgid "`close` — instance _(class: `Client`)_"
 msgstr "`close` — 实例 _(类: `Client`)_"
 
-#: src/api/reference.md:4107
+#: src/api/reference.md:4147
 msgid "`closeClient` — module"
 msgstr "`closeClient` — 模块"
 
-#: src/api/reference.md:4108
+#: src/api/reference.md:4149
 msgid "`handleUpgrade` — instance"
 msgstr "`handleUpgrade` — 实例"
 
-#: src/api/reference.md:4110
+#: src/api/reference.md:4151
 msgid "`on` — instance _(class: `Client`)_"
 msgstr "`on` — 实例 _(类: `Client`)_"
 
-#: src/api/reference.md:4111
+#: src/api/reference.md:4152
 msgid "`readyState` — instance"
 msgstr "`readyState` 实例"
 
-#: src/api/reference.md:4113
+#: src/api/reference.md:4154
 msgid "`send` — instance _(class: `Client`)_"
 msgstr "`send` — 实例 _(类: `Client`)_"
 
-#: src/api/reference.md:4114
+#: src/api/reference.md:4155
 msgid "`sendToClient` — module"
 msgstr "`sendToClient` — 模块"
 
-#: src/api/reference.md:4118
+#: src/api/reference.md:4159
 msgid "`CLOSED`"
 msgstr "`CLOSED`"
 
-#: src/api/reference.md:4119
+#: src/api/reference.md:4160
 msgid "`CLOSING`"
 msgstr "`CLOSING`"
 
-#: src/api/reference.md:4120
+#: src/api/reference.md:4161
 msgid "`CONNECTING`"
 msgstr "`CONNECTING`"
 
-#: src/api/reference.md:4121
+#: src/api/reference.md:4162
 msgid "`OPEN`"
 msgstr "`OPEN`"
 
-#: src/api/reference.md:4127 src/api/reference.md:4128
+#: src/api/reference.md:4168 src/api/reference.md:4169
 msgid "`BrotliCompress`"
 msgstr "`BrotliCompress`"
 
-#: src/api/reference.md:4129 src/api/reference.md:4130
+#: src/api/reference.md:4170 src/api/reference.md:4171
 msgid "`BrotliDecompress`"
 msgstr "`BrotliDecompress`"
 
-#: src/api/reference.md:4131 src/api/reference.md:4132
+#: src/api/reference.md:4172 src/api/reference.md:4173
 msgid "`Deflate`"
 msgstr "`Deflate`"
 
-#: src/api/reference.md:4133 src/api/reference.md:4134
+#: src/api/reference.md:4174 src/api/reference.md:4175
 msgid "`DeflateRaw`"
 msgstr "`DeflateRaw`"
 
-#: src/api/reference.md:4135 src/api/reference.md:4136
+#: src/api/reference.md:4176 src/api/reference.md:4177
 msgid "`Gunzip`"
 msgstr "`Gunzip`"
 
-#: src/api/reference.md:4137 src/api/reference.md:4138
+#: src/api/reference.md:4178 src/api/reference.md:4179
 msgid "`Gzip`"
 msgstr "`Gzip`"
 
-#: src/api/reference.md:4139 src/api/reference.md:4140
+#: src/api/reference.md:4180 src/api/reference.md:4181
 msgid "`Inflate`"
 msgstr "`Inflate`"
 
-#: src/api/reference.md:4141 src/api/reference.md:4142
+#: src/api/reference.md:4182 src/api/reference.md:4183
 msgid "`InflateRaw`"
 msgstr "`InflateRaw`"
 
-#: src/api/reference.md:4143 src/api/reference.md:4144
+#: src/api/reference.md:4184 src/api/reference.md:4185
 msgid "`Unzip`"
 msgstr "`Unzip`"
 
-#: src/api/reference.md:4145
+#: src/api/reference.md:4186
 msgid "`ZstdCompress`"
 msgstr "`ZstdCompress`"
 
-#: src/api/reference.md:4146
+#: src/api/reference.md:4187
 msgid "`ZstdDecompress`"
 msgstr "`ZstdDecompress`"
 
-#: src/api/reference.md:4150
+#: src/api/reference.md:4191
 msgid "`brotliCompress` — module"
 msgstr "`brotliCompress` — 模块"
 
-#: src/api/reference.md:4151
+#: src/api/reference.md:4192
 msgid "`brotliCompressSync` — module"
 msgstr "`brotliCompressSync` — 模块"
 
-#: src/api/reference.md:4152
+#: src/api/reference.md:4193
 msgid "`brotliDecompress` — module"
 msgstr "`brotliDecompress` — 模块"
 
-#: src/api/reference.md:4153
+#: src/api/reference.md:4194
 msgid "`brotliDecompressSync` — module"
 msgstr "`brotliDecompressSync` — 模块"
 
-#: src/api/reference.md:4154
+#: src/api/reference.md:4195
 msgid "`crc32` — module"
 msgstr "`crc32` — 模块"
 
-#: src/api/reference.md:4155
+#: src/api/reference.md:4196
 msgid ""
 "`createBrotliCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -44856,7 +45169,7 @@ msgstr ""
 "`createBrotliCompress`  模块 **一个小块** params/quality 选项被接受但被忽略,"
 "警告一次 (#4917)"
 
-#: src/api/reference.md:4156
+#: src/api/reference.md:4197
 msgid ""
 "`createBrotliDecompress` — module ⚠ **stub** — params/quality options "
 "accepted but ignored, warns once (#4917)"
@@ -44864,7 +45177,7 @@ msgstr ""
 "`createBrotliDecompress`  模块 **一个小块** params/quality 选项被接受但被忽"
 "略,警告一次 (#4917)"
 
-#: src/api/reference.md:4157
+#: src/api/reference.md:4198
 msgid ""
 "`createDeflate` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -44872,7 +45185,7 @@ msgstr ""
 "`createDeflate`  模块 **一个小块** 已实现级别;strategy/memLevel已验证但未应"
 "用 (#4917)"
 
-#: src/api/reference.md:4158
+#: src/api/reference.md:4199
 msgid ""
 "`createDeflateRaw` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -44880,11 +45193,11 @@ msgstr ""
 "`createDeflateRaw`  模块 **一个小块** 已实现级别;strategy/memLevel已验证但未"
 "应用 (#4917)"
 
-#: src/api/reference.md:4159
+#: src/api/reference.md:4200
 msgid "`createGunzip` — module"
 msgstr "`createGunzip` — 模块"
 
-#: src/api/reference.md:4160
+#: src/api/reference.md:4201
 msgid ""
 "`createGzip` — module ⚠ **stub** — level honored; strategy/memLevel "
 "validated but not applied (#4917)"
@@ -44892,19 +45205,19 @@ msgstr ""
 "`createGzip`  模块 **一个小块** 已实现级别;strategy/memLevel已验证但未应用 "
 "(#4917)"
 
-#: src/api/reference.md:4161
+#: src/api/reference.md:4202
 msgid "`createInflate` — module"
 msgstr "`createInflate` — 模块"
 
-#: src/api/reference.md:4162
+#: src/api/reference.md:4203
 msgid "`createInflateRaw` — module"
 msgstr "`createInflateRaw` — 模块"
 
-#: src/api/reference.md:4163
+#: src/api/reference.md:4204
 msgid "`createUnzip` — module"
 msgstr "`createUnzip` — 模块"
 
-#: src/api/reference.md:4164
+#: src/api/reference.md:4205
 msgid ""
 "`createZstdCompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -44912,7 +45225,7 @@ msgstr ""
 "`createZstdCompress`  模块 **一个小块** params/quality 选项被接受但被忽略,警"
 "告一次 (#4917)"
 
-#: src/api/reference.md:4165
+#: src/api/reference.md:4206
 msgid ""
 "`createZstdDecompress` — module ⚠ **stub** — params/quality options accepted "
 "but ignored, warns once (#4917)"
@@ -44920,79 +45233,71 @@ msgstr ""
 "`createZstdDecompress`  模块 **一个小块** params/quality 选项被接受但被忽略,"
 "警告一次 (#4917)"
 
-#: src/api/reference.md:4166
+#: src/api/reference.md:4207
 msgid "`deflate` — module"
 msgstr "`deflate` — 模块"
 
-#: src/api/reference.md:4167
+#: src/api/reference.md:4208
 msgid "`deflateRaw` — module"
 msgstr "`deflateRaw` — 模块"
 
-#: src/api/reference.md:4168
+#: src/api/reference.md:4209
 msgid "`deflateRawSync` — module"
 msgstr "`deflateRawSync` — 模块"
 
-#: src/api/reference.md:4169
+#: src/api/reference.md:4210
 msgid "`deflateSync` — module"
 msgstr "`deflateSync` — 模块"
 
-#: src/api/reference.md:4170
+#: src/api/reference.md:4211
 msgid "`gunzip` — module"
 msgstr "`gunzip` — 模块"
 
-#: src/api/reference.md:4171
+#: src/api/reference.md:4212
 msgid "`gunzipSync` — module"
 msgstr "`gunzipSync` — 模块"
 
-#: src/api/reference.md:4172
+#: src/api/reference.md:4213
 msgid "`gzip` — module"
 msgstr "`gzip` — 模块"
 
-#: src/api/reference.md:4173
+#: src/api/reference.md:4214
 msgid "`gzipSync` — module"
 msgstr "`gzipSync` — 模块"
 
-#: src/api/reference.md:4174
+#: src/api/reference.md:4215
 msgid "`inflate` — module"
 msgstr "`inflate` — 模块"
 
-#: src/api/reference.md:4175
+#: src/api/reference.md:4216
 msgid "`inflateRaw` — module"
 msgstr "`inflateRaw` — 模块"
 
-#: src/api/reference.md:4176
+#: src/api/reference.md:4217
 msgid "`inflateRawSync` — module"
 msgstr "`inflateRawSync` — 模块"
 
-#: src/api/reference.md:4177
+#: src/api/reference.md:4218
 msgid "`inflateSync` — module"
 msgstr "`inflateSync` — 模块"
 
-#: src/api/reference.md:4178
+#: src/api/reference.md:4219
 msgid "`unzip` — module"
 msgstr "`unzip` — 模块"
 
-#: src/api/reference.md:4179
+#: src/api/reference.md:4220
 msgid "`unzipSync` — module"
 msgstr "`unzipSync` — 模块"
 
-#: src/api/reference.md:4180
+#: src/api/reference.md:4221
 msgid "`zstdCompress` — module"
 msgstr "`zstdCompress` — 模块"
 
-#: src/api/reference.md:4181
+#: src/api/reference.md:4222
 msgid "`zstdCompressSync` — module"
 msgstr "`zstdCompressSync` — 模块"
 
-#: src/api/reference.md:4182
-msgid "`zstdDecompress` — module"
-msgstr "`zstdDecompress` — 模块"
-
-#: src/api/reference.md:4183
-msgid "`zstdDecompressSync` — module"
-msgstr "`zstdDecompressSync` — 模块"
-
-#: src/api/reference.md:4187
+#: src/api/reference.md:4228
 msgid "`codes`"
 msgstr "`codes`"
 
@@ -45499,9 +45804,10 @@ msgid "You'd otherwise reach for a `docker-compose.yaml` file."
 msgstr "原本打算使用 `docker-compose.yaml` 文件的场景。"
 
 #: src/container/overview.md:185
+#, fuzzy
 msgid ""
 "The two modules share a runtime; you can mix them in the same program if you "
-"e.g. use `perry/compose` for the long-running stack and `perry/  container` "
+"e.g. use `perry/compose` for the long-running stack and `perry/ container` "
 "for one-off tasks against the same containers."
 msgstr ""
 "两个模块共享运行时间;如果您使用 e.g,可以在同一程序中混合它们. 使用 `perry/"
@@ -46019,12 +46325,13 @@ msgid "`force=true` is `docker rm -f`."
 msgstr "`force=true` 等同于 `docker rm -f`。"
 
 #: src/container/containers.md:139
+#, fuzzy
 msgid ""
 "**Note on the `logs` and `exec` return shape:** today the FFI returns a "
 "registry-id handle into a `Vec<ContainerLogs>` rather than a JS object. "
 "Treat the returned value as opaque — a future ergonomics task will expose "
 "`.stdout` / `.stderr` directly on the JS side. The `ContainerLogs` shape "
-"over the wire is `{ stdout: string, stderr:  string }`."
+"over the wire is `{ stdout: string, stderr: string }`."
 msgstr ""
 "**关于返回形式 `logs` 和 `exec` 的注释:** 今天,FFI返回一个注册表ID处理器到一"
 "个`Vec<ContainerLogs>`而不是一个JS对象. 将返回的值视为不透明  未来的人体工程"
@@ -46147,9 +46454,10 @@ msgstr ""
 "名称；后续调用将命中缓存的 `OnceLock` 并立即返回。"
 
 #: src/container/containers.md:215
+#, fuzzy
 msgid ""
 "`detectBackend()` is async and returns a JSON array of _every_ probed "
-"candidate with `{ name, available, reason, version, mode,  isolationLevel }` "
+"candidate with `{ name, available, reason, version, mode, isolationLevel }` "
 "per entry. Use it to surface a \"diagnostics\" view in your CLI / dashboard."
 msgstr ""
 "`detectBackend()`是异步的,并返回每次输入`{ name, available, reason, version, "
@@ -46877,9 +47185,10 @@ msgstr ""
 "始提供服务："
 
 #: src/container/compose.md:332
+#, fuzzy
 msgid ""
 "**Use the `healthcheck` block on the service** (built-in, runtime handles "
-"it). Combined with `depends_on: { svc: { condition:  'service_healthy' } }`, "
+"it). Combined with `depends_on: { svc: { condition: 'service_healthy' } }`, "
 "dependent services wait for the dependency to report healthy."
 msgstr ""
 "**在服务上使用`healthcheck`块** (内置,运行时处理它). 结合`depends_on: { svc: "
@@ -47240,8 +47549,9 @@ msgstr ""
 "```"
 
 #: src/container/networking.md:128
+#, fuzzy
 msgid ""
-"The Forgejo example uses this portable pattern (`container_name:  'forgejo-"
+"The Forgejo example uses this portable pattern (`container_name: 'forgejo-"
 "db'` + `FORGEJO__database__HOST: 'forgejo-db:5432'`)."
 msgstr ""
 "在Forgejo示例中使用这种可移植模式 (`container_name:  'forgejo-db'` + "
@@ -47310,8 +47620,9 @@ msgid "Single-network shorthand"
 msgstr "单网络简写"
 
 #: src/container/networking.md:150
+#, fuzzy
 msgid ""
-"When every service joins the same network, you can put `networks:  "
+"When every service joins the same network, you can put `networks: "
 "['<name>']` on each service and `networks: { <name>: {...} }` once at the "
 "root. The engine deduplicates network creation across services."
 msgstr ""
@@ -47703,9 +48014,10 @@ msgid "External volumes"
 msgstr "外部卷"
 
 #: src/container/volumes.md:111
+#, fuzzy
 msgid ""
 "Mark a volume `external: true` to share it across stacks or to use a volume "
-"created by a different process (e.g. `docker volume create  team-shared-"
+"created by a different process (e.g. `docker volume create team-shared-"
 "cache` ahead of time):"
 msgstr ""
 "标记一个卷`external: true`,以便在堆中共享或使用由不同的过程创建的卷 (e.g. 时"
@@ -47726,8 +48038,9 @@ msgstr ""
 "```"
 
 #: src/container/volumes.md:121
+#, fuzzy
 msgid ""
-"External volumes are **never removed** by `down(handle, { volumes: true  })` "
+"External volumes are **never removed** by `down(handle, { volumes: true })` "
 "— that flag only drops volumes the engine itself created. This matches "
 "docker-compose semantics; if you want the external volume gone, remove it "
 "explicitly with `docker volume rm team-shared-cache`."
@@ -47792,15 +48105,18 @@ msgstr ""
 "辅助方法——暂时请使用底层运行时 CLI 进行检查："
 
 #: src/container/volumes.md:154
-msgid "# list app-prefixed volumes"
+#, fuzzy
+msgid "# list app-prefixed volumes\n"
 msgstr "# 列表应用程序前置的卷"
 
 #: src/container/volumes.md:155
-msgid "# mountpoint, driver, labels"
+#, fuzzy
+msgid "# mountpoint, driver, labels\n"
 msgstr "# 固定点,驱动器,标签"
 
 #: src/container/volumes.md:156
-msgid "# mount + inspect contents"
+#, fuzzy
+msgid "# mount + inspect contents\n"
 msgstr "# 安装 + 检查内容"
 
 #: src/container/volumes.md:160
@@ -47955,9 +48271,10 @@ msgid "Docker / Podman / Lima only — dropped on apple/container"
 msgstr "Docker / Podman / Lima only — dropped on apple/container"
 
 #: src/container/security.md:25
+#, fuzzy
 msgid ""
 "On a compose service the last two are spelled in compose-spec form instead: "
-"`security_opt: [\"seccomp=<path-or-default>\",  \"no-new-privileges\"]`. The "
+"`security_opt: [\"seccomp=<path-or-default>\", \"no-new-privileges\"]`. The "
 "engine parses those entries into the same internal `SecurityProfile` that "
 "`run()`/`create()` build from the spec-level fields, so both APIs hand the "
 "backend identical flags."
@@ -48135,8 +48452,9 @@ msgstr ""
 "销。"
 
 #: src/container/security.md:114
+#, fuzzy
 msgid ""
-"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY}  --"
+"Runs `cosign verify --certificate-identity ${CHAINGUARD_IDENTITY} --"
 "certificate-oidc-issuer ${CHAINGUARD_ISSUER} <ref>@<digest>` and caches pass/"
 "fail."
 msgstr ""
@@ -48394,8 +48712,9 @@ msgid "**Run as non-root** (`user: \"nobody\"` or numeric UID)."
 msgstr "**以非 root 用户运行**（`user: \"nobody\"` 或数字 UID）。"
 
 #: src/container/security.md:207
+#, fuzzy
 msgid ""
-"**Drop all capabilities, add specific ones back** (`cap_drop:  [\"ALL\"]` + "
+"**Drop all capabilities, add specific ones back** (`cap_drop: [\"ALL\"]` + "
 "minimal `cap_add`)."
 msgstr ""
 "**放下所有功能,再添加特定的功能** (`cap_drop:  [\"ALL\"]` + 最少`cap_add`)"
@@ -48533,7 +48852,8 @@ msgid "Print an operator-facing banner with URLs + \"how to tear down\"."
 msgstr "打印面向运维人员的横幅，包含 URL 及\"如何拆除\"说明。"
 
 #: src/container/production-patterns.md:39
-msgid "Exit 0. Containers keep running thanks to `restart:  unless-stopped`."
+#, fuzzy
+msgid "Exit 0. Containers keep running thanks to `restart: unless-stopped`."
 msgstr "这里是0号出口. 由于`restart:  unless-stopped`,集装箱继续运行."
 
 #: src/container/production-patterns.md:42
@@ -48750,11 +49070,12 @@ msgid "Healthcheck-gated dependency startup"
 msgstr "基于健康检查的依赖启动顺序"
 
 #: src/container/production-patterns.md:135
+#, fuzzy
 msgid ""
 "postgres takes ~5–10 seconds to initialise on first run (initdb + listener "
 "bind). Without gating, forgejo starts immediately, can't connect, and burns "
 "retry budget. The fix is a per-service `healthcheck` plus `depends_on: "
-"{ svc: { condition: 'service_healthy'  } }`:"
+"{ svc: { condition: 'service_healthy' } }`:"
 msgstr ""
 "在首次运行时,postgres需要 ~510秒的启动时间 (initdb + 听器绑定). 没有网"
 "关,forgejo即时启动,无法连接,并燃烧重试预算. 解决方案是每次服务`healthcheck`加"
@@ -48917,7 +49238,8 @@ msgid ""
 msgstr "在生产环境中，请通过 `.env` 文件或密钥管理器**将其设置为稳定值**："
 
 #: src/container/production-patterns.md:224
-msgid "# .env"
+#, fuzzy
+msgid "# .env\n"
 msgstr "# 其他"
 
 #: src/container/production-patterns.md:225
@@ -48930,7 +49252,8 @@ msgid "$(openssl rand -hex 52)"
 msgstr "$(openssl rand -hex 52)"
 
 #: src/container/production-patterns.md:228
-msgid "# deploy.sh"
+#, fuzzy
+msgid "# deploy.sh\n"
 msgstr "# deploy.sh"
 
 #: src/container/production-patterns.md:234
@@ -48988,11 +49311,13 @@ msgstr ""
 "行显式的 `--down`："
 
 #: src/container/production-patterns.md:264
-msgid "# preserve volumes"
+#, fuzzy
+msgid "# preserve volumes\n"
 msgstr "# 保存量"
 
 #: src/container/production-patterns.md:265
-msgid "# redeploy with new version"
+#, fuzzy
+msgid "# redeploy with new version\n"
 msgstr "# 用新版本重新部署"
 
 #: src/container/production-patterns.md:268
@@ -49009,35 +49334,42 @@ msgid "Running it"
 msgstr "运行示例"
 
 #: src/container/production-patterns.md:275
-msgid "# Build perry once"
+#, fuzzy
+msgid "# Build perry once\n"
 msgstr "# 一次建造佩里"
 
 #: src/container/production-patterns.md:277
-msgid "# Build the example"
+#, fuzzy
+msgid "# Build the example\n"
 msgstr "# 树立一个榜样"
 
 #: src/container/production-patterns.md:281
-msgid "# Deploy"
+#, fuzzy
+msgid "# Deploy\n"
 msgstr "# Deploy"
 
 #: src/container/production-patterns.md:283
-msgid "# 🔧 Backend: docker"
+#, fuzzy
+msgid "# 🔧 Backend: docker\n"
 msgstr "# 后端:码头"
 
 #: src/container/production-patterns.md:285
-msgid "# …"
-msgstr "# …"
+msgid "# …\n"
+msgstr ""
 
 #: src/container/production-patterns.md:288
-msgid "# Visit http://localhost:3000/ in a browser."
+#, fuzzy
+msgid "# Visit http://localhost:3000/ in a browser.\n"
 msgstr "# 在浏览器中访问 http://localhost:3000/."
 
 #: src/container/production-patterns.md:290
-msgid "# Tear down (preserves volumes for redeploy):"
+#, fuzzy
+msgid "# Tear down (preserves volumes for redeploy):\n"
 msgstr "# 停止（保留卷以便重新部署）："
 
 #: src/container/production-patterns.md:293
-msgid "# Tear down + drop volumes (DESTROYS DATA):"
+#, fuzzy
+msgid "# Tear down + drop volumes (DESTROYS DATA):\n"
 msgstr "# 拆除+降低体积 (破坏数据):"
 
 #: src/container/production-patterns.md:300
@@ -49334,19 +49666,23 @@ msgstr ""
 "称在后端之间保持稳定,值分离."
 
 #: src/container/determinism.md:149
-msgid "// tested + emitted as-is"
+#, fuzzy
+msgid "// tested + emitted as-is\n"
 msgstr "// 测试 + 发射如今"
 
 #: src/container/determinism.md:150
-msgid "// engine emulates host-side"
+#, fuzzy
+msgid "// engine emulates host-side\n"
 msgstr "// 引擎模拟主机端"
 
 #: src/container/determinism.md:151
-msgid "// dropped + warning"
+#, fuzzy
+msgid "// dropped + warning\n"
 msgstr "// 丢失 + 警告"
 
 #: src/container/determinism.md:152
-msgid "// limited subset; reason documented"
+#, fuzzy
+msgid "// limited subset; reason documented\n"
 msgstr "// 有限子集; 原因已记录"
 
 #: src/container/determinism.md:156
@@ -49470,7 +49806,8 @@ msgid "Each protocol returns its constant from a `capabilities()` method:"
 msgstr "每个协议都返回其常数从`capabilities()`方法:"
 
 #: src/container/determinism.md:188
-msgid "// ... arg builders"
+#, fuzzy
+msgid "// ... arg builders\n"
 msgstr "// ... 建筑工程师"
 
 #: src/container/determinism.md:192
@@ -49496,7 +49833,8 @@ msgid "\"spec field dropped/translated for backend\""
 msgstr "\"后端的规格字段dropped/translated\""
 
 #: src/container/determinism.md:209
-msgid "// <-- clean spec"
+#, fuzzy
+msgid "// <-- clean spec\n"
 msgstr "// <-- 清洁的规格"
 
 #: src/container/determinism.md:212
@@ -49508,15 +49846,18 @@ msgstr ""
 "`Vec<NormalizationWarning>`:"
 
 #: src/container/determinism.md:225
-msgid "// field removed"
+#, fuzzy
+msgid "// field removed\n"
 msgstr "// 已删除"
 
 #: src/container/determinism.md:226
-msgid "// mapped to equivalent"
+#, fuzzy
+msgid "// mapped to equivalent\n"
 msgstr "// 映射到同等"
 
 #: src/container/determinism.md:227
-msgid "// engine emulates instead"
+#, fuzzy
+msgid "// engine emulates instead\n"
 msgstr "// 而不是模拟引擎"
 
 #: src/container/determinism.md:231
@@ -49524,15 +49865,18 @@ msgid "3. Enforcement mode — pick how warnings are surfaced"
 msgstr "3. 执行模式 选择如何显示警告"
 
 #: src/container/determinism.md:235
-msgid "// default — silent tracing::warn!"
+#, fuzzy
+msgid "// default — silent tracing::warn!\n"
 msgstr "// 默认无声追踪::警告!"
 
 #: src/container/determinism.md:236
-msgid "// surface to TS console.warn"
+#, fuzzy
+msgid "// surface to TS console.warn\n"
 msgstr "// 表面到TS console.warn"
 
 #: src/container/determinism.md:237
-msgid "// unsupported field → hard up() failure"
+#, fuzzy
+msgid "// unsupported field → hard up() failure\n"
 msgstr "// 不支持字段 → 硬up() 失败"
 
 #: src/container/determinism.md:241
@@ -49593,7 +49937,8 @@ msgid "Output normalization — same shape regardless of backend"
 msgstr "输出标准化  不论后端是什么,都相同的形状"
 
 #: src/container/determinism.md:291
-msgid "// Docker shape (NDJSON line)"
+#, fuzzy
+msgid "// Docker shape (NDJSON line)\n"
 msgstr "// Docker 形状 (NDJSON 行)"
 
 #: src/container/determinism.md:292
@@ -49601,7 +49946,8 @@ msgid "/* docker JSON */"
 msgstr "接下来,我们将使用"
 
 #: src/container/determinism.md:293
-msgid "// Apple shape (JSON array of `configuration`-wrapped objects)"
+#, fuzzy
+msgid "// Apple shape (JSON array of `configuration`-wrapped objects)\n"
 msgstr "//果形状 (JSON阵列的`configuration`-wrapped对象)"
 
 #: src/container/determinism.md:294
@@ -49609,7 +49955,8 @@ msgid "/* apple JSON */"
 msgstr "果 JSON 字体:"
 
 #: src/container/determinism.md:295
-msgid "// Both produce ContainerInfo with the same field semantics:"
+#, fuzzy
+msgid "// Both produce ContainerInfo with the same field semantics:\n"
 msgstr "// 两者都产生相同字段语义的ContainerInfo:"
 
 #: src/container/determinism.md:301
@@ -49926,7 +50273,8 @@ msgstr "这会扫描你的源文件并创建 `locales/en.json` 与 `locales/de.j
 
 #: src/i18n/overview.md:46 src/i18n/interpolation.md:17
 #: src/i18n/interpolation.md:51
-msgid "// locales/en.json"
+#, fuzzy
+msgid "// locales/en.json\n"
 msgstr "// locales/en.json"
 
 #: src/i18n/overview.md:48 src/i18n/overview.md:54 src/i18n/overview.md:65
@@ -49939,7 +50287,8 @@ msgid "\"Back\""
 msgstr "\"Back\""
 
 #: src/i18n/overview.md:51
-msgid "// locales/de.json (empty values = needs translation)"
+#, fuzzy
+msgid "// locales/de.json (empty values = needs translation)\n"
 msgstr "// locales/de.json (空值=需要翻译)"
 
 #: src/i18n/overview.md:54 src/i18n/overview.md:55
@@ -50157,7 +50506,8 @@ msgid "\"Total: {price}\""
 msgstr "\"Total: {price}\""
 
 #: src/i18n/interpolation.md:22 src/i18n/interpolation.md:56
-msgid "// locales/de.json"
+#, fuzzy
+msgid "// locales/de.json\n"
 msgstr "// locales/de.json"
 
 #: src/i18n/interpolation.md:25
@@ -50270,7 +50620,8 @@ msgid "\"Du hast {count} Artikel.\""
 msgstr "\"Du hast {count} Artikel.\""
 
 #: src/i18n/interpolation.md:62
-msgid "// locales/pl.json (Polish: one, few, many)"
+#, fuzzy
+msgid "// locales/pl.json (Polish: one, few, many)\n"
 msgstr "// locales/pl.json (波兰语:一个,几个,许多)"
 
 #: src/i18n/interpolation.md:65
@@ -51020,19 +51371,23 @@ msgid "Typical translation workflow:"
 msgstr "典型的翻译工作流:"
 
 #: src/i18n/cli.md:37
-msgid "# 1. Write code with English strings"
+#, fuzzy
+msgid "# 1. Write code with English strings\n"
 msgstr "# 1. 用英语字符串编写代码"
 
 #: src/i18n/cli.md:39
-msgid "# 2. Extract strings to locale files"
+#, fuzzy
+msgid "# 2. Extract strings to locale files\n"
 msgstr "# 2. 将字符串提取到本地文件中"
 
 #: src/i18n/cli.md:42
-msgid "# 3. Send locales/de.json to translators (empty values need filling)"
+#, fuzzy
+msgid "# 3. Send locales/de.json to translators (empty values need filling)\n"
 msgstr "# 3. 将locales/de.json发送给翻译者 (空值需要填写)"
 
 #: src/i18n/cli.md:44
-msgid "# 4. Build — Perry validates everything"
+#, fuzzy
+msgid "# 4. Build — Perry validates everything\n"
 msgstr "# 4. 构建  Perry 验证一切"
 
 #: src/i18n/cli.md:49
@@ -51680,52 +52035,22 @@ msgstr ""
 "消耗的认证宣言."
 
 #: src/updater/overview.md:200
-msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and"
+#, fuzzy
+msgid "# 1) One-time keypair generation. Save kp.json with mode 0600 and\n"
 msgstr "# 1) 一次性关键对生成. 保存 kp.json 在模式 0600 和"
 
 #: src/updater/overview.md:203
-msgid "# 2) Per-release signing. The output JSON envelope contains every"
+#, fuzzy
+msgid "# 2) Per-release signing. The output JSON envelope contains every\n"
 msgstr "# 2) 每次发行签名. 输出 JSON 封面包含所有"
 
-#: src/updater/overview.md:210
-msgid "# 3) Sanity-check the signature locally before uploading the manifest —"
-msgstr "# 在上传公告之前,"
-
-#: src/updater/overview.md:212
-msgid "#    here predicts a passing verify on the client."
-msgstr "#    这里预测一个通过验证客户."
-
-#: src/updater/overview.md:217
-msgid "'<base64 from step 2>'"
-msgstr "'<base64 from step 2>'"
-
-#: src/updater/overview.md:218
-msgid "'<public_key from kp.json>'"
-msgstr "'<public_key from kp.json>'"
-
-#: src/updater/overview.md:219
-msgid ""
-"# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
-msgstr "# 4) 发布CI签署了CLI宣言,绑定其档案URL,平台,"
-
-#: src/updater/overview.md:225
-msgid ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-msgstr ""
-"'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
-"x86_64.tar.gz'"
-
-#: src/updater/overview.md:228
-msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
-
 #: src/updater/overview.md:231
+#, fuzzy
 msgid ""
 "Compose a final manifest by piping `sign` output through `jq` for each "
 "asset, then merging into the per-platform layout shown above. CI tip: pass "
-"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key  file` "
-"so the secret can come from a repository secret without ever hitting the "
+"`--secret-key-b64 \"$ED25519_SECRET_KEY\"` instead of `--secret-key file` so "
+"the secret can come from a repository secret without ever hitting the "
 "worker's filesystem."
 msgstr ""
 "编写一个最终的公示文件,将`sign`输出通过`jq`,然后合并到上面显示的每个平台布"
@@ -53306,9 +53631,10 @@ msgstr ""
 "声）。"
 
 #: src/system/audio_module.md:11
+#, fuzzy
 msgid ""
 "**`Bus`** — a mixer group. Sounds route through a Bus, Buses route through "
-"their parent (default: master). One `setVolume(musicBus,  0.3)` scales every "
+"their parent (default: master). One `setVolume(musicBus, 0.3)` scales every "
 "voice on it."
 msgstr ""
 "**`Bus`** 一个混合组. 声音路由通过巴士,巴士路由通过其父 (默认:主). 一个"
@@ -54286,6 +54612,7 @@ msgstr ""
 "动，按墙钟时间比较限流到 100 ms。"
 
 #: src/system/media.md:159
+#, fuzzy
 msgid ""
 "**HarmonyOS** — Perry's `.so` cannot reach `@ohos.multimedia.media` "
 "directly, so `perry/media` calls record intents into Mutex-protected drain "
@@ -54295,7 +54622,7 @@ msgid ""
 "queues, dispatches each op against the matching `media.AVPlayer` instance "
 "(allocated lazily on the first `createPlayer` drain), and pushes state "
 "observations back into the runtime via the `pushMediaState(handle, state, "
-"current,  duration)` NAPI export. AVPlayer's own `stateChange` / "
+"current, duration)` NAPI export. AVPlayer's own `stateChange` / "
 "`timeUpdate` / `error` / `endOfStream` events feed the same callback path. "
 "The pump runs on the ArkTS UI thread, so closures fired by "
 "`media_playback::push_media_state` share the same arena as Perry's `main()`. "
@@ -55442,23 +55769,28 @@ msgid ""
 msgstr "编译器为每个平台生成完整的原生控件扩展——无需了解平台特定的语言知识。"
 
 #: src/widgets/overview.md:53
-msgid "# iOS WidgetKit extension"
+#, fuzzy
+msgid "# iOS WidgetKit extension\n"
 msgstr "# iOS WidgetKit 的扩展"
 
 #: src/widgets/overview.md:54
-msgid "# Android App Widget"
+#, fuzzy
+msgid "# Android App Widget\n"
 msgstr "# Android应用程序工具"
 
 #: src/widgets/overview.md:55
-msgid "# watchOS Complication"
+#, fuzzy
+msgid "# watchOS Complication\n"
 msgstr "# watchOS复杂性"
 
 #: src/widgets/overview.md:56
-msgid "# watchOS Simulator"
+#, fuzzy
+msgid "# watchOS Simulator\n"
 msgstr "# 模拟器 watchOS"
 
 #: src/widgets/overview.md:57
-msgid "# Wear OS Tile"
+#, fuzzy
+msgid "# Wear OS Tile\n"
 msgstr "# Wear OS 片"
 
 #: src/widgets/overview.md:60
@@ -56339,10 +56671,6 @@ msgstr ""
 "Text(\"Custom\", { color: \"#FF6600\" })\n"
 "```"
 
-#: src/widgets/components.md:155
-msgid "Padding"
-msgstr "内边距"
-
 #: src/widgets/components.md:161
 msgid "Frame"
 msgstr "Frame"
@@ -56922,11 +57250,13 @@ msgid "Build Commands"
 msgstr "构建命令"
 
 #: src/widgets/configuration.md:132
-msgid "# iOS"
+#, fuzzy
+msgid "# iOS\n"
 msgstr "# iOS"
 
 #: src/widgets/configuration.md:134
-msgid "# Android"
+#, fuzzy
+msgid "# Android\n"
 msgstr "# Android"
 
 #: src/widgets/configuration.md:141
@@ -57768,19 +58098,23 @@ msgid "Build Instructions"
 msgstr "构建说明"
 
 #: src/widgets/platforms.md:78
-msgid "# Copy .kt files to app/src/main/java/com/example/app/"
+#, fuzzy
+msgid "# Copy .kt files to app/src/main/java/com/example/app/\n"
 msgstr "# 将kt文件复制到app/src/main/java/com/example/app/"
 
 #: src/widgets/platforms.md:80
-msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml into AndroidManifest.xml\n"
 msgstr "# 将AndroidManifest_snippet.xml合并到AndroidManifest.xml中"
 
 #: src/widgets/platforms.md:94
-msgid "# Copy .kt files to Wear OS module"
+#, fuzzy
+msgid "# Copy .kt files to Wear OS module\n"
 msgstr "# 将kt文件复制到Wear OS模块"
 
 #: src/widgets/platforms.md:96
-msgid "# Merge AndroidManifest_snippet.xml"
+#, fuzzy
+msgid "# Merge AndroidManifest_snippet.xml\n"
 msgstr "# 合并AndroidManifest_snippet.xml"
 
 #: src/widgets/watchos.md:3
@@ -57965,11 +58299,13 @@ msgid "Background refresh uses `BackgroundTask` framework"
 msgstr "后台刷新使用 `BackgroundTask` 框架"
 
 #: src/widgets/watchos.md:63
-msgid "# For Apple Watch device"
+#, fuzzy
+msgid "# For Apple Watch device\n"
 msgstr "# 对于Apple Watch设备"
 
 #: src/widgets/watchos.md:65
-msgid "# For Apple Watch Simulator"
+#, fuzzy
+msgid "# For Apple Watch Simulator\n"
 msgstr "# 对于果手表模拟器"
 
 #: src/widgets/watchos.md:70
@@ -59513,11 +59849,13 @@ msgstr ""
 "实现所声明的函数："
 
 #: src/plugins/native-extensions.md:182
-msgid "// Perry runtime FFI"
+#, fuzzy
+msgid "// Perry runtime FFI\n"
 msgstr "// 在运行时使用Perry"
 
 #: src/plugins/native-extensions.md:194
-msgid "// ... call platform API, resolve promise when done ..."
+#, fuzzy
+msgid "// ... call platform API, resolve promise when done ...\n"
 msgstr "// ...调用平台API,解决承诺当完成..."
 
 #: src/plugins/native-extensions.md:200
@@ -59646,23 +59984,21 @@ msgstr ""
 "目标："
 
 #: src/plugins/native-extensions.md:240
-msgid "// build.rs (simplified)"
+#, fuzzy
+msgid "// build.rs (simplified)\n"
 msgstr "// build.rs (简化)"
 
 #: src/plugins/native-extensions.md:242
-msgid "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
-msgstr "// 检测目标:aarch64-apple-ios → arm64-apple-ios16.0,iPhoneOS SDK"
-
-#: src/plugins/native-extensions.md:243
 msgid ""
-"// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
-"StoreKit"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 msgstr ""
-"//编译:快速编译-emit-library -static -target ... -sdk ... -framework StoreKit"
-
-#: src/plugins/native-extensions.md:244
-msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
-msgstr "//链接:货物:rustc-link-lib=static=review_bridge"
+"// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
+"    // Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+"StoreKit\n"
+"    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
 
 #: src/plugins/native-extensions.md:248
 msgid "JNI bridge (Android)"
@@ -59689,7 +60025,8 @@ msgid "Resolve the Perry promise with the result"
 msgstr "用结果兑现 Perry promise"
 
 #: src/plugins/native-extensions.md:265
-msgid "// Get Activity from PerryBridge"
+#, fuzzy
+msgid "// Get Activity from PerryBridge\n"
 msgstr "// 从PerryBridge获取活动"
 
 #: src/plugins/native-extensions.md:266
@@ -59705,7 +60042,8 @@ msgid "\"()Landroid/app/Activity;\""
 msgstr "\"()Landroid/app/Activity;\""
 
 #: src/plugins/native-extensions.md:270
-msgid "// Call platform APIs via JNI..."
+#, fuzzy
+msgid "// Call platform APIs via JNI...\n"
 msgstr "//通过JNI调用平台API..."
 
 #: src/plugins/native-extensions.md:275
@@ -60283,15 +60621,18 @@ msgstr ""
 "`lint`任务,需要大约五分之一秒,不需要编译器,无节点和没有构建."
 
 #: src/testing/test-registration.md:13
-msgid "# the gate"
+#, fuzzy
+msgid "# the gate\n"
 msgstr "# 门"
 
 #: src/testing/test-registration.md:14
-msgid "# what is in scope, and what is not"
+#, fuzzy
+msgid "# what is in scope, and what is not\n"
 msgstr "# 什么是适用范围,什么不是"
 
 #: src/testing/test-registration.md:15
-msgid "# prove the gate can still fail"
+#, fuzzy
+msgid "# prove the gate can still fail\n"
 msgstr "# 证明门仍然可以失败"
 
 #: src/testing/test-registration.md:18
@@ -60613,31 +60954,38 @@ msgstr ""
 "无需任何外部依赖。当你使用 `--enable-geisterhand` 编译时，服务器会自动启动。"
 
 #: src/testing/geisterhand.md:12
-msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)"
+#, fuzzy
+msgid "# 1. Compile with geisterhand enabled (libs auto-build on first use)\n"
 msgstr "# 1. 编译时启用geisterhand (libs首次使用时自动构建)"
 
 #: src/testing/geisterhand.md:14
-msgid "# 2. Run the app"
+#, fuzzy
+msgid "# 2. Run the app\n"
 msgstr "# 2. 运行应用程序"
 
 #: src/testing/geisterhand.md:16
-msgid "# [geisterhand] listening on http://127.0.0.1:7676"
+#, fuzzy
+msgid "# [geisterhand] listening on http://127.0.0.1:7676\n"
 msgstr "# [geisterhand] listening on http://127.0.0.1:7676"
 
 #: src/testing/geisterhand.md:18
-msgid "# 3. In another terminal — interact with the app"
+#, fuzzy
+msgid "# 3. In another terminal — interact with the app\n"
 msgstr "# 3. 在另一个终端与应用程序交互"
 
 #: src/testing/geisterhand.md:20
-msgid "# List all widgets"
+#, fuzzy
+msgid "# List all widgets\n"
 msgstr "# 列出所有小程序"
 
 #: src/testing/geisterhand.md:21
-msgid "# Click button with handle 3"
+#, fuzzy
+msgid "# Click button with handle 3\n"
 msgstr "# 按与3手柄"
 
 #: src/testing/geisterhand.md:22
-msgid "# Capture window screenshot"
+#, fuzzy
+msgid "# Capture window screenshot\n"
 msgstr "# 捕获窗口屏幕截图"
 
 #: src/testing/geisterhand.md:25
@@ -60653,7 +61001,8 @@ msgstr ""
 "geisterhand`，因此不需要同时指定两个标志）："
 
 #: src/testing/geisterhand.md:30
-msgid "# or with perry run:"
+#, fuzzy
+msgid "# or with perry run:\n"
 msgstr "# 或是佩里跑:"
 
 #: src/testing/geisterhand.md:35
@@ -60794,8 +61143,8 @@ msgid "Menu item"
 msgstr "菜单项"
 
 #: src/testing/geisterhand.md:92 src/cli/perry-toml.md:426
-#: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
-#: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
 msgid "6"
 msgstr "6"
 
@@ -60807,8 +61156,8 @@ msgstr "键盘快捷键"
 msgid "Data table"
 msgstr "数据表"
 
-#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:577
+#: src/testing/geisterhand.md:94 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:591
 msgid "8"
 msgstr "8"
 
@@ -60917,17 +61266,6 @@ msgid ""
 "text as a NaN-boxed string."
 msgstr "设置文本字段的内容，并以 NaN-boxed 字符串形式触发其 `onChange` 回调。"
 
-#: src/testing/geisterhand.md:135 src/testing/geisterhand.md:152
-#: src/testing/geisterhand.md:182 src/testing/geisterhand.md:217
-#: src/testing/geisterhand.md:236 src/testing/geisterhand.md:281
-#: src/testing/geisterhand.md:498
-msgid "'Content-Type: application/json'"
-msgstr "\"内容类型:application/json\""
-
-#: src/testing/geisterhand.md:136
-msgid "'{\"text\":\"hello world\"}'"
-msgstr "您可以在下面的页面上查看"
-
 #: src/testing/geisterhand.md:139
 msgid "Move a Slider"
 msgstr "移动滑块"
@@ -60951,10 +61289,6 @@ msgstr ""
 #: src/testing/geisterhand.md:148
 msgid "Sets the slider position and fires `onChange` with the numeric value."
 msgstr "设置滑块位置，并以数值触发 `onChange`。"
-
-#: src/testing/geisterhand.md:153
-msgid "'{\"value\":0.75}'"
-msgstr "\"{\"值\":0.75}\""
 
 #: src/testing/geisterhand.md:156
 msgid "Toggle a Switch"
@@ -61004,10 +61338,6 @@ msgid ""
 msgstr ""
 "直接设置 `State` 单元的值，绕过控件回调。这会触发附加到该状态上的任何响应式绑"
 "定（绑定的文本标签、可见性、forEach 循环等）。"
-
-#: src/testing/geisterhand.md:183
-msgid "'{\"value\":42}'"
-msgstr "\"{\"价值\":42}\""
 
 #: src/testing/geisterhand.md:186
 msgid "Hover"
@@ -61083,10 +61413,6 @@ msgstr ""
 "`menuAddItem` 的键字符串匹配（例如 `\"s\"` 对应 Cmd+S，`\"S\"` 对应 "
 "Cmd+Shift+S，`\"n\"` 对应 Cmd+N）。"
 
-#: src/testing/geisterhand.md:218
-msgid "'{\"shortcut\":\"s\"}'"
-msgstr "现在,我们可以在这个问题上做些什么"
-
 #: src/testing/geisterhand.md:221
 msgid ""
 "Returns `{\"ok\":true}` if a matching shortcut was found, or 404 if no match."
@@ -61117,10 +61443,6 @@ msgid ""
 "Sets the scroll offset of a ScrollView widget. Both `x` and `y` are in "
 "points."
 msgstr "设置 ScrollView 控件的滚动偏移。`x` 和 `y` 均以点（point）为单位。"
-
-#: src/testing/geisterhand.md:237
-msgid "'{\"x\":0,\"y\":200}'"
-msgstr "'{\"x\":0,\"y\":200}'"
 
 #: src/testing/geisterhand.md:240
 msgid "Capture Screenshot"
@@ -61218,12 +61540,9 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:279
-msgid "# Fire random inputs every 200ms"
+#, fuzzy
+msgid "# Fire random inputs every 200ms\n"
 msgstr "# 每200毫秒一次发射随机输入"
-
-#: src/testing/geisterhand.md:282
-msgid "'{\"interval_ms\":200}'"
-msgstr "'{\"interval_ms\":200}'"
 
 #: src/testing/geisterhand.md:285
 msgid ""
@@ -61356,12 +61675,17 @@ msgstr ""
 "`libimobiledevice` 中的 `iproxy`："
 
 #: src/testing/geisterhand.md:357
-msgid "# Install and launch via Xcode/devicectl"
+#, fuzzy
+msgid "# Install and launch via Xcode/devicectl\n"
 msgstr "# 通过Xcode/devicectl安装和启动"
 
 #: src/testing/geisterhand.md:359
-msgid "'s IP:"
-msgstr "的IP:"
+msgid ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
+msgstr ""
+"'s IP:\n"
+"curl http://192.168.1.42:7676/widgets\n"
 
 #: src/testing/geisterhand.md:363
 msgid "Android (Emulator or Device)"
@@ -61388,7 +61712,8 @@ msgstr ""
 "```"
 
 #: src/testing/geisterhand.md:373
-msgid "# Package into APK and install"
+#, fuzzy
+msgid "# Package into APK and install\n"
 msgstr "# 包到APK并安装"
 
 #: src/testing/geisterhand.md:381
@@ -61396,7 +61721,8 @@ msgid "Install GTK4 development libraries first:"
 msgstr "首先安装 GTK4 开发库："
 
 #: src/testing/geisterhand.md:384
-msgid "# Ubuntu/Debian"
+#, fuzzy
+msgid "# Ubuntu/Debian\n"
 msgstr "# Ubuntu/Debian"
 
 #: src/testing/geisterhand.md:402
@@ -61420,15 +61746,18 @@ msgid "A simple end-to-end test using bash:"
 msgstr "使用 bash 编写的简单端到端测试："
 
 #: src/testing/geisterhand.md:411
-msgid "#!/bin/bash"
+#, fuzzy
+msgid "#!/bin/bash\n"
 msgstr "#!/bin/bash"
 
 #: src/testing/geisterhand.md:413
-msgid "# Build with geisterhand"
+#, fuzzy
+msgid "# Build with geisterhand\n"
 msgstr "# 用灵魂的手来建造"
 
 #: src/testing/geisterhand.md:416
-msgid "# Start the app in background"
+#, fuzzy
+msgid "# Start the app in background\n"
 msgstr "# 在后台启动应用程序"
 
 #: src/testing/geisterhand.md:419
@@ -61440,33 +61769,37 @@ msgid "\"kill $APP_PID 2>/dev/null\""
 msgstr "\"kill $APP_PID 2>/dev/null\""
 
 #: src/testing/geisterhand.md:421
-msgid "# Wait for the app to be ready"
+#, fuzzy
+msgid "# Wait for the app to be ready\n"
 msgstr "# 等到应用程序准备好"
 
 #: src/testing/geisterhand.md:427
-msgid "# Get widgets"
+#, fuzzy
+msgid "# Get widgets\n"
 msgstr "# 获取小程序"
-
-#: src/testing/geisterhand.md:429
-msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
-msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
 
 #: src/testing/geisterhand.md:430
 msgid "\"Registered widgets: $WIDGETS\""
 msgstr "\"Registered widgets: $WIDGETS\""
 
 #: src/testing/geisterhand.md:431
-msgid "# Find the button labeled \"Submit\""
+#, fuzzy
+msgid "# Find the button labeled \"Submit\"\n"
 msgstr "# 找到标有\"提交\"的按"
 
 #: src/testing/geisterhand.md:433
-msgid ""
-"$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
+msgid "\"$WIDGETS\""
+msgstr "\"$WIDGETS\""
+
+#: src/testing/geisterhand.md:433
+#, fuzzy
+msgid "'.[] | select(.label == \"Submit\") | .handle'"
 msgstr ""
 "$(echo \"$WIDGETS\" | jq -r '.[] | select(.label == \"Submit\") | .handle')"
 
 #: src/testing/geisterhand.md:434
-msgid "# Click it"
+#, fuzzy
+msgid "# Click it\n"
 msgstr "# 按下它"
 
 #: src/testing/geisterhand.md:436
@@ -61474,7 +61807,8 @@ msgid "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 msgstr "\"http://127.0.0.1:7676/click/$SUBMIT_HANDLE\""
 
 #: src/testing/geisterhand.md:437
-msgid "# Take a screenshot after interaction"
+#, fuzzy
+msgid "# Take a screenshot after interaction\n"
 msgstr "# 在互动后拍摄屏幕截图"
 
 #: src/testing/geisterhand.md:441
@@ -61486,7 +61820,8 @@ msgid "Python Test Example"
 msgstr "Python 测试示例"
 
 #: src/testing/geisterhand.md:448
-msgid "# Start the app"
+#, fuzzy
+msgid "# Start the app\n"
 msgstr "# 启动应用程序"
 
 #: src/testing/geisterhand.md:450
@@ -61494,11 +61829,13 @@ msgid "\"./testapp\""
 msgstr "\"./testapp\""
 
 #: src/testing/geisterhand.md:451 src/testing/geisterhand.md:492
-msgid "# Wait for startup"
+#, fuzzy
+msgid "# Wait for startup\n"
 msgstr "# 等待启动"
 
 #: src/testing/geisterhand.md:454
-msgid "# List widgets"
+#, fuzzy
+msgid "# List widgets\n"
 msgstr "# 列表小程序"
 
 #: src/testing/geisterhand.md:455
@@ -61506,11 +61843,13 @@ msgid "\"http://127.0.0.1:7676/widgets\""
 msgstr "\"http://127.0.0.1:7676/widgets\""
 
 #: src/testing/geisterhand.md:457
-msgid "# Find widgets by label"
+#, fuzzy
+msgid "# Find widgets by label\n"
 msgstr "# 按标签搜索小程序"
 
 #: src/testing/geisterhand.md:461
-msgid "# Type into the first text field"
+#, fuzzy
+msgid "# Type into the first text field\n"
 msgstr "# 输入第一个文本字段"
 
 #: src/testing/geisterhand.md:464
@@ -61530,7 +61869,8 @@ msgid "\"test@example.com\""
 msgstr "\"test@example.com\""
 
 #: src/testing/geisterhand.md:468
-msgid "# Click the first button"
+#, fuzzy
+msgid "# Click the first button\n"
 msgstr "# 点击第一个按"
 
 #: src/testing/geisterhand.md:470
@@ -61538,7 +61878,8 @@ msgid "\"http://127.0.0.1:7676/click/"
 msgstr "\"http://127.0.0.1:7676/click/"
 
 #: src/testing/geisterhand.md:472
-msgid "# Capture screenshot for visual regression"
+#, fuzzy
+msgid "# Capture screenshot for visual regression\n"
 msgstr "# 捕获视觉回归的屏幕截图"
 
 #: src/testing/geisterhand.md:473
@@ -61554,7 +61895,8 @@ msgid "\"wb\""
 msgstr "\"wb\""
 
 #: src/testing/geisterhand.md:477
-msgid "# Assert the app is still healthy"
+#, fuzzy
+msgid "# Assert the app is still healthy\n"
 msgstr "# 确认应用程序仍然正常"
 
 #: src/testing/geisterhand.md:478
@@ -61584,40 +61926,14 @@ msgid ""
 msgstr "针对你的应用运行混沌模式来发现崩溃、卡死或意外状态："
 
 #: src/testing/geisterhand.md:489
-msgid "# Build and launch"
+#, fuzzy
+msgid "# Build and launch\n"
 msgstr "# 构建和发射"
 
 #: src/testing/geisterhand.md:495
-msgid "# Start aggressive chaos (every 50ms)"
+#, fuzzy
+msgid "# Start aggressive chaos (every 50ms)\n"
 msgstr "# 开始激进的混乱 (每50毫秒)"
-
-#: src/testing/geisterhand.md:499
-msgid "'{\"interval_ms\":50}'"
-msgstr "'{\"interval_ms\":50}'"
-
-#: src/testing/geisterhand.md:500
-msgid "# Let it run for 30 seconds"
-msgstr "# 让它运行30秒钟"
-
-#: src/testing/geisterhand.md:503
-msgid "# Check stats"
-msgstr "# 检查统计数据"
-
-#: src/testing/geisterhand.md:505
-msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
-msgstr "# 现在我们要做些什么events_fired\"六百\",uptime_secs没有人知道"
-
-#: src/testing/geisterhand.md:507
-msgid "# Take a screenshot to see final state"
-msgstr "# 截图以查看最终状态"
-
-#: src/testing/geisterhand.md:510
-msgid "# Stop chaos"
-msgstr "# 停止混乱"
-
-#: src/testing/geisterhand.md:513
-msgid "# Check the app is still alive"
-msgstr "# 检查应用程序是否还在使用"
 
 #: src/testing/geisterhand.md:518
 msgid "Visual Regression Testing"
@@ -61629,11 +61945,13 @@ msgid ""
 msgstr "在关键交互点捕获截图并与基线进行比对："
 
 #: src/testing/geisterhand.md:523
-msgid "# Initial state"
+#, fuzzy
+msgid "# Initial state\n"
 msgstr "# 开始状态"
 
 #: src/testing/geisterhand.md:525
-msgid "# Interact"
+#, fuzzy
+msgid "# Interact\n"
 msgstr "# Interact"
 
 #: src/testing/geisterhand.md:528
@@ -61641,24 +61959,26 @@ msgid "'{\"text\":\"Hello\"}'"
 msgstr "'{\"text\":\"Hello\"}'"
 
 #: src/testing/geisterhand.md:529
-msgid "# Capture after interaction"
+#, fuzzy
+msgid "# Capture after interaction\n"
 msgstr "# 相互作用后捕获"
 
 #: src/testing/geisterhand.md:532
-msgid "# Compare (using ImageMagick)"
+#, fuzzy
+msgid "# Compare (using ImageMagick)\n"
 msgstr "# 比较 (使用ImageMagick)"
 
 #: src/testing/geisterhand.md:537
 msgid "CI Pipeline Integration"
 msgstr "CI 流水线集成"
 
-#: src/testing/geisterhand.md:540 src/cli/perry-toml.md:618
-msgid "# GitHub Actions example"
-msgstr "# GitHub 操作示例"
-
 #: src/testing/geisterhand.md:540
-msgid "jobs"
-msgstr "jobs"
+msgid ""
+"# GitHub Actions example\n"
+"jobs"
+msgstr ""
+"# GitHub Actions example\n"
+"jobs"
 
 #: src/testing/geisterhand.md:542
 msgid "ui-test"
@@ -61707,7 +62027,8 @@ msgid "Run UI tests"
 msgstr "Run UI tests"
 
 #: src/testing/geisterhand.md:554
-msgid "# Run your test script"
+#, fuzzy
+msgid "# Run your test script\n"
 msgstr "# 运行您的测试脚本"
 
 #: src/testing/geisterhand.md:568
@@ -61885,20 +62206,23 @@ msgid "After compiling with `--enable-geisterhand` and running:"
 msgstr "在使用 `--enable-geisterhand` 编译并运行后："
 
 #: src/testing/geisterhand.md:654
-msgid "# See all interactive widgets"
+#, fuzzy
+msgid "# See all interactive widgets\n"
 msgstr "# 查看所有交互式小工具"
 
 #: src/testing/geisterhand.md:655
-msgid "# ["
-msgstr "# ["
+msgid "# [\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:657
 msgid "\"Increment\""
 msgstr "\"Increment\""
 
 #: src/testing/geisterhand.md:657
+#, fuzzy
 msgid ""
-"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":\"Reset\"},"
+"#   {\"handle\":4,\"widget_type\":0,\"callback_kind\":0,\"label\":"
+"\"Reset\"},\n"
 msgstr ""
 "#   现在我们要做些什么widget_type\"0,\"callback_kind\"0,\"标签\":\"重新设置"
 "\"},"
@@ -61908,8 +62232,9 @@ msgid "\"Enter your name\""
 msgstr "\"Enter your name\""
 
 #: src/testing/geisterhand.md:659
+#, fuzzy
 msgid ""
-"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},"
+"#   {\"handle\":6,\"widget_type\":2,\"callback_kind\":1,\"label\":\"\"},\n"
 msgstr ""
 "#   现在,我们需要更多的时间widget_type\"两个\",callback_kind\":1,\"标签:"
 "\"\"},"
@@ -61919,19 +62244,22 @@ msgid "\"Dark Mode\""
 msgstr "\"Dark Mode\""
 
 #: src/testing/geisterhand.md:661
-msgid "# ]"
-msgstr "# ]"
+msgid "# ]\n"
+msgstr ""
 
 #: src/testing/geisterhand.md:663
-msgid "# Click Increment 3 times"
+#, fuzzy
+msgid "# Click Increment 3 times\n"
 msgstr "# 点击增量3次"
 
 #: src/testing/geisterhand.md:665
-msgid "# Counter label now shows \"Count: 3\""
+#, fuzzy
+msgid "# Counter label now shows \"Count: 3\"\n"
 msgstr "# 计数器标签现在显示\"计数:3\""
 
 #: src/testing/geisterhand.md:667
-msgid "# Type a name"
+#, fuzzy
+msgid "# Type a name\n"
 msgstr "# 输入一个名字"
 
 #: src/testing/geisterhand.md:669
@@ -61939,7 +62267,8 @@ msgid "'{\"text\":\"Perry\"}'"
 msgstr "'{\"text\":\"Perry\"}'"
 
 #: src/testing/geisterhand.md:670
-msgid "# Set slider to 80%"
+#, fuzzy
+msgid "# Set slider to 80%\n"
 msgstr "# 设置滑块为80%"
 
 #: src/testing/geisterhand.md:672
@@ -61947,11 +62276,13 @@ msgid "'{\"value\":0.8}'"
 msgstr "'{\"value\":0.8}'"
 
 #: src/testing/geisterhand.md:673
-msgid "# Toggle dark mode on"
+#, fuzzy
+msgid "# Toggle dark mode on\n"
 msgstr "# 启用暗模式"
 
 #: src/testing/geisterhand.md:676
-msgid "# Screenshot"
+#, fuzzy
+msgid "# Screenshot\n"
 msgstr "# Screenshot"
 
 #: src/testing/geisterhand.md:685
@@ -62243,16 +62574,13 @@ msgid "If auto-build fails or you want to cross-compile manually:"
 msgstr "如果自动构建失败，或你希望手动交叉编译："
 
 #: src/testing/geisterhand.md:806
-msgid "# Build geisterhand libs for macOS"
+#, fuzzy
+msgid "# Build geisterhand libs for macOS\n"
 msgstr "# 为macOS构建灵魂手版"
 
-#: src/testing/geisterhand.md:807 src/testing/geisterhand.md:813
+#: src/testing/geisterhand.md:807
 msgid "target/geisterhand"
 msgstr "target/geisterhand"
-
-#: src/testing/geisterhand.md:811
-msgid "# Build for iOS (cross-compile)"
-msgstr "# 为 iOS 构建 (交叉编译)"
 
 #: src/testing/geisterhand.md:824
 msgid ""
@@ -62422,15 +62750,18 @@ msgstr ""
 "pin/`下,因此随后的运行只是Perry编译+运行. 进一步缩小:"
 
 #: src/testing/node-compat-matrix.md:25
-msgid "# a few modules"
+#, fuzzy
+msgid "# a few modules\n"
 msgstr "# 一些模块"
 
 #: src/testing/node-compat-matrix.md:26
-msgid "# only these exports"
+#, fuzzy
+msgid "# only these exports\n"
 msgstr "# 只有这些出口"
 
 #: src/testing/node-compat-matrix.md:27
-msgid "# combined mod.export form"
+#, fuzzy
+msgid "# combined mod.export form\n"
 msgstr "# 组合形式 mod.export"
 
 #: src/testing/node-compat-matrix.md:30
@@ -62449,15 +62780,18 @@ msgid "Full sweep and the CI gate"
 msgstr "完全扫描和CI门"
 
 #: src/testing/node-compat-matrix.md:38
-msgid "# whole matrix + summary table"
+#, fuzzy
+msgid "# whole matrix + summary table\n"
 msgstr "# 整个矩阵 + 总结表"
 
 #: src/testing/node-compat-matrix.md:39
-msgid "# exit 1 on regressions vs the baseline"
+#, fuzzy
+msgid "# exit 1 on regressions vs the baseline\n"
 msgstr "# 在回归与基线上1出口"
 
 #: src/testing/node-compat-matrix.md:40
-msgid "# rewrite the committed baseline"
+#, fuzzy
+msgid "# rewrite the committed baseline\n"
 msgstr "# 重写承诺的基线"
 
 #: src/testing/node-compat-matrix.md:43
@@ -62717,7 +63051,7 @@ msgstr ""
 "个任务 (`plan`) 中决定. 其他所有工作都是`needs: plan`, 关闭在"
 "`fromJSON(needs.plan.outputs.plan).jobs.<name>`上."
 
-#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:13 src/testing/ci-tiers.md:124
 msgid "tier"
 msgstr "tier"
 
@@ -62807,11 +63141,11 @@ msgstr "job"
 msgid "pr"
 msgstr "pr"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:128
 msgid "sweep"
 msgstr "sweep"
 
-#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:24 src/testing/ci-tiers.md:129
 msgid "full"
 msgstr "full"
 
@@ -62836,94 +63170,107 @@ msgid "`cargo-test`"
 msgstr "`cargo-test`"
 
 #: src/testing/ci-tiers.md:30
+#, fuzzy
+msgid "`cargo-test-perry`"
+msgstr "`cargo-test`"
+
+#: src/testing/ci-tiers.md:31
 msgid "`gap-suite`"
 msgstr "`gap-suite`"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "6x fast"
 msgstr "6倍的速度"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "3x fast"
 msgstr "快3倍"
 
-#: src/testing/ci-tiers.md:30
+#: src/testing/ci-tiers.md:31
 msgid "8x full"
 msgstr "8倍满"
 
-#: src/testing/ci-tiers.md:31
+#: src/testing/ci-tiers.md:32
 msgid "`gc-stress`"
 msgstr "`gc-stress`"
 
 #: src/testing/ci-tiers.md:32
+msgid "1x pr"
+msgstr ""
+
+#: src/testing/ci-tiers.md:32
+msgid "4x all"
+msgstr ""
+
+#: src/testing/ci-tiers.md:33
 msgid "`e2e-scoped`"
 msgstr "`e2e-scoped`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "`security-audit`"
 msgstr "`security-audit`"
 
-#: src/testing/ci-tiers.md:33
+#: src/testing/ci-tiers.md:34
 msgid "deps only"
 msgstr "仅限于"
 
-#: src/testing/ci-tiers.md:34
+#: src/testing/ci-tiers.md:35
 msgid "`windows-build`"
 msgstr "`windows-build`"
 
-#: src/testing/ci-tiers.md:35
+#: src/testing/ci-tiers.md:36
 msgid "`windows-arm64-build`"
 msgstr "`windows-arm64-build`"
 
-#: src/testing/ci-tiers.md:36
+#: src/testing/ci-tiers.md:37
 msgid "`compiler-output-regression`"
 msgstr "`compiler-output-regression`"
 
-#: src/testing/ci-tiers.md:37
+#: src/testing/ci-tiers.md:38
 msgid "`repsel-census`"
 msgstr "`repsel-census`"
 
-#: src/testing/ci-tiers.md:38
+#: src/testing/ci-tiers.md:39
 msgid "`harmonyos-smoke`"
 msgstr "`harmonyos-smoke`"
 
-#: src/testing/ci-tiers.md:39
+#: src/testing/ci-tiers.md:40
 msgid "`binary-size`"
 msgstr "`binary-size`"
 
-#: src/testing/ci-tiers.md:40
+#: src/testing/ci-tiers.md:41
 msgid "`parity`"
 msgstr "`parity`"
 
-#: src/testing/ci-tiers.md:41
+#: src/testing/ci-tiers.md:42
 msgid "`compile-smoke`"
 msgstr "`compile-smoke`"
 
-#: src/testing/ci-tiers.md:42
+#: src/testing/ci-tiers.md:43
 msgid "`native-abi-evidence-packet`"
 msgstr "`native-abi-evidence-packet`"
 
-#: src/testing/ci-tiers.md:43
+#: src/testing/ci-tiers.md:44
 msgid "`drizzle-mysql-smoke`"
 msgstr "`drizzle-mysql-smoke`"
 
-#: src/testing/ci-tiers.md:44
+#: src/testing/ci-tiers.md:45
 msgid "`ink-link-smoke`"
 msgstr "`ink-link-smoke`"
 
-#: src/testing/ci-tiers.md:45
+#: src/testing/ci-tiers.md:46
 msgid "`effect-basic-smoke`"
 msgstr "`effect-basic-smoke`"
 
-#: src/testing/ci-tiers.md:46
+#: src/testing/ci-tiers.md:47
 msgid "`doc-tests`"
 msgstr "`doc-tests`"
 
-#: src/testing/ci-tiers.md:48
+#: src/testing/ci-tiers.md:49
 msgid "Within the **pr** tier the changed-file list narrows the plan further:"
 msgstr "在 **在线** 变更文件列表进一步缩小了计划:"
 
-#: src/testing/ci-tiers.md:50
+#: src/testing/ci-tiers.md:51
 msgid ""
 "**docs-only** (only `docs/`, `*.md`, `benchmarks/`, `npm/`, `packaging/`, "
 "`.claude/`, … — see `NON_CORE_GLOBS` in `ci_plan.py`) → only `lint` runs."
@@ -62931,13 +63278,13 @@ msgstr ""
 "**仅用于文献** (只有`docs/`,`*.md`,`benchmarks/`,`npm/`,`packaging/"
 "`,`.claude/`, ... 见`NON_CORE_GLOBS`在`ci_plan.py`中) →只有`lint`运行."
 
-#: src/testing/ci-tiers.md:52
+#: src/testing/ci-tiers.md:53
 msgid ""
 "**core** (anything that can change the compiler, the runtime, or a test "
 "outcome) → the whole PR tier."
 msgstr "**核心** (任何可以改变编译器,运行时间或测试结果的东西) →整个PR层."
 
-#: src/testing/ci-tiers.md:54
+#: src/testing/ci-tiers.md:55
 msgid ""
 "**deps** (a lockfile, manifest, `deny.toml`, `package.json`, `.claude/`, "
 "`skills/`, …) → additionally the `security-audit` reusable workflow."
@@ -62945,7 +63292,7 @@ msgstr ""
 "**没有** (一个锁文件,公示,`deny.toml`,`package.json`,`.claude/`,`skills/"
 "`, ...) → 另外是`security-audit`可重复使用的工作流程."
 
-#: src/testing/ci-tiers.md:57
+#: src/testing/ci-tiers.md:58
 msgid ""
 "`e2e-scoped` runs integration suites selected by the diff, but its "
 "`SUITE_EXCLUSIONS` check is deliberately not scoped: whenever that list is "
@@ -62957,7 +63304,7 @@ msgstr ""
 "围:当该列表不空时,每个核心PR重启每个排除的精确测试,如果不再失败,则失败. 这可"
 "以捕获在HIR,转换或其他依赖性中进行的修复,而无需添加Rust设置到仅用于doc PR中."
 
-#: src/testing/ci-tiers.md:63
+#: src/testing/ci-tiers.md:64
 msgid ""
 "An empty or failed file listing is treated as **core** and a failed `plan` "
 "job fails the gate outright — a broken planner must never turn into "
@@ -62966,11 +63313,11 @@ msgstr ""
 "一个空的或失败的文件列表被视为 **核心** 一个失败的 `plan` 工作完全失败了  一"
 "个坏的规划器永远不会变成\"一切都跳过了,因此绿色\"."
 
-#: src/testing/ci-tiers.md:67
+#: src/testing/ci-tiers.md:68
 msgid "Why it looks like this (measured 2026-08-16)"
 msgstr "为什么它看起来像这样 (测量2026-08-16)"
 
-#: src/testing/ci-tiers.md:69
+#: src/testing/ci-tiers.md:70
 msgid ""
 "The organisation runs on GitHub's Free plan: **20 concurrent hosted jobs, 5 "
 "of them macOS**, for the whole org. Before this shape, every PR push fanned "
@@ -62981,11 +63328,11 @@ msgstr ""
 "说. 在这种形状之前, **14个工作流程 / 48个工作 / ~ 650 个运行分钟**,而`main`每"
 "天看到~66次 PR 推送和~58次合并. 这就是1.52×总容量,所以:"
 
-#: src/testing/ci-tiers.md:74
+#: src/testing/ci-tiers.md:75
 msgid "job queue waits were 3–7 h (`conformance-smoke` shards: median 4 h);"
 msgstr "工作排队时间为37小时 (`conformance-smoke`碎片:中位数为4小时);"
 
-#: src/testing/ci-tiers.md:75
+#: src/testing/ci-tiers.md:76
 msgid ""
 "**0 of 66** PR runs of the `Tests` workflow reached a conclusion in the "
 "sample window — 8 failed, 56 were cancelled by the next push;"
@@ -62993,7 +63340,7 @@ msgstr ""
 "**在66个中** 在示例窗口中完成了 `Tests` 工作流的 PR 运行  8 个失败,56 个被下"
 "次推断取消;"
 
-#: src/testing/ci-tiers.md:77
+#: src/testing/ci-tiers.md:78
 msgid ""
 "the required contexts included two jobs (`parity`, `compile-smoke`) that "
 "never ran on a PR and one (`conformance-smoke-complete`) that had been red "
@@ -63004,7 +63351,7 @@ msgstr ""
 "(`conformance-smoke-complete`) 在`main`上一直处于红色状态,因此 **在过去的12次"
 "合并中,** 在`lint`和`cargo-test`仍然排队时."
 
-#: src/testing/ci-tiers.md:82
+#: src/testing/ci-tiers.md:83
 msgid ""
 "The always-red required-gate incident was tracked in [\\#8092](https://"
 "github.com/PerryTS/perry/issues/8092). #8087 restored `lint`, \\#8095 made "
@@ -63017,11 +63364,11 @@ msgstr ""
 "定的ELF源身份,因此`cargo-test`可以传输到Linux,#8187取代了上面描述的单个`pr-"
 "gate`粉丝."
 
-#: src/testing/ci-tiers.md:88
+#: src/testing/ci-tiers.md:89
 msgid "Two specific costs dominated:"
 msgstr "主导两个具体成本:"
 
-#: src/testing/ci-tiers.md:90
+#: src/testing/ci-tiers.md:91
 msgid ""
 "`conformance-smoke` was 8 shards × ~60 min = **480 job-minutes per push**, "
 "and 96 % of each shard's test time was ~10 tests at ~200 s each — the auto-"
@@ -63039,7 +63386,7 @@ msgstr ""
 "`fast` 间隙模式. 8分的自动优化模式保持在全层,因为它是唯一看到自动优化链接错误"
 "的手臂."
 
-#: src/testing/ci-tiers.md:97
+#: src/testing/ci-tiers.md:98
 msgid ""
 "Every job saved a fresh ~0.5–1.3 GB sccache tarball on every PR push (~200 "
 "GB/day into a 10 GB repo cache budget), evicting every useful entry within "
@@ -63051,7 +63398,19 @@ msgstr ""
 "GB/day 进入 10 GB repo cache 预算),在一个小时内驱逐每一个有用的条目. `cache-"
 "warm.yml`已经消失:扫描是`main`上生成缓存的构建."
 
-#: src/testing/ci-tiers.md:103
+#: src/testing/ci-tiers.md:104
+msgid ""
+"A later release run exposed a separate serial bottleneck: its 246 `perry` "
+"integration-test binaries had not reached their midpoint when `cargo-test` "
+"hit its 180-minute cap. In the full tier, `cargo-test` now retains the "
+"`perry` bin/unit target and every other package while `cargo-test-perry` "
+"assigns every `perry` integration target exactly once across eight "
+"deterministic, count-balanced shards. The shards restore the shared compiler "
+"cache but do not upload eight near-duplicate copies. Their aggregate matrix "
+"result is a direct dependency of `full-suite-gate`."
+msgstr ""
+
+#: src/testing/ci-tiers.md:112
 msgid ""
 "The **satellite gates** (`gc-ratchet`, `gc-root-dominance`, `gc-native-"
 "roots`, `gc-moving-witnesses`, `gc-parse-churn-gate`, `gc-ptr-shape-off-"
@@ -63072,75 +63431,75 @@ msgstr ""
 "与 `test.yml` 的 `full` 层一起运行. 没有标签的公关人员仍然会在每次跳过工作时"
 "获得每的运行,"
 
-#: src/testing/ci-tiers.md:113
+#: src/testing/ci-tiers.md:122
 msgid "Budgets"
 msgstr "Budgets"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical jobs"
 msgstr "典型的工作"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "typical runner-minutes"
 msgstr "典型的跑步时间"
 
-#: src/testing/ci-tiers.md:115
+#: src/testing/ci-tiers.md:124
 msgid "target wall clock"
 msgstr "目标壁钟"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "pr (core)"
 msgstr "核心"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~13 (6 gap shards)"
 msgstr "~13 (6个空隙碎片)"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "~200"
 msgstr "~200"
 
-#: src/testing/ci-tiers.md:117
+#: src/testing/ci-tiers.md:126
 msgid "≤ 30 min once queued"
 msgstr "一次排队时 ≤ 30 分钟"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "pr (docs-only)"
 msgstr "专用文件"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "~5"
 msgstr "~5"
 
-#: src/testing/ci-tiers.md:118
+#: src/testing/ci-tiers.md:127
 msgid "≤ 5 min"
 msgstr "≤ 5 分钟"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~19"
 msgstr "~19"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "~300"
 msgstr "~300"
 
-#: src/testing/ci-tiers.md:119
+#: src/testing/ci-tiers.md:128
 msgid "not a target — it coalesces"
 msgstr "这不是一个目标它合并"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~30"
 msgstr "~30"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "~1500"
 msgstr "~1500"
 
-#: src/testing/ci-tiers.md:120
+#: src/testing/ci-tiers.md:129
 msgid "not a target"
 msgstr "不是一个目标"
 
-#: src/testing/ci-tiers.md:122
+#: src/testing/ci-tiers.md:131
 msgid ""
 "`push` to `main` uses ONE constant concurrency group with `cancel-in-"
 "progress: false`: GitHub keeps at most one running + one pending run per "
@@ -63164,11 +63523,20 @@ msgstr ""
 "时占据每一个选手. 扫描故障的归因是窗口 (`previous sweep SHA .. this sweep "
 "SHA`),就像六小时门一样."
 
-#: src/testing/ci-tiers.md:133
+#: src/testing/ci-tiers.md:142
 msgid "Opting a PR into more"
 msgstr "选择更多的公关"
 
-#: src/testing/ci-tiers.md:135
+#: src/testing/ci-tiers.md:144
+msgid ""
+"**`run-cc-parity` label** — runs the [Claude Code bundle parity gate](cc-"
+"parity.md) on changes to crates, build inputs, or the gate. This "
+"independent, initially non-required check compiles pinned Claude Code "
+"2.1.112 and compares offline native help/version output with checked-in Node "
+"goldens on one macOS runner."
+msgstr ""
+
+#: src/testing/ci-tiers.md:148
 msgid ""
 "**`run-extended-tests` label** — promotes the PR's `test.yml` run to the "
 "`full` tier AND enables the PR arm of every satellite gate. Use it for GC / "
@@ -63180,7 +63548,7 @@ msgstr ""
 "个卫星门的 PR 臂. 使用它来测量在合并之前的GC/codegen变化,以及任何涉及全层单独"
 "套件的东西. 应用标签重新启动运行 (`labeled`触发)."
 
-#: src/testing/ci-tiers.md:139
+#: src/testing/ci-tiers.md:152
 msgid ""
 "**`skip-changelog` label** — skips the changeset step in `lint` (a `crates/` "
 "change must otherwise add a `changelog.d/<PR>-<slug>.md` fragment)."
@@ -63188,7 +63556,7 @@ msgstr ""
 "**标签 `skip-changelog`** 跳过 `lint` 中的变化组步骤 (否则 `crates/` 变化必须"
 "添加 `changelog.d/<PR>-<slug>.md` 片段)."
 
-#: src/testing/ci-tiers.md:141
+#: src/testing/ci-tiers.md:154
 msgid ""
 "**`workflow_dispatch`** on any branch: `tier` (`pr` / `sweep` / `full`) and "
 "`update_gap_snapshot`."
@@ -63196,11 +63564,11 @@ msgstr ""
 "**`workflow_dispatch`** 在任何分支机构:`tier` (`pr` / `sweep` / `full`) 和 "
 "`update_gap_snapshot`."
 
-#: src/testing/ci-tiers.md:144
+#: src/testing/ci-tiers.md:157
 msgid "Re-baselining the gap snapshot"
 msgstr "重新调整差距快照"
 
-#: src/testing/ci-tiers.md:146
+#: src/testing/ci-tiers.md:159
 msgid ""
 "`test-parity/gap_snapshot.json` is a both-direction snapshot: any divergence "
 "— a test that started failing OR started passing — is red. When `main` has "
@@ -63211,15 +63579,17 @@ msgstr ""
 "的测试是红色的. 当 `main` 正确移动 (一个排序回归,一个神话变化),再生它 **来自"
 "CI**,不是从笔记本电脑 (所需的基线是Linux,`fast`模式):"
 
-#: src/testing/ci-tiers.md:152
-msgid "# wait for the run, then:"
+#: src/testing/ci-tiers.md:165
+#, fuzzy
+msgid "# wait for the run, then:\n"
 msgstr "# 然后等待运行:"
 
-#: src/testing/ci-tiers.md:155
-msgid "# fill in `issue` / `reason` for every new entry, then commit"
+#: src/testing/ci-tiers.md:168
+#, fuzzy
+msgid "# fill in `issue` / `reason` for every new entry, then commit\n"
 msgstr "# 填写 `issue` / `reason` 每个新条目,然后提交"
 
-#: src/testing/ci-tiers.md:159
+#: src/testing/ci-tiers.md:172
 msgid ""
 "New entries land as `category: untriaged`; give each an issue and a reason "
 "before merging. A crash may never be parked in the snapshot "
@@ -63228,11 +63598,11 @@ msgstr ""
 "新的条目登陆为`category: untriaged`; 在合并之前给每个条目一个问题和一个原因. "
 "一个碰撞可能永远不会停在快照中 (`run_gap_tests.sh`拒绝)."
 
-#: src/testing/ci-tiers.md:162
+#: src/testing/ci-tiers.md:175
 msgid "Branch protection"
 msgstr "树枝保护"
 
-#: src/testing/ci-tiers.md:164
+#: src/testing/ci-tiers.md:177
 msgid ""
 "Required status checks on `main`: **`pr-gate`** only. Adding, removing or "
 "renaming a job in `test.yml` never needs a branch-protection edit again; the "
@@ -63246,11 +63616,11 @@ msgstr ""
 "freshness.yml` (`scripts/gate_freshness.json`) 检查每个主线扫描都在预算范围内"
 "产生了 _完成_ 结果; 门的运行是否通过或失败,都会进行."
 
-#: src/testing/ci-tiers.md:170
+#: src/testing/ci-tiers.md:183
 msgid "Release"
 msgstr "Release"
 
-#: src/testing/ci-tiers.md:172
+#: src/testing/ci-tiers.md:185
 msgid ""
 "`release-packages.yml`'s `await-tests` dispatches `test.yml` with "
 "`tier=full` on the pinned release branch and polls the SHA for a run whose "
@@ -63261,7 +63631,7 @@ msgstr ""
 "布分支上发送,并对 SHA 进行投票, **`full-suite-gate`** 工作 succeeded 同一SHA"
 "上的绿色扫描或PR级运行不计数. 参见[Releasing](../contributing/releasing.md)."
 
-#: src/testing/ci-tiers.md:177
+#: src/testing/ci-tiers.md:190
 msgid ""
 "`parity` runs as 8 shards (`run_parity_tests.sh --shard N/8`) after the "
 "unsharded job was killed by GitHub's 6-hour job cap on 2026-08-16. "
@@ -63275,6 +63645,173 @@ msgstr ""
 "运行 (它是设计上安全的);值最小值和每个模块矩阵趋势在 `parity-aggregate` 中一"
 "次运行在合并报告上 (`scripts/parity_report_merge.py`,拒绝缺失的碎片而不是缩小"
 "套件)."
+
+#: src/testing/cc-parity.md:1
+msgid "Claude Code bundle parity"
+msgstr ""
+
+#: src/testing/cc-parity.md:3
+msgid ""
+"The `cc-parity` workflow compiles the standalone Claude Code **2.1.112** npm "
+"bundle with Perry and compares native `--help` and `--version` stdout with "
+"checked-in Node output. It covers the bundle-scale regressions described in "
+"[\\#9346](https://github.com/PerryTS/perry/issues/9346)."
+msgstr ""
+
+#: src/testing/cc-parity.md:8
+msgid "Opt in"
+msgstr ""
+
+#: src/testing/cc-parity.md:10
+msgid ""
+"Apply **`run-cc-parity`** to a PR changing compiler/runtime crates, build "
+"inputs, or the gate itself. The workflow also supports manual dispatch. "
+"Unlabelled PRs skip every job; labelled documentation-only PRs skip the "
+"expensive job. A new commit supersedes the previous run on the same PR."
+msgstr ""
+
+#: src/testing/cc-parity.md:15
+msgid ""
+"This starts as a **non-required** check. Adding it to branch protection is a "
+"separate maintainer decision after successful hosted runs. It has no push, "
+"schedule, or release-tag trigger and is independent of `run-extended-tests`."
+msgstr ""
+
+#: src/testing/cc-parity.md:19
+msgid ""
+"The expensive job uses one `macos-15-intel` runner. Its [14 GB RAM "
+"allocation](https://docs.github.com/en/actions/reference/runners/github-"
+"hosted-runners) provides more headroom for bundle IR construction than the 7 "
+"GB ARM runner. The job removes unused simulator images and disables Cargo "
+"incremental artifacts to leave disk space for LLVM and the native archives. "
+"The issue estimated 25–40 minutes for bundle compilation; local validation "
+"took **57 minutes 25 seconds** on macOS arm64 with five LLVM workers. The "
+"hosted Intel run with four workers remains to be measured. Allow additional "
+"time for toolchain setup, especially on a cold cache. The job has a 90-"
+"minute cap, compilation a 75-minute cap, and each CLI invocation a 60-second "
+"cap. Timings are recorded for diagnosis, not compared with a performance "
+"threshold."
+msgstr ""
+
+#: src/testing/cc-parity.md:31
+#, fuzzy
+msgid "What the check proves"
+msgstr "一张支票送什么"
+
+#: src/testing/cc-parity.md:33
+msgid ""
+"`tests/cc-parity/manifest.json` pins the npm tarball and extracted `package/"
+"cli.js` by both size and SHA-256. Only that regular file is extracted; no "
+"package install hooks run. The compiler is built first, then the runtime, "
+"stdlib, Wasm host, and all native extension archives are built together with "
+"`perry-runtime/wasm-host`. This avoids stale runtime copies in extension "
+"archives (#6303). Compilation uses `--no-auto-optimize --no-cache --enable-"
+"wasm-runtime`, with four LLVM workers (`PERRY_CODEGEN_UNIT_JOBS=4`) to use "
+"the Intel runner's four cores within its memory budget."
+msgstr ""
+
+#: src/testing/cc-parity.md:42
+msgid ""
+"The runtime arm requires a native Mach-O executable. Each invocation gets "
+"its own temporary HOME, XDG directories, working directory, and TMPDIR, with "
+"a small environment allowlist and no inherited credentials or compiler "
+"tuning knobs. macOS `sandbox-exec` denies network access; the gate fails if "
+"that sandbox is unavailable. The harness tests include an attempted "
+"connection to prove the network restriction is active."
+msgstr ""
+
+#: src/testing/cc-parity.md:49
+msgid ""
+"Both commands must exit zero before their deadlines and produce exactly the "
+"golden bytes: **9,175 bytes** for help and **22 bytes** for version. A "
+"crash, timeout, empty output, or one-byte difference fails. The manifest "
+"also pins the goldens themselves, so changing a golden without updating its "
+"identity fails."
+msgstr ""
+
+#: src/testing/cc-parity.md:54
+msgid ""
+"Downloading the bundle, LLVM, and Rust dependencies requires network access "
+"during setup. The two CLI executions are offline and use no Node "
+"installation or API key. The artifact contains source identity, build/"
+"compile logs, actual stdout/stderr, and JSON results; it excludes the "
+"downloaded bundle and executable."
+msgstr ""
+
+#: src/testing/cc-parity.md:59
+#, fuzzy
+msgid "Run locally on macOS"
+msgstr "在本地运行:"
+
+#: src/testing/cc-parity.md:61
+msgid ""
+"From the repository root, with LLVM 22 and the pinned Rust toolchain "
+"available:"
+msgstr ""
+
+#: src/testing/cc-parity.md:64
+msgid "\"$(brew --prefix llvm@22)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:66
+msgid "\"$(mktemp -d)\""
+msgstr ""
+
+#: src/testing/cc-parity.md:68 src/testing/cc-parity.md:69
+#: src/testing/cc-parity.md:70 src/testing/cc-parity.md:71
+#: src/testing/cc-parity.md:91
+msgid "\"$cc_work\""
+msgstr ""
+
+#: src/testing/cc-parity.md:70
+msgid "\"$PWD/target/perry-dev/perry\""
+msgstr ""
+
+#: src/testing/cc-parity.md:74
+msgid ""
+"If using `CARGO_TARGET_DIR`, pass the compiler in that directory instead. A "
+"local tarball can be supplied to `prepare --archive <path>`; the same hashes "
+"are still required. Inspect `$cc_work/logs/` for output differences and "
+"failure details. Never run the bundle using your regular HOME: Claude can "
+"write its configuration even on startup paths."
+msgstr ""
+
+#: src/testing/cc-parity.md:80
+msgid "Refresh the pin and oracle deliberately"
+msgstr ""
+
+#: src/testing/cc-parity.md:82
+msgid ""
+"2.1.112 is a standalone `cli.js` release. A newer package may have a "
+"different distribution shape; confirm it still supplies the full bundle "
+"before changing the pin. Update the manifest's version, URL, archive "
+"identity, and bundle identity from the exact public npm tarball, then run "
+"`prepare` again."
+msgstr ""
+
+#: src/testing/cc-parity.md:87
+msgid ""
+"The recorded reference used Node **v26.5.1** on macOS arm64. To verify that "
+"oracle with the same scratch environment and network sandbox:"
+msgstr ""
+
+#: src/testing/cc-parity.md:91
+#, fuzzy
+msgid "\"$(command -v node)\""
+msgstr "\"command\""
+
+#: src/testing/cc-parity.md:94
+msgid ""
+"This writes `logs/node-help.stdout`, `logs/node-version.stdout`, and `logs/"
+"node-parity.json`. A deliberate version refresh may fail the old golden "
+"comparison; inspect both command results, require zero exit codes and no "
+"timeout, and review the output changes before copying those two stdout files "
+"into `tests/cc-parity/`. Update their byte counts and SHA-256 values and the "
+"oracle provenance in the manifest. Rerun the Node check, harness tests, "
+"native compilation, and native check. Commit the manifest and goldens "
+"together; never accept output from a failing native executable as the new "
+"oracle."
+msgstr ""
 
 #: src/testing/ci-gate-scheduling.md:1
 msgid ""
@@ -63390,36 +63927,13 @@ msgid "Reproduce the core of it with:"
 msgstr "复制它的核心:"
 
 #: src/testing/ci-gate-scheduling.md:32
-msgid "# What is actually running, repo-wide, at the job level:"
+#, fuzzy
+msgid "# What is actually running, repo-wide, at the job level:\n"
 msgstr "# 实际上在工作层面上是什么:"
 
 #: src/testing/ci-gate-scheduling.md:33
 msgid "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
 msgstr "\"repos/PerryTS/perry/actions/runs?status=in_progress&per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:34 src/testing/ci-gate-scheduling.md:41
-msgid "'.workflow_runs[].id'"
-msgstr "\".workflow_runs[].id\""
-
-#: src/testing/ci-gate-scheduling.md:36 src/testing/ci-gate-scheduling.md:43
-msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:37
-msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
-msgstr "\"就业\" | select(.status==\"in_progress\") | (标签|join(\",\"))'"
-
-#: src/testing/ci-gate-scheduling.md:39
-msgid "# How deep the queue is, and on which pools:"
-msgstr "# 排队的深度,以及哪些池:"
-
-#: src/testing/ci-gate-scheduling.md:41
-msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
-
-#: src/testing/ci-gate-scheduling.md:44
-msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
-msgstr "\"就业\" | select(.status==\"queued\") | (标签|join(\",\"))'"
 
 #: src/testing/ci-gate-scheduling.md:48
 msgid ""
@@ -63582,24 +64096,22 @@ msgid "pull_request"
 msgstr "pull_request"
 
 #: src/testing/ci-gate-scheduling.md:121
-msgid "# unchanged — every PR is still measured"
+#, fuzzy
+msgid ""
+"# unchanged — every PR is still measured\n"
+"  schedule"
 msgstr "# 不变每一个PR仍然被测量"
-
-#: src/testing/ci-gate-scheduling.md:122
-msgid "schedule"
-msgstr "schedule"
 
 #: src/testing/ci-gate-scheduling.md:123 src/testing/ci-gate-scheduling.md:133
 msgid "cron"
 msgstr "cron"
 
 #: src/testing/ci-gate-scheduling.md:123
-msgid "\"7 */6 * * *\"   # staggered; see the table below"
+#, fuzzy
+msgid ""
+"\"7 */6 * * *\"   # staggered; see the table below\n"
+"  push"
 msgstr "\"7 */6 * * *\" # 摇摆;请参见下面的表格"
-
-#: src/testing/ci-gate-scheduling.md:124
-msgid "push"
-msgstr "push"
 
 #: src/testing/ci-gate-scheduling.md:125
 msgid "tags"
@@ -63610,12 +64122,11 @@ msgid "\"v*\""
 msgstr "\"v*\""
 
 #: src/testing/ci-gate-scheduling.md:125
-msgid "# releases stay individually gated"
+#, fuzzy
+msgid ""
+"# releases stay individually gated\n"
+"  workflow_dispatch"
 msgstr "# 释放的物品保持单独的密封"
-
-#: src/testing/ci-gate-scheduling.md:126
-msgid "workflow_dispatch"
-msgstr "workflow_dispatch"
 
 #: src/testing/ci-gate-scheduling.md:129
 msgid ""
@@ -63872,11 +64383,13 @@ msgstr ""
 "证据;"
 
 #: src/testing/ci-gate-scheduling.md:203
-msgid "# proves it can still fail"
+#, fuzzy
+msgid "# proves it can still fail\n"
 msgstr "# 证明它仍然可以失败"
 
 #: src/testing/ci-gate-scheduling.md:204
-msgid "# real API, no issue writes"
+#, fuzzy
+msgid "# real API, no issue writes\n"
 msgstr "# 真正的API,没有问题写"
 
 #: src/testing/ci-gate-scheduling.md:207
@@ -63906,66 +64419,105 @@ msgstr ""
 "test`意味着检测器工作,"
 
 #: src/testing/ci-gate-scheduling.md:218
+msgid "A completed red gate must create work (#9830)"
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:220
+msgid ""
+"Fresh execution is only half of the contract. A scheduled gate can run, fail "
+"correctly, and stay red in the Actions list without anyone owning the "
+"failure. `gate-failure-watch.yml` observes the completed post-merge "
+"workflows in `scripts/gate_failure_watch.json` and maintains one issue per "
+"failing workflow. The issue records the run URL, head SHA, failed job/step "
+"rows, the rows added or removed since the previous failure, and the last "
+"green main SHA. Repeated failures update the same issue; the next green run "
+"comments and closes it."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:228
+msgid ""
+"The observer accepts scheduled and main-branch dispatch runs, main pushes, "
+"and release-tag pushes. It ignores pull-request and feature-branch runs. Its "
+"`workflow_run` job has `issues: write`, so it always checks out the trusted "
+"`main` copy of the script; pull requests run only the offline self-test and "
+"configuration check with read-only permissions."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:234
+msgid ""
+"When adding or renaming a post-merge gate, update `gate_failure_watch.json` "
+"and the observer's `workflow_run.workflows` list together. The configuration "
+"check also requires every workflow tracked by `gate_freshness.json` to be "
+"watched or explicitly excluded with a reason."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:239
+msgid ""
+"For every gate, ask: if this fails on `main` tonight, who finds out, and "
+"how? A run visible only in the Actions list has no owner."
+msgstr ""
+
+#: src/testing/ci-gate-scheduling.md:242
 msgid "The queue in front of the schedule (#7966)"
 msgstr "时间表前排队 (#7966)"
 
-#: src/testing/ci-gate-scheduling.md:220
+#: src/testing/ci-gate-scheduling.md:244
 msgid ""
 "A six-hourly sweep only helps if the queue drains faster than six hours. On "
 "2026-08-12 it did not, and the reason was not the gates:"
 msgstr "如果排队时间超过六个小时, 2026年8月12日没有,原因不是门:"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "metric"
 msgstr "metric"
 
-#: src/testing/ci-gate-scheduling.md:223
+#: src/testing/ci-gate-scheduling.md:247
 msgid "value"
 msgstr "value"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "queued runs"
 msgstr "排队运行"
 
-#: src/testing/ci-gate-scheduling.md:225
+#: src/testing/ci-gate-scheduling.md:249
 msgid "1,529"
 msgstr "1,529"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "concurrent runs observed"
 msgstr "观察到的同时运行"
 
-#: src/testing/ci-gate-scheduling.md:226
+#: src/testing/ci-gate-scheduling.md:250
 msgid "12–14"
 msgstr "12–14"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "queued by event"
 msgstr "按事件排队"
 
-#: src/testing/ci-gate-scheduling.md:227
+#: src/testing/ci-gate-scheduling.md:251
 msgid "794 `pull_request`, 181 `push`, 19 `schedule`"
 msgstr "794 `pull_request`, 181 `push`, 19 `schedule`"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "distinct head branches among queued PR runs"
 msgstr "在排队的PR运行中,有不同的头枝"
 
-#: src/testing/ci-gate-scheduling.md:228
+#: src/testing/ci-gate-scheduling.md:252
 msgid "63"
 msgstr "63"
 
-#: src/testing/ci-gate-scheduling.md:229
+#: src/testing/ci-gate-scheduling.md:253
 msgid "**branches that still existed**"
 msgstr "**仍然存在的分支**"
 
-#: src/testing/ci-gate-scheduling.md:229
-#: src/internals/gc-rooting-invariant.md:296
-#: src/internals/gc-rooting-invariant.md:297
+#: src/testing/ci-gate-scheduling.md:253
+#: src/internals/gc-rooting-invariant.md:325
+#: src/internals/gc-rooting-invariant.md:326
 msgid "**2**"
 msgstr "**2**"
 
-#: src/testing/ci-gate-scheduling.md:231
+#: src/testing/ci-gate-scheduling.md:255
 msgid ""
 "GitHub does not reliably cancel a queued run when its pull request merges "
 "and the branch auto-deletes. Perry squash-merges, auto-deletes branches, and "
@@ -63979,11 +64531,12 @@ msgstr ""
 "合并的 PR 的工作**,在32个多小时内未完成的十个`main`门前占据了跑步者. 没有任何"
 "时间安排的节奏可以从中恢复; 垃圾必须被清除."
 
-#: src/testing/ci-gate-scheduling.md:238
+#: src/testing/ci-gate-scheduling.md:262
+#, fuzzy
 msgid ""
 "`ci-queue-reaper.yml` runs `scripts/reap_stale_ci_runs.py` every 30 minutes. "
 "It cancels a run only when all of these hold: `event == \"pull_request\"`, "
-"`status ==  \"queued\"`, and the head branch has **no open pull request**. A "
+"`status == \"queued\"`, and the head branch has **no open pull request**. A "
 "`push`, `schedule`, tag or `workflow_dispatch` run is therefore structurally "
 "out of reach, and an in-flight run is left alone because it has already "
 "consumed the scarce thing. The predicate keys on open PRs rather than on "
@@ -63997,7 +64550,7 @@ msgstr ""
 "耗了稀缺的东西而被单独留下来的. 开放PR的预言键,而不是分支存在,这使得分叉PR安"
 "全分叉的头分支从未出现在这个 repo的参考中."
 
-#: src/testing/ci-gate-scheduling.md:246
+#: src/testing/ci-gate-scheduling.md:270
 msgid ""
 "**It cannot bootstrap.** The reaper queues like everything else, so it will "
 "not dig the repo out of an already-saturated queue. The first drain is a "
@@ -64007,13 +64560,13 @@ msgstr ""
 "**它不能启动.** 收获者像其他任何东西一样排队, 第一个排水是手动的`python3 "
 "scripts/reap_stale_ci_runs.py --apply` (干运行是默认);时间表之后保持清理."
 
-#: src/testing/ci-gate-scheduling.md:251
+#: src/testing/ci-gate-scheduling.md:275
 msgid ""
 "Why \"the gate was dark\" is not the same as \"the gate would have caught "
 "it\""
 msgstr "为什么\"门是黑暗的\"与\"门会抓住它\"不一样"
 
-#: src/testing/ci-gate-scheduling.md:253
+#: src/testing/ci-gate-scheduling.md:277
 msgid ""
 "\\#7966 landed alongside #7965, a 2.2–4.8× regression that reached `main` "
 "while `gc-ratchet` was dark. The tempting conclusion — the dark gate let it "
@@ -64023,7 +64576,7 @@ msgstr ""
 "\\#7966降落在#7965旁边,这是一个2.24.8×回归,在`gc-ratchet`是暗的同时达到"
 "`main`. 诱人的结论是, 黑暗门让它穿过,"
 
-#: src/testing/ci-gate-scheduling.md:257
+#: src/testing/ci-gate-scheduling.md:281
 msgid ""
 "`gc-ratchet`'s gating metrics are heap/cycle/copy/promote/freed counts. "
 "**There is no full-mark-sweep or major-cycle count**, and the counter that "
@@ -64034,7 +64587,7 @@ msgstr ""
 "描或主要周期计数**,并且实际发现\\#7965的计数器 (`collection_kind: \"full\"`为"
 "0 → 2) 并不是其中之一. 没有 repo 中的网关可以计算收藏类型."
 
-#: src/testing/ci-gate-scheduling.md:261
+#: src/testing/ci-gate-scheduling.md:285
 msgid ""
 "The two dimensions that did move — wall time and RSS — are explicitly "
 "`\"gating\": false` in the `shared_ci` profile CI runs, with the rationale "
@@ -64044,7 +64597,7 @@ msgstr ""
 "移动了墙时间和RSS的两个维度是`\"gating\": false`,在`shared_ci`配置文件CI中运"
 "行,逻辑记录在`tolerances.json`中. 他们只使用`pinned_host`,"
 
-#: src/testing/ci-gate-scheduling.md:264
+#: src/testing/ci-gate-scheduling.md:288
 msgid ""
 "The workloads that showed it (`retain`, `deeplist`, …) are the gc-handoff "
 "corpus, not `gc-ratchet`'s fixed 14 probes."
@@ -64052,7 +64605,7 @@ msgstr ""
 "显示它的工作负载 (`retain`,`deeplist`, ...) 是 gc-handoff 集体,而不是 `gc-"
 "ratchet` 的固定 14 个探测器."
 
-#: src/testing/ci-gate-scheduling.md:267
+#: src/testing/ci-gate-scheduling.md:291
 msgid ""
 "So the human counter census was not a lucky substitute for a starved gate; "
 "**it was the only instrument that covered that dimension at all.** Restoring "
@@ -64270,14 +64823,15 @@ msgid "Compile TypeScript to a native executable."
 msgstr "将 TypeScript 编译为原生可执行文件。"
 
 #: src/cli/commands.md:43
-msgid "# Or shorthand (auto-detects compile):"
+#, fuzzy
+msgid "# Or shorthand (auto-detects compile):\n"
 msgstr "# 或简写 (自动检测编译):"
 
 #: src/cli/commands.md:48 src/cli/commands.md:142 src/cli/commands.md:183
 #: src/cli/commands.md:216 src/cli/commands.md:230 src/cli/commands.md:283
 #: src/cli/commands.md:295 src/cli/flags.md:11 src/cli/flags.md:74
-#: src/cli/flags.md:94 src/cli/flags.md:171 src/cli/flags.md:258
-#: src/cli/flags.md:289 src/cli/flags.md:296
+#: src/cli/flags.md:115 src/cli/flags.md:215 src/cli/flags.md:302
+#: src/cli/flags.md:333 src/cli/flags.md:340
 msgid "Flag"
 msgstr "标志"
 
@@ -64306,7 +64860,7 @@ msgstr "`--output-type <TYPE>`"
 msgid "`executable` (default) or `dylib` (plugin)"
 msgstr "`executable`（默认）或 `dylib`（插件）"
 
-#: src/cli/commands.md:53 src/cli/flags.md:173
+#: src/cli/commands.md:53 src/cli/flags.md:217
 msgid "`--print-hir`"
 msgstr "`--print-hir`"
 
@@ -64314,7 +64868,7 @@ msgstr "`--print-hir`"
 msgid "Print HIR intermediate representation"
 msgstr "打印 HIR 中间表示"
 
-#: src/cli/commands.md:54 src/cli/flags.md:176
+#: src/cli/commands.md:54 src/cli/flags.md:220
 msgid "`--no-link`"
 msgstr "`--no-link`"
 
@@ -64324,7 +64878,7 @@ msgid ""
 "Flags](flags.md))"
 msgstr "仅生成对象 file(s,跳过链接;写入 `-o` (见 [编译器标志](flags.md))"
 
-#: src/cli/commands.md:55 src/cli/flags.md:178
+#: src/cli/commands.md:55 src/cli/flags.md:222
 msgid "`--keep-intermediates`"
 msgstr "`--keep-intermediates`"
 
@@ -64332,7 +64886,7 @@ msgstr "`--keep-intermediates`"
 msgid "Keep `.o` and `.asm` files"
 msgstr "保留 `.o` 与 `.asm` 文件"
 
-#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:298
+#: src/cli/commands.md:56 src/cli/commands.md:103 src/cli/flags.md:342
 msgid "`--enable-js-runtime`"
 msgstr "`--enable-js-runtime`"
 
@@ -64340,7 +64894,7 @@ msgstr "`--enable-js-runtime`"
 msgid "Enable V8 JavaScript runtime fallback"
 msgstr "启用 V8 JavaScript 运行时回退"
 
-#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:299
+#: src/cli/commands.md:57 src/cli/commands.md:104 src/cli/flags.md:343
 msgid "`--enable-wasm-runtime`"
 msgstr "`--enable-wasm-runtime`"
 
@@ -64351,8 +64905,8 @@ msgid ""
 msgstr ""
 "强制链接 wasmi WebAssembly 宿主运行时（在使用 `WebAssembly.*` 时自动检测）"
 
-#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:80
-#: src/cli/flags.md:300
+#: src/cli/commands.md:58 src/cli/commands.md:105 src/cli/flags.md:81
+#: src/cli/flags.md:344
 msgid "`--type-check`"
 msgstr "`--type-check`"
 
@@ -64360,15 +64914,15 @@ msgstr "`--type-check`"
 msgid "Enable type checking via tsgo"
 msgstr "通过 tsgo 启用类型检查"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "`--minify`"
 msgstr "`--minify`"
 
-#: src/cli/commands.md:59 src/cli/flags.md:260
+#: src/cli/commands.md:59 src/cli/flags.md:304
 msgid "Minify and obfuscate output (auto-enabled for `--target web`)"
 msgstr "压缩并混淆输出（`--target web` 时自动启用）"
 
-#: src/cli/commands.md:60 src/cli/flags.md:78
+#: src/cli/commands.md:60 src/cli/flags.md:79
 msgid "`--app-bundle-id <ID>`"
 msgstr "`--app-bundle-id <ID>`"
 
@@ -64376,7 +64930,7 @@ msgstr "`--app-bundle-id <ID>`"
 msgid "Bundle ID (required for widget targets)"
 msgstr "Bundle ID（widget 目标必填）"
 
-#: src/cli/commands.md:61 src/cli/flags.md:79
+#: src/cli/commands.md:61 src/cli/flags.md:80
 msgid "`--bundle-extensions <DIR>`"
 msgstr "`--bundle-extensions <DIR>`"
 
@@ -64385,23 +64939,28 @@ msgid "Bundle TypeScript extensions from directory"
 msgstr "从指定目录打包 TypeScript 扩展"
 
 #: src/cli/commands.md:64
-msgid "# Basic compilation"
+#, fuzzy
+msgid "# Basic compilation\n"
 msgstr "# 基本编译"
 
 #: src/cli/commands.md:66
-msgid "# Cross-compile for iOS Simulator"
+#, fuzzy
+msgid "# Cross-compile for iOS Simulator\n"
 msgstr "# 对于iOS模拟器进行交叉编译"
 
 #: src/cli/commands.md:69
-msgid "# Build a plugin"
+#, fuzzy
+msgid "# Build a plugin\n"
 msgstr "# 创建一个插件"
 
 #: src/cli/commands.md:72
-msgid "# Debug: view intermediate representation"
+#, fuzzy
+msgid "# Debug: view intermediate representation\n"
 msgstr "# 调试:查看中间表示"
 
 #: src/cli/commands.md:75
-msgid "# Build an iOS widget"
+#, fuzzy
+msgid "# Build an iOS widget\n"
 msgstr "# 创建一个iOS小程序"
 
 #: src/cli/commands.md:82
@@ -64409,23 +64968,28 @@ msgid "Compile and launch your app in one step."
 msgstr "一步完成应用编译并启动。"
 
 #: src/cli/commands.md:85
-msgid "# Auto-detect entry file"
+#, fuzzy
+msgid "# Auto-detect entry file\n"
 msgstr "# 自动检测输入文件"
 
 #: src/cli/commands.md:86
-msgid "# Run on iOS device/simulator"
+#, fuzzy
+msgid "# Run on iOS device/simulator\n"
 msgstr "# 在 iOS device/simulator 上运行"
 
 #: src/cli/commands.md:87
-msgid "# Run on Apple Vision Pro simulator/device"
+#, fuzzy
+msgid "# Run on Apple Vision Pro simulator/device\n"
 msgstr "# 在Apple Vision Pro simulator/device上运行"
 
 #: src/cli/commands.md:88
-msgid "# Run on Android device"
+#, fuzzy
+msgid "# Run on Android device\n"
 msgstr "# 在Android设备上运行"
 
 #: src/cli/commands.md:89
-msgid "# Forward args to your program"
+#, fuzzy
+msgid "# Forward args to your program\n"
 msgstr "# 转发到您的程序"
 
 #: src/cli/commands.md:92 src/cli/commands.md:268
@@ -64557,19 +65121,23 @@ msgstr ""
 "径。"
 
 #: src/cli/commands.md:118
-msgid "# Run a CLI program"
+#, fuzzy
+msgid "# Run a CLI program\n"
 msgstr "# 运行一个CLI程序"
 
 #: src/cli/commands.md:120
-msgid "# Run on a specific simulator"
+#, fuzzy
+msgid "# Run on a specific simulator\n"
 msgstr "# 在特定模拟器上运行"
 
 #: src/cli/commands.md:123
-msgid "# Force remote build"
+#, fuzzy
+msgid "# Force remote build\n"
 msgstr "# 强制远程构建"
 
 #: src/cli/commands.md:126
-msgid "# Run web target"
+#, fuzzy
+msgid "# Run web target\n"
 msgstr "# 运行网络目标"
 
 #: src/cli/commands.md:131
@@ -64583,19 +65151,23 @@ msgid ""
 msgstr "监视 TypeScript 源码树，每次保存自动重新编译并重启。"
 
 #: src/cli/commands.md:136
-msgid "# watch + rebuild + relaunch on save"
+#, fuzzy
+msgid "# watch + rebuild + relaunch on save\n"
 msgstr "# 观看+重建+重启在保存"
 
 #: src/cli/commands.md:137
-msgid "# forward args to the child"
+#, fuzzy
+msgid "# forward args to the child\n"
 msgstr "# 向前向孩子"
 
 #: src/cli/commands.md:138
-msgid "# watch an extra directory"
+#, fuzzy
+msgid "# watch an extra directory\n"
 msgstr "# 看一个额外的目录"
 
 #: src/cli/commands.md:139
-msgid "# override output path"
+#, fuzzy
+msgid "# override output path\n"
 msgstr "# 取代输出路径"
 
 #: src/cli/commands.md:144
@@ -64720,7 +65292,7 @@ msgid ""
 "target."
 msgstr "跨重建保留状态 / HMR——“快速重启”才是诚实的目标。"
 
-#: src/cli/commands.md:175 src/internals/garbage-collector.md:230
+#: src/cli/commands.md:175 src/internals/garbage-collector.md:292
 msgid "check"
 msgstr "check"
 
@@ -64785,19 +65357,23 @@ msgid "Include medium-confidence fixes"
 msgstr "包含中等置信度的修复"
 
 #: src/cli/commands.md:194
-msgid "# Check a single file"
+#, fuzzy
+msgid "# Check a single file\n"
 msgstr "# 检查一个文件"
 
 #: src/cli/commands.md:196
-msgid "# Check with dependency analysis"
+#, fuzzy
+msgid "# Check with dependency analysis\n"
 msgstr "# 检查依赖性分析"
 
 #: src/cli/commands.md:199
-msgid "# Auto-fix issues"
+#, fuzzy
+msgid "# Auto-fix issues\n"
 msgstr "# 自动修复问题"
 
 #: src/cli/commands.md:202
-msgid "# Preview fixes without applying"
+#, fuzzy
+msgid "# Preview fixes without applying\n"
 msgstr "# 没有应用的预览修复"
 
 #: src/cli/commands.md:207
@@ -65086,27 +65662,33 @@ msgid ""
 msgstr "用于应用分发的交互式凭据向导，并提供 Windows 工具链安装。"
 
 #: src/cli/commands.md:310
-msgid "# Show platform menu"
+#, fuzzy
+msgid "# Show platform menu\n"
 msgstr "# 显示平台菜单"
 
 #: src/cli/commands.md:311
-msgid "# macOS setup (signing credentials)"
+#, fuzzy
+msgid "# macOS setup (signing credentials)\n"
 msgstr "# 设置macOS (签名凭证)"
 
 #: src/cli/commands.md:312
-msgid "# iOS setup (signing credentials)"
+#, fuzzy
+msgid "# iOS setup (signing credentials)\n"
 msgstr "# 设置iOS (签名凭证)"
 
 #: src/cli/commands.md:313
-msgid "# visionOS setup (signing credentials)"
+#, fuzzy
+msgid "# visionOS setup (signing credentials)\n"
 msgstr "# 设置visionOS (签名凭证)"
 
 #: src/cli/commands.md:314
-msgid "# Android setup (signing credentials)"
+#, fuzzy
+msgid "# Android setup (signing credentials)\n"
 msgstr "# 设置Android (签名凭证)"
 
 #: src/cli/commands.md:315
-msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)"
+#, fuzzy
+msgid "# Windows toolchain (downloads MS CRT + Windows SDK via xwin)\n"
 msgstr "# Windows工具链 (通过xwin下载MS CRT+Windows SDK)"
 
 #: src/cli/commands.md:318
@@ -65133,19 +65715,23 @@ msgid "update"
 msgstr "update"
 
 #: src/cli/commands.md:327
-msgid "# Update to latest"
+#, fuzzy
+msgid "# Update to latest\n"
 msgstr "# 最新更新"
 
 #: src/cli/commands.md:328
-msgid "# Check without installing"
+#, fuzzy
+msgid "# Check without installing\n"
 msgstr "# 检查没有安装"
 
 #: src/cli/commands.md:329
-msgid "# Ignore the cached answer"
+#, fuzzy
+msgid "# Ignore the cached answer\n"
 msgstr "# 忽略缓存的答案"
 
 #: src/cli/commands.md:330
-msgid "# Save how updates should behave, then exit"
+#, fuzzy
+msgid "# Save how updates should behave, then exit\n"
 msgstr "# 保存更新应该如何行为,然后退出"
 
 #: src/cli/commands.md:333
@@ -65160,7 +65746,7 @@ msgid "`--mode` writes `[update] mode` to `~/.perry/config.toml`:"
 msgstr "`--mode` 将 `[update] mode` 写入 `~/.perry/config.toml`:"
 
 #: src/cli/commands.md:339 src/cli/updates.md:47
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "mode"
 msgstr "mode"
 
@@ -65266,14 +65852,6 @@ msgstr "`perry native init <name>`"
 #: src/cli/commands.md:376
 msgid "Scaffold a new native-bindings package:"
 msgstr "搭建一个新的原生绑定包："
-
-#: src/cli/commands.md:380
-msgid "\"Native bindings for libfoo\""
-msgstr "\"本地绑定libfoo\""
-
-#: src/cli/commands.md:381
-msgid "'libfoo = \"1.0\"'"
-msgstr "\"libfoo = \"1.0\""
 
 #: src/cli/commands.md:385
 msgid "Creates a directory with:"
@@ -65795,99 +66373,143 @@ msgid "Output executable, bundle, shared library, archive, or object path."
 msgstr "输出可执行文件,捆绑,共享库,档案或对象路径."
 
 #: src/cli/flags.md:77
+#, fuzzy
+msgid "`--platform node\\|bun`"
+msgstr "`platform-core`"
+
+#: src/cli/flags.md:77
+msgid ""
+"Select the JavaScript host global surface. `node` is the default; `bun` "
+"installs a real, stable `Bun === globalThis.Bun` namespace."
+msgstr ""
+
+#: src/cli/flags.md:78
 msgid "`--libc glibc\\|musl`"
 msgstr "`--libc glibc\\|musl`"
 
-#: src/cli/flags.md:77
+#: src/cli/flags.md:78
 msgid ""
 "Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to "
 "a fully static headless build."
 msgstr ""
 "选择 Linux libc/linkage; `musl` 将相应的 Linux 目标升级为完全静态的无头构建."
 
-#: src/cli/flags.md:78
+#: src/cli/flags.md:79
 msgid "Bundle identifier required by home-screen widget targets."
 msgstr "首页屏幕小工具目标所需的捆绑标识符."
 
-#: src/cli/flags.md:79
+#: src/cli/flags.md:80
 msgid ""
 "Discover and statically bundle native extension packages from a directory."
 msgstr "从目录中发现并静态捆绑原生扩展包."
 
-#: src/cli/flags.md:80
+#: src/cli/flags.md:81
 msgid ""
 "Run the native TypeScript checker (`@typescript/native-preview`) before "
 "codegen."
 msgstr "在代码生成之前运行原生TypeScript检查器 (`@typescript/native-preview`)."
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid "`--min-windows-version 7\\|8\\|10`"
 msgstr "`--min-windows-version 7\\|8\\|10`"
 
-#: src/cli/flags.md:81
+#: src/cli/flags.md:82
 msgid ""
 "Set the Windows PE compatibility floor; ignored for non-Windows targets."
 msgstr "设置 Windows PE 兼容性底部;对于非 Windows 目标被忽略."
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid "`--windows-subsystem auto\\|console\\|windows`"
 msgstr "`--windows-subsystem auto\\|console\\|windows`"
 
-#: src/cli/flags.md:82
+#: src/cli/flags.md:83
 msgid ""
 "Select the Windows PE subsystem instead of relying on import-based auto "
 "detection."
 msgstr "选择Windows PE子系统,而不是依赖基于进口的自动检测."
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid "`--skip-swift-build`"
 msgstr "`--skip-swift-build`"
 
-#: src/cli/flags.md:83
+#: src/cli/flags.md:84
 msgid ""
 "For Apple widget targets, emit SwiftUI source and metadata without invoking "
 "`swiftc`."
 msgstr "对于果小工具目标,在不调用 `swiftc` 的情况下发出 SwiftUI 源和元数据."
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 msgstr "`--p12-keystore <PATH>` / `--p12-password <VALUE>`"
 
-#: src/cli/flags.md:84
+#: src/cli/flags.md:85
 msgid ""
 "Select HarmonyOS HAP signing material. Prefer the corresponding environment/"
 "config sources for secrets."
 msgstr "选择HarmonyOS HAP签名材料 对于秘密,更喜欢相应的environment/config源."
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "`--harmonyos-cert <PATH>`"
 msgstr "`--harmonyos-cert <PATH>`"
 
-#: src/cli/flags.md:85
+#: src/cli/flags.md:86
 msgid "HarmonyOS application certificate chain."
 msgstr "HarmonyOS 应用证书链."
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "`--harmonyos-profile <PATH>`"
 msgstr "`--harmonyos-profile <PATH>`"
 
-#: src/cli/flags.md:86
+#: src/cli/flags.md:87
 msgid "HarmonyOS signed provisioning profile."
 msgstr "标签为HarmonyOS 签署的配置配置."
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "`--harmonyos-key-alias <NAME>`"
 msgstr "`--harmonyos-key-alias <NAME>`"
 
-#: src/cli/flags.md:87
+#: src/cli/flags.md:88
 msgid "HarmonyOS keystore alias; defaults to `debugKey`."
 msgstr "HarmonyOS 键库别名;默认为 `debugKey`."
 
-#: src/cli/flags.md:89
+#: src/cli/flags.md:90
+#, fuzzy
+msgid "Bun platform mode"
+msgstr "`platform` — 模块"
+
+#: src/cli/flags.md:92
+msgid ""
+"`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs "
+"through one real global namespace. Direct calls, extracted or destructured "
+"methods, optional chaining, and computed property reads all resolve through "
+"the same `Bun` object. The default `node` mode preserves the historical "
+"behavior: `typeof Bun` remains `\"undefined\"`, while Perry's existing "
+"direct Bun shims and imports from `\"bun\"` continue to work."
+msgstr ""
+
+#: src/cli/flags.md:99
+msgid ""
+"In this mode, `Bun.version` is Perry's runtime crate version, not a claimed "
+"Bun release number. `Bun.isStandaloneExecutable` is always `true`, because "
+"Perry produces standalone binaries. Unsupported properties are absent; a "
+"direct call to an unsupported `Bun.*` member raises Perry's Bun "
+"compatibility error."
+msgstr ""
+
+#: src/cli/flags.md:104
+msgid ""
+"`Bun.spawn` supports the command-array and `{ cmd, ...options }` forms, "
+"piped output consumers such as `child.stdout.text()`, lifecycle controls, "
+"and raw-fd or `Bun.file` stdio. On POSIX targets, `Bun.Terminal` can attach "
+"a subprocess to Perry's native PTY implementation; ConPTY-backed terminals "
+"are not yet available on Windows."
+msgstr ""
+
+#: src/cli/flags.md:110
 msgid "Embedding Assets"
 msgstr "嵌入资产"
 
-#: src/cli/flags.md:91
+#: src/cli/flags.md:112
 msgid ""
 "Bake static files (an SPA `dist/`, images, JSON, fonts, …) into the "
 "standalone executable so it runs with no external files on disk (#5731)."
@@ -65895,11 +66517,11 @@ msgstr ""
 "将静态文件 (SPA `dist/`,图像,JSON,字体等) 入独立可执行文件中,以便在磁盘上没有"
 "外部文件 (# 5731) 运行."
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid "`--embed <pattern>`"
 msgstr "`--embed <pattern>`"
 
-#: src/cli/flags.md:96
+#: src/cli/flags.md:117
 msgid ""
 "Embed a file, directory, or `*`/`**` glob (relative to the project root). "
 "Repeatable. Merged with `perry.embed` (package.json) and `[compile] embed` "
@@ -65908,11 +66530,23 @@ msgstr ""
 "嵌入一个文件,目录或 `*`/`**` glob (相对于项目根). Repeatable. 合并了"
 "`perry.embed` (package.json) 和`[compile] embed` (perry.toml)."
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:118
+#, fuzzy
+msgid "`--bunfs-root <dir>`"
+msgstr "`unrooted`"
+
+#: src/cli/flags.md:118
+msgid ""
+"Map an extracted Bun standalone root to `/$bunfs/root/`; mapped module paths "
+"resolve natively and literal file paths remain readable from the relocated "
+"executable."
+msgstr ""
+
+#: src/cli/flags.md:119
 msgid "`--asset-module <specifier=dir>`"
 msgstr "`--asset-module <specifier=dir>`"
 
-#: src/cli/flags.md:97
+#: src/cli/flags.md:119
 msgid ""
 "Generate a virtual module whose default export maps every file below `dir` "
 "to a stable `$perryfs` handle. Repeatable; source maps are excluded."
@@ -65920,19 +66554,20 @@ msgstr ""
 "生成一个虚拟模块,其默认导出将`dir`以下的每个文件映射到一个稳定的`$perryfs`处"
 "理器. 可重复;源地图不包括."
 
-#: src/cli/flags.md:101
+#: src/cli/flags.md:123
 msgid "\"./dist/**\""
 msgstr "\"./dist/**\""
 
-#: src/cli/flags.md:102
-msgid "# serves dist/ from memory — no dist/ folder needed"
+#: src/cli/flags.md:124
+#, fuzzy
+msgid "# serves dist/ from memory — no dist/ folder needed\n"
 msgstr "# 服务于从内存 dist/ 不需要 dist/ 文件"
 
-#: src/cli/flags.md:105
+#: src/cli/flags.md:127
 msgid "Embedded files are reachable at runtime three ways:"
 msgstr "嵌入式文件在运行时可通过三种方式访问:"
 
-#: src/cli/flags.md:107
+#: src/cli/flags.md:129
 msgid ""
 "```typescript,no-test\n"
 "import { embeddedFiles, readEmbedded, isStandaloneExecutable } from "
@@ -65964,7 +66599,7 @@ msgstr ""
 "const html = readFileSync(\"$perryfs/dist/index.html\", \"utf8\");\n"
 "```"
 
-#: src/cli/flags.md:120
+#: src/cli/flags.md:142
 msgid ""
 "`embeddedFiles()` is a function (not a bare value like Bun's "
 "`embeddedFiles`) so that array methods dispatch on its result. "
@@ -65975,7 +66610,7 @@ msgstr ""
 "数组方法就会在它的结果上发送. `readEmbedded(path)` 和 `node:fs` 接受 "
 "`$perryfs/<path>` 虚拟路径或嵌入式相对键."
 
-#: src/cli/flags.md:124
+#: src/cli/flags.md:146
 msgid ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
@@ -65983,7 +66618,7 @@ msgstr ""
 "Bun-compatible file-loader imports embed the referenced binary automatically "
 "and bind the default import to its `$perryfs` path:"
 
-#: src/cli/flags.md:127
+#: src/cli/flags.md:149
 msgid ""
 "```typescript,no-test\n"
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
@@ -65993,7 +66628,35 @@ msgstr ""
 "import sound from \"./sound.mp3\" with { type: \"file\" };\n"
 "```"
 
-#: src/cli/flags.md:131
+#: src/cli/flags.md:153
+msgid ""
+"For source extracted from a Bun standalone executable, mount its extracted "
+"`root/` directory at Bun's original virtual prefix:"
+msgstr ""
+
+#: src/cli/flags.md:160
+msgid ""
+"Static imports, re-exports, literal dynamic imports, literal `require()`, "
+"and `import.meta.require()` calls below `/$bunfs/root/` resolve against that "
+"directory. Perry canonicalizes their real targets, so importing the same "
+"module through `./chunk.js` and `/$bunfs/root/chunk.js` still initializes "
+"one module. Literal mapped file paths are embedded under their original "
+"names and work through both `node:fs` and `Bun.file()` after the extracted "
+"directory is removed. No host-level `/$bunfs` directory or compatibility "
+"symlink is needed."
+msgstr ""
+
+#: src/cli/flags.md:169
+msgid ""
+"Bun bundles can load compiled chunks synchronously with "
+"`import.meta.require(\"./chunk.js\")` or `import.meta[\"require\"](\"./"
+"chunk.js\")`. Both return the module namespace immediately and initialize "
+"the target once, at its first load. Computed paths use the existing bounded "
+"synchronous `require(expr)` resolver; unknown targets throw "
+"`MODULE_NOT_FOUND` at the call."
+msgstr ""
+
+#: src/cli/flags.md:175
 msgid ""
 "Some build pipelines inject a generated module rather than writing it into "
 "the source checkout. Reproduce that file-map step with `--asset-module`. "
@@ -66005,7 +66668,7 @@ msgstr ""
 "件-地图步骤. Perry 排序目录走路,保存每个 `{ type: \"file\" }` 边缘,并将生成的"
 "源存储在缓存中,而不是修改结账."
 
-#: src/cli/flags.md:136
+#: src/cli/flags.md:180
 msgid ""
 "For the pinned OpenCode source graph, build the upstream web UI first, then "
 "compile from `packages/opencode`'s package root:"
@@ -66013,11 +66676,7 @@ msgstr ""
 "对于固定 OpenCode 源图,首先构建上游 Web UI,然后从 `packages/opencode` 的包根"
 "编译:"
 
-#: src/cli/flags.md:142
-msgid "'opencode-web-ui.gen.ts=../app/dist'"
-msgstr "'opencode-web-ui.gen.ts=../app/dist'"
-
-#: src/cli/flags.md:146
+#: src/cli/flags.md:190
 msgid ""
 "The first command is the upstream preparation step; Perry reproduces only "
 "the deterministic `opencode-web-ui.gen.ts` file map. A missing/empty `dist` "
@@ -66029,7 +66688,7 @@ msgstr ""
 "件地图. 一个 missing/empty `dist` 或一个缺失的生成导入失败了修复消息,而不是成"
 "为未解决的导入警告. 运行每个源修改的准备命令,以便生成的输入不能过时."
 
-#: src/cli/flags.md:152
+#: src/cli/flags.md:196
 msgid ""
 "Every compile also writes `<cache-dir>/assets.json`, a deterministic report "
 "of text, JSON, file-loader, WASM, and explicitly embedded assets. It records "
@@ -66040,7 +66699,7 @@ msgstr ""
 "载器,WASM,以及明确嵌入的资产. 它记录了包装的处理器,项目相关的源源,字节大"
 "小,SHA-256摘要,以及适用时生成资产模块."
 
-#: src/cli/flags.md:157
+#: src/cli/flags.md:201
 msgid ""
 "**Note** `node:fs` consults the embedded registry _before_ disk, and a bare "
 "embed-relative key matches too — so `readFileSync(\"dist/index.html\")` "
@@ -66053,7 +66712,7 @@ msgstr ""
 "盘上存在`dist/index.html`. 通过绝对路径读取真正的磁盘文件,并且当您具体指嵌入"
 "的副本时,使用明确的`$perryfs/<path>`形式."
 
-#: src/cli/flags.md:164
+#: src/cli/flags.md:208
 msgid ""
 "Embedding supports host builds on macOS, Linux, and Windows. Windows uses "
 "LLVM clang to emit a COFF registration object; set `PERRY_LLVM_CLANG` when "
@@ -66064,19 +66723,19 @@ msgstr ""
 "注册对象;设置 `PERRY_LLVM_CLANG` 当匹配响应不是 `PATH` 上的第一个时. 目前不支"
 "持跨目标嵌入."
 
-#: src/cli/flags.md:169
+#: src/cli/flags.md:213
 msgid "Debug Flags"
 msgstr "调试标志"
 
-#: src/cli/flags.md:173
+#: src/cli/flags.md:217
 msgid "Print HIR (intermediate representation) to stdout"
 msgstr "将 HIR（中间表示）打印到 stdout"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid "`--trace <STAGES>`"
 msgstr "`--trace <STAGES>`"
 
-#: src/cli/flags.md:174
+#: src/cli/flags.md:218
 msgid ""
 "Dump IR at one or more pipeline stages. Comma-separated: `hir` (post-"
 "transform HIR), `llvm` (per-module `.ll` into `.perry-trace/llvm/`), or `all`"
@@ -66084,11 +66743,11 @@ msgstr ""
 "在一个或多个流水线阶段转储 IR。以逗号分隔：`hir`（转换后的 HIR）、`llvm`（每"
 "模块 `.ll` 文件输出到 `.perry-trace/llvm/`），或 `all`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid "`--focus <NAME>`"
 msgstr "`--focus <NAME>`"
 
-#: src/cli/flags.md:175
+#: src/cli/flags.md:219
 msgid ""
 "Restrict `--trace hir` to functions/methods/classes whose name contains "
 "`NAME`, suppressing import/export/init noise. Implies `--trace hir` if no "
@@ -66097,7 +66756,7 @@ msgstr ""
 "将 `--trace hir` 限制到名称包含 `NAME` 的函数/方法/类，抑制 import/export/"
 "init 噪声。若未指定阶段，则隐式启用 `--trace hir`"
 
-#: src/cli/flags.md:176
+#: src/cli/flags.md:220
 msgid ""
 "Produce `.o` object file(s) only, skip linking. The objects are written to `-"
 "o` — verbatim for a single-module program, otherwise into `-o`'s directory "
@@ -66109,11 +66768,11 @@ msgstr ""
 "则在 `-o` 的目录中以模块衍生名称,因为一个 `-o` 不能命名几个文件. 如果没有`-"
 "o`,它们就会登陆当前目录. 每条路径都以`Wrote object file: <path>`打印"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid "`--no-codegen`"
 msgstr "`--no-codegen`"
 
-#: src/cli/flags.md:177
+#: src/cli/flags.md:221
 msgid ""
 "Skip the `package.json` `perry.codegen` build-time steps (also "
 "`PERRY_SKIP_CODEGEN=1`). See [Project Configuration](../getting-started/"
@@ -66123,70 +66782,70 @@ msgstr ""
 "`PERRY_SKIP_CODEGEN=1`）。参见[项目配置](../getting-started/project-"
 "config.md)"
 
-#: src/cli/flags.md:178
+#: src/cli/flags.md:222
 msgid "Keep `.o` and `.asm` intermediate files"
 msgstr "保留 `.o` 与 `.asm` 中间文件"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid "`--debug-symbols`"
 msgstr "`--debug-symbols`"
 
-#: src/cli/flags.md:179
+#: src/cli/flags.md:223
 msgid ""
 "Retain symbols/DWARF (and emit a Windows PDB) instead of stripping the "
 "result."
 msgstr "保留 symbols/DWARF (并发出 Windows PDB) 而不是删除结果."
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid "`--no-cache`"
 msgstr "`--no-cache`"
 
-#: src/cli/flags.md:180
+#: src/cli/flags.md:224
 msgid ""
 "Disable the per-module object cache for this build; also `PERRY_NO_CACHE=1`."
 msgstr "在此构建中禁用每个模块对象缓存;也禁用 `PERRY_NO_CACHE=1`."
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid "`--cache-dir <PATH>`"
 msgstr "`--cache-dir <PATH>`"
 
-#: src/cli/flags.md:181
+#: src/cli/flags.md:225
 msgid ""
 "Override the machine-local cache root; see [Cache Directory](cache-dir.md)."
 msgstr "覆盖机器本地缓存根;见[缓存目录](cache-dir.md)."
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid "`--verify-native-regions`"
 msgstr "`--verify-native-regions`"
 
-#: src/cli/flags.md:182
+#: src/cli/flags.md:226
 msgid ""
 "Run native-representation lowering invariants and force codegen instead of "
 "cache reuse."
 msgstr "运行原生表示降低不变量并强制代码生成器,而不是缓存重用."
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "`--disable-buffer-fast-path`"
 msgstr "`--disable-buffer-fast-path`"
 
-#: src/cli/flags.md:183
+#: src/cli/flags.md:227
 msgid "Disable native Buffer/Uint8Array load/store lowering for A/B diagnosis."
 msgstr "禁用原生Buffer/Uint8Array load/store降低用于A/B诊断."
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid "`--explain-lowering`"
 msgstr "`--explain-lowering`"
 
-#: src/cli/flags.md:184
+#: src/cli/flags.md:228
 msgid ""
 "Emit a type-lowering evidence report; implies native-region verification."
 msgstr "发出一种类型降低证据报告;意味着本地区域的验证."
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid "`--opt-report[=json]`"
 msgstr "`--opt-report[=json]`"
 
-#: src/cli/flags.md:185
+#: src/cli/flags.md:229
 msgid ""
 "Report which values Perry could **not** statically type, why, and whether "
 "you can fix it. Text by default; `--opt-report=json` emits a stable schema "
@@ -66195,11 +66854,11 @@ msgstr ""
 "报告哪些值可以是Perry **没有** 没有什么问题. 默认的文本; `--opt-report=json` "
 "发出了一个稳定的工具方案. 也可以通过`PERRY_OPT_REPORT=1`设置"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid "`--statepoint-report[=json]`"
 msgstr "`--statepoint-report[=json]`"
 
-#: src/cli/flags.md:186
+#: src/cli/flags.md:230
 msgid ""
 "Report native-stack GC root pressure: calls with live roots, audited non-"
 "collecting calls omitted, relocations, plain-map fallbacks, and live-root "
@@ -66210,7 +66869,7 @@ msgstr ""
 "图回落和活根宽度. 仅用于研究;需要`PERRY_RS4GC=1`,一个原生根后端 (它也命名的平"
 "面堆地图和明确桥模式已经消失)"
 
-#: src/cli/flags.md:188
+#: src/cli/flags.md:232
 msgid ""
 "The `--trace`/`--focus` pair localizes \"compiled to the wrong thing\" bugs: "
 "`perry compile foo.ts --trace hir,llvm --focus parseRow` dumps just the "
@@ -66225,11 +66884,11 @@ msgstr ""
 "制完整重新编译（否则对象缓存会跳过未变更模块的代码生成，导致 trace 目录为"
 "空）。"
 
-#: src/cli/flags.md:195
+#: src/cli/flags.md:239
 msgid "`--opt-report` — why a value stayed boxed"
 msgstr "`--opt-report` 为什么一个值保持框中"
 
-#: src/cli/flags.md:197
+#: src/cli/flags.md:241
 msgid ""
 "Perry's speed comes from proving static types and selecting unboxed "
 "representations (see the [representation-selection RFC](https://github.com/"
@@ -66245,11 +66904,11 @@ msgstr ""
 "`-Rpass-missed` 注释的表示选择模拟:它打印了被证明的,没有的,以及哪个规则进行了"
 "调用."
 
-#: src/cli/flags.md:224
+#: src/cli/flags.md:268
 msgid "Each denied value carries:"
 msgstr "每一个被拒绝的值都包含:"
 
-#: src/cli/flags.md:226
+#: src/cli/flags.md:270
 msgid ""
 "**Position** — `local`, `param`, `return`, `field`, or `alloc-site` (an "
 "object literal that is never bound to a local, the `.map(x => ({...}))` "
@@ -66258,14 +66917,14 @@ msgstr ""
 "**位置** `local`,`param`,`return`,`field`,或`alloc-site` (一个从未与本地字母"
 "绑定的对象字母,`.map(x => ({...}))`语法)."
 
-#: src/cli/flags.md:229
+#: src/cli/flags.md:273
 msgid ""
 "**The rule that denied it**, in the collector's own numbering, so you can "
 "check it against the named source file."
 msgstr ""
 "**这条规则否认了**在收藏家自己的编号中, 您可以将其与命名的源文件进行检查."
 
-#: src/cli/flags.md:231
+#: src/cli/flags.md:275
 msgid ""
 "**An actionability tier**: _Fixable in your source_ (stop reassigning it, "
 "don't capture it in a closure), _Inherently polymorphic_ (correctly boxed — "
@@ -66275,7 +66934,7 @@ msgstr ""
 "**一个可操作级别**: _可固定在您的源_ (停止重新分配,不要在封闭中捕获它), _固有"
 "多态_ (正确框无行动),或 _佩里限制_ (不是您的代码;在存在的情况下命名跟踪问题)."
 
-#: src/cli/flags.md:235
+#: src/cli/flags.md:279
 msgid ""
 "**A hotness proxy.** Loop-nesting depth **and**, separately, whether the "
 "enclosing region is an iterating builtin's callback. The two are reported as "
@@ -66287,13 +66946,13 @@ msgstr ""
 "这两个是故意的单独列:一个`map`/`sort`/`reduce`回调没有自己的循环,但每个元素运"
 "行一次,因此循环深度单独排名最后. 它们是静态代理."
 
-#: src/cli/flags.md:241
+#: src/cli/flags.md:285
 msgid ""
 "Wins are reported alongside the misses, so the ratio is visible rather than "
 "just the complaints."
 msgstr "获胜率与失败率一起报道,"
 
-#: src/cli/flags.md:244
+#: src/cli/flags.md:288
 msgid ""
 "**It is observational only** — emitted code is byte-identical with the flag "
 "on and off. Like `--trace llvm`, it disables build and object cache reuse "
@@ -66305,7 +66964,7 @@ msgstr ""
 "用构建和对象缓存重复使用,因为缓存的成功完全跳过了代码,没有什么可报告的. 这份"
 "报告说: **这里**所以它永远不会与`--format json`的有效载荷或程序的输出混合."
 
-#: src/cli/flags.md:250
+#: src/cli/flags.md:294
 msgid ""
 "Values are identified by **function and binding name**: Perry's HIR keeps "
 "names through lowering but drops source positions, so there is no "
@@ -66317,15 +66976,15 @@ msgstr ""
 "没有`file:line`. `--opt-report=json`在`schema_version: 1`下运载相同的数据;不"
 "同两种构建的JSON是一个廉价的CI检查,对象无声回归到零."
 
-#: src/cli/flags.md:256
+#: src/cli/flags.md:300
 msgid "Output Optimization"
 msgstr "输出优化"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid "`--march <CPU>`"
 msgstr "`--march <CPU>`"
 
-#: src/cli/flags.md:261
+#: src/cli/flags.md:305
 msgid ""
 "CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, "
 "`x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — "
@@ -66344,44 +67003,44 @@ msgstr ""
 "native_tuning = false` 是 `generic` 的缩写. 适用于应用程序代码和自动优化的 "
 "runtime/stdlib 重建."
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid "`--features <LIST>`"
 msgstr "`--features <LIST>`"
 
-#: src/cli/flags.md:262
+#: src/cli/flags.md:306
 msgid ""
 "Define comma-separated compile-time `__feature_NAME__` constants for dead-"
 "code elimination."
 msgstr "定义 `__feature_NAME__` 编译时的逗号分离常数,以消除死码."
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid "`--no-auto-optimize`"
 msgstr "`--no-auto-optimize`"
 
-#: src/cli/flags.md:263
+#: src/cli/flags.md:307
 msgid ""
 "Use the prebuilt full runtime/stdlib instead of rebuilding the smallest "
 "reachable feature set."
 msgstr "使用预先构建的完整 runtime/stdlib,而不是重建最小可访问的功能集."
 
-#: src/cli/flags.md:264 src/cli/fast-math.md:13 src/cli/fast-math.md:108
+#: src/cli/flags.md:308 src/cli/fast-math.md:13 src/cli/fast-math.md:108
 #: src/cli/fast-math.md:132
 msgid "`--fast-math`"
 msgstr "`--fast-math`"
 
-#: src/cli/flags.md:264
+#: src/cli/flags.md:308
 msgid "Permit floating-point reassociation; see [Fast-math](fast-math.md)."
 msgstr "允许浮点重新关联;见[Fast-math](fast-math.md)."
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "`--fp-contract off\\|on\\|fast`"
 msgstr "`--fp-contract off\\|on\\|fast`"
 
-#: src/cli/flags.md:265
+#: src/cli/flags.md:309
 msgid "Control fused multiply-add contraction separately from reassociation."
 msgstr "控制合式复合收缩与重新关联分开."
 
-#: src/cli/flags.md:267
+#: src/cli/flags.md:311
 msgid ""
 "Minification strips comments, collapses whitespace, and mangles local "
 "variable/parameter/non-exported function names for smaller output."
@@ -66389,11 +67048,11 @@ msgstr ""
 "压缩会去除注释、合并空白，并对局部变量/参数/未导出函数名做混淆，以减小输出体"
 "积。"
 
-#: src/cli/flags.md:269
+#: src/cli/flags.md:313
 msgid "Size-optimized builds"
 msgstr "优化尺寸的构建"
 
-#: src/cli/flags.md:271
+#: src/cli/flags.md:315
 msgid ""
 "For the smallest possible native binaries, two opt-in environment variables "
 "rebuild the auto-optimized runtime/stdlib archives tuned for size instead of "
@@ -66403,11 +67062,11 @@ msgstr ""
 "对于最小可能的本地二进制文件,两个选择环境变量重建自动优化的 runtime/stdlib 档"
 "案,调整为大小而不是速度 (它们需要 Perry 工作区检查,就像其他自动优化):"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid "`PERRY_SIZE_OPT=z` (or `s`)"
 msgstr "`PERRY_SIZE_OPT=z` (or `s`)"
 
-#: src/cli/flags.md:278
+#: src/cli/flags.md:322
 msgid ""
 "Rebuild the runtime/stdlib at `-C opt-level=z`/`s` instead of `3`. Roughly "
 "halves a small program's binary at some runtime-speed cost (compute-heavy "
@@ -66418,11 +67077,11 @@ msgstr ""
 "二进制值减半,以运行时的速度成本 (计算重的内部循环可以运行2-3倍慢). 大小优化的"
 "和正常的档案是独立缓存的."
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid "`PERRY_SIZE_LTO=fat`"
 msgstr "`PERRY_SIZE_LTO=fat`"
 
-#: src/cli/flags.md:279
+#: src/cli/flags.md:323
 msgid ""
 "Additionally run whole-archive fat LTO over the rebuilt archives (slower "
 "rebuild, smaller binary). Only meaningful together with `PERRY_SIZE_OPT`."
@@ -66430,11 +67089,11 @@ msgstr ""
 "此外,在重建的档案中运行整个档案脂肪 LTO (重建速度较慢,二进制更小). 只有与"
 "`PERRY_SIZE_OPT`一起有意义."
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid "`PERRY_SIZE_PANIC=abort-immediate`"
 msgstr "`PERRY_SIZE_PANIC=abort-immediate`"
 
-#: src/cli/flags.md:280
+#: src/cli/flags.md:324
 msgid ""
 "Additionally rebuild the Rust standard library with the `immediate-abort` "
 "panic strategy when auto-optimize proves that no UI/thread/plugin callback "
@@ -66449,7 +67108,7 @@ msgstr ""
 "具链 (`-Zbuild-std`);只与`PERRY_SIZE_OPT`一起有意义. 级内部恐慌则失败,没有象"
 "征的回溯 JS `throw`/`catch`,`finally`,错误堆和`uncaughtException`不受影响."
 
-#: src/cli/flags.md:282
+#: src/cli/flags.md:326
 msgid ""
 "A `console.log` hello world on macOS arm64: 4.03 MB default → 2.17 MB with "
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB adding "
@@ -66460,15 +67119,15 @@ msgstr ""
 "`PERRY_SIZE_OPT=z PERRY_SIZE_LTO=fat` → 1.87 MB 添加 `PERRY_SIZE_PANIC=abort-"
 "immediate`. 那些使用更多运行时间的程序, 比例缩小."
 
-#: src/cli/flags.md:287
+#: src/cli/flags.md:331
 msgid "Testing Flags"
 msgstr "测试标志"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid "`--enable-geisterhand`"
 msgstr "`--enable-geisterhand`"
 
-#: src/cli/flags.md:291
+#: src/cli/flags.md:335
 msgid ""
 "Embed the [Geisterhand](../testing/geisterhand.md) HTTP server for "
 "programmatic UI testing (default port 7676)"
@@ -66476,24 +67135,24 @@ msgstr ""
 "嵌入 [Geisterhand](../testing/geisterhand.md) HTTP 服务器以便对 UI 进行编程式"
 "测试（默认端口 7676）"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid "`--geisterhand-port <PORT>`"
 msgstr "`--geisterhand-port <PORT>`"
 
-#: src/cli/flags.md:292
+#: src/cli/flags.md:336
 msgid ""
 "Set a custom port for the Geisterhand server (implies `--enable-geisterhand`)"
 msgstr "为 Geisterhand 服务器设置自定义端口（隐含 `--enable-geisterhand`）"
 
-#: src/cli/flags.md:294
+#: src/cli/flags.md:338
 msgid "Runtime Flags"
 msgstr "运行时标志"
 
-#: src/cli/flags.md:298
+#: src/cli/flags.md:342
 msgid "Enable V8 JavaScript runtime for unsupported npm packages"
 msgstr "为不支持的 npm 包启用 V8 JavaScript 运行时"
 
-#: src/cli/flags.md:299
+#: src/cli/flags.md:343
 msgid ""
 "Force-link the wasmi WebAssembly host runtime (auto-detected when "
 "`WebAssembly.*` is referenced; needed only when loading via dlopen / FFI "
@@ -66502,15 +67161,15 @@ msgstr ""
 "强制链接 wasmi WebAssembly 宿主运行时（在引用 `WebAssembly.*` 时自动检测；仅"
 "在通过 dlopen / FFI 动态加载且无静态引用时才需要手动指定）"
 
-#: src/cli/flags.md:300
+#: src/cli/flags.md:344
 msgid "Enable type checking via tsgo IPC"
 msgstr "通过 tsgo IPC 启用类型检查"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid "`--strict-eval`"
 msgstr "`--strict-eval`"
 
-#: src/cli/flags.md:301
+#: src/cli/flags.md:345
 msgid ""
 "Fail the build if any runtime-unknown `eval(...)` / `new Function(<dynamic "
 "body>)` site is reachable. By default such a site is compiled to a deferred "
@@ -66525,11 +67184,11 @@ msgstr ""
 "(package.json或perry.toml) 设置. `PERRY_ALLOW_EVAL=1`强迫它关闭. 参见"
 "[Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid "`--strict-dynamic-import`"
 msgstr "`--strict-dynamic-import`"
 
-#: src/cli/flags.md:302
+#: src/cli/flags.md:346
 msgid ""
 "Fail the build if a dynamic `import(...)` has a runtime-computed (non-"
 "resolvable) specifier. By default such a site is compiled to a rejected "
@@ -66549,11 +67208,11 @@ msgstr ""
 "解决臂的三元字母,对局限局域的模板字母,有限的联合类型的参数,球) 不受影响. 参见"
 "[Limitations](../language/limitations.md#no-eval-or-dynamic-code)."
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid "`--strict-unimplemented`"
 msgstr "`--strict-unimplemented`"
 
-#: src/cli/flags.md:303
+#: src/cli/flags.md:347
 msgid ""
 "Fail at compile time when a recognized but unimplemented Node/stdlib API is "
 "referenced instead of emitting a deferred runtime error."
@@ -66561,50 +67220,50 @@ msgstr ""
 "在编译时失败,当引用一个已识别但未实现的Node/stdlib API,而不是发出延期运行时错"
 "误时."
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "`--emit-attest`"
 msgstr "`--emit-attest`"
 
-#: src/cli/flags.md:304
+#: src/cli/flags.md:348
 msgid "Emit `<binary>.attest.json`; see [Binary attestation](emit-attest.md)."
 msgstr "发出 `<binary>.attest.json`;见 [双重证明](emit-attest.md)."
 
-#: src/cli/flags.md:305
+#: src/cli/flags.md:349
 msgid ""
 "Emit the platform sandbox sidecar; see [Sandbox profiles](emit-sandbox.md)."
 msgstr "排放平台沙箱侧车;见[沙箱配置文件](emit-sandbox.md)."
 
-#: src/cli/flags.md:306
+#: src/cli/flags.md:350
 msgid ""
 "Refuse reachable arbitrary-code-execution surfaces; see [Lockdown]"
 "(lockdown.md)."
 msgstr "拒绝可达到的任意代码执行表面;见[Lockdown](lockdown.md)."
 
-#: src/cli/flags.md:308 src/cli/perry-toml.md:512
+#: src/cli/flags.md:352 src/cli/perry-toml.md:512
 msgid "Environment Variables"
 msgstr "环境变量"
 
-#: src/cli/flags.md:312 src/cli/perry-toml.md:520
+#: src/cli/flags.md:356 src/cli/perry-toml.md:520
 msgid "`PERRY_LICENSE_KEY`"
 msgstr "`PERRY_LICENSE_KEY`"
 
-#: src/cli/flags.md:312
+#: src/cli/flags.md:356
 msgid "Perry Hub license key for `perry publish`"
 msgstr "用于 `perry publish` 的 Perry Hub 许可证密钥"
 
-#: src/cli/flags.md:313 src/cli/perry-toml.md:522
+#: src/cli/flags.md:357 src/cli/perry-toml.md:522
 msgid "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 msgstr "`PERRY_APPLE_CERTIFICATE_PASSWORD`"
 
-#: src/cli/flags.md:313
+#: src/cli/flags.md:357
 msgid "Password for .p12 certificate"
 msgstr ".p12 证书的密码"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid "`PERRY_TARGET_CPU`"
 msgstr "`PERRY_TARGET_CPU`"
 
-#: src/cli/flags.md:314
+#: src/cli/flags.md:358
 msgid ""
 "CPU baseline for generated machine code (same values as `--march`; the flag "
 "and perry.toml `[build] march` win over the env var)"
@@ -66612,59 +67271,59 @@ msgstr ""
 "生成机器代码的CPU基线 (与`--march`相同的值;标志和perry.toml `[build] march`超"
 "过环境)"
 
-#: src/cli/flags.md:315 src/cli/updates.md:146
+#: src/cli/flags.md:359 src/cli/updates.md:146
 msgid "`PERRY_NO_UPDATE_CHECK=1`"
 msgstr "`PERRY_NO_UPDATE_CHECK=1`"
 
-#: src/cli/flags.md:315
+#: src/cli/flags.md:359
 msgid "Disable automatic update checks"
 msgstr "禁用自动更新检查"
 
-#: src/cli/flags.md:316 src/cli/updates.md:147
+#: src/cli/flags.md:360 src/cli/updates.md:147
 msgid "`NO_UPDATE_NOTIFIER`"
 msgstr "`NO_UPDATE_NOTIFIER`"
 
-#: src/cli/flags.md:316
+#: src/cli/flags.md:360
 msgid "The same, using the ecosystem-wide spelling"
 msgstr "通过全生态系统的拼写,"
 
-#: src/cli/flags.md:317 src/cli/updates.md:148
+#: src/cli/flags.md:361 src/cli/updates.md:148
 msgid "`PERRY_UPDATE_MODE`"
 msgstr "`PERRY_UPDATE_MODE`"
 
-#: src/cli/flags.md:317
+#: src/cli/flags.md:361
 msgid "`off`/`notify`/`prompt`/`auto` for one run — see [Updates](updates.md)"
 msgstr "一次运行时使用`off`/`notify`/`prompt`/`auto` 见[Updates](updates.md)"
 
-#: src/cli/flags.md:318 src/cli/updates.md:149
+#: src/cli/flags.md:362 src/cli/updates.md:149
 msgid "`PERRY_UPDATE_SERVER`"
 msgstr "`PERRY_UPDATE_SERVER`"
 
-#: src/cli/flags.md:318
+#: src/cli/flags.md:362
 msgid "Custom update server URL"
 msgstr "自定义更新服务器 URL"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "`CI=true`"
 msgstr "`CI=true`"
 
-#: src/cli/flags.md:319
+#: src/cli/flags.md:363
 msgid "Auto-skip update checks (set by most CI systems)"
 msgstr "自动跳过更新检查（大多数 CI 系统会设置此变量）"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "`RUST_LOG`"
 msgstr "`RUST_LOG`"
 
-#: src/cli/flags.md:320
+#: src/cli/flags.md:364
 msgid "Debug logging level (`debug`, `info`, `trace`)"
 msgstr "调试日志级别（`debug`、`info`、`trace`）"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid "`PERRY_OPT_REPORT`"
 msgstr "`PERRY_OPT_REPORT`"
 
-#: src/cli/flags.md:321
+#: src/cli/flags.md:365
 msgid ""
 "`1`/`text` or `json` — same as `--opt-report[=json]`, for driving the report "
 "from an environment where adding a flag is awkward"
@@ -66672,7 +67331,7 @@ msgstr ""
 "`1`/`text` 或 `json`  与 `--opt-report[=json]` 一样,用于从添加标志不舒服的环"
 "境中驱动报告"
 
-#: src/cli/flags.md:323
+#: src/cli/flags.md:367
 msgid ""
 "The native-stack GC root-pressure report has **no** environment spelling: "
 "use `--statepoint-report[=json]`. The `PERRY_STATEPOINT_REPORT` variable is "
@@ -66685,15 +67344,15 @@ msgstr ""
 "代码工作者,而不是作为用户输入读取,这是一个没有CI臂的第五个GC env旋,并且根据"
 "CLAUDE.md的GC旋杀死政策被删除."
 
-#: src/cli/flags.md:329
+#: src/cli/flags.md:373
 msgid "Configuration Files"
 msgstr "配置文件"
 
-#: src/cli/flags.md:331
+#: src/cli/flags.md:375
 msgid "perry.toml (project)"
 msgstr "perry.toml（项目级）"
 
-#: src/cli/flags.md:333
+#: src/cli/flags.md:377
 msgid ""
 "```toml\n"
 "[project]\n"
@@ -66773,11 +67432,11 @@ msgstr ""
 "category = \"Development\"\n"
 "```"
 
-#: src/cli/flags.md:371
+#: src/cli/flags.md:415
 msgid "~/.perry/config.toml (global)"
 msgstr "~/.perry/config.toml（全局）"
 
-#: src/cli/flags.md:373
+#: src/cli/flags.md:417
 msgid ""
 "```toml\n"
 "[apple]\n"
@@ -66799,57 +67458,253 @@ msgstr ""
 "key_alias = \"my-key\"\n"
 "```"
 
-#: src/cli/flags.md:386
-msgid "# Simple CLI program"
+#: src/cli/flags.md:430
+#, fuzzy
+msgid "# Simple CLI program\n"
 msgstr "# 简单的CLI程序"
 
-#: src/cli/flags.md:388
-msgid "# iOS app for simulator"
+#: src/cli/flags.md:432
+#, fuzzy
+msgid "# iOS app for simulator\n"
 msgstr "# 模拟器的iOS应用程序"
 
-#: src/cli/flags.md:391
-msgid "# visionOS app for simulator"
+#: src/cli/flags.md:435
+#, fuzzy
+msgid "# visionOS app for simulator\n"
 msgstr "# 模拟器的visionOS应用程序"
 
-#: src/cli/flags.md:394
-msgid "# Web app (WASM with DOM bridge — alias: --target wasm)"
+#: src/cli/flags.md:438
+#, fuzzy
+msgid "# Web app (WASM with DOM bridge — alias: --target wasm)\n"
 msgstr "# 网络应用程序 (WASM与DOM桥别名:--target wasm)"
 
-#: src/cli/flags.md:397
-msgid "# Plugin shared library"
+#: src/cli/flags.md:441
+#, fuzzy
+msgid "# Plugin shared library\n"
 msgstr "# 插件共享库"
 
-#: src/cli/flags.md:400
-msgid "# iOS widget with bundle ID"
+#: src/cli/flags.md:444
+#, fuzzy
+msgid "# iOS widget with bundle ID\n"
 msgstr "# 具有捆绑ID的iOS小程序"
 
-#: src/cli/flags.md:403
-msgid "# Debug compilation"
+#: src/cli/flags.md:447
+#, fuzzy
+msgid "# Debug compilation\n"
 msgstr "# 调试编译"
 
-#: src/cli/flags.md:406
-msgid "# Verbose compilation"
+#: src/cli/flags.md:450
+#, fuzzy
+msgid "# Verbose compilation\n"
 msgstr "# 词汇汇编"
 
-#: src/cli/flags.md:409
-msgid "# Type-checked compilation"
+#: src/cli/flags.md:453
+#, fuzzy
+msgid "# Type-checked compilation\n"
 msgstr "# 类型检查编译"
 
-#: src/cli/flags.md:412
-msgid "# Raw WASM binary (no HTML wrapper)"
+#: src/cli/flags.md:456
+#, fuzzy
+msgid "# Raw WASM binary (no HTML wrapper)\n"
 msgstr "# 原WASM二进制 (没有HTML包装)"
 
-#: src/cli/flags.md:415
-msgid "# Minified web output (compresses embedded JS bridge)"
+#: src/cli/flags.md:459
+#, fuzzy
+msgid "# Minified web output (compresses embedded JS bridge)\n"
 msgstr "# 缩小Web输出 (压缩嵌入式JS桥)"
 
-#: src/cli/flags.md:422
+#: src/cli/flags.md:466
 msgid "[Commands](commands.md) — All CLI commands"
 msgstr "[命令](commands.md) — 所有 CLI 命令"
 
-#: src/cli/flags.md:423
+#: src/cli/flags.md:467
 msgid "[Platform Overview](../platforms/overview.md) — Platform targets"
 msgstr "[平台概览](../platforms/overview.md) — 平台目标"
+
+#: src/cli/flags.md:469
+msgid "Typed-feedback profile replay"
+msgstr ""
+
+#: src/cli/flags.md:471
+msgid ""
+"`--typed-feedback-profile <path>` supplies an **advisory** profile to native "
+"LLVM lowering. Default builds do not read a profile. The first supported "
+"observation, `numeric_array_element`, can select the existing guarded "
+"numeric-array read at an otherwise generic checked `array[index]` site. "
+"Already specialized reads and other site/observation kinds are ignored and "
+"explained."
+msgstr ""
+
+#: src/cli/flags.md:477
+msgid ""
+"Capture a workload, then replay it with the **same compiler executable, "
+"source, target and lowering options**:"
+msgstr ""
+
+#: src/cli/flags.md:491
+msgid ""
+"The conversion utility is in the Perry source checkout. Pair the catalog "
+"with the trace from that exact capture build. It retains only observed "
+"numeric array reads and excludes runtime addresses, shape IDs and method "
+"identities. A trace without supported observations produces a diagnostic "
+"instead of an empty profile. The capture build must enable "
+"`PERRY_TYPED_FEEDBACK` at compile time; enabling it only when running a "
+"normal binary cannot restore omitted instrumentation."
+msgstr ""
+
+#: src/cli/flags.md:498
+msgid "The JSON replay schema is version 1:"
+msgstr ""
+
+#: src/cli/flags.md:502
+#, fuzzy
+msgid "\"schema_version\""
+msgstr "`schemaVersion`"
+
+#: src/cli/flags.md:503
+#, fuzzy
+msgid "\"compiler\""
+msgstr "compile"
+
+#: src/cli/flags.md:503
+msgid "\"sha256:<exact compiler executable hash>\""
+msgstr ""
+
+#: src/cli/flags.md:504 src/cli/perry-audit-sbom.md:48
+msgid "\"modules\""
+msgstr "\"模块\""
+
+#: src/cli/flags.md:505
+#, fuzzy
+msgid "\"identity\""
+msgstr "缓存身份"
+
+#: src/cli/flags.md:506
+#, fuzzy
+msgid "\"module\""
+msgstr "\"模块\""
+
+#: src/cli/flags.md:506
+msgid "\"app.ts\""
+msgstr ""
+
+#: src/cli/flags.md:507
+#, fuzzy
+msgid "\"source_hash\""
+msgstr "\"来源\""
+
+#: src/cli/flags.md:507
+msgid "\"sha256:<source bytes hash>\""
+msgstr ""
+
+#: src/cli/flags.md:508
+#, fuzzy
+msgid "\"hir_hash\""
+msgstr "\"snippet_hash\""
+
+#: src/cli/flags.md:508
+msgid "\"<stable post-transform HIR hash>\""
+msgstr ""
+
+#: src/cli/flags.md:509
+#, fuzzy
+msgid "\"lowering_hash\""
+msgstr "没有人知道"
+
+#: src/cli/flags.md:509
+msgid "\"<compiler lowering-input fingerprint>\""
+msgstr ""
+
+#: src/cli/flags.md:510
+#, fuzzy
+msgid "\"target\""
+msgstr "\"targets\""
+
+#: src/cli/flags.md:510
+msgid "\"x86_64-unknown-linux-gnu\""
+msgstr ""
+
+#: src/cli/flags.md:512
+msgid "\"sites\""
+msgstr ""
+
+#: src/cli/flags.md:513
+#, fuzzy
+msgid "\"site_id\""
+msgstr "\"client_id\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"function\""
+msgstr "\"functions\""
+
+#: src/cli/flags.md:514
+#, fuzzy
+msgid "\"perry_fn_app_ts__read\""
+msgstr "\"libperry_appreview.a\""
+
+#: src/cli/flags.md:515
+#, fuzzy
+msgid "\"array_element\""
+msgstr "\"Increment\""
+
+#: src/cli/flags.md:516
+#, fuzzy
+msgid "\"operation\""
+msgstr "\"caption\""
+
+#: src/cli/flags.md:516
+msgid "\"array[index]\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"observation_kind\""
+msgstr ""
+
+#: src/cli/flags.md:517
+msgid "\"numeric_array_element\""
+msgstr ""
+
+#: src/cli/flags.md:523
+msgid ""
+"Use generated identities, rather than copying this illustrative site ID. "
+"Site IDs identify deterministic lowering sites within an exact module/"
+"compiler/input combination; function, kind and operation must also match. "
+"The lowering hash includes target CPU/features, codegen settings and "
+"imported capabilities using the object cache's complete input fingerprint. "
+"Capture instrumentation and native-region reporting/verification are "
+"excluded so they can vary during replay. Even a comment-only source change "
+"invalidates the source hash, and rebuilding Perry invalidates the compiler "
+"hash without needing a version bump. No cross-version or best-effort stale "
+"replay is attempted."
+msgstr ""
+
+#: src/cli/flags.md:533
+msgid ""
+"Malformed or unreadable explicit input is a compilation error naming the "
+"profile and how to create it. Well-formed schema/compiler/target/source/HIR/"
+"options mismatches, unknown modules/sites, duplicate identities and "
+"unsupported observations are ignored for specialization. Each rejected fact "
+"is reported on stderr with its reason. Accepted and rejected facts also "
+"appear in native-rep artifacts (`PERRY_NATIVE_REPS=1`) and `--explain-"
+"lowering`'s typed-path evidence and reason counts. Replay and catalog builds "
+"bypass build/object cache reuse to produce evidence from this compilation. "
+"Artifact filenames and report paths have run-specific nonces; decisions and "
+"lowering are deterministic for identical inputs."
+msgstr ""
+
+#: src/cli/flags.md:543
+msgid ""
+"Profiles and TypeScript annotations never authorize an unchecked operation. "
+"Every replay-selected read rechecks the live receiver, array representation, "
+"descriptors/prototype state and bounds with the existing numeric-array "
+"runtime guard. Strings, holes, changed layouts, non-array receivers and "
+"other guard failures use the original boxed JavaScript fallback, with no "
+"added number coercion. Replay does not relax ownership, alias, lifetime or "
+"method-identity checks. Native-region verification requires a consumed fresh "
+"replay fact, a matching runtime guard and an explicit fallback/"
+"materialization record for every claimed profile selection."
+msgstr ""
 
 #: src/cli/cache-dir.md:1
 msgid "Cache directory"
@@ -67077,15 +67932,18 @@ msgid "CLI flag wins over env var, env var wins over package.json:"
 msgstr "CLI 标志优先于环境变量，环境变量优先于 package.json："
 
 #: src/cli/fast-math.md:26
-msgid "# 1. Per-build CLI flag"
+#, fuzzy
+msgid "# 1. Per-build CLI flag\n"
 msgstr "# 1. 每个构建CLI标志"
 
 #: src/cli/fast-math.md:28
-msgid "# 2. Per-shell environment"
+#, fuzzy
+msgid "# 2. Per-shell environment\n"
 msgstr "# 2. 每个外环境"
 
 #: src/cli/fast-math.md:31
-msgid "# 3. Per-project package.json (most common)"
+#, fuzzy
+msgid "# 3. Per-project package.json (most common)\n"
 msgstr "# 3. 每个项目 package.json (最常见的)"
 
 #: src/cli/fast-math.md:35
@@ -67101,17 +67959,20 @@ msgid "Contraction is separate from reassociation:"
 msgstr "收缩与重新关联是独立的："
 
 #: src/cli/fast-math.md:45
-msgid "# Permit FMA contraction only."
+#, fuzzy
+msgid "# Permit FMA contraction only.\n"
 msgstr "# 只有允许FMA收缩."
 
 #: src/cli/fast-math.md:47
+#, fuzzy
 msgid ""
 "# Permit the frontend's most aggressive contraction mode without "
-"reassociation."
+"reassociation.\n"
 msgstr "# 允许前端最具攻击性的收缩模式,"
 
 #: src/cli/fast-math.md:50
-msgid "# Keep reassociation from --fast-math but block FMA contraction."
+#, fuzzy
+msgid "# Keep reassociation from --fast-math but block FMA contraction.\n"
 msgstr "# 保持从--fast-math重新关联,但阻止FMA收缩."
 
 #: src/cli/fast-math.md:55
@@ -68035,7 +68896,8 @@ msgid "Emit"
 msgstr "生成"
 
 #: src/cli/emit-attest.md:22
-msgid "# → myapp"
+#, fuzzy
+msgid "# → myapp\n"
 msgstr "# → myapp"
 
 #: src/cli/emit-attest.md:27
@@ -68116,7 +68978,7 @@ msgstr "\"abcd1234...\""
 msgid "\"size\""
 msgstr "\"大小\""
 
-#: src/cli/emit-attest.md:64 src/cli/telemetry.md:31
+#: src/cli/emit-attest.md:64 src/cli/telemetry.md:34
 msgid "\"perry_version\""
 msgstr "\"perry_version\""
 
@@ -69270,10 +70132,6 @@ msgstr ""
 msgid "produces:"
 msgstr "会生成："
 
-#: src/cli/perry-audit-sbom.md:48
-msgid "\"modules\""
-msgstr "\"模块\""
-
 #: src/cli/perry-audit-sbom.md:50
 msgid "\"/repo/main.ts\""
 msgstr "\"/repo/main.ts\""
@@ -69354,9 +70212,10 @@ msgstr ""
 "在文本模式下，按所属 npm 包对模块分组；宿主源文件以 `<host source>` 报告。"
 
 #: src/cli/perry-audit-sbom.md:81
+#, fuzzy
 msgid ""
-"Returns a clear error if the manifest doesn't exist yet — `perry  compile` "
-"or `perry run` writes it on every successful build."
+"Returns a clear error if the manifest doesn't exist yet — `perry compile` or "
+"`perry run` writes it on every successful build."
 msgstr ""
 "返回一个明显的错误,如果显示尚未存在,则 `perry  compile` 或 `perry run` 在每个"
 "成功的构建中写出它."
@@ -71429,7 +72288,7 @@ msgstr "Perry 会同时读取两个文件中的配置。下面说明各项设置
 msgid "Setting"
 msgstr "设置项"
 
-#: src/cli/perry-toml.md:581 src/internals/memory-model.md:299
+#: src/cli/perry-toml.md:581 src/internals/memory-model.md:310
 msgid "File"
 msgstr "文件"
 
@@ -71511,15 +72370,18 @@ msgstr ""
 "`perry.toml` 和 `~/.perry/config.toml` 中："
 
 #: src/cli/perry-toml.md:600
-msgid "# Configure iOS signing (certificate, provisioning profile)"
+#, fuzzy
+msgid "# Configure iOS signing (certificate, provisioning profile)\n"
 msgstr "# 设置iOS签名 (证书,配置配置)"
 
 #: src/cli/perry-toml.md:601
-msgid "# Configure Android signing (keystore, Play Store key)"
+#, fuzzy
+msgid "# Configure Android signing (keystore, Play Store key)\n"
 msgstr "# 设置Android签名 (键盘,播放商店键)"
 
 #: src/cli/perry-toml.md:602
-msgid "# Configure macOS distribution (App Store, notarization)"
+#, fuzzy
+msgid "# Configure macOS distribution (App Store, notarization)\n"
 msgstr "# 配置macOS分发 (应用商店,公证)"
 
 #: src/cli/perry-toml.md:605
@@ -71553,8 +72415,11 @@ msgid ""
 msgstr "对于 CI 环境，请使用环境变量，而不是将凭据存储在 `perry.toml` 中："
 
 #: src/cli/perry-toml.md:618
-msgid "env"
-msgstr "env"
+#, fuzzy
+msgid ""
+"# GitHub Actions example\n"
+"env"
+msgstr "# GitHub 操作示例"
 
 #: src/cli/perry-toml.md:620
 msgid "PERRY_LICENSE_KEY"
@@ -72717,19 +73582,20 @@ msgstr ""
 
 #: src/cli/telemetry.md:3
 msgid ""
-"Perry ships **two independent opt-in channels** for sending data home — "
-"nothing leaves your machine without an explicit `enabled = true` or `on` in "
-"`~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and `CI=true`."
+"Perry sends no telemetry unless you accept the first-run prompt (or "
+"explicitly set `telemetry.enabled = true` in `~/.perry/config.toml`). This "
+"setting is the master consent gate for every telemetry channel. If it is "
+"false or missing, nothing is sent, even when `compatibility_reports = "
+"\"on\"`. The environment overrides `PERRY_NO_TELEMETRY=1` and `CI=true` "
+"always win as well."
 msgstr ""
-"Perry 船舶 **两个独立的选择道** 为了将数据发回家  没有任何东西离开你的机器没"
-"有一个明确的`enabled = true`或`on`在`~/.perry/config.toml`. 它们都尊重"
-"`PERRY_NO_TELEMETRY=1`和`CI=true`."
-
-#: src/cli/telemetry.md:7
-msgid "1. Generic usage analytics — `telemetry.enabled`"
-msgstr "1. 一般使用分析  `telemetry.enabled`"
 
 #: src/cli/telemetry.md:9
+#, fuzzy
+msgid "1. Master consent and generic usage analytics — `telemetry.enabled`"
+msgstr "1. 一般使用分析  `telemetry.enabled`"
+
+#: src/cli/telemetry.md:11
 msgid ""
 "Counts `perry compile`, `perry init`, `perry publish` invocations on a "
 "background HTTP POST. Sends: command name, platform (`darwin`/`linux`/...), "
@@ -72739,14 +73605,16 @@ msgstr ""
 "命令名称,平台 (`darwin`/`linux`/...),Perry版本,success/error状态,以及匿名的客"
 "户端 UUID."
 
-#: src/cli/telemetry.md:13
+#: src/cli/telemetry.md:15
 msgid "2. Compatibility reports — `telemetry.compatibility_reports` (#849)"
 msgstr "2. 兼容性报告  `telemetry.compatibility_reports` (#849)"
 
-#: src/cli/telemetry.md:15
+#: src/cli/telemetry.md:17
+#, fuzzy
 msgid ""
-"Separate opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
-"Sends a structured report when the compiler emits one of these diagnostic "
+"Additional opt-in for \"I hit an unsupported TS/Node feature and bailed.\" "
+"This channel is available only while the master `enabled` consent is true. "
+"It sends a structured report when the compiler emits one of these diagnostic "
 "codes: `UnsupportedBinaryOp`, `UnsupportedExpression`, "
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
@@ -72756,15 +73624,15 @@ msgstr ""
 "`UnsupportedStatement`, `DynamicPropertyAccess`, `ImplicitCoercion`, "
 "`UnresolvedImport`, `NoOpStub`."
 
-#: src/cli/telemetry.md:20
+#: src/cli/telemetry.md:23
 msgid "Three modes:"
 msgstr "三种模式:"
 
-#: src/cli/telemetry.md:22
+#: src/cli/telemetry.md:25
 msgid "`off` — never send. Sink isn't even installed; zero overhead."
 msgstr "`off` 永远不会发送. 洗手间甚至没有安装, 没有任何开支."
 
-#: src/cli/telemetry.md:23
+#: src/cli/telemetry.md:26
 msgid ""
 "`ask` (default) — when a qualifying diagnostic fires, prompt once per "
 "session: `[y] just this once / [a] always / [n] not this time / [N] never`."
@@ -72772,99 +73640,99 @@ msgstr ""
 "`ask` (默认) 当合格诊断发射时,每次提示一次:`[y] just this once / [a] "
 "always / [n] not this time / [N] never`."
 
-#: src/cli/telemetry.md:25
+#: src/cli/telemetry.md:28
 msgid "`on` — always send (after dedup + redaction). No prompt."
 msgstr "`on`  始终发送 (删除 + 删除后). 没有提示."
 
-#: src/cli/telemetry.md:27
+#: src/cli/telemetry.md:30
 msgid "**What's sent (the entire payload schema):**"
 msgstr "**发送的内容 (整个有效载荷方案):**"
 
-#: src/cli/telemetry.md:31
+#: src/cli/telemetry.md:34
 msgid "\"0.5.x\""
 msgstr "\"0.5.x\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"client_id\""
 msgstr "\"client_id\""
 
-#: src/cli/telemetry.md:32
+#: src/cli/telemetry.md:35
 msgid "\"uuid\""
 msgstr "没有\"uuid\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"code\""
 msgstr "\"代码\""
 
-#: src/cli/telemetry.md:33
+#: src/cli/telemetry.md:36
 msgid "\"UnsupportedExpression\""
 msgstr "\"UnsupportedExpression\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"category\""
 msgstr "\"类别\""
 
-#: src/cli/telemetry.md:34
+#: src/cli/telemetry.md:37
 msgid "\"gap-categorical\""
 msgstr "\"空白类别\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"stage\""
 msgstr "\"阶段\""
 
-#: src/cli/telemetry.md:35
+#: src/cli/telemetry.md:38
 msgid "\"hir-lower\""
 msgstr "\"高低\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"snippet_hash\""
 msgstr "\"snippet_hash\""
 
-#: src/cli/telemetry.md:36
+#: src/cli/telemetry.md:39
 msgid "\"sha256:...\""
 msgstr "\"sha256:"
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"snippet_redacted\""
 msgstr "\"snippet_redacted\""
 
-#: src/cli/telemetry.md:37
+#: src/cli/telemetry.md:40
 msgid "\"let <id1> = await <id2>();\""
 msgstr "\"let <id1> = await <id2>();\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"ts_feature\""
 msgstr "\"ts_feature\""
 
-#: src/cli/telemetry.md:38
+#: src/cli/telemetry.md:41
 msgid "\"decorator\""
 msgstr "\"装饰师\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node_api\""
 msgstr "\"node_api\""
 
-#: src/cli/telemetry.md:39
+#: src/cli/telemetry.md:42
 msgid "\"node:async_hooks.createHook\""
 msgstr "\"节点:async_hooks.createHook\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"os\""
 msgstr "\"我们\""
 
-#: src/cli/telemetry.md:40
+#: src/cli/telemetry.md:43
 msgid "\"darwin-arm64\""
 msgstr "\"达尔文手臂64\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"node_target\""
 msgstr "\"node_target\""
 
-#: src/cli/telemetry.md:41
+#: src/cli/telemetry.md:44
 msgid "\"20\""
 msgstr "\"20\""
 
-#: src/cli/telemetry.md:45
+#: src/cli/telemetry.md:48
 msgid ""
 "**What's NEVER sent:** raw source, file paths, project names, env vars, your "
 "program's stdout/stderr, dependency tree, or anything tied to identity "
@@ -72879,7 +73747,7 @@ msgstr ""
 "`Promise`等内置) → `<id1>`, `<id2>`,限于200个字符,如果任何变量失败,则会被拒"
 "绝."
 
-#: src/cli/telemetry.md:52
+#: src/cli/telemetry.md:55
 msgid ""
 "A local 30-day dedup cache at `~/.perry/.report-cache` prevents resending "
 "the same `snippet_hash` on every reload."
@@ -72887,32 +73755,36 @@ msgstr ""
 "在`~/.perry/.report-cache`处的本地30天的缓存阻止在每次重新加载时重新发送相同"
 "的`snippet_hash`."
 
-#: src/cli/telemetry.md:55
+#: src/cli/telemetry.md:58
 msgid "Inspecting & managing"
 msgstr "检查和管理"
 
-#: src/cli/telemetry.md:58
-msgid "# shows current mode, sent/queued counts"
+#: src/cli/telemetry.md:61
+#, fuzzy
+msgid "# shows current mode, sent/queued counts\n"
 msgstr "# 显示当前模式,sent/queued计数"
 
-#: src/cli/telemetry.md:59
-msgid "# print redacted payloads queued this run"
+#: src/cli/telemetry.md:62
+#, fuzzy
+msgid "# print redacted payloads queued this run\n"
 msgstr "# 打印编辑了该运行排队的有效载荷"
 
-#: src/cli/telemetry.md:60
-msgid "# wipe the 30-day dedup cache"
+#: src/cli/telemetry.md:63
+#, fuzzy
+msgid "# wipe the 30-day dedup cache\n"
 msgstr "# 清除30天的缓存"
 
-#: src/cli/telemetry.md:63
+#: src/cli/telemetry.md:66
 msgid "To opt out at the file level, edit `~/.perry/config.toml`:"
 msgstr "在文件级别上选择退出,编辑`~/.perry/config.toml`:"
 
-#: src/cli/telemetry.md:65
+#: src/cli/telemetry.md:68
+#, fuzzy
 msgid ""
 "```toml\n"
 "[telemetry]\n"
-"enabled = false                  # generic analytics off\n"
-"compatibility_reports = \"off\"    # #849 compat reports off\n"
+"enabled = false                  # all telemetry off\n"
+"compatibility_reports = \"off\"    # optional; master opt-out already wins\n"
 "```"
 msgstr ""
 "```toml\n"
@@ -72921,7 +73793,7 @@ msgstr ""
 "compatibility_reports = \"off\"    # #849 compat reports off\n"
 "```"
 
-#: src/cli/telemetry.md:71
+#: src/cli/telemetry.md:74
 msgid ""
 "See also the [`PERRY_NO_TELEMETRY` row in the perry.toml reference](perry-"
 "toml.md)."
@@ -73158,15 +74030,18 @@ msgstr ""
 "types.rs`) 前置:"
 
 #: src/internals/memory-model.md:62
-msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
+#, fuzzy
+msgid "// GC_TYPE_ARRAY, GC_TYPE_STRING, …\n"
 msgstr "// GC_TYPE_ARRAY, GC_TYPE_STRING, …"
 
 #: src/internals/memory-model.md:63
-msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
+#, fuzzy
+msgid "// MARKED | ARENA | PINNED | TENURED | HAS_SURVIVED | …\n"
 msgstr "// 标记 | ARENA | PINNED | TENURED | HAS_SURVIVED | …"
 
 #: src/internals/memory-model.md:65
-msgid "// total alloc size, used for arena block walking"
+#, fuzzy
+msgid "// total alloc size, used for arena block walking\n"
 msgstr "// 总分配大小,用于竞技场区块行走"
 
 #: src/internals/memory-model.md:69
@@ -73462,7 +74337,7 @@ msgstr ""
 "在编译时禁用 codegen 生成的写屏障，同时在运行时禁用精确辅助写屏障，用于基准测"
 "试或调试二分定位。未设置、`=1`、`=on` 或 `=true` 时保持屏障启用。"
 
-#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:197
+#: src/internals/memory-model.md:174 src/internals/garbage-collector.md:258
 msgid "`PERRY_GC_DIAG=1`"
 msgstr "`PERRY_GC_DIAG=1`"
 
@@ -73628,10 +74503,11 @@ msgstr ""
 "retired_set=#N`行."
 
 #: src/internals/memory-model.md:200
+#, fuzzy
 msgid ""
 "**Depth is the knob to raise when a suspected bug does not fault.** A stale "
 "pointer is only caught while the page-set it names is still quarantined, and "
-"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1  "
+"at `PERRY_GC_SCHEDULE_SEED=<u64> PERRY_GC_SCHEDULE_RATE=1 "
 "PERRY_GC_SCHEDULE_ALLOC_KB=0` a value can cross hundreds of collections "
 "between its last valid observation and its stale use — one per loop back-"
 "edge poll. (`ALLOC_KB=0` is what makes that literally per-poll: rate 1 "
@@ -73827,10 +74703,24 @@ msgstr ""
 "在压力下实际上会保持什么."
 
 #: src/internals/memory-model.md:294
+msgid ""
+"**`__DATA` dirty is not the inline caches any more.** Every property-access "
+"site used to own a 96-byte `[12 x i64]` cache global — 25 MB of `__bss` on a "
+"Claude Code build, 18.7 MB of it dirty at idle because a page is dirtied by "
+"the first cache touched on it (#9708). A site now owns an 8-byte pointer "
+"**slot** (`@perry_ic_N = private global ptr null`); the cache words are "
+"allocated from a runtime arena on the site's first _priming_ miss and "
+"published into the slot, so an unexecuted site costs its zero-filled slot "
+"and nothing resident. The arena is one row of `PERRY_GC_CENSUS`'s "
+"`side_tables` (`ic.lazy_caches`: resolved sites, arena bytes); a program "
+"that reports `0` there executed no property site that could prime."
+msgstr ""
+
+#: src/internals/memory-model.md:305
 msgid "Source map"
 msgstr "源码索引"
 
-#: src/internals/memory-model.md:296
+#: src/internals/memory-model.md:307
 msgid ""
 "Paths, not line numbers: a line number is a claim nothing re-derives, and "
 "every row of this table once pointed into a `gc.rs` that no longer exists."
@@ -73838,183 +74728,183 @@ msgstr ""
 "路径,而不是行号:行号是一个索赔,没有任何重新导出,并且这个表中的每一行都指向了"
 "一个不再存在的`gc.rs`."
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Topic"
 msgstr "主题"
 
-#: src/internals/memory-model.md:299
+#: src/internals/memory-model.md:310
 msgid "Symbol to look for"
 msgstr "需要寻找的符号"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "NaN-boxing tags"
 msgstr "标签 NaN-盒子"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`crates/perry-runtime/src/value/tags.rs`"
 msgstr "`crates/perry-runtime/src/value/tags.rs`"
 
-#: src/internals/memory-model.md:301
+#: src/internals/memory-model.md:312
 msgid "`POINTER_TAG`, `STRING_TAG`"
 msgstr "`POINTER_TAG`, `STRING_TAG`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`, type/flag constants"
 msgstr "`GcHeader`、类型/标志常量"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`crates/perry-runtime/src/gc/types.rs`"
 msgstr "`crates/perry-runtime/src/gc/types.rs`"
 
-#: src/internals/memory-model.md:302
+#: src/internals/memory-model.md:313
 msgid "`GcHeader`"
 msgstr "`GcHeader`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`gc_malloc`"
 msgstr "`gc_malloc`"
 
-#: src/internals/memory-model.md:303
+#: src/internals/memory-model.md:314
 msgid "`crates/perry-runtime/src/gc/malloc.rs`"
 msgstr "`crates/perry-runtime/src/gc/malloc.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "Shadow frames (fallback root lowering)"
 msgstr "阴影框架 (后置根降低)"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots/shadow_stack.rs`"
 
-#: src/internals/memory-model.md:304
+#: src/internals/memory-model.md:315
 msgid "`js_shadow_frame_push`"
 msgstr "`js_shadow_frame_push`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "Registered root scanners"
 msgstr "已注册的根扫描器"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`crates/perry-runtime/src/gc/roots.rs`"
 msgstr "`crates/perry-runtime/src/gc/roots.rs`"
 
-#: src/internals/memory-model.md:305
+#: src/internals/memory-model.md:316
 msgid "`gc_register_mutable_root_scanner`"
 msgstr "`gc_register_mutable_root_scanner`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "Copying minor"
 msgstr "复制小"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`crates/perry-runtime/src/gc/copying.rs`"
 msgstr "`crates/perry-runtime/src/gc/copying.rs`"
 
-#: src/internals/memory-model.md:306
+#: src/internals/memory-model.md:317
 msgid "`move_young`"
 msgstr "`move_young`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "Whole-block in-place promotion"
 msgstr "整个区块的现场推广"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`crates/perry-runtime/src/arena/promote.rs`"
 msgstr "`crates/perry-runtime/src/arena/promote.rs`"
 
-#: src/internals/memory-model.md:307
+#: src/internals/memory-model.md:318
 msgid "`finish_in_place_promotion`"
 msgstr "`finish_in_place_promotion`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "Promotion policy"
 msgstr "促销政策"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 msgstr "`crates/perry-runtime/src/gc/promote_in_place.rs`"
 
-#: src/internals/memory-model.md:308
+#: src/internals/memory-model.md:319
 msgid "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 msgstr "`PROMOTE_SURVIVAL_THRESHOLD_PERMILLE`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "Adaptive tenuring threshold"
 msgstr "适应性任期值"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`crates/perry-runtime/src/gc/tenuring.rs`"
 msgstr "`crates/perry-runtime/src/gc/tenuring.rs`"
 
-#: src/internals/memory-model.md:309
+#: src/internals/memory-model.md:320
 msgid "`tenuring_survivals`"
 msgstr "`tenuring_survivals`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "Write barriers"
 msgstr "写出障碍"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`crates/perry-runtime/src/gc/barrier_store.rs`"
 msgstr "`crates/perry-runtime/src/gc/barrier_store.rs`"
 
-#: src/internals/memory-model.md:310
+#: src/internals/memory-model.md:321
 msgid "`runtime_write_barrier_slot`"
 msgstr "`runtime_write_barrier_slot`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "Explicit pinning"
 msgstr "显式的固定"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`crates/perry-runtime/src/gc/pin.rs`"
 msgstr "`crates/perry-runtime/src/gc/pin.rs`"
 
-#: src/internals/memory-model.md:311
+#: src/internals/memory-model.md:322
 msgid "`pin_object`"
 msgstr "`pin_object`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "Conservative-pin predicate"
 msgstr "保守式引脚 predicate"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`crates/perry-runtime/src/gc/verify.rs`"
 msgstr "`crates/perry-runtime/src/gc/verify.rs`"
 
-#: src/internals/memory-model.md:312
+#: src/internals/memory-model.md:323
 msgid "`is_conservatively_pinned`"
 msgstr "`is_conservatively_pinned`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "Collection triggers and pacing"
 msgstr "收集触发器和节奏"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`crates/perry-runtime/src/gc/policy.rs`"
 msgstr "`crates/perry-runtime/src/gc/policy.rs`"
 
-#: src/internals/memory-model.md:313
+#: src/internals/memory-model.md:324
 msgid "`gc_check_trigger`"
 msgstr "`gc_check_trigger`"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "Current operations page"
 msgstr "目前操作页面"
 
-#: src/internals/memory-model.md:314
+#: src/internals/memory-model.md:325
 msgid "`docs/src/internals/garbage-collector.md`"
 msgstr "`docs/src/internals/garbage-collector.md`"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "Design plan (historical)"
 msgstr "设计计划 (历史)"
 
-#: src/internals/memory-model.md:315
+#: src/internals/memory-model.md:326
 msgid "`docs/generational-gc-plan.md`"
 msgstr "`docs/generational-gc-plan.md`"
 
-#: src/internals/memory-model.md:329
+#: src/internals/memory-model.md:340
 msgid ""
 "Those rows are not decorative: each is bound to a `gc-symbol` marker above "
 "and re-derived by `scripts/check_gc_doc_claims.py`, so a rename that leaves "
@@ -74395,19 +75285,25 @@ msgstr ""
 "runtime/src/gc/heap_budget.rs`: 64 MiB"
 
 #: src/internals/garbage-collector.md:171
+#, fuzzy
 msgid ""
 "on an unconstrained desktop/server process, scaled to one eighth of a device/"
 "container budget with a 1 MiB floor. Overflow is returned to the allocator, "
 "thread exit drains that thread's pool, and a critical-pressure drain request "
 "is sticky: it survives unsafe/deferred periods and empties the pool when the "
-"owed full collection finishes its arena reclamation."
+"owed full collection finishes its arena reclamation. A full cycle's reclaim "
+"tail then asks the allocator itself to release what it is holding — "
+"mimalloc's `mi_collect` on the default `alloc-mimalloc` builds, plus glibc "
+"`malloc_trim` or Darwin zone pressure relief for the system allocator — "
+"because a block deallocated into mimalloc's segment cache otherwise waits "
+"for a purge the idle program would never trigger."
 msgstr ""
 "在一个不受限制的 desktop/server 过程中,缩放到 device/container 预算的八分之"
 "一,并设置 1 MiB 地板. 溢出流量返回分配器,线程出口排放该线程的池,并且一个临界"
 "压力排放请求是粘性的:它存活到unsafe/deferred周期,并在欠款完整收藏完成竞技场回"
 "收时,将池清空."
 
-#: src/internals/garbage-collector.md:178
+#: src/internals/garbage-collector.md:183
 msgid ""
 "Reported heap usage (`js_arena_stats`, `process.memoryUsage().heapUsed`) is "
 "an exact post-collection **live census** plus incremental deltas, not a sum "
@@ -74416,100 +75312,214 @@ msgstr ""
 "报告的堆积使用量 (`js_arena_stats`,`process.memoryUsage().heapUsed`) 是收集后"
 "的确切数据 **活人口普查** 而不是区块高水位偏移的总和."
 
-#: src/internals/garbage-collector.md:182
+#: src/internals/garbage-collector.md:187
+msgid "Idle-time reclaim"
+msgstr ""
+
+#: src/internals/garbage-collector.md:189
+msgid ""
+"Every automatic collection above is scheduled by allocation, so a program "
+"that bursts and then goes quiet keeps whatever the last mid-burst cycle left "
+"in old-gen until the next burst. The idle-time reclaim (`crates/perry-"
+"runtime/src/gc/idle_reclaim.rs`) closes that gap at the event loop's park "
+"site. When the loop is about to sleep — no notify, no microtask, no timer "
+"due — and at least one collection the reducer did not start itself has "
+"completed since its last full, and 3000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:197
+msgid ""
+"have passed since that collection was observed, it opens a full budgeted "
+"cycle with the block-pool drain armed and steps it in 4000 µs"
+msgstr ""
+
+#: src/internals/garbage-collector.md:200
+msgid ""
+"slices, returning to the loop the moment a wake is pending. Two reducer "
+"fulls are never closer than 10000 ms"
+msgstr ""
+
+#: src/internals/garbage-collector.md:203
+msgid "apart. A full that lowers old-gen occupancy by less than 5 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:205
+msgid "of what it started with (or by less than 4 MiB"
+msgstr ""
+
+#: src/internals/garbage-collector.md:207
+msgid ""
+") doubles the number of collections required before the next attempt, up to "
+"32"
+msgstr ""
+
+#: src/internals/garbage-collector.md:209
+msgid ""
+"(two to that power); a productive full resets the requirement to one. The "
+"same slicing finishes a budgeted cycle the pacer left open when the mutator "
+"went quiet."
+msgstr ""
+
+#: src/internals/garbage-collector.md:213
+msgid ""
+"Arena capacity has a second re-arm signal because returning a proven-empty "
+"block deliberately takes two full collection observations, while the "
+"activity clock above excludes the reducer's own fulls. Above a 32 MiB "
+"capacity floor,"
+msgstr ""
+
+#: src/internals/garbage-collector.md:217
+msgid "two consecutive post-collection live/capacity readings"
+msgstr ""
+
+#: src/internals/garbage-collector.md:219
+msgid "at or below 50 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:221
+msgid ""
+"open a bounded right-size episode. It grants only enough idle fulls to reach "
+"two full observations"
+msgstr ""
+
+#: src/internals/garbage-collector.md:224
+msgid ""
+"(counting any full already in the low-utilization streak), and stops early "
+"once live data reaches 60 percent of capacity."
+msgstr ""
+
+#: src/internals/garbage-collector.md:227
+msgid ""
+"After a bounded episode, stable low occupancy cannot immediately repeat it: "
+"a new episode re-arms only after utilization reaches 70 percent"
+msgstr ""
+
+#: src/internals/garbage-collector.md:230
+msgid "or capacity grows by at least both 25 percent and 8 MiB."
+msgstr ""
+
+#: src/internals/garbage-collector.md:233
+msgid ""
+"That hysteresis preserves burst headroom and prevents an unreleasably "
+"fragmented heap from buying a full every ten seconds. The right-size debt "
+"still passes through the reducer's quiet, rate, wake, and work-budget gates."
+msgstr ""
+
+#: src/internals/garbage-collector.md:238
+msgid ""
+"`PERRY_GC_DIAG=1` reports the reducer's counters on the `[gc-idle-reclaim]` "
+"exit line, and `PERRY_GC_IDLE_RECLAIM=0` disables it."
+msgstr ""
+
+#: src/internals/garbage-collector.md:243
 msgid "Supported controls"
 msgstr "支持的控制"
 
-#: src/internals/garbage-collector.md:184
+#: src/internals/garbage-collector.md:245
 msgid ""
 "These are the operational controls most useful outside collector development:"
 msgstr "以下是最有用的操作控制系统:"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "knob"
 msgstr "knob"
 
-#: src/internals/garbage-collector.md:186
+#: src/internals/garbage-collector.md:247
 msgid "purpose"
 msgstr "purpose"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "`PERRY_GEN_GC=0`"
 msgstr "`PERRY_GEN_GC=0`"
 
-#: src/internals/garbage-collector.md:188
+#: src/internals/garbage-collector.md:249
 msgid "bisection fallback to full mark-sweep"
 msgstr "切割回归到完全的标志扫描"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "`PERRY_WRITE_BARRIERS=0`"
 msgstr "`PERRY_WRITE_BARRIERS=0`"
 
-#: src/internals/garbage-collector.md:189
+#: src/internals/garbage-collector.md:250
 msgid "compile/runtime barrier bisection; also forces full mark-sweep"
 msgstr "compile/runtime屏障分隔;也强制全面标记扫描"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "`PERRY_GC_SCAVENGE=0`"
 msgstr "`PERRY_GC_SCAVENGE=0`"
 
-#: src/internals/garbage-collector.md:190
+#: src/internals/garbage-collector.md:251
 msgid "disable direct nursery scavenging for pacing comparison"
 msgstr "禁用直接的幼儿园清除步伐比较"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 msgstr "`PERRY_GC_PROMOTE_IN_PLACE=0`"
 
-#: src/internals/garbage-collector.md:191
+#: src/internals/garbage-collector.md:252
 msgid "revert whole-block promotion to object-by-object evacuation"
 msgstr "将整个区块的推广恢复为对象逐个疏散"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 msgstr "`PERRY_GC_SCAVENGE_NURSERY_MB=N`"
 
-#: src/internals/garbage-collector.md:192
+#: src/internals/garbage-collector.md:253
 msgid "set the base nursery cap"
 msgstr "设置基座托儿室帽子"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "`PERRY_GC_HEAP_LIMIT=N`"
 msgstr "`PERRY_GC_HEAP_LIMIT=N`"
 
-#: src/internals/garbage-collector.md:193
+#: src/internals/garbage-collector.md:254
 msgid "override the process heap budget in MiB"
 msgstr "在 MiB 中覆盖过程堆预算"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "`PERRY_RS4GC=0`"
 msgstr "`PERRY_RS4GC=0`"
 
-#: src/internals/garbage-collector.md:194
+#: src/internals/garbage-collector.md:255
 msgid "select shadow roots on a native-root-capable target"
 msgstr "在一个具有原生根能力的目标上选择影子根"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 msgstr "`PERRY_CONSERVATIVE_STACK_SCAN=full`"
 
-#: src/internals/garbage-collector.md:195
+#: src/internals/garbage-collector.md:256
 msgid "diagnostic full native-stack scan; disables copying"
 msgstr "诊断完全本地堆扫描;禁用复制"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "`PERRY_GC_TRACE=1`"
 msgstr "`PERRY_GC_TRACE=1`"
 
-#: src/internals/garbage-collector.md:196
+#: src/internals/garbage-collector.md:257
 msgid "emit structured per-cycle trace records"
 msgstr "发出结构化循环记录"
 
-#: src/internals/garbage-collector.md:197
-msgid "emit human-readable collector diagnostics"
-msgstr "发出人类可读的收集器诊断"
+#: src/internals/garbage-collector.md:258
+msgid ""
+"emit human-readable collector diagnostics (per cycle, plus `[gc-trigger]`/"
+"`[gc-full]`/`[gc-budgeted]`/`[gc-charge]` decision and charge attribution "
+"and the per-minor `[gc-survival]` root attribution)"
+msgstr ""
 
-#: src/internals/garbage-collector.md:199
+#: src/internals/garbage-collector.md:259
+#, fuzzy
+msgid "`PERRY_ALLOC_SITE_SAMPLE=N`"
+msgstr "`PERRY_GC_HEAP_LIMIT=N`"
+
+#: src/internals/garbage-collector.md:259
+msgid ""
+"sample the arena allocation-site histogram every N bytes (`[alloc-site]`); "
+"`1`/`on` selects the default interval"
+msgstr ""
+
+#: src/internals/garbage-collector.md:261
+#, fuzzy
 msgid ""
 "Rooting stress uses `PERRY_GC_SCHEDULE_SEED`, `PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_SCHEDULE_ALLOC_KB`, `PERRY_GC_FORCE_EVACUATE`, "
@@ -74518,10 +75528,11 @@ msgid ""
 "`PERRY_GC_FROMSPACE_SCAN_ABORT`. Their exact contracts and non-vacuity "
 "requirements live in the [rooting invariant](gc-rooting-invariant.md). "
 "Research/bisection controls such as `PERRY_GC_INCREMENTAL`, "
-"`PERRY_GC_MAJOR_PACING_FLOOR_MB`, `PERRY_GC_MAJOR_PACING_GROWTH`, "
-"`PERRY_GC_MOVING_SAFEPOINT`, `PERRY_GC_MOVING_LOOP_POLLS`, "
-"`PERRY_GC_SAFEPOINT_ONLY`, and `PERRY_STACKMAP_WALKER` are accepted but are "
-"not additional supported collector modes."
+"`PERRY_GC_IDLE_RECLAIM`, `PERRY_GC_MAJOR_PACING_FLOOR_MB`, "
+"`PERRY_GC_MAJOR_PACING_GROWTH`, `PERRY_GC_MOVING_SAFEPOINT`, "
+"`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY`, and "
+"`PERRY_STACKMAP_WALKER` are accepted but are not additional supported "
+"collector modes."
 msgstr ""
 "根源应力使用的是 "
 "`PERRY_GC_SCHEDULE_SEED`,`PERRY_GC_SCHEDULE_RATE`,`PERRY_GC_SCHEDULE_ALLOC_KB`,`PERRY_GC_FORCE_EVACUATE`,`PERRY_GC_VERIFY_EVACUATION`,`PERRY_GC_PROTECT_FROMSPACE`,`PERRY_GC_PROTECT_FROMSPACE_DEPTH`,`PERRY_GC_FROMSPACE_SCAN` "
@@ -74532,7 +75543,7 @@ msgstr ""
 "`PERRY_GC_MOVING_LOOP_POLLS`, `PERRY_GC_SAFEPOINT_ONLY` 和 "
 "`PERRY_STACKMAP_WALKER`,但不是额外支持的收藏器模式."
 
-#: src/internals/garbage-collector.md:212
+#: src/internals/garbage-collector.md:274
 msgid ""
 "`scripts/check_gc_env_knobs.py` derives the accepted names from live runtime/"
 "codegen/compiler parsers and rejects a current document, executable script, "
@@ -74555,11 +75566,11 @@ msgstr ""
 "有器切片,整个工艺池盖,粘的临界压力排水,并在现场推广. 删除或更名其中一个测试失"
 "败了`lint`,改变行为失败了`cargo-test`;"
 
-#: src/internals/garbage-collector.md:224
+#: src/internals/garbage-collector.md:286
 msgid "Validation and CI authority"
 msgstr "验证机构和CI机构"
 
-#: src/internals/garbage-collector.md:226
+#: src/internals/garbage-collector.md:288
 msgid ""
 "As of 2026-08-16, branch protection requires exactly one status, `pr-gate` — "
 "the fan-in of `test.yml`'s PR tier (see `docs/src/testing/ci-tiers.md`; the "
@@ -74570,91 +75581,91 @@ msgstr ""
 "粉丝 (见`docs/src/testing/ci-tiers.md`;层策略是`scripts/ci_plan.py`). 具体的 "
 "GC 覆盖范围是故意分为:"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "where it runs"
 msgstr "它在哪里运行"
 
-#: src/internals/garbage-collector.md:230
+#: src/internals/garbage-collector.md:292
 msgid "required status"
 msgstr "需要的状态"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "root-holder custody, GC-knob drift, and this page's path/number claims"
 msgstr "根持有者托管,GC-knob漂移,以及本页面的path/number索赔"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "`test.yml` → `lint`"
 msgstr "`test.yml` → `lint`"
 
-#: src/internals/garbage-collector.md:232
+#: src/internals/garbage-collector.md:294
 msgid "yes (via `pr-gate`)"
 msgstr "是的 (通过`pr-gate`)"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "runtime unit suite and `run_memory_stability_tests.sh` four-mode matrix"
 msgstr "运行时间单元套件和`run_memory_stability_tests.sh`四模式矩阵"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid "`test.yml` → `cargo-test`"
 msgstr "`test.yml` → `cargo-test`"
 
-#: src/internals/garbage-collector.md:233
+#: src/internals/garbage-collector.md:295
 msgid ""
 "yes (via `pr-gate`; the PR tier is diff-scoped, the sweep/full tiers run the "
 "workspace)"
 msgstr "是的 (通过 `pr-gate`; PR 层是不同范围的, sweep/full 层运行工作空间)"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid ""
 "GC × representation-selection matrix, rooting-bug instruments, write-barrier "
 "stress"
 msgstr "GC × 表示选择矩阵,根源错误仪器,写入阻碍应力"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "`test.yml` → `gc-stress`"
 msgstr "`test.yml` → `gc-stress`"
 
-#: src/internals/garbage-collector.md:234
+#: src/internals/garbage-collector.md:296
 msgid "yes (via `pr-gate`; PR subset on PRs, full matrix in the sweep)"
 msgstr "是的 (通过`pr-gate`;PR的PR子集,全矩阵在扫描中)"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "emitted root dominance, including native statepoint IR"
 msgstr "发射的根主导性,包括本地状态点IR"
 
-#: src/internals/garbage-collector.md:235
+#: src/internals/garbage-collector.md:297
 msgid "`gc-root-dominance.yml`"
 msgstr "`gc-root-dominance.yml`"
 
-#: src/internals/garbage-collector.md:235
-#: src/internals/garbage-collector.md:236
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:297
+#: src/internals/garbage-collector.md:298
+#: src/internals/garbage-collector.md:299
 msgid ""
 "not branch-required; PR arm opt-in via `run-extended-tests`, six-hourly on "
 "`main`"
 msgstr "不需要分支机构;通过`run-extended-tests`选择PR部门,每六小时在`main`上"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "pinned collector counters/RSS/wall matrix"
 msgstr "固定收纳器 counters/RSS/wall矩阵"
 
-#: src/internals/garbage-collector.md:236
+#: src/internals/garbage-collector.md:298
 msgid "`gc-ratchet.yml`"
 msgstr "`gc-ratchet.yml`"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "thread-local mechanism/policy budget"
 msgstr "线程本地mechanism/policy预算"
 
-#: src/internals/garbage-collector.md:237
+#: src/internals/garbage-collector.md:299
 msgid "`tls-budget.yml`"
 msgstr "`tls-budget.yml`"
 
-#: src/internals/garbage-collector.md:239
+#: src/internals/garbage-collector.md:301
 msgid "Useful local preflight commands:"
 msgstr "有用的地方飞行前命令:"
 
-#: src/internals/garbage-collector.md:252
+#: src/internals/garbage-collector.md:314
 msgid ""
 "The dedicated performance/rooting workflows have broader compiler and host "
 "requirements; their workflow files are the authority for exact commands and "
@@ -74663,11 +75674,11 @@ msgstr ""
 "专门的 performance/rooting 工作流具有更广泛的编译器和主机要求;它们的工作流文"
 "件是准确命令和相关性过器的权威."
 
-#: src/internals/garbage-collector.md:256
+#: src/internals/garbage-collector.md:318
 msgid "Historical evidence"
 msgstr "历史证据"
 
-#: src/internals/garbage-collector.md:258
+#: src/internals/garbage-collector.md:320
 msgid ""
 "[Generational GC plan](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md): original design and phase-by-phase landing log."
@@ -74675,7 +75686,7 @@ msgstr ""
 "[一代一代的总经理计划](https://github.com/PerryTS/perry/blob/main/docs/"
 "generational-gc-plan.md):原始设计和逐阶段的着陆日志."
 
-#: src/internals/garbage-collector.md:260
+#: src/internals/garbage-collector.md:322
 msgid ""
 "[Statepoint GC experiment](https://github.com/PerryTS/perry/blob/main/docs/"
 "statepoint-gc-experiment.md): chronological prototype measurements and "
@@ -74684,7 +75695,7 @@ msgstr ""
 "[状态点 GC 实验](https://github.com/PerryTS/perry/blob/main/docs/statepoint-"
 "gc-experiment.md):时间表原型测量和更正导致原生根默认."
 
-#: src/internals/garbage-collector.md:262
+#: src/internals/garbage-collector.md:324
 msgid ""
 "[GC rooting invariant](gc-rooting-invariant.md): current codegen soundness "
 "rule, checker modes, known blind spots, and debugging instruments."
@@ -74692,7 +75703,7 @@ msgstr ""
 "[GC根源变量](gc-rooting-invariant.md):当前的代码基因稳定性规则,检查模式,已知"
 "盲点和调试工具."
 
-#: src/internals/garbage-collector.md:264
+#: src/internals/garbage-collector.md:326
 msgid ""
 "[Memory Model](memory-model.md): NaN-boxing, allocation representation, and "
 "platform memory-tooling notes."
@@ -74985,7 +75996,8 @@ msgid ""
 msgstr "在一天内出货了4个. 检测的延迟,而不是解决,是每次的成本."
 
 #: src/internals/gc-rooting-invariant.md:63
-msgid "The five ways it has actually broken"
+#, fuzzy
+msgid "The six ways it has actually broken"
 msgstr "这五种方式实际上是破碎的"
 
 #: src/internals/gc-rooting-invariant.md:65
@@ -75126,14 +76138,55 @@ msgstr ""
 "`gc_register_mutable_root_scanner` 中,在 `gc/mod.rs` 中."
 
 #: src/internals/gc-rooting-invariant.md:132
+msgid "6. The root decision trusted a structural type inference (`?? null`)"
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:134
+msgid ""
+"`const masks = opts?.masks ?? null`, from a Three.js world builder. Optional "
+"chaining lowers the left side to an `Any`\\-typed conditional, and the `??` "
+"inference rule (`analysis/value_types.rs`, with an AST-level twin in "
+"`lower_types.rs`) answered the RIGHT operand's type for an unknown left, so "
+"the binding was declared `Null`. `collectors/pointer_locals.rs` distrusts "
+"declared types on purpose (#7846) and proves pointer-ness from the "
+"initializer — but its generic `expr_value_type` fallback ran that same "
+"inference and took `Null` as proof. No shadow slot, so no `ptr addrspace(1)` "
+"retype and nothing for `root_reload` to reload: the array's NaN-boxed "
+"address sat in a plain `alloca double` across the loop back-edge poll, the "
+"copying minor moved the array, and `masks[0]` read from-space (SIGBUS under "
+"`PERRY_GC_PROTECT_FROMSPACE=1`, silent garbage otherwise)."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:147
+msgid ""
+"An explicit `number[] | null` annotation changed the HIR type and nothing "
+"else. A plain ternary was rooted all along, because the collector's "
+"`Conditional` arm fails closed when either branch is unclassifiable — which "
+"is how the `??` path was isolated. The fix is both halves: `coalesce_type` "
+"keeps an unknown left unknown, and the collector's `Logical` arm requires "
+"both operands to classify before it answers, so a root decision never again "
+"rides on the inference."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:154
+msgid ""
+"_Tell:_ a local whose HIR type is `Null`, `Void` or `Number` while its "
+"initializer reads a property, calls, or coalesces. `--unrooted-allocas` was "
+"silent here: the stored value's provenance is a property read "
+"(`js_object_get_field_*`, an inline-cache slot load), which its heap-source "
+"vocabulary does not include — the same one-load gap #7664 closed for string "
+"handles, still open for field reads."
+msgstr ""
+
+#: src/internals/gc-rooting-invariant.md:161
 msgid "How to check your work"
 msgstr "如何检查自己的工作"
 
-#: src/internals/gc-rooting-invariant.md:134
+#: src/internals/gc-rooting-invariant.md:163
 msgid "1. The static checker — run this one"
 msgstr "1. 静态检查器运行这个"
 
-#: src/internals/gc-rooting-invariant.md:136
+#: src/internals/gc-rooting-invariant.md:165
 msgid ""
 "**Scope: emitted-LLVM rooting hazards only** — a stale register or an "
 "unrooted alloca in generated code. Within that scope it is the only "
@@ -75142,13 +76195,13 @@ msgstr ""
 "**适用范围:仅限于发射的LLVM根源危险** 生成代码中的一个老旧的注册或未根源的"
 "alloca. 在这种范围内,它是唯一能在撞车前发现缺陷的仪器,"
 
-#: src/internals/gc-rooting-invariant.md:140
+#: src/internals/gc-rooting-invariant.md:169
 msgid ""
 "**It is blind to three classes, all found the hard way. A clean report is "
 "not evidence for any of them:**"
 msgstr "**它对三种类型是盲目的, 一份清洁的报告并不是任何证据:**"
 
-#: src/internals/gc-rooting-invariant.md:143
+#: src/internals/gc-rooting-invariant.md:172
 msgid ""
 "**Runtime tables and interning caches** (#7231) — it reads emitted IR and "
 "cannot see a runtime cell. Tell: fails 10/10 rather than intermittently."
@@ -75156,7 +76209,7 @@ msgstr ""
 "**运行时间表和内部缓存** (#7231) 它读出发射的红外线,无法看到运行时的单元. 告"
 "诉:失败了10/10,而不是间歇性."
 
-#: src/internals/gc-rooting-invariant.md:145
+#: src/internals/gc-rooting-invariant.md:174
 msgid ""
 "**Unrooted locals in runtime Rust** (#7249) — same reason. It read `0 "
 "violations` on both sides of a real bug whose fix was a one-line "
@@ -75166,7 +76219,7 @@ msgstr ""
 "的虫子的两侧, 解决方案是一个行 `GcSuppressScope` 在 `globalThis` 这是一个很棒"
 "的机会."
 
-#: src/internals/gc-rooting-invariant.md:148
+#: src/internals/gc-rooting-invariant.md:177
 msgid ""
 "**Anything its symbol sets do not name** (#7284) — `POLL_CAPABLE_RUNTIME` is "
 "an _exact emitted-symbol_ set. It carried `js_object_get_field_by_name`, "
@@ -75182,7 +76235,7 @@ msgstr ""
 "性得到`MOVING: no`,并且31个过时的用途被`--moving-only`取消. **检查这些集与代"
 "码的实际发射, #7227检查`ALLOC_RE`.**"
 
-#: src/internals/gc-rooting-invariant.md:155
+#: src/internals/gc-rooting-invariant.md:184
 msgid ""
 "For the classes above, the instruments that catch them are the schedule/"
 "quarantine arms below and a _dependency-scale_ workload — #7280 records 25 "
@@ -75191,7 +76244,7 @@ msgstr ""
 "对于上述类,捕获它们的工具是下面的schedule/quarantine臂和一个_依赖度尺度_工作"
 "负载#7280记录了25个整理的文件,而20行的库存数据失败."
 
-#: src/internals/gc-rooting-invariant.md:159
+#: src/internals/gc-rooting-invariant.md:188
 msgid ""
 "**A fourth class was on this list until #7663 and is now covered: the "
 "lowering that actually ships.** The corpus used to be compiled under "
@@ -75205,26 +76258,13 @@ msgstr ""
 "子堆,因为检查器定在 `@js_shadow_slot_bind` 上,原生降低发出了零. 这使得绿色的"
 "`gc-root-dominance`是一个关于降低的声明, **两者都运行**并且知道你跑了哪一个:"
 
-#: src/internals/gc-rooting-invariant.md:168
+#: src/internals/gc-rooting-invariant.md:197
+#, fuzzy
 msgid ""
-"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64"
+"# SHADOW (PERRY_RS4GC=0): still the lowering on arm64_32 watchOS and ARM64\n"
 msgstr "# 阴影 (PERRY_RS4GC=0):仍然是arm64_32,watchOS和ARM64的降低"
 
-#: src/internals/gc-rooting-invariant.md:174
-msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
-msgstr "# 本地 (PERRY_RS4GC=1):其他地方的默认. 着"
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid "\"gc-live\""
-msgstr "\"gc-live\""
-
-#: src/internals/gc-rooting-invariant.md:176
-msgid ""
-"# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, so "
-"the"
-msgstr "# `ptr addrspace(1)` 根配置,并 LLVM 插入后的安全点,所以"
-
-#: src/internals/gc-rooting-invariant.md:184
+#: src/internals/gc-rooting-invariant.md:213
 msgid ""
 "Each mode **refuses the other's corpus** rather than reporting it clean: the "
 "native corpus has zero root stores, so `--min-binds` fails there, and the "
@@ -75233,11 +76273,11 @@ msgstr ""
 "每一个模式 **拒绝对方的身体** 而不是报告清洁:原始体没有根存储,所以`--min-"
 "binds`失败了,而影子体没有安全点,所以`--min-statepoints`失败了."
 
-#: src/internals/gc-rooting-invariant.md:188
+#: src/internals/gc-rooting-invariant.md:217
 msgid "What `--statepoints` checks, and how it differs"
 msgstr "`--statepoints` 检查的内容,以及它的区别"
 
-#: src/internals/gc-rooting-invariant.md:190
+#: src/internals/gc-rooting-invariant.md:219
 msgid ""
 "Under native roots a value is a root at a safepoint iff it appears in that "
 "`gc.statepoint`'s `\"gc-live\"` bundle, and its identity below the safepoint "
@@ -75248,13 +76288,13 @@ msgstr ""
 "上的根,并且其安全点下方的身份是 `gc.relocate` 结果. 所以\"根储存必须主导每一"
 "个后来的收集点\"变成:"
 
-#: src/internals/gc-rooting-invariant.md:195
+#: src/internals/gc-rooting-invariant.md:224
 msgid ""
 "No register naming a GC object may be USED below a safepoint unless it is "
 "the relocated value."
 msgstr "除非它是移动值,否则在安全点以下不能使用命名GC对象的注册."
 
-#: src/internals/gc-rooting-invariant.md:198
+#: src/internals/gc-rooting-invariant.md:227
 msgid ""
 "The line that does the work is **tracked vs untracked**. LLVM relocates `ptr "
 "addrspace(1)` SSA values and rewrites their dominated uses, so those are "
@@ -75267,23 +76307,23 @@ msgstr ""
 "JSValue花费大部分时间作为一个 `double`这里是我的家. 两类判决,因为它们有两种不"
 "同的解决方案:"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "class"
 msgstr "class"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "means"
 msgstr "means"
 
-#: src/internals/gc-rooting-invariant.md:204
+#: src/internals/gc-rooting-invariant.md:233
 msgid "fix"
 msgstr "fix"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "`unrooted`"
 msgstr "`unrooted`"
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid ""
 "no `ptr addrspace(1)` value in the register's cast chain is in the "
 "safepoint's live bundle. Nothing marks or rewrites the object."
@@ -75291,25 +76331,25 @@ msgstr ""
 "没有`ptr addrspace(1)`值在注册的链中,在安全点的活束中. 没有什么标记或重写物"
 "体."
 
-#: src/internals/gc-rooting-invariant.md:206
+#: src/internals/gc-rooting-invariant.md:235
 msgid "root it"
 msgstr "根除它"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "`stale`"
 msgstr "`stale`"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid ""
 "the object IS in the bundle and is relocated, but a raw copy of its pre-move "
 "address is used below"
 msgstr "该对象在包中并被移动,但下面使用了其移动前地址的原始副本"
 
-#: src/internals/gc-rooting-invariant.md:207
+#: src/internals/gc-rooting-invariant.md:236
 msgid "re-derive from the relocated value (`OperandProtection::Reload`)"
 msgstr "从移动值 (`OperandProtection::Reload`) 中重新导出"
 
-#: src/internals/gc-rooting-invariant.md:209
+#: src/internals/gc-rooting-invariant.md:238
 msgid ""
 "Two things this mode gets for free that the shadow modes cannot: "
 "**`NONCOLLECTING` is not consulted** — LLVM already decided which calls are "
@@ -75323,7 +76363,7 @@ msgstr ""
 "隐藏此处的危险; **它的名字是包裹的**,所以`--moving-only`根据实际符号而不是"
 "`llvm.experimental.gc.statepoint.p0`进行分类."
 
-#: src/internals/gc-rooting-invariant.md:216
+#: src/internals/gc-rooting-invariant.md:245
 msgid ""
 "It parses the emitted LLVM IR, builds per-function CFGs, computes real "
 "Cooper/Harvey/Kennedy dominance, and reports every **collection point** that "
@@ -75343,15 +76383,15 @@ msgstr ""
 "的. 它是片面的:一个不被识别的电话被认为是收集的,所以其模型中的漏洞需要一个假"
 "阳性,永远不会错过错误."
 
-#: src/internals/gc-rooting-invariant.md:226
+#: src/internals/gc-rooting-invariant.md:255
 msgid "For a single file you are iterating on:"
 msgstr "对于您正在代的单个文件:"
 
-#: src/internals/gc-rooting-invariant.md:234
+#: src/internals/gc-rooting-invariant.md:263
 msgid "Both env knobs matter, for different reasons."
 msgstr "两种环保杆都很重要,"
 
-#: src/internals/gc-rooting-invariant.md:236
+#: src/internals/gc-rooting-invariant.md:265
 msgid ""
 "`PERRY_GC_MOVING_LOOP_POLLS=1` is what puts `js_gc_loop_safepoint` in the "
 "IR. It is the only collection point a **back edge itself** introduces — a "
@@ -75365,7 +76405,7 @@ msgstr ""
 "次,只有这样. 所以一个需要在不动循环体的两个点之间收集的虫子, 没有它就不能出现"
 "在体内."
 
-#: src/internals/gc-rooting-invariant.md:242
+#: src/internals/gc-rooting-invariant.md:271
 msgid ""
 "It is **not** what makes the `MOVING` classification work, and it is not the "
 "only collection point that can run inside a loop — a `POLL_CAPABLE_RUNTIME` "
@@ -75385,18 +76425,18 @@ msgstr ""
 "如 `js_object_set_field_by_name`, `js_object_get_field_ic_miss` 和 "
 "`js_closure_call1`. 没有任何民意调查."
 
-#: src/internals/gc-rooting-invariant.md:252
+#: src/internals/gc-rooting-invariant.md:281
 msgid ""
 "So: turn the knob on, because it widens what the corpus can express, but do "
 "not read a poll-free function as safe."
 msgstr "所以:打开按,因为它扩大了体内表达的内容,"
 
-#: src/internals/gc-rooting-invariant.md:255
+#: src/internals/gc-rooting-invariant.md:284
 msgid ""
 "`POLL_CAPABLE_RUNTIME` is by EXACT emitted symbol, and that has bitten twice"
 msgstr "`POLL_CAPABLE_RUNTIME`是EXACT发出的符号,并且已经咬了两次"
 
-#: src/internals/gc-rooting-invariant.md:257
+#: src/internals/gc-rooting-invariant.md:286
 msgid ""
 "`movers` is a set-membership test on the callee name, so an entry that names "
 "a symbol codegen does not emit classifies nothing, forever, and looks "
@@ -75406,7 +76446,8 @@ msgstr ""
 "`movers`是对调用名的集合成员测试,所以一个命名符号的条目不会发出任何永远的分"
 "类,并且看起来完全像覆盖. 现在已经测量了两轮:"
 
-#: src/internals/gc-rooting-invariant.md:261
+#: src/internals/gc-rooting-invariant.md:290
+#, fuzzy
 msgid ""
 "**A real symbol codegen never emits.** The set carried "
 "`js_object_get_field_by_name` next to `js_object_set_field_by_name`, which "
@@ -75417,7 +76458,7 @@ msgid ""
 "set. Property sets classified `MOVING: YES`, property gets classified "
 "`MOVING: no`, and 31 `--stale-registers` hits on the gate corpus were "
 "dropped by `--moving-only` as a result — including the shape that faults "
-"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1  "
+"deterministically under `PERRY_GC_PROTECT_FROMSPACE=1 "
 "PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` at zod's `clone`. The protector and "
 "the checker disagreed; the checker was wrong."
 msgstr ""
@@ -75430,7 +76471,7 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1  PERRY_GC_PROTECT_FROMSPACE_DEPTH=800` 在Zod的"
 "房间里 `clone`这里是我的家. 保护者和检查者不同意;检查者错了."
 
-#: src/internals/gc-rooting-invariant.md:273
+#: src/internals/gc-rooting-invariant.md:302
 msgid ""
 "**Ten names that were not symbols at all.** `js_apply_function`, "
 "`js_array_for_each`, `js_array_sort`, `js_call_closure`, `js_call_value`, "
@@ -75448,7 +76489,7 @@ msgstr ""
 "说\"调用JS关闭\"的四种不同的方法,因此语言中最明显的投票操作被覆盖了零次;真正"
 "的输入点是`js_closure_callN`,该文件中的`RECEIVER_SINKS`已经正确拼写."
 
-#: src/internals/gc-rooting-invariant.md:283
+#: src/internals/gc-rooting-invariant.md:312
 msgid ""
 "**A real symbol that was simply not in the set** (#7616 / #7453). The two "
 "rounds above are both a NAME WITH NO REFERENT, and both audits look only in "
@@ -75465,60 +76506,60 @@ msgstr ""
 "评论说\"这个差距是检查器为什么没有标记#7453\"_并停止了一个短的列表,因此形状从"
 "未在CI运行模式下被捕获. 重新植入这个准确的代码并运行每个模式 (#7616):"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "clean"
 msgstr "clean"
 
-#: src/internals/gc-rooting-invariant.md:292
+#: src/internals/gc-rooting-invariant.md:321
 msgid "sabotaged"
 msgstr "sabotaged"
 
-#: src/internals/gc-rooting-invariant.md:294
+#: src/internals/gc-rooting-invariant.md:323
 msgid "`--moving-only` (dominance)"
 msgstr "`--moving-only` (占主导地位)"
 
-#: src/internals/gc-rooting-invariant.md:294
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:324
 msgid "**0**"
 msgstr "**0**"
 
-#: src/internals/gc-rooting-invariant.md:295
+#: src/internals/gc-rooting-invariant.md:324
 msgid "`--unrooted-allocas --moving-only`"
 msgstr "`--unrooted-allocas --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:296
+#: src/internals/gc-rooting-invariant.md:325
 msgid "`--stale-registers --moving-only`"
 msgstr "`--stale-registers --moving-only`"
 
-#: src/internals/gc-rooting-invariant.md:297
+#: src/internals/gc-rooting-invariant.md:326
 msgid "`--statepoints --moving-only` (the lowering that ships)"
 msgstr "`--statepoints --moving-only` (降低的船只)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "`--stale-registers` (unfiltered)"
 msgstr "`--stale-registers` (没有过)"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "24"
 msgstr "24"
 
-#: src/internals/gc-rooting-invariant.md:298
+#: src/internals/gc-rooting-invariant.md:327
 msgid "35"
 msgstr "35"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "`--statepoints` (unfiltered)"
 msgstr "`--statepoints` (没有过)"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "15"
 msgstr "15"
 
-#: src/internals/gc-rooting-invariant.md:299
+#: src/internals/gc-rooting-invariant.md:328
 msgid "21"
 msgstr "21"
 
-#: src/internals/gc-rooting-invariant.md:301
+#: src/internals/gc-rooting-invariant.md:330
 msgid ""
 "Every gated arm blind, both unfiltered arms not — _including_ `--"
 "statepoints`, added in #7663 precisely because the other three were blind to "
@@ -75529,7 +76570,7 @@ msgstr ""
 "他三个是盲人的运输降低. 添加一个名字使得破坏的武器达到13和8, 清洁的武器则为2"
 "和2."
 
-#: src/internals/gc-rooting-invariant.md:306
+#: src/internals/gc-rooting-invariant.md:335
 msgid ""
 "**A poll-capable symbol NO audit can ask for** (#8809). `--audit-poll-reach` "
 "walks only symbols `ALLOC_RE` matches, so a helper that allocates but spells "
@@ -75554,7 +76595,7 @@ msgstr ""
 "分配的运行时辅助器时, 将其添加到同一个提交中的`POLL_CAPABLE_RUNTIME`中.** 没"
 "有人会要求你."
 
-#: src/internals/gc-rooting-invariant.md:319
+#: src/internals/gc-rooting-invariant.md:348
 msgid ""
 "`--audit-poll-capable` is the gate for rounds 1–2 and `--audit-poll-reach` "
 "is the gate for round 3; round 4 has no gate. `gc-root-dominance.yml` runs "
@@ -75563,7 +76604,7 @@ msgstr ""
 "`--audit-poll-capable`是轮12的门,`--audit-poll-reach`是轮3的门,轮4没有门. 在"
 "构建之前,`gc-root-dominance.yml` 与 `--audit-alloc-re` 一起运行."
 
-#: src/internals/gc-rooting-invariant.md:323
+#: src/internals/gc-rooting-invariant.md:352
 msgid ""
 "**Those pre-build audits are also the job's single point of failure, and it "
 "has already cost ten days.** `--audit-poll-reach` went red on `main` on "
@@ -75584,7 +76625,7 @@ msgstr ""
 "管理的警告, `--audit-poll-capable` 失败在任何没有出口 `extern \"C\" fn js_*` "
 "的条目中. 当它变成红色时, **取代** 而不是删除它删除会使审计绿色,并离开洞."
 
-#: src/internals/gc-rooting-invariant.md:334
+#: src/internals/gc-rooting-invariant.md:363
 msgid ""
 "`--audit-poll-reach` fails when a symbol `ALLOC_RE` matches reaches a "
 "`POLL_CAPABLE_RUNTIME` symbol through the runtime's own call graph without "
@@ -75607,19 +76648,15 @@ msgstr ""
 "固定点 (一个跳转版本报告了52个名字,并且在添加它们后重新运行发现了10个),评论和"
 "字符串字母首先被剥离,因此散文中提到的名字不能成为前提."
 
-#: src/internals/gc-rooting-invariant.md:347
+#: src/internals/gc-rooting-invariant.md:376
 msgid "Checking a _plausible_ name is not enough. Confirm against emitted IR:"
 msgstr "检查一个_可信的_名字不够. 通过发射IR确认:"
 
-#: src/internals/gc-rooting-invariant.md:350
+#: src/internals/gc-rooting-invariant.md:379
 msgid "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 msgstr "'call [^@]*@js_[A-Za-z0-9_.$]*('"
 
-#: src/internals/gc-rooting-invariant.md:351
-msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
-
-#: src/internals/gc-rooting-invariant.md:354
+#: src/internals/gc-rooting-invariant.md:383
 msgid ""
 "`PERRY_INLINE_SHADOW_SLOT=0` makes every root store the "
 "`js_shadow_slot_bind` call form the checker anchors on."
@@ -75627,7 +76664,7 @@ msgstr ""
 "`PERRY_INLINE_SHADOW_SLOT=0`使每个根存储 `js_shadow_slot_bind`调用表格的检查"
 "器."
 
-#: src/internals/gc-rooting-invariant.md:357
+#: src/internals/gc-rooting-invariant.md:386
 msgid ""
 "`--stale-registers` (#7206) additionally catches values that are _never_ "
 "rooted — read out of a root and held in a register across a collection "
@@ -75640,7 +76677,7 @@ msgstr ""
 "现案例3和4的模式. 它运输和运行,但 **上面的门命令不能传递它**: 绑定固扫描是由"
 "允许列表基线的臂,所以当您手动运行此模式时,"
 
-#: src/internals/gc-rooting-invariant.md:363
+#: src/internals/gc-rooting-invariant.md:392
 msgid ""
 "`--unrooted-allocas` (#7207) covers the remaining shape, and is the one the "
 "bind-anchored check is structurally blind to: the value lives in a plain "
@@ -75654,7 +76691,7 @@ msgstr ""
 "`js_shadow_slot_bind`可以定,从绑定开始的扫描将函数称为清洁. 它发现了"
 "`lower_call/new.rs`的直线导数`this_slot`,"
 
-#: src/internals/gc-rooting-invariant.md:370
+#: src/internals/gc-rooting-invariant.md:399
 msgid ""
 "**The gate runs this mode as of #7236, and the corpus reads 0.** It could "
 "not before: #7210 measured 66 hits and triaged every one as a false "
@@ -75669,15 +76706,15 @@ msgstr ""
 "`collectors/pointer_locals.rs`将`Type::Symbol`归类为直接的,因此`Symbol`本地没"
 "有任何阴影槽. 当您触摸一个`alloca_entry`网站时,手动运行:"
 
-#: src/internals/gc-rooting-invariant.md:382
+#: src/internals/gc-rooting-invariant.md:411
 msgid "2. The runtime instruments — second, and mind the depth"
 msgstr "2. 运行时间仪器秒,并注意深度"
 
-#: src/internals/gc-rooting-invariant.md:384
+#: src/internals/gc-rooting-invariant.md:413
 msgid "From #7196:"
 msgstr "从7196号:"
 
-#: src/internals/gc-rooting-invariant.md:386
+#: src/internals/gc-rooting-invariant.md:415
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` (with a seed) — collect at every candidate "
 "safepoint, allocation-paced (#7728): one candidate per "
@@ -75690,7 +76727,7 @@ msgstr ""
 "`PERRY_GC_SCHEDULE_ALLOC_KB=0` 为字面上的每次投票模式,当您正在搜索的窗口只执"
 "行一次时,它要慢得多."
 
-#: src/internals/gc-rooting-invariant.md:391
+#: src/internals/gc-rooting-invariant.md:420
 msgid ""
 "`PERRY_GC_PROTECT_FROMSPACE=1` — `mprotect` from-space after evacuation so a "
 "stale read faults immediately instead of reading plausible garbage."
@@ -75698,11 +76735,12 @@ msgstr ""
 "`PERRY_GC_PROTECT_FROMSPACE=1`  `mprotect` 在疏散后从太空,所以一个陈旧的阅读"
 "错误立即而不是阅读可信的垃圾."
 
-#: src/internals/gc-rooting-invariant.md:393
+#: src/internals/gc-rooting-invariant.md:422
 msgid "`PERRY_GC_FROMSPACE_SCAN_ABORT` — now actually runs."
 msgstr "`PERRY_GC_FROMSPACE_SCAN_ABORT` 现在实际运行."
 
-#: src/internals/gc-rooting-invariant.md:394
+#: src/internals/gc-rooting-invariant.md:423
+#, fuzzy
 msgid ""
 "`PERRY_GC_SCHEDULE_SEED=<u64>` (+ `PERRY_GC_SCHEDULE_RATE`, default `0.05`) "
 "— collect on a deterministic pseudo-random schedule. At `RATE=1` it collects "
@@ -75710,7 +76748,7 @@ msgid ""
 "that is _too_ blunt — on a workload whose timing it distorts enough to kill "
 "somewhere uninteresting — and the schedule thins out without losing the "
 "property that matters. The schedule is a pure function of `(seed, per-thread "
-"safepoint  ordinal)`, so a seed that fails is a reproducer, which is what "
+"safepoint ordinal)`, so a seed that fails is a reproducer, which is what "
 "turns \"1 run in 60\" into something you can bisect against. `scripts/"
 "gc_schedule_fuzz.sh <binary> [seed-count]` sweeps seeds and prints a "
 "reproduce command per failure."
@@ -75722,7 +76760,7 @@ msgstr ""
 "`scripts/gc_schedule_fuzz.sh <binary> [seed-count]` 扫描种子,并按每次失败打印"
 "一个重现命令."
 
-#: src/internals/gc-rooting-invariant.md:405
+#: src/internals/gc-rooting-invariant.md:434
 msgid ""
 "**A rate is not a substitute for a schedule.** Re-running one binary 60 "
 "times re-runs one schedule 60 times; with zero failures in `N` runs the 95% "
@@ -75734,7 +76772,7 @@ msgstr ""
 "运行上限95%的真实率只有~`3/N`所以120个干净的运行 1.7百分之百的虫 2.5没有任何"
 "证据. 变化是唯一便宜的方式来探索虫子实际生活的空间."
 
-#: src/internals/gc-rooting-invariant.md:411
+#: src/internals/gc-rooting-invariant.md:440
 msgid ""
 "**`PERRY_GC_PROTECT_FROMSPACE_DEPTH` defaults to 4, and that default "
 "produces FALSE GREENS.** Four levels of retained from-space is not enough to "
@@ -75745,7 +76783,7 @@ msgstr ""
 "有四个层次的存储空间不足以保持您的老旧指针在被删除时的区块. **使用800号.** 在"
 "默认的深度上进行清洁运行意味着什么."
 
-#: src/internals/gc-rooting-invariant.md:416
+#: src/internals/gc-rooting-invariant.md:445
 msgid ""
 "Depth is a **detection-window** knob, not a sensitivity knob, and the "
 "difference matters when the two instruments disagree. A page-set enters the "
@@ -75767,7 +76805,7 @@ msgstr ""
 "成功不能制造假阳性. 所以\"保护器有故障,但只有在DEPTH=800时\"永远不是怀疑保护"
 "器的理由;当它与静态检查器不一致时, 这就是如何解决Zod `clone`的分歧."
 
-#: src/internals/gc-rooting-invariant.md:428
+#: src/internals/gc-rooting-invariant.md:457
 msgid ""
 "And when a fault does fire, **walk UP the stack**. The reporter names the "
 "frame that DEREFERENCED the stale value, which is usually not the frame that "
@@ -75777,7 +76815,7 @@ msgstr ""
 "而当一个错误发生时, **走上堆**. 报告员命名的框架是DEREFERENCE的陈旧值,通常不"
 "是拥有注册的框架,值通常来自一个调用者,让它陈旧."
 
-#: src/internals/gc-rooting-invariant.md:433
+#: src/internals/gc-rooting-invariant.md:462
 msgid ""
 "And remember the ceiling on all of these: if the collection happens while "
 "the only copy is in a register, there is nothing at that moment for any "
@@ -75787,11 +76825,11 @@ msgstr ""
 "记住所有这些的上限:如果收集发生在唯一的副本在注册表中, 这些仪器会在后面捕捉到"
 "后果. 静态检查器现在捕获了原因."
 
-#: src/internals/gc-rooting-invariant.md:438
+#: src/internals/gc-rooting-invariant.md:467
 msgid "The mirror image: a missing write barrier (#8185)"
 msgstr "镜像:一个缺失的写字屏障 (#8185)"
 
-#: src/internals/gc-rooting-invariant.md:440
+#: src/internals/gc-rooting-invariant.md:469
 msgid ""
 "Everything above is about a value the collector cannot **find**. The write "
 "barrier is about an edge the collector is never **told about**. The two are "
@@ -75802,43 +76840,43 @@ msgstr ""
 "器是永远不会 **关于**. 这两个是双重的, 这是继续抓住人们的部分 **它们的探测器"
 "被换了**."
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "rooting bug"
 msgstr "根虫"
 
-#: src/internals/gc-rooting-invariant.md:445
+#: src/internals/gc-rooting-invariant.md:474
 msgid "missing/deleted write barrier"
 msgstr "missing/deleted 写入屏障"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "what goes wrong"
 msgstr "有什么问题"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "a live value is invisible to the root scan"
 msgstr "一个现存值是无形的根扫描"
 
-#: src/internals/gc-rooting-invariant.md:447
+#: src/internals/gc-rooting-invariant.md:476
 msgid "an old→young edge is absent from the remembered set"
 msgstr "一个旧→年轻的边缘不在记忆集中"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "when it goes wrong"
 msgstr "当事情不顺利时"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "at the collection, silently"
 msgstr "在收藏中,默默地"
 
-#: src/internals/gc-rooting-invariant.md:448
+#: src/internals/gc-rooting-invariant.md:477
 msgid "not at the store at all; at some _later_ minor"
 msgstr "没有在商店;在一些 _ 后来_ 小"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "the detector"
 msgstr "检测器"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid ""
 "the runtime instruments (`PERRY_GC_SCHEDULE_RATE`, "
 "`PERRY_GC_PROTECT_FROMSPACE`), plus the static checker for the IR-visible "
@@ -75847,28 +76885,28 @@ msgstr ""
 "运行时仪器 (`PERRY_GC_SCHEDULE_RATE`,`PERRY_GC_PROTECT_FROMSPACE`),加上IR可见"
 "半径的静态检查器"
 
-#: src/internals/gc-rooting-invariant.md:449
+#: src/internals/gc-rooting-invariant.md:478
 msgid "a **static IR assertion**, and nothing else"
 msgstr "a **静态IR断言**没有别的"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "the blind spot"
 msgstr "盲点"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid ""
 "the static checker cannot see a runtime-side cache of a heap pointer (see §5)"
 msgstr "静态检查器无法看到堆指针的运行时侧缓存 (见第5段)"
 
-#: src/internals/gc-rooting-invariant.md:450
+#: src/internals/gc-rooting-invariant.md:479
 msgid "**every runtime probe we have**"
 msgstr "**我们的每一个运行时间探测器**"
 
-#: src/internals/gc-rooting-invariant.md:452
+#: src/internals/gc-rooting-invariant.md:481
 msgid "Why no runtime probe can see it"
 msgstr "为什么没有运行时间探测器可以看到它"
 
-#: src/internals/gc-rooting-invariant.md:454
+#: src/internals/gc-rooting-invariant.md:483
 msgid ""
 "A dropped barrier corrupts nothing at the moment of the store. The store "
 "still writes the right bits into the right slot; the object graph is "
@@ -75880,16 +76918,16 @@ msgstr ""
 "中, 只有记住的集合输入不被写入,所以集合只是不完整的. 为了将它变成可观察的故"
 "障,需要程序自行提供一个结合:"
 
-#: src/internals/gc-rooting-invariant.md:460
+#: src/internals/gc-rooting-invariant.md:489
 msgid ""
 "the parent has to survive into old-gen (or be tenured) **before** the store;"
 msgstr "父母必须活到老年 (或是持有职位) **在之前** 商店;"
 
-#: src/internals/gc-rooting-invariant.md:461
+#: src/internals/gc-rooting-invariant.md:490
 msgid "the child has to still be in the nursery **at the next minor**;"
 msgstr "孩子必须还在幼儿园 **在下一个未成年**;"
 
-#: src/internals/gc-rooting-invariant.md:462
+#: src/internals/gc-rooting-invariant.md:491
 msgid ""
 "a **minor** collection — not a full mark-sweep, which retraces everything "
 "and papers over the whole class — has to land in that window; and"
@@ -75897,26 +76935,26 @@ msgstr ""
 "a **较小的** 收藏不是一个完整的标记扫描, 追溯一切和整个课堂上的文件必须落在窗"
 "口;"
 
-#: src/internals/gc-rooting-invariant.md:464
+#: src/internals/gc-rooting-invariant.md:493
 msgid ""
 "that edge has to be the _only_ path to the child, or some other root finds "
 "it anyway and the collection is clean."
 msgstr "这边必须是唯一的路径,或者其他根找到它,集合是干净的."
 
-#: src/internals/gc-rooting-invariant.md:467
+#: src/internals/gc-rooting-invariant.md:496
 msgid ""
 "Miss any one and the minor collects correctly, the program prints the right "
 "answer, and the probe reports success. Nothing was tried."
 msgstr "错过任何一个,未成年人正确收集,程序打印出正确的答案, 没有尝试过."
 
-#: src/internals/gc-rooting-invariant.md:470
+#: src/internals/gc-rooting-invariant.md:499
 msgid ""
 "The individual knobs are worse than merely insensitive — three of them are "
 "aimed at a different property entirely, and it is easy to read their green "
 "as evidence:"
 msgstr "单独的旋不仅仅是不敏感的, 它们中的三个完全针对不同的特性,"
 
-#: src/internals/gc-rooting-invariant.md:474
+#: src/internals/gc-rooting-invariant.md:503
 msgid ""
 "`PERRY_GC_FORCE_EVACUATE` / `PERRY_GC_VERIFY_EVACUATION` verify "
 "**rewriting**: that every live slot pointing at a forwarded object was "
@@ -75928,7 +76966,7 @@ msgstr ""
 "向转发对象的每个现场插槽. 收藏家从来没有找到的位置并不是他无法重写的位置. 记"
 "住和重写是不同的特性,验证器只询问第二个特性."
 
-#: src/internals/gc-rooting-invariant.md:479
+#: src/internals/gc-rooting-invariant.md:508
 msgid ""
 "`PERRY_GEN_GC=0` reverts to full mark-sweep, which **does not consult the "
 "remembered set at all**. It does not make the bug visible; it makes the bug "
@@ -75938,7 +76976,7 @@ msgstr ""
 "`PERRY_GEN_GC=0` 返回到完全标记扫描, **没有查询记忆集**. 这并不是使虫子看得"
 "见,而是使虫子无法接触. 这里的绿色走势是三者中看起来最强大,最空洞的证据."
 
-#: src/internals/gc-rooting-invariant.md:483
+#: src/internals/gc-rooting-invariant.md:512
 msgid ""
 "`PERRY_GC_SCHEDULE_RATE=1` + `PERRY_GC_PROTECT_FROMSPACE` catch a _stale "
 "read of a moved object_ — condition (4)'s aftermath, on the rooting side of "
@@ -75949,7 +76987,7 @@ msgstr ""
 "移动对象_ 条件 (4) 的后果. 它们的错误来自悬挂在太空的指针, 而不是从未被追踪的"
 "活物体."
 
-#: src/internals/gc-rooting-invariant.md:488
+#: src/internals/gc-rooting-invariant.md:517
 msgid ""
 "And check the knob you are about to cite is a knob. `scripts/"
 "check_gc_env_knobs.py` is in `lint` precisely because this drifts: a matrix "
@@ -75961,7 +76999,7 @@ msgstr ""
 "在于 `lint` 中:一个矩阵臂命名变量 nothing parses 运行了 DEFAULT 配置,并再次报"
 "告成功 危险 4,升级了一级. 这份文件中的每一个名字都是一个现场解析器所拥有的."
 
-#: src/internals/gc-rooting-invariant.md:494
+#: src/internals/gc-rooting-invariant.md:523
 msgid ""
 "This is CLAUDE.md's hazard 4 (\"the gate runs but its subject never did\") "
 "with the subject inverted: **the absence of a barrier cannot be observed by "
@@ -75971,7 +77009,7 @@ msgstr ""
 "这是CLAUDE.md的危险4 (\"门运行,但主体从来没有\") **通过运行程序无法观察到缺失"
 "障碍.** 没有任何处决案例\"不经过障碍\"是可区分的事件."
 
-#: src/internals/gc-rooting-invariant.md:499
+#: src/internals/gc-rooting-invariant.md:528
 msgid ""
 "**Recorded, because it is the whole reason the IR assertions exist "
 "(#8183):** a **release** build with the write barrier deleted from the "
@@ -75988,18 +77026,18 @@ msgstr ""
 "和强制收集与空间保护在深度400 **字节相同输出,输出0**,在一个间隙固定器和一个更"
 "大的对抗. 静态红外测试是唯一拒绝的."
 
-#: src/internals/gc-rooting-invariant.md:507
+#: src/internals/gc-rooting-invariant.md:536
 msgid "What a PR that adds or moves a store on a GC slot owes"
 msgstr "增加或移动一个商店的公关人员欠什么"
 
-#: src/internals/gc-rooting-invariant.md:509
+#: src/internals/gc-rooting-invariant.md:538
 msgid ""
 "Its barrier evidence is a **static IR assertion**, not a behavioural test. "
 "Four things it has to pin, each because a sabotage that skipped it was _not_ "
 "caught:"
 msgstr "它的屏障证据是 **静态IR断言**这不是一种行为测试. 它们必须住四个东西,"
 
-#: src/internals/gc-rooting-invariant.md:512
+#: src/internals/gc-rooting-invariant.md:541
 msgid ""
 "**The bookkeeping is present** in the pointer-capable arm — the write "
 "barrier, the layout note, and the string addref. Any one of the three going "
@@ -76008,7 +77046,7 @@ msgstr ""
 "**账户管理人员已经到来** 在指针可用的臂上写入屏障,布局注释和字符串addref. 任"
 "何一个失踪的三人都是#5094 / #7511家庭的沉默浅."
 
-#: src/internals/gc-rooting-invariant.md:515
+#: src/internals/gc-rooting-invariant.md:544
 msgid ""
 "**The arm is REACHED.** Assert a `br i1` _into_ the block, not merely that a "
 "block with that label exists. #8183's third sabotage — routing reference "
@@ -76020,7 +77058,7 @@ msgstr ""
 "的助手 离开了手臂后面 **死亡 IR** 每个内容的断言都被快乐地检查, 代码的存在并"
 "不是它运行的证据."
 
-#: src/internals/gc-rooting-invariant.md:520
+#: src/internals/gc-rooting-invariant.md:549
 msgid ""
 "**The negative arm stays clean.** The pointer-free arm must _not_ contain "
 "the bookkeeping. A barrier leaking into it means the discriminator stopped "
@@ -76029,7 +77067,7 @@ msgstr ""
 "**负手保持清洁.** 没有指针的手臂不能包含会计. 一个障碍泄漏到它意味着歧视者停"
 "止歧视,"
 
-#: src/internals/gc-rooting-invariant.md:523
+#: src/internals/gc-rooting-invariant.md:552
 msgid ""
 "**Sabotage runs, reported.** Delete each element in turn and record that the "
 "test goes red. A test that has never failed is a test whose failure mode is "
@@ -76038,9 +77076,10 @@ msgstr ""
 "**据报道是破坏行动.** 轮流删除每个元素,并记录测试变红. 一个从未失败的测试是未"
 "知失败模式的测试."
 
-#: src/internals/gc-rooting-invariant.md:527
+#: src/internals/gc-rooting-invariant.md:556
+#, fuzzy
 msgid ""
-"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib  --"
+"And put it where it runs. `test.yml`'s per-PR `cargo-test` arm is `--lib --"
 "bins` only; `crates/*/tests/*.rs` is nightly/tag (`e2e-scoped` runs only the "
 "suites the diff happens to name). A barrier assertion parked in `tests/` "
 "gates its own PR and no future one — which is exactly the PR that will move "
@@ -76056,30 +77095,23 @@ msgstr ""
 "perry-codegen/src/expr/class_field_barrier_tests.rs`、"
 "`index_set_barrier_tests.rs` 和 `write_pic_barrier_tests.rs` 的形式。"
 
-#: src/internals/gc-rooting-invariant.md:535
+#: src/internals/gc-rooting-invariant.md:564
 msgid "The `GC_STORE_AUDIT` marker, and what it does and does not prove"
 msgstr "`GC_STORE_AUDIT`标记器,以及它所做的和不证明的"
 
-#: src/internals/gc-rooting-invariant.md:537
+#: src/internals/gc-rooting-invariant.md:566
 msgid ""
 "Every raw GC-relevant store site carries a nearby marker naming its verdict:"
 msgstr "每个原始的GC相关的商店网站都有附近的标记,"
 
-#: src/internals/gc-rooting-invariant.md:540
+#: src/internals/gc-rooting-invariant.md:569
 msgid ""
-"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
-msgstr "// GC_STORE_AUDIT(BARRIERED): 插槽写作是无条件的; 屏障"
+"// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier\n"
+"// below is guarded only by a live test that the stored bits carry no heap\n"
+"// pointer, which is the barrier's own first test.\n"
+msgstr ""
 
-#: src/internals/gc-rooting-invariant.md:540
-msgid ""
-"// below is guarded only by a live test that the stored bits carry no heap"
-msgstr "// 在下面只通过实时测试来保护存储的位没有堆"
-
-#: src/internals/gc-rooting-invariant.md:541
-msgid "// pointer, which is the barrier's own first test."
-msgstr "//指针,这是屏障的第一个测试."
-
-#: src/internals/gc-rooting-invariant.md:545
+#: src/internals/gc-rooting-invariant.md:574
 msgid ""
 "The classes are `BARRIERED`, `EXTERNAL_BARRIERED`, `ROOT`, `INIT`, "
 "`POINTER_FREE`, `STACK`. `scripts/gc_store_site_inventory.py` (in `lint`) "
@@ -76091,14 +77123,14 @@ msgstr ""
 "`lint`中,`scripts/gc_store_site_inventory.py`扫描第一方商店网站,当一个没有标"
 "记器时失败 **新的** 商店网站不能在没有回答问题的情况下登陆."
 
-#: src/internals/gc-rooting-invariant.md:550
+#: src/internals/gc-rooting-invariant.md:579
 msgid ""
 "Since #8185 landed its second half, the script verifies the **claim**, not "
 "just the comment, for the two classes where a false claim strands objects:"
 msgstr ""
 "由于8185号登陆了第二半, **索赔**, 不仅仅是评论, 对于两个类别, 假声称链接对象:"
 
-#: src/internals/gc-rooting-invariant.md:553
+#: src/internals/gc-rooting-invariant.md:582
 msgid ""
 "**`BARRIERED` in `perry-codegen`** is bound to an IR witness. Every call to "
 "the stem-taking barrier emitters "
@@ -76132,7 +77164,7 @@ msgstr ""
 "i1 true` 失败了. 通过四次红外外科 (删除通话,硬线接入门,将通话移动到外面,绕过"
 "门)"
 
-#: src/internals/gc-rooting-invariant.md:571
+#: src/internals/gc-rooting-invariant.md:600
 msgid ""
 "**`BARRIERED` / `EXTERNAL_BARRIERED` in `perry-runtime` / `perry-stdlib`** "
 "are rustc-compiled, so there is no perry-emitted IR; the claim is verified "
@@ -76155,7 +77187,7 @@ msgstr ""
 "色. 颗粒度是封闭函数 (两个屏障存储器和一个屏障调用在同一个函数中仍然通过),脚"
 "本打印了限制."
 
-#: src/internals/gc-rooting-invariant.md:583
+#: src/internals/gc-rooting-invariant.md:612
 msgid ""
 "What is still trusted: `ROOT`, `INIT`, `POINTER_FREE` and `STACK` verdicts "
 "are human-audited only, and the script says so in its summary on every run — "
@@ -76175,17 +77207,17 @@ msgstr ""
 "(`gc_rekeyed_key_tables.py`学科),它的`--self-test`植物十五个形状,每一个必须被"
 "判断."
 
-#: src/internals/gc-rooting-invariant.md:593
+#: src/internals/gc-rooting-invariant.md:622
 msgid "The corpus problem, and the two corpora (#7280)"
 msgstr "机体问题,以及两个机体 (#7280)"
 
-#: src/internals/gc-rooting-invariant.md:595
+#: src/internals/gc-rooting-invariant.md:624
 msgid ""
 "**A hand-written corpus cannot express this class of bug at dependency "
 "scale, and for a while nobody could tell, because it was green.**"
 msgstr "**一个手写的文档不能用依赖度来表达这种类型的错误,**"
 
-#: src/internals/gc-rooting-invariant.md:598
+#: src/internals/gc-rooting-invariant.md:627
 msgid ""
 "`scripts/gc_root_dominance_corpus.sh` compiles ~124 `test-files/` sources "
 "chosen for the lowerings they exercise. It reads **zero** in both modes the "
@@ -76198,7 +77230,7 @@ msgstr ""
 "`zod`在`PERRY_GC_PROTECT_FROMSPACE_DEPTH=800`下确定性错误. #7280用一个句子来"
 "说: _25组合文件通过,而20行库存fail._"
 
-#: src/internals/gc-rooting-invariant.md:604
+#: src/internals/gc-rooting-invariant.md:633
 msgid ""
 "That is not a size problem. Both corpora were measured on the same compiler "
 "with `--stale-registers --moving-only`:"
@@ -76206,39 +77238,39 @@ msgstr ""
 "这不是尺寸问题. 这两种体体都在同一个编译器上测量, `--stale-registers --"
 "moving-only`没有"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "corpus"
 msgstr "corpus"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "stale uses"
 msgstr "过时使用"
 
-#: src/internals/gc-rooting-invariant.md:607
+#: src/internals/gc-rooting-invariant.md:636
 msgid "what dominates"
 msgstr "什么是主要的"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "curated, 124 sources / 144 modules"
 msgstr "编辑, 124 个来源 / 144 个模块"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "116"
 msgstr "116"
 
-#: src/internals/gc-rooting-invariant.md:609
+#: src/internals/gc-rooting-invariant.md:638
 msgid "property-GET helper windows, `js_number_coerce`, `js_closure_callN`"
 msgstr "属性获取辅助窗口,`js_number_coerce`,`js_closure_callN`"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "dependency-scale, 81 modules / 62 MB"
 msgstr "依赖度尺度,81个模块 / 62 MB"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid "370"
 msgstr "370"
 
-#: src/internals/gc-rooting-invariant.md:610
+#: src/internals/gc-rooting-invariant.md:639
 msgid ""
 "`js_object_assign_one` (object spread) 137, `js_new_function_construct` 102, "
 "`js_closure_call*` 30"
@@ -76246,7 +77278,7 @@ msgstr ""
 "`js_object_assign_one` (对象传播) 137,`js_new_function_construct` "
 "102,`js_closure_call*` 30"
 
-#: src/internals/gc-rooting-invariant.md:612
+#: src/internals/gc-rooting-invariant.md:641
 msgid ""
 "The curated corpus produces 12 of the first population and 1 of the second. "
 "A hand-written test allocates a couple of objects and calls a couple of "
@@ -76259,7 +77291,7 @@ msgstr ""
 "对象,并调用了几个助手;一个图书馆将对象分散到对象中, **根源的危险存在于形状中"
 "**所以一个没有形状的体不能表达它们,"
 
-#: src/internals/gc-rooting-invariant.md:619
+#: src/internals/gc-rooting-invariant.md:648
 msgid ""
 "So there is a second corpus, generated from a real npm dependency rather "
 "than from anything written for the occasion:"
@@ -76267,11 +77299,12 @@ msgstr ""
 "这里有一个第二个库, 由一个真正的 npm 依赖生成, 而不是从为此写的任何东西中生"
 "成:"
 
-#: src/internals/gc-rooting-invariant.md:623
-msgid "# zod is a package.json devDependency"
+#: src/internals/gc-rooting-invariant.md:652
+#, fuzzy
+msgid "# zod is a package.json devDependency\n"
 msgstr "# 代码是一个package.json devDependency"
 
-#: src/internals/gc-rooting-invariant.md:628
+#: src/internals/gc-rooting-invariant.md:657
 msgid ""
 "`test-files/gc-dep-corpus/main.ts` is the only entry point; the rest of that "
 "directory reaches the compiler by being imported from it, and the generator "
@@ -76283,7 +77316,7 @@ msgstr ""
 "到编译器,而生成器 **声称目录中的每个`.ts`都产生了一个模块** 这是一个检查一个"
 "尺寸的地板不能,因为~90模块的`zod`沼泽任何数量一个缺失的40行源会穿过."
 
-#: src/internals/gc-rooting-invariant.md:634
+#: src/internals/gc-rooting-invariant.md:663
 msgid ""
 "Nothing is sampled away: all 81 modules and all 62 MB are checked. Emitting "
 "costs ~8s and the two gated arms ~4s, because those are linear in "
@@ -76294,11 +77327,11 @@ msgstr ""
 "4s,因为它们在指令数量上是线性的. `--stale-registers`预算是最昂贵的 (~5分钟):"
 "其扫描是超线性,62 MB是62 MB."
 
-#: src/internals/gc-rooting-invariant.md:639
+#: src/internals/gc-rooting-invariant.md:668
 msgid "The CI gate"
 msgstr "关闭门"
 
-#: src/internals/gc-rooting-invariant.md:641
+#: src/internals/gc-rooting-invariant.md:670
 msgid ""
 "`.github/workflows/gc-root-dominance.yml` runs the checker on every PR over "
 "both corpora. The whole job is a few minutes plus the compiler build; the "
@@ -76308,22 +77341,22 @@ msgstr ""
 "`.github/workflows/gc-root-dominance.yml`可以检查两个体的每个 PR. 整个工作需"
 "要几分钟,加上编译器构建;两个关闭检查每次大约3秒,超过~2000和~12900个函数."
 
-#: src/internals/gc-rooting-invariant.md:645
+#: src/internals/gc-rooting-invariant.md:674
 msgid "It is built to be able to fail, against all four hazards in CLAUDE.md:"
 msgstr "它的设计是能够抵御CLAUDE.md中的所有四种危险:"
 
-#: src/internals/gc-rooting-invariant.md:647
+#: src/internals/gc-rooting-invariant.md:676
 msgid ""
 "the checker's exit status is the job's — no `continue-on-error`, no pipe;"
 msgstr "检查员的退出状态是工作没有`continue-on-error`,没有管道;"
 
-#: src/internals/gc-rooting-invariant.md:648
+#: src/internals/gc-rooting-invariant.md:677
 msgid ""
 "`concurrency` cancels pull-request runs only, so `main` runs are never "
 "starved;"
 msgstr "`concurrency` 仅取消拉动请求运行,因此 `main` 运行永远不会被饿死;"
 
-#: src/internals/gc-rooting-invariant.md:649
+#: src/internals/gc-rooting-invariant.md:678
 msgid ""
 "`--min-files` / `--min-binds` / `--min-funcs` refuse a clean verdict over a "
 "corpus too thin to have exercised anything, and the run prints `checked N "
@@ -76332,7 +77365,7 @@ msgstr ""
 "`--min-files` / `--min-binds` / `--min-funcs`拒绝对太薄的体进行清洁判决,并且"
 "运行打印`checked N functions / M modules`,因此可以看到无声的空运行;"
 
-#: src/internals/gc-rooting-invariant.md:652
+#: src/internals/gc-rooting-invariant.md:681
 msgid ""
 "`--self-test` proves it still fires on planted fixtures, and `--seeded-"
 "violations 40` splices collection points into the **real** corpus IR and "
@@ -76343,7 +77376,7 @@ msgstr ""
 "点到 **真实的** 需要报告所有40个,即抓住检查器无声失去阅读佩里输出的能力的手"
 "臂;"
 
-#: src/internals/gc-rooting-invariant.md:656
+#: src/internals/gc-rooting-invariant.md:685
 msgid ""
 "`--audit-alloc-re` and `--audit-poll-capable` refuse a name that matches no "
 "exported runtime symbol, in the two tables that decide _whether a register "
@@ -76357,11 +77390,11 @@ msgstr ""
 "两者都在构建之前运行,因为两者都是静态和即时的,并且两者都运送了死亡条"
 "目:`ALLOC_RE`中的九个在两个轮中,`POLL_CAPABLE_RUNTIME`中的十个."
 
-#: src/internals/gc-rooting-invariant.md:663
+#: src/internals/gc-rooting-invariant.md:692
 msgid "The allowlist, and why it is not a number"
 msgstr "允许名单,为什么它不是一个数字"
 
-#: src/internals/gc-rooting-invariant.md:665
+#: src/internals/gc-rooting-invariant.md:694
 msgid ""
 "Known-remaining violations live in `scripts/"
 "gc_root_dominance_allowlist.json`, one entry each with a fingerprint, an "
@@ -76370,7 +77403,7 @@ msgstr ""
 "已知剩余违规行为存储在`scripts/gc_root_dominance_allowlist.json`中, 每个条目"
 "都有指纹,问题和书面理由."
 
-#: src/internals/gc-rooting-invariant.md:668
+#: src/internals/gc-rooting-invariant.md:697
 msgid ""
 "A numeric threshold cannot tell a new violation from an old one: fix one "
 "bug, introduce another, and the total is unchanged and the gate stays green. "
@@ -76378,11 +77411,11 @@ msgid ""
 "number by one, and nothing in the diff says what was conceded."
 msgstr "一个数字值不能区分一个新的违规行为, 没有什么在差别中说什么被放弃了."
 
-#: src/internals/gc-rooting-invariant.md:673
+#: src/internals/gc-rooting-invariant.md:702
 msgid "So the checker enforces three properties:"
 msgstr "所以检查器强制执行三个属性:"
 
-#: src/internals/gc-rooting-invariant.md:675
+#: src/internals/gc-rooting-invariant.md:704
 msgid ""
 "**an entry that matches nothing fails the build.** When you fix the bug, "
 "delete the entry in the same PR. That is the ratchet, and it is why a fixed "
@@ -76391,7 +77424,7 @@ msgstr ""
 "**一个与任何东西不匹配的条目失败.** 在修复错误时,删除同一个PR条目. 这就是杆, "
 "这就是为什么一个固定的虫子不能留下一个墓碑, 静静地扩大覆盖范围."
 
-#: src/internals/gc-rooting-invariant.md:678
+#: src/internals/gc-rooting-invariant.md:707
 msgid ""
 "**an entry suppresses at most its `count`.** A second violation of the same "
 "shape in the same function is new, and fails."
@@ -76399,12 +77432,12 @@ msgstr ""
 "**一个条目最多会删除它的 `count`.** 另一次违反相同形状,同样的功能是新的,并且"
 "失败了."
 
-#: src/internals/gc-rooting-invariant.md:680
+#: src/internals/gc-rooting-invariant.md:709
 msgid ""
 "**a violation with no entry fails**, regardless of how many entries exist."
 msgstr "**一个违规没有入口失败**无论有多少条目存在."
 
-#: src/internals/gc-rooting-invariant.md:682
+#: src/internals/gc-rooting-invariant.md:711
 msgid ""
 "Adding an entry is a code-review event. Bumping a `count` to green a build "
 "is the exact thing this file exists to prevent."
@@ -76412,11 +77445,11 @@ msgstr ""
 "添加一个条目是一个代码审查事件. 为了防止此文件的出现, 必须使用`count`来绿色构"
 "建."
 
-#: src/internals/gc-rooting-invariant.md:685
+#: src/internals/gc-rooting-invariant.md:714
 msgid "Promoting this gate"
 msgstr "推广这个门"
 
-#: src/internals/gc-rooting-invariant.md:687
+#: src/internals/gc-rooting-invariant.md:716
 msgid ""
 "**As of this writing the job is NOT in branch protection's required "
 "contexts**, which means it cannot turn a merge red — hazard 2."
@@ -76424,11 +77457,11 @@ msgstr ""
 "**截至本文撰写时，该作业尚未列入分支保护的必需检查项**，这意味着它无法使合并"
 "失败——风险 2。"
 
-#: src/internals/gc-rooting-invariant.md:690
+#: src/internals/gc-rooting-invariant.md:719
 msgid "Both of the conditions #7198 named are now met:"
 msgstr "现在已经满足了第7198号的两个条件:"
 
-#: src/internals/gc-rooting-invariant.md:692
+#: src/internals/gc-rooting-invariant.md:721
 msgid ""
 "the bind-anchored dominance check is green on `main` with an **empty** "
 "allowlist (the #7211 entries were deleted when that predicate was fixed in "
@@ -76437,7 +77470,7 @@ msgstr ""
 "在`main`上,绑定固的主导权检查是绿色的, **没有** allowlist (在\\#7226中修改了"
 "该语句时删除了#7211条目);"
 
-#: src/internals/gc-rooting-invariant.md:695
+#: src/internals/gc-rooting-invariant.md:724
 msgid ""
 "`--unrooted-allocas --moving-only` reads **0** and is a step in the job "
 "(#7236). That was the outstanding one: it was 98 before #7235, 2 after, and "
@@ -76446,7 +77479,7 @@ msgstr ""
 "读取`--unrooted-allocas --moving-only` **0** 并且是工作中的一步 (#7236). 这是"
 "一个突出的:在7235之前是98,之后是2,一旦`Type::Symbol`不再被归类为即时,则是0."
 
-#: src/internals/gc-rooting-invariant.md:699
+#: src/internals/gc-rooting-invariant.md:728
 msgid ""
 "So the remaining step is for a **repo admin** to add `gc-root-dominance` to "
 "branch protection's required contexts:"
@@ -76454,7 +77487,7 @@ msgstr ""
 "所以剩下的步骤是为 **管理员** 为了将 `gc-root-dominance` 添加到分支保护所需的"
 "语境中:"
 
-#: src/internals/gc-rooting-invariant.md:707
+#: src/internals/gc-rooting-invariant.md:736
 msgid ""
 "A workflow cannot do this to itself, and neither can a PR. Until it is done, "
 "this is documentation. Per CLAUDE.md's corollary, promote it **after** the "
@@ -76466,7 +77499,7 @@ msgstr ""
 "之后** 工作的第一个绿色运行 `main`  `--unrooted-allocas` 步骤包括  一个从未绿"
 "色的门在当前的形状中阻止每一个开放的 PR 当它成为必要的日子."
 
-#: src/internals/gc-rooting-invariant.md:713
+#: src/internals/gc-rooting-invariant.md:742
 msgid ""
 "**`gc-root-dominance-statepoints` is a SEPARATE context and a separate "
 "decision.** It was added by #7663 as a second job for exactly that reason: "
@@ -76483,11 +77516,11 @@ msgstr ""
 "行后,从来没有之前,并注意它的`--max-unrooted`预算是一个在分类中的子,而不是一个"
 "校准的零:剩余数被列为#7664中的形状. 随着人口的增长而降低; 结预算的促销,"
 
-#: src/internals/gc-rooting-invariant.md:723
+#: src/internals/gc-rooting-invariant.md:752
 msgid "Rules of thumb"
 msgstr "指规则"
 
-#: src/internals/gc-rooting-invariant.md:725
+#: src/internals/gc-rooting-invariant.md:754
 msgid ""
 "**Root before you call, not after.** If a value must survive a call, its "
 "root store belongs above the call, unconditionally. Do not predicate it on a "
@@ -76500,7 +77533,7 @@ msgstr ""
 "#7211的`ClassExprFresh`尝试了,并且只询问了作者提供的初始化器,从来没有关于降低"
 "自己的发射的`js_object_set_field_by_name`调用."
 
-#: src/internals/gc-rooting-invariant.md:730
+#: src/internals/gc-rooting-invariant.md:759
 msgid ""
 "**Re-read the root after every collection point.** Never cache a load out of "
 "a root slot across a call. `rooted_handle_get` exists for this."
@@ -76508,7 +77541,7 @@ msgstr ""
 "**在每一个收集点后重新读取根.** 永远不要在通话中从根插槽中缓存负载. 对于此,存"
 "在`rooted_handle_get`."
 
-#: src/internals/gc-rooting-invariant.md:732
+#: src/internals/gc-rooting-invariant.md:761
 msgid ""
 "**Evaluate-then-allocate is the hazard.** Any lowering with two or more "
 "operands where one is materialized before another is lowered needs the first "
@@ -76517,7 +77550,7 @@ msgstr ""
 "**评估然后分配是危险.** 任何有两个或更多操作符的降低,其中一个在另一个降低之前"
 "实现,需要第一个根."
 
-#: src/internals/gc-rooting-invariant.md:735
+#: src/internals/gc-rooting-invariant.md:764
 msgid ""
 "**`--trace llvm` and read it.** Three seconds of the checker beats a day of "
 "bisecting a `not a function` five cycles downstream."
@@ -76525,7 +77558,7 @@ msgstr ""
 "**`--trace llvm` 并且阅读它.** 检查器的3秒钟比一个`not a function`的5个周期下"
 "游."
 
-#: src/internals/gc-rooting-invariant.md:737
+#: src/internals/gc-rooting-invariant.md:766
 msgid ""
 "**When in doubt, root it.** A redundant shadow slot costs a store. A missing "
 "one costs a day, and it costs it to whoever hits the crash, not to you."
@@ -76750,6 +77783,175 @@ msgstr ""
 #: src/internals/local-binding-type-evidence.md:98
 msgid "Run it locally with:"
 msgstr "在本地运行:"
+
+#: src/internals/codegen-mechanisms.md:3
+msgid ""
+"An optimization's benchmark result does not establish that another program "
+"uses the same generated path. Record the admission rule, the workload and "
+"compiler snapshot, and evidence of emitted code before attributing a result "
+"to that mechanism."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:8
+msgid ""
+"The [mechanism index](https://github.com/PerryTS/perry/blob/main/scripts/"
+"codegen_mechanisms.json) starts with the per-site concat cache from [\\#9514]"
+"(https://github.com/PerryTS/perry/pull/9514), following the correction in "
+"[\\#9824](https://github.com/PerryTS/perry/issues/"
+"9824#issuecomment-5554137476). It is an evidence index, not a complete "
+"inventory or a new CI gate. Missing entries mean unrecorded. Each entry "
+"names its lowering, runtime helper, admission conditions, workload "
+"expectations, observations, and existing regression tests. Refresh "
+"observations when the compiler, bundle, flags, or proof changes; a "
+"historical negative is not a permanent property of an app."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:18
+msgid "Per-site concat cache"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:20
+msgid ""
+"The [lowering](https://github.com/PerryTS/perry/blob/main/crates/perry-"
+"codegen/src/concat_site_cache.rs) requires a string literal on the left in "
+"HIR and one of these right operands:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Right operand"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:23
+msgid "Admission proof"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:25
+#, fuzzy
+msgid "Compile-time integer"
+msgstr "编译期校验"
+
+#: src/internals/codegen-mechanisms.md:25
+msgid ""
+"Value in `0..=255`, including supported constant arithmetic and integer-"
+"constant locals."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid "Loop-induction local"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:26
+msgid ""
+"Proven interval with a nonnegative lower bound and upper bound at most 255."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid "`x % C`"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:27
+msgid ""
+"Compile-time integer modulus `C` in `1..=256`; negative remainders fall back "
+"at runtime."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:29
+msgid ""
+"The admission limit is **255**, but each site has only **32 slots**. At "
+"runtime, an integral numeric value in `0..31` can hit a filled slot. The "
+"fill arm calls `js_string_concat_site_value`; the plain arm handles values "
+"outside the table. Ordered comparisons reject NaN and boxed non-numbers. An "
+"unproven site keeps the ordinary fused helper and process-wide memo without "
+"this per-site diamond. `PERRY_CONCAT_SITE_CACHE=0` disables the lowering "
+"**when compiling the program**."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:36
+msgid ""
+"The counted-loop shape in [`bench_object_property.ts`](https://github.com/"
+"PerryTS/perry/blob/main/benchmarks/suite/bench_object_property.ts) is "
+"admitted: `\"field_\" + j` has `j` in `0..19`. Fresh object compilation with "
+"the codegen at `d36a1af0c` produced three tables and three fill call sites; "
+"disabling the cache produced none. Both builds retained the ordinary helper. "
+"This confirms applicability; it does not add a timing measurement to #9514."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:43
+msgid ""
+"The #9824 report found zero fill-helper executions in three runs of the "
+"compiled `cli_2.1.112.js` bundle and no fill-helper symbol in its inspected "
+"binary. Its roughly 8,600 concatenations per reply do not by themselves meet "
+"the admission proof. The record therefore expects no emitted path for that "
+"**reported snapshot**, not for every version of Claude Code. This is "
+"expected workload selectivity, not evidence that the cache is broken. The "
+"rule also admits constants and bounded remainders; it is not restricted to "
+"counted loops."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:51
+#, fuzzy
+msgid "Recheck a workload"
+msgstr "用户选择每个工作负载的后端"
+
+#: src/internals/codegen-mechanisms.md:53
+msgid ""
+"From the repository root, using the compiler whose behavior you want to "
+"audit:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:67
+msgid ""
+"The last command should have no match (exit 1). `PERRY_NO_CACHE` forces "
+"fresh code generation; `--no-link` makes this an object-level check. For a "
+"module graph, inspect every generated object and every retained IR path in "
+"the log."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:71
+msgid ""
+"Open the file named by each `kept LLVM IR:` log line. Count **call/invoke "
+"instructions** to `@js_string_concat_site_value(` and definitions of "
+"`@perry_concat_site_*` globals. A `declare` line is not a call site; "
+"searching for the helper name alone gives a false positive. Confirm the "
+"disabled arm still calls `js_string_concat_value_box` so the negative "
+"control is meaningful."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:77
+msgid "Keep these evidence levels separate:"
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:79
+msgid ""
+"Retained pre-optimization IR shows whether codegen emitted the lowering."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:80
+msgid ""
+"An object reference shows that a call survived compilation. Its absence "
+"alone cannot distinguish non-emission from later dead-code elimination."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:82
+msgid "Linked-binary symbol inspection must account for stripping and linkage."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:83
+msgid ""
+"A counter at the helper entry measures fill-helper executions, not inline "
+"cache hits. Zero executions alone does not prove the lowering was absent."
+msgstr ""
+
+#: src/internals/codegen-mechanisms.md:86
+msgid ""
+"The [existing compiler tests](https://github.com/PerryTS/perry/blob/main/"
+"crates/perry/tests/concat_site_cache.rs) pin positive and negative "
+"admission, the disable switch, and Node parity under evacuation. The "
+"[runtime lifecycle test](https://github.com/PerryTS/perry/blob/main/crates/"
+"perry-runtime/src/gc/tests/concat_site.rs) checks that collection rewrites a "
+"filled slot. These cover the public admitted shape even when the application "
+"bundle legitimately has no eligible sites."
+msgstr ""
 
 #: src/internals/gc-step-bounds.md:1
 msgid "What the incremental collector's step budget actually bounds"
@@ -77156,7 +78358,8 @@ msgid "\"js_object_alloc\""
 msgstr "\"js_object_alloc\""
 
 #: src/internals/rfc-rooting-by-construction.md:49
-msgid "// obj: String   -- the register name, e.g. \"%r10\""
+#, fuzzy
+msgid "// obj: String   -- the register name, e.g. \"%r10\"\n"
 msgstr "// obj:字符串 -- 寄存器名称,e.g. \"%r10\""
 
 #: src/internals/rfc-rooting-by-construction.md:51
@@ -77192,31 +78395,31 @@ msgid "Three types and one rule."
 msgstr "三种和一个规则."
 
 #: src/internals/rfc-rooting-by-construction.md:68
-msgid "/// A register holding a GC-managed value that is NOT rooted."
+#, fuzzy
+msgid ""
+"/// A register holding a GC-managed value that is NOT rooted.\n"
+"///\n"
+"/// Borrows the emitter immutably. Not Clone, not Copy.\n"
 msgstr "/// 一个存储GC管理值的寄存器,它不是rooted的."
 
-#: src/internals/rfc-rooting-by-construction.md:69
-msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
-msgstr "/// 借用发射器不变. 没有克隆,没有复制."
-
 #: src/internals/rfc-rooting-by-construction.md:75
+#, fuzzy
 msgid ""
-"/// A shadow-slot root. Outlives collection points; cannot be read directly."
+"/// A shadow-slot root. Outlives collection points; cannot be read "
+"directly.\n"
 msgstr "一个阴影的根. 超过收集点,不能直接读取."
 
 #: src/internals/rfc-rooting-by-construction.md:78
-msgid "// only obtainable from ShadowFrame::alloc_slot"
+#, fuzzy
+msgid "// only obtainable from ShadowFrame::alloc_slot\n"
 msgstr "// 只有从ShadowFrame::alloc_slot获取"
 
 #: src/internals/rfc-rooting-by-construction.md:80
+#, fuzzy
 msgid ""
-"/// A register holding something the GC does not manage: i32, double, bool,"
+"/// A register holding something the GC does not manage: i32, double, bool,\n"
+"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter.\n"
 msgstr "///一个存储GC无法管理的注册器:i32,double, bool,"
-
-#: src/internals/rfc-rooting-by-construction.md:81
-msgid ""
-"/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
-msgstr "一个插槽指数. 无需使用发射器."
 
 #: src/internals/rfc-rooting-by-construction.md:87
 msgid ""
@@ -77225,22 +78428,27 @@ msgid ""
 msgstr "整个设计依赖于 **通过它们是否能收集**:"
 
 #: src/internals/rfc-rooting-by-construction.md:92
+#, fuzzy
 msgid ""
-"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid."
+"/// Cannot collect. Takes &self, so outstanding `Raw` handles stay valid.\n"
 msgstr "///不能收取. 接收&self,所以优秀的`Raw`手柄仍然有效."
 
 #: src/internals/rfc-rooting-by-construction.md:95
+#, fuzzy
 msgid ""
-"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` borrow."
+"/// CAN collect. Takes &mut self, which ends every outstanding `Raw` "
+"borrow.\n"
 msgstr "我们可以收取. 需要&mut自己,这结束了每一个未偿还的`Raw`借款."
 
 #: src/internals/rfc-rooting-by-construction.md:100
+#, fuzzy
 msgid ""
-"/// Re-read the slot. The returned Raw is valid until the next &mut emit."
+"/// Re-read the slot. The returned Raw is valid until the next &mut emit.\n"
 msgstr "/// 再读一遍. 返回的Raw是有效的,直到下一个&mut发出."
 
 #: src/internals/rfc-rooting-by-construction.md:105
-msgid "/// Consume this register into a root. The only way to make a Rooted."
+#, fuzzy
+msgid "/// Consume this register into a root. The only way to make a Rooted.\n"
 msgstr "它们将会被消耗到根部. 只有这样才能做一个根源."
 
 #: src/internals/rfc-rooting-by-construction.md:110
@@ -77257,24 +78465,22 @@ msgstr ""
 "不能在一个收集点上使用 `Raw`** 编译器拒绝它."
 
 #: src/internals/rfc-rooting-by-construction.md:117
-msgid "// Raw<'_>, borrows e"
+#, fuzzy
+msgid "// Raw<'_>, borrows e\n"
 msgstr "// 原料<'_>,借用e"
 
 #: src/internals/rfc-rooting-by-construction.md:118
-msgid "// needs &mut e"
+#, fuzzy
+msgid "// needs &mut e\n"
 msgstr "// 需要"
 
 #: src/internals/rfc-rooting-by-construction.md:119
-msgid "// ERROR: obj borrows e,"
-msgstr "//错误:obj借用了e,"
-
-#: src/internals/rfc-rooting-by-construction.md:120
-msgid "//        which is mutably"
-msgstr "// 这是一个可变的"
-
-#: src/internals/rfc-rooting-by-construction.md:121
-msgid "//        borrowed above"
-msgstr "// 在上面借来的"
+msgid ""
+"// ERROR: obj borrows e,\n"
+"                                                  //        which is "
+"mutably\n"
+"                                                  //        borrowed above\n"
+msgstr ""
 
 #: src/internals/rfc-rooting-by-construction.md:124
 msgid ""
@@ -77282,7 +78488,8 @@ msgid ""
 msgstr "修复是正确的代码,也是出错的最短途径:"
 
 #: src/internals/rfc-rooting-by-construction.md:129
-msgid "// re-read, correct"
+#, fuzzy
+msgid "// re-read, correct\n"
 msgstr "// 重读,正确"
 
 #: src/internals/rfc-rooting-by-construction.md:132
@@ -77855,8 +79062,9 @@ msgid "**The escape hatch**, for as long as any caller uses it."
 msgstr "**逃生口**只要任何一个电话用户使用它."
 
 #: src/internals/rfc-rooting-by-construction.md:308
+#, fuzzy
 msgid ""
-"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e  "
+"**Confusion of two emitters, or of two shadow frames.** `PhantomData<&'e "
 "Emitter>` records a _lifetime_, not an _instance_, and `&'e T` makes "
 "`Raw<'e>` **covariant** in `'e` — a longer-lived `Raw` shortens to any "
 "compatible `'e`. Nothing in the type names _which_ emitter it came from, so "
@@ -79286,17 +80494,35 @@ msgstr ""
 "以及节点API策略版本. 运行时加载永远不会查询构建机的`node_modules`树."
 
 #: src/internals/node-api-host.md:455
+#, fuzzy
 msgid ""
 "This sidecar model has no first-run write, so read-only install directories "
 "are supported. Moving the executable requires moving its `.perry-native` "
 "sibling. Missing or hash-mismatched files fail before `dlopen` with a "
-"packaging error."
+"packaging error. The loader also requires the canonical entry path passed to "
+"the dynamic loader to equal the canonical path of a payload file whose size "
+"and hash were just verified. An existing file that is selected only by "
+"`entry`, but omitted from `files`, is rejected."
 msgstr ""
 "这款侧车模型没有首次运行写入,因此支持只读安装目录. 移动可执行文件需要移动它的"
 "`.perry-native`兄弟. 缺失或哈希不匹配的文件在 `dlopen` 之前失败,并出现包装错"
 "误."
 
-#: src/internals/node-api-host.md:459
+#: src/internals/node-api-host.md:463
+msgid ""
+"The platform dynamic-loader APIs reopen that canonical pathname; they do not "
+"provide one portable way to load from the file handle used for verification. "
+"There is consequently an accepted time-of-check/time-of-use window between "
+"the last payload hash and `dlopen`/`LoadLibraryExW`. Exploiting it requires "
+"write access to the installed sidecar directory, which is outside this "
+"loader's integrity boundary. Deployments must protect the executable and its "
+"sidecar with the same ownership and write permissions (and platform signing "
+"where applicable). The manifest checks detect packaging damage and tampering "
+"before the first load; they are not a defense against a concurrent local "
+"writer."
+msgstr ""
+
+#: src/internals/node-api-host.md:473
 msgid ""
 "For a macOS app bundle the directory is placed under `Contents/Frameworks`. "
 "Every Mach-O sidecar and nested dylib is signed before the outer executable "
@@ -79310,7 +80536,7 @@ msgstr ""
 "松的命令行执行文件,在执行文件之前释放每个侧车的工具标志并将它们发送到一个档案"
 "中. 在运行时,Perry不会从未可信的下载二进制文件中删除隔离属性."
 
-#: src/internals/node-api-host.md:466
+#: src/internals/node-api-host.md:480
 msgid ""
 "Cross-compilation selects the target's platform package, never the host's. "
 "Perry does not perform an unpinned registry download during compilation. The "
@@ -79325,41 +80551,41 @@ msgstr ""
 "包. 这样在包管理器中保留注册表凭证和依赖度解决,同时防止主机 `.node` 文件进入"
 "目标文物."
 
-#: src/internals/node-api-host.md:474
+#: src/internals/node-api-host.md:488
 msgid "Cache identity"
 msgstr "缓存身份"
 
-#: src/internals/node-api-host.md:476
+#: src/internals/node-api-host.md:490
 msgid ""
 "The compile-time addon manifest is sorted deterministically and contributes "
 "the following to the build and link cache identities:"
 msgstr "编译时的添加程序显示是确定性排序的,并为构建和链接缓存身份贡献以下内容:"
 
-#: src/internals/node-api-host.md:479
+#: src/internals/node-api-host.md:493
 msgid "policy schema version and advertised Node-API version;"
 msgstr "策略方案版本和广告中的节点API版本;"
 
-#: src/internals/node-api-host.md:480
+#: src/internals/node-api-host.md:494
 msgid "target tuple and normalized allowlist;"
 msgstr "目标和标准化允许清单;"
 
-#: src/internals/node-api-host.md:481
+#: src/internals/node-api-host.md:495
 msgid "selected package name/version and relative entry path;"
 msgstr "选择的包 name/version 和相对的输入路径;"
 
-#: src/internals/node-api-host.md:482
+#: src/internals/node-api-host.md:496
 msgid "SHA-256 and size of every sidecar payload file;"
 msgstr "SHA-256 和每个侧车有效载荷文件的大小;"
 
-#: src/internals/node-api-host.md:483
+#: src/internals/node-api-host.md:497
 msgid "ordered exported-symbol inventory;"
 msgstr "订购的出口符号清单;"
 
-#: src/internals/node-api-host.md:484
+#: src/internals/node-api-host.md:498
 msgid "shipping model (`sidecar-v1`)."
 msgstr "运输模型 (`sidecar-v1`)."
 
-#: src/internals/node-api-host.md:486
+#: src/internals/node-api-host.md:500
 msgid ""
 "The entry module's object-cache key also includes the canonical logical "
 "addon ids it can load, because those ids appear in generated loader calls. "
@@ -79371,11 +80597,11 @@ msgstr ""
 "成的加载器调用中. 绝对构建路径不进入任何关键或生成的对象. 一个侧车哈希更改必"
 "须错过顶级构建缓存,即使所有TypeScript和对象文件没有改变."
 
-#: src/internals/node-api-host.md:492
+#: src/internals/node-api-host.md:506
 msgid "Node-API surface inventory"
 msgstr "Node-API surface inventory"
 
-#: src/internals/node-api-host.md:494
+#: src/internals/node-api-host.md:508
 msgid ""
 "The inventory is pinned to Node v26.5.1's [`js_native_api.h`](https://"
 "github.com/nodejs/node/blob/v26.5.1/src/js_native_api.h) and [`node_api.h`]"
@@ -79391,22 +80617,15 @@ msgstr ""
 "表示声明比广告中的版本或试验版本更新,不出口. `never` 表示 Perry 在需要二进制"
 "分辨率时将版本-8符号导出,但它决定性地报告了所述不支持的功能."
 
-#: src/internals/node-api-host.md:502
+#: src/internals/node-api-host.md:516
 msgid "`js_native_api.h`: core through version 4"
 msgstr "`js_native_api.h`:核心到第 4 版本"
 
-#: src/internals/node-api-host.md:504 src/internals/node-api-host.md:540
-#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:579
 msgid "Entry points"
 msgstr "进入地点"
 
-#: src/internals/node-api-host.md:506 src/internals/node-api-host.md:507
-#: src/internals/node-api-host.md:508 src/internals/node-api-host.md:509
-#: src/internals/node-api-host.md:510 src/internals/node-api-host.md:511
-#: src/internals/node-api-host.md:512 src/internals/node-api-host.md:513
-#: src/internals/node-api-host.md:514 src/internals/node-api-host.md:515
-#: src/internals/node-api-host.md:516 src/internals/node-api-host.md:517
-#: src/internals/node-api-host.md:518 src/internals/node-api-host.md:519
 #: src/internals/node-api-host.md:520 src/internals/node-api-host.md:521
 #: src/internals/node-api-host.md:522 src/internals/node-api-host.md:523
 #: src/internals/node-api-host.md:524 src/internals/node-api-host.md:525
@@ -79414,49 +80633,56 @@ msgstr "进入地点"
 #: src/internals/node-api-host.md:528 src/internals/node-api-host.md:529
 #: src/internals/node-api-host.md:530 src/internals/node-api-host.md:531
 #: src/internals/node-api-host.md:532 src/internals/node-api-host.md:533
-#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:534 src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:536 src/internals/node-api-host.md:537
+#: src/internals/node-api-host.md:538 src/internals/node-api-host.md:539
+#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:541
 #: src/internals/node-api-host.md:542 src/internals/node-api-host.md:543
 #: src/internals/node-api-host.md:544 src/internals/node-api-host.md:545
 #: src/internals/node-api-host.md:546 src/internals/node-api-host.md:547
-#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:549
-#: src/internals/node-api-host.md:550 src/internals/node-api-host.md:567
-#: src/internals/node-api-host.md:568 src/internals/node-api-host.md:569
-#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
-#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
-#: src/internals/node-api-host.md:575 src/internals/node-api-host.md:576
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:548 src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:562 src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:564 src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:582 src/internals/node-api-host.md:583
+#: src/internals/node-api-host.md:584 src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:587 src/internals/node-api-host.md:588
+#: src/internals/node-api-host.md:589 src/internals/node-api-host.md:590
+#: src/internals/node-api-host.md:591
 msgid "v1"
 msgstr "v1"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "`napi_get_last_error_info`"
 msgstr "`napi_get_last_error_info`"
 
-#: src/internals/node-api-host.md:506
+#: src/internals/node-api-host.md:520
 msgid "Stable per-environment storage"
 msgstr "稳定的环境存储"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 msgstr ""
 "`napi_get_undefined`, `napi_get_null`, `napi_get_global`, `napi_get_boolean`"
 
-#: src/internals/node-api-host.md:507
+#: src/internals/node-api-host.md:521
 msgid "Singleton values receive ordinary scoped handles"
 msgstr "单项值接受普通的范围处理器"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 msgstr ""
 "`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`"
 
-#: src/internals/node-api-host.md:508
+#: src/internals/node-api-host.md:522
 msgid "Perry object/array allocators"
 msgstr "区分器 Perry object/array"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
@@ -79464,11 +80690,11 @@ msgstr ""
 "`napi_create_double`, `napi_create_int32`, `napi_create_uint32`, "
 "`napi_create_int64`"
 
-#: src/internals/node-api-host.md:509
+#: src/internals/node-api-host.md:523
 msgid "Perry NaN-box conversions"
 msgstr "Perry NaN框转换"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
@@ -79476,37 +80702,37 @@ msgstr ""
 "`napi_create_string_latin1`, `napi_create_string_utf8`, "
 "`napi_create_string_utf16`"
 
-#: src/internals/node-api-host.md:510
+#: src/internals/node-api-host.md:524
 msgid "Length-bounded; `NAPI_AUTO_LENGTH` supported"
 msgstr "长度限制;支持`NAPI_AUTO_LENGTH`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "`napi_create_symbol`, `napi_create_function`"
 msgstr "`napi_create_symbol`, `napi_create_function`"
 
-#: src/internals/node-api-host.md:511
+#: src/internals/node-api-host.md:525
 msgid "Native callbacks use host records"
 msgstr "本地回调使用主机记录"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 msgstr ""
 "`napi_create_error`, `napi_create_type_error`, `napi_create_range_error`"
 
-#: src/internals/node-api-host.md:512
+#: src/internals/node-api-host.md:526
 msgid "`code` is installed when supplied"
 msgstr "在提供时安装`code`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "`napi_typeof`"
 msgstr "`napi_typeof`"
 
-#: src/internals/node-api-host.md:513
+#: src/internals/node-api-host.md:527
 msgid "Includes function, external, symbol, and bigint distinctions"
 msgstr "包括功能,外部,符号和大字符区别"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
@@ -79514,11 +80740,11 @@ msgstr ""
 "`napi_get_value_double`, `napi_get_value_int32`, `napi_get_value_uint32`, "
 "`napi_get_value_int64`, `napi_get_value_bool`"
 
-#: src/internals/node-api-host.md:514
+#: src/internals/node-api-host.md:528
 msgid "Checked type/status behavior"
 msgstr "检查了type/status行为"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
@@ -79526,11 +80752,11 @@ msgstr ""
 "`napi_get_value_string_latin1`, `napi_get_value_string_utf8`, "
 "`napi_get_value_string_utf16`"
 
-#: src/internals/node-api-host.md:515
+#: src/internals/node-api-host.md:529
 msgid "Query-length and NUL-termination semantics included"
 msgstr "包括查询长度和NUL终结语义"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
@@ -79538,19 +80764,19 @@ msgstr ""
 "`napi_coerce_to_bool`, `napi_coerce_to_number`, `napi_coerce_to_object`, "
 "`napi_coerce_to_string`"
 
-#: src/internals/node-api-host.md:516
+#: src/internals/node-api-host.md:530
 msgid "User code is exception-trapped"
 msgstr "用户代码是异常陷"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "`napi_get_prototype`, `napi_get_property_names`"
 msgstr "`napi_get_prototype`, `napi_get_property_names`"
 
-#: src/internals/node-api-host.md:517
+#: src/internals/node-api-host.md:531
 msgid "General object semantics"
 msgstr "一般对象语义"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
@@ -79558,11 +80784,11 @@ msgstr ""
 "`napi_set_property`, `napi_has_property`, `napi_get_property`, "
 "`napi_delete_property`, `napi_has_own_property`"
 
-#: src/internals/node-api-host.md:518
+#: src/internals/node-api-host.md:532
 msgid "String, symbol, and numeric keys"
 msgstr "字符串,符号和数字键"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
@@ -79570,11 +80796,11 @@ msgstr ""
 "`napi_set_named_property`, `napi_has_named_property`, "
 "`napi_get_named_property`"
 
-#: src/internals/node-api-host.md:519
+#: src/internals/node-api-host.md:533
 msgid "UTF-8 names"
 msgstr "UTF-8 名称"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
@@ -79582,43 +80808,43 @@ msgstr ""
 "`napi_set_element`, `napi_has_element`, `napi_get_element`, "
 "`napi_delete_element`"
 
-#: src/internals/node-api-host.md:520
+#: src/internals/node-api-host.md:534
 msgid "Arrays and exotic indexed objects"
 msgstr "阵列和异国情调索引对象"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "`napi_define_properties`"
 msgstr "`napi_define_properties`"
 
-#: src/internals/node-api-host.md:521
+#: src/internals/node-api-host.md:535
 msgid "Data, method, and accessor descriptors"
 msgstr "数据,方法和接入器描述器"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 msgstr "`napi_is_array`, `napi_get_array_length`, `napi_strict_equals`"
 
-#: src/internals/node-api-host.md:522
+#: src/internals/node-api-host.md:536
 msgid "No pointer-identity shortcut"
 msgstr "没有指针识别快捷方式"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 msgstr "`napi_call_function`, `napi_new_instance`, `napi_instanceof`"
 
-#: src/internals/node-api-host.md:523
+#: src/internals/node-api-host.md:537
 msgid "General Perry dispatch/construction"
 msgstr "总体 Perry dispatch/construction"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 msgstr "`napi_get_cb_info`, `napi_get_new_target`, `napi_define_class`"
 
-#: src/internals/node-api-host.md:524
+#: src/internals/node-api-host.md:538
 msgid "Callback-info lifetime is the native call"
 msgstr "呼叫回来-信息终身是本地呼叫"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
@@ -79626,11 +80852,11 @@ msgstr ""
 "`napi_wrap`, `napi_unwrap`, `napi_remove_wrap`, `napi_create_external`, "
 "`napi_get_value_external`"
 
-#: src/internals/node-api-host.md:525
+#: src/internals/node-api-host.md:539
 msgid "Native object metadata table"
 msgstr "本地对象元数据表"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
@@ -79638,11 +80864,11 @@ msgstr ""
 "`napi_create_reference`, `napi_delete_reference`, `napi_reference_ref`, "
 "`napi_reference_unref`, `napi_get_reference_value`"
 
-#: src/internals/node-api-host.md:526
+#: src/internals/node-api-host.md:540
 msgid "Strong and weak reference design above"
 msgstr "上方强弱的参考设计"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid ""
 "`napi_open_handle_scope`, `napi_close_handle_scope`, "
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
@@ -79652,11 +80878,11 @@ msgstr ""
 "`napi_open_escapable_handle_scope`, `napi_close_escapable_handle_scope`, "
 "`napi_escape_handle`"
 
-#: src/internals/node-api-host.md:527
+#: src/internals/node-api-host.md:541
 msgid "Strict nesting and generation validation"
 msgstr "严格的嵌套和生成验证"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
@@ -79664,19 +80890,19 @@ msgstr ""
 "`napi_throw`, `napi_throw_error`, `napi_throw_type_error`, "
 "`napi_throw_range_error`, `napi_is_error`"
 
-#: src/internals/node-api-host.md:528
+#: src/internals/node-api-host.md:542
 msgid "Pending-slot model"
 msgstr "在等待时段的模型"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 msgstr "`napi_is_exception_pending`, `napi_get_and_clear_last_exception`"
 
-#: src/internals/node-api-host.md:529
+#: src/internals/node-api-host.md:543
 msgid "Available while pending"
 msgstr "在等待期间可用"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
@@ -79684,37 +80910,37 @@ msgstr ""
 "`napi_is_arraybuffer`, `napi_create_arraybuffer`, "
 "`napi_create_external_arraybuffer`, `napi_get_arraybuffer_info`"
 
-#: src/internals/node-api-host.md:530
+#: src/internals/node-api-host.md:544
 msgid "Stable backing pointers"
 msgstr "稳定的支持指针"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 msgstr ""
 "`napi_is_typedarray`, `napi_create_typedarray`, `napi_get_typedarray_info`"
 
-#: src/internals/node-api-host.md:531
+#: src/internals/node-api-host.md:545
 msgid "All eleven declared typed-array kinds"
 msgstr "所有11个声明的类型类型"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 msgstr "`napi_create_dataview`, `napi_is_dataview`, `napi_get_dataview_info`"
 
-#: src/internals/node-api-host.md:532
+#: src/internals/node-api-host.md:546
 msgid "Backing identity and offsets preserved"
 msgstr "保持了支持身份和抵消"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "`napi_get_version`"
 msgstr "`napi_get_version`"
 
-#: src/internals/node-api-host.md:533
+#: src/internals/node-api-host.md:547
 msgid "Returns 8"
 msgstr "返回 8"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
@@ -79722,58 +80948,58 @@ msgstr ""
 "`napi_create_promise`, `napi_resolve_deferred`, `napi_reject_deferred`, "
 "`napi_is_promise`"
 
-#: src/internals/node-api-host.md:534
+#: src/internals/node-api-host.md:548
 msgid "Deferred records are environment-owned roots"
 msgstr "延期记录是环境所拥有的根"
 
-#: src/internals/node-api-host.md:535 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:549 src/internals/node-api-host.md:586
 msgid "never"
 msgstr "never"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid "`napi_run_script`"
 msgstr "`napi_run_script`"
 
-#: src/internals/node-api-host.md:535
+#: src/internals/node-api-host.md:549
 msgid ""
 "Returns `napi_generic_failure`; arbitrary runtime source execution would "
 "violate the no-runtime-engine model"
 msgstr "返回 `napi_generic_failure`;任意的运行时源执行会违反无运行时引擎模型"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "`napi_adjust_external_memory`"
 msgstr "`napi_adjust_external_memory`"
 
-#: src/internals/node-api-host.md:536
+#: src/internals/node-api-host.md:550
 msgid "Collector pressure accounting"
 msgstr "收纳器压力计算"
 
-#: src/internals/node-api-host.md:538
+#: src/internals/node-api-host.md:552
 msgid "`js_native_api.h`: versions 5 through 8"
 msgstr "`js_native_api.h`:第 5 个到第 8 个版本"
 
-#: src/internals/node-api-host.md:540 src/internals/node-api-host.md:554
-#: src/internals/node-api-host.md:565
+#: src/internals/node-api-host.md:554 src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:579
 msgid "Version"
 msgstr "Version"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 msgstr "`napi_create_date`, `napi_is_date`, `napi_get_date_value`"
 
-#: src/internals/node-api-host.md:542
+#: src/internals/node-api-host.md:556
 msgid "Perry `Date` identity/value"
 msgstr "Perry `Date` identity/value"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "`napi_add_finalizer`"
 msgstr "`napi_add_finalizer`"
 
-#: src/internals/node-api-host.md:543
+#: src/internals/node-api-host.md:557
 msgid "Queued post-GC finalization"
 msgstr "排队后GC完成"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
@@ -79781,11 +81007,11 @@ msgstr ""
 "`napi_create_bigint_int64`, `napi_create_bigint_uint64`, "
 "`napi_create_bigint_words`"
 
-#: src/internals/node-api-host.md:544
+#: src/internals/node-api-host.md:558
 msgid "Arbitrary precision"
 msgstr "任意的精度"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
@@ -79793,68 +81019,68 @@ msgstr ""
 "`napi_get_value_bigint_int64`, `napi_get_value_bigint_uint64`, "
 "`napi_get_value_bigint_words`"
 
-#: src/internals/node-api-host.md:545
+#: src/internals/node-api-host.md:559
 msgid "Exact `lossless` and word-count behavior"
 msgstr "正确的`lossless`和字数行为"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "`napi_get_all_property_names`"
 msgstr "`napi_get_all_property_names`"
 
-#: src/internals/node-api-host.md:546
+#: src/internals/node-api-host.md:560
 msgid "Collection mode, filter, and key conversion honored"
 msgstr "收集模式,过器,和关键转换被尊重"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid "`napi_set_instance_data`, `napi_get_instance_data`"
 msgstr "`napi_set_instance_data`, `napi_get_instance_data`"
 
-#: src/internals/node-api-host.md:547
+#: src/internals/node-api-host.md:561
 msgid ""
 "One record per environment; replacement overwrites without calling the "
 "previous finalizer"
 msgstr "每个环境一个记录; 替换重写,而不需要调用之前的终结器"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 msgstr "`napi_detach_arraybuffer`, `napi_is_detached_arraybuffer`"
 
-#: src/internals/node-api-host.md:548
+#: src/internals/node-api-host.md:562
 msgid "Existing detach propagation"
 msgstr "现有的脱离传播"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "`napi_type_tag_object`, `napi_check_object_type_tag`"
 msgstr "`napi_type_tag_object`, `napi_check_object_type_tag`"
 
-#: src/internals/node-api-host.md:549
+#: src/internals/node-api-host.md:563
 msgid "128-bit tag in object metadata"
 msgstr "对象元数据中的128位标签"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "`napi_object_freeze`, `napi_object_seal`"
 msgstr "`napi_object_freeze`, `napi_object_seal`"
 
-#: src/internals/node-api-host.md:550
+#: src/internals/node-api-host.md:564
 msgid "Perry descriptor machinery"
 msgstr "描述器机器 Perry"
 
-#: src/internals/node-api-host.md:552
+#: src/internals/node-api-host.md:566
 msgid "`js_native_api.h`: version 9, version 10, and experimental"
 msgstr "`js_native_api.h`:版本9,版本10和实验"
 
-#: src/internals/node-api-host.md:554
+#: src/internals/node-api-host.md:568
 msgid "Reason"
 msgstr "Reason"
 
-#: src/internals/node-api-host.md:556 src/internals/node-api-host.md:557
-#: src/internals/node-api-host.md:558 src/internals/node-api-host.md:559
-#: src/internals/node-api-host.md:560 src/internals/node-api-host.md:561
-#: src/internals/node-api-host.md:578 src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:570 src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:572 src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:574 src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:592 src/internals/node-api-host.md:593
 msgid "later"
 msgstr "later"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
@@ -79862,16 +81088,16 @@ msgstr ""
 "`node_api_symbol_for`, `node_api_create_syntax_error`, "
 "`node_api_throw_syntax_error`"
 
-#: src/internals/node-api-host.md:556
+#: src/internals/node-api-host.md:570
 msgid "Advertise only with a complete version-9 surface"
 msgstr "只有使用完整的版本-9表面进行广告"
 
-#: src/internals/node-api-host.md:557 src/internals/node-api-host.md:558
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:571 src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:593
 msgid "10"
 msgstr "10"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
@@ -79879,11 +81105,11 @@ msgstr ""
 "`node_api_create_external_string_latin1`, "
 "`node_api_create_external_string_utf16`"
 
-#: src/internals/node-api-host.md:557
+#: src/internals/node-api-host.md:571
 msgid "Requires external string lifetime/accounting work"
 msgstr "需要外部字符串 lifetime/accounting 工作"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
@@ -79891,29 +81117,29 @@ msgstr ""
 "`node_api_create_property_key_latin1`, `node_api_create_property_key_utf8`, "
 "`node_api_create_property_key_utf16`"
 
-#: src/internals/node-api-host.md:558
+#: src/internals/node-api-host.md:572
 msgid "Version-10 fast-path aliases"
 msgstr "第10版本快速通道别名"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "experimental"
 msgstr "experimental"
 
-#: src/internals/node-api-host.md:559
+#: src/internals/node-api-host.md:573
 msgid "`node_api_post_finalizer`"
 msgstr "`node_api_post_finalizer`"
 
-#: src/internals/node-api-host.md:559 src/internals/node-api-host.md:560
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:573 src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:575
 msgid "Not part of the advertised stable ABI"
 msgstr "不属于广告中的稳定ABI"
 
-#: src/internals/node-api-host.md:560
+#: src/internals/node-api-host.md:574
 msgid "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 msgstr "`node_api_create_object_with_properties`, `node_api_set_prototype`"
 
-#: src/internals/node-api-host.md:561
+#: src/internals/node-api-host.md:575
 msgid ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
@@ -79921,33 +81147,33 @@ msgstr ""
 "`node_api_create_sharedarraybuffer`, "
 "`node_api_create_external_sharedarraybuffer`, `node_api_is_sharedarraybuffer`"
 
-#: src/internals/node-api-host.md:563
+#: src/internals/node-api-host.md:577
 msgid "`node_api.h`"
 msgstr "`node_api.h`"
 
-#: src/internals/node-api-host.md:567 src/internals/node-api-host.md:568
-#: src/internals/node-api-host.md:569 src/internals/node-api-host.md:570
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:581 src/internals/node-api-host.md:582
+#: src/internals/node-api-host.md:583 src/internals/node-api-host.md:584
+#: src/internals/node-api-host.md:585
 msgid "base"
 msgstr "base"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "`napi_module_register`, `napi_fatal_error`"
 msgstr "`napi_module_register`, `napi_fatal_error`"
 
-#: src/internals/node-api-host.md:567
+#: src/internals/node-api-host.md:581
 msgid "Legacy registration and abort path"
 msgstr "遗留注册和中止路径"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 msgstr "`napi_async_init`, `napi_async_destroy`, `napi_make_callback`"
 
-#: src/internals/node-api-host.md:568
+#: src/internals/node-api-host.md:582
 msgid "Existing async-hooks integration"
 msgstr "现有的异步集成"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
@@ -79955,11 +81181,11 @@ msgstr ""
 "`napi_create_buffer`, `napi_create_external_buffer`, "
 "`napi_create_buffer_copy`, `napi_is_buffer`, `napi_get_buffer_info`"
 
-#: src/internals/node-api-host.md:569
+#: src/internals/node-api-host.md:583
 msgid "Perry `Buffer` identity and stable bytes"
 msgstr "Perry `Buffer`身份和稳定的字节"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
@@ -79967,29 +81193,29 @@ msgstr ""
 "`napi_create_async_work`, `napi_delete_async_work`, `napi_queue_async_work`, "
 "`napi_cancel_async_work`"
 
-#: src/internals/node-api-host.md:570
+#: src/internals/node-api-host.md:584
 msgid "Explicit state machine above"
 msgstr "上方的明确状态机器"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid "`napi_get_node_version`"
 msgstr "`napi_get_node_version`"
 
-#: src/internals/node-api-host.md:571
+#: src/internals/node-api-host.md:585
 msgid ""
 "Returns Perry's semver components with release string `perry`; it does not "
 "claim a Node release"
 msgstr "返回 Perry 的 semver 组件与发布字符串 `perry`;它不要求节点发布"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "`napi_get_uv_event_loop`"
 msgstr "`napi_get_uv_event_loop`"
 
-#: src/internals/node-api-host.md:572
+#: src/internals/node-api-host.md:586
 msgid "Returns `napi_generic_failure` and a null loop; Perry has no libuv"
 msgstr "返回 `napi_generic_failure` 和一个零循环; Perry 没有 libuv"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
@@ -79997,19 +81223,19 @@ msgstr ""
 "`napi_fatal_exception`, `napi_add_env_cleanup_hook`, "
 "`napi_remove_env_cleanup_hook`"
 
-#: src/internals/node-api-host.md:573
+#: src/internals/node-api-host.md:587
 msgid "Main-thread lifecycle"
 msgstr "主线程生命周期"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "`napi_open_callback_scope`, `napi_close_callback_scope`"
 msgstr "`napi_open_callback_scope`, `napi_close_callback_scope`"
 
-#: src/internals/node-api-host.md:574
+#: src/internals/node-api-host.md:588
 msgid "Async context and strict nesting"
 msgstr "异步背景和严格嵌套"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
@@ -80017,11 +81243,11 @@ msgstr ""
 "`napi_create_threadsafe_function`, `napi_get_threadsafe_function_context`, "
 "`napi_call_threadsafe_function`"
 
-#: src/internals/node-api-host.md:575
+#: src/internals/node-api-host.md:589
 msgid "Event-pump-backed TSFN"
 msgstr "事件支持TSFN"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
@@ -80029,35 +81255,35 @@ msgstr ""
 "`napi_acquire_threadsafe_function`, `napi_release_threadsafe_function`, "
 "`napi_unref_threadsafe_function`, `napi_ref_threadsafe_function`"
 
-#: src/internals/node-api-host.md:576
+#: src/internals/node-api-host.md:590
 msgid "Thread count and event-loop keepalive"
 msgstr "线程数量和事件循环保持"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 msgstr "`napi_add_async_cleanup_hook`, `napi_remove_async_cleanup_hook`"
 
-#: src/internals/node-api-host.md:577
+#: src/internals/node-api-host.md:591
 msgid "Shutdown waits for completion"
 msgstr "关闭等待完成"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "`node_api_get_module_file_name`"
 msgstr "`node_api_get_module_file_name`"
 
-#: src/internals/node-api-host.md:578
+#: src/internals/node-api-host.md:592
 msgid "Environment already records the future value"
 msgstr "环境已经记录了未来的价值"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "`node_api_create_buffer_from_arraybuffer`"
 msgstr "`node_api_create_buffer_from_arraybuffer`"
 
-#: src/internals/node-api-host.md:579
+#: src/internals/node-api-host.md:593
 msgid "Advertise with version 10"
 msgstr "广告版本10"
 
-#: src/internals/node-api-host.md:581
+#: src/internals/node-api-host.md:595
 msgid ""
 "The addon-side initializer exports `node_api_module_get_api_version_v1` and "
 "`napi_register_module_v1`; these are looked up in the addon and are not host "
@@ -80066,16 +81292,16 @@ msgstr ""
 "添加程序侧初始化器导出`node_api_module_get_api_version_v1`和"
 "`napi_register_module_v1`;这些在添加程序中查找,而不是主机导出."
 
-#: src/internals/node-api-host.md:585
+#: src/internals/node-api-host.md:599
 msgid "Required gates"
 msgstr "需要的门"
 
-#: src/internals/node-api-host.md:587
+#: src/internals/node-api-host.md:601
 msgid ""
 "Implementation is not complete until the gates below can independently fail:"
 msgstr "在下面的门独立失败之前,实现还没有完成:"
 
-#: src/internals/node-api-host.md:589
+#: src/internals/node-api-host.md:603
 msgid ""
 "**Handle/GC gate:** scopes, strong and weak refs, wrap metadata, callbacks, "
 "and pending exceptions survive forced copied minors and full collections; "
@@ -80086,7 +81312,7 @@ msgstr ""
 "年人和完整的集合;陈旧的处理器失败生成验证;根持有器和 rekey-table 审计脚本清"
 "洁."
 
-#: src/internals/node-api-host.md:593
+#: src/internals/node-api-host.md:607
 msgid ""
 "**Exception gate:** a throwing getter, native callback, finalizer misuse, "
 "and TSFN callback all return through C before Perry raises; an instrumented "
@@ -80095,7 +81321,7 @@ msgstr ""
 "**异常门:** 在Perry升级之前,一个投射getter,原生回调,最终化器滥用和TSFN回调都"
 "通过C返回;一个仪器附加器声称没有放松进入其."
 
-#: src/internals/node-api-host.md:596
+#: src/internals/node-api-host.md:610
 msgid ""
 "**Loader/export gate:** a real addon records the address of a called "
 "`napi_*` function and the test proves that address belongs to the Perry "
@@ -80104,7 +81330,7 @@ msgstr ""
 "**Loader/export 门:** 一个真正的添加程序记录了一个叫做 `napi_*` 函数的地址,测"
 "试证明地址属于 Perry 执行文件. 烟雾电话数量必须大于零."
 
-#: src/internals/node-api-host.md:599
+#: src/internals/node-api-host.md:613
 msgid ""
 "**Real-addon gate:** one node-addon-api addon and one napi-rs addon cover "
 "properties, classes, async work, TSFN, instance data, wrap/finalizers, and "
@@ -80115,7 +81341,7 @@ msgstr ""
 "异步工作, TSFN,实例数据,wrap/finalizers 和缓冲区. 不支持的NAPI版本,NAN/V8和"
 "`uv_*`具,可以确认它们的确切诊断."
 
-#: src/internals/node-api-host.md:603
+#: src/internals/node-api-host.md:617
 msgid ""
 "**Watcher differential gate:** the real `@parcel/watcher` binary and Perry's "
 "facade observe the same fixture tree and emit identical coalesced streams; "
@@ -80124,7 +81350,7 @@ msgstr ""
 "**监视器差异门:** 真正的`@parcel/watcher`二进制和Perry的外观观察到相同的固定"
 "树,并发出相同的合并流;双方都声称他们的原生实现实际运行."
 
-#: src/internals/node-api-host.md:606
+#: src/internals/node-api-host.md:620
 msgid ""
 "**Distribution gate:** move the executable plus sidecar directory to a read-"
 "only location and load successfully; deletion or mutation of a sidecar fails "
@@ -80133,14 +81359,14 @@ msgstr ""
 "**分销门:** 将可执行文件加上侧车目录移动到仅读位置并成功加载;删除或突变侧车未"
 "能检查显示哈希."
 
-#: src/internals/node-api-host.md:609
+#: src/internals/node-api-host.md:623
 msgid ""
 "**Cache gate:** changing only addon bytes or policy misses the build cache; "
 "rebuilding unchanged inputs hits it."
 msgstr ""
 "**缓存门:** 仅改变添加字节或策略就会错过构建缓存;重建未改变的输入就会击中它."
 
-#: src/internals/node-api-host.md:611
+#: src/internals/node-api-host.md:625
 msgid ""
 "**Size gate:** byte-identical hello-world outputs with an empty addon graph; "
 "report the host-only delta for an addon build and enforce the 0.6 MB budget."
@@ -80148,7 +81374,7 @@ msgstr ""
 "**尺寸门:** 字节相同的 hello-world 输出与空的添加图; 报告一个添加构建的只主机"
 "三角,并执行 0.6 MB 预算."
 
-#: src/internals/node-api-host.md:614
+#: src/internals/node-api-host.md:628
 msgid ""
 "The host is not enabled merely because its unit tests pass. The real-addon "
 "and symbol-provenance gates are the acceptance boundary: a green run in "
@@ -80668,28 +81894,14 @@ msgid "Use explicit commands for broader scopes:"
 msgstr "使用明确命令用于更广泛的范围:"
 
 #: src/contributing/crate-policy.md:86
-msgid "# Product feedback loop"
+#, fuzzy
+msgid "# Product feedback loop\n"
 msgstr "# 产品feedback循环"
 
 #: src/contributing/crate-policy.md:89
-msgid "# Every host-compatible workspace member (Bash)"
+#, fuzzy
+msgid "# Every host-compatible workspace member (Bash)\n"
 msgstr "# 每个与主机兼容的工作空间成员 (Bash)"
-
-#: src/contributing/crate-policy.md:94
-msgid "\"${excluded[@]}\""
-msgstr "\"${excluded[@]}\""
-
-#: src/contributing/crate-policy.md:94
-msgid "\"$package\""
-msgstr "\"$包装\""
-
-#: src/contributing/crate-policy.md:95 src/contributing/crate-policy.md:96
-msgid "\"${cargo_args[@]}\""
-msgstr "\"${cargo_args[@]}\""
-
-#: src/contributing/crate-policy.md:97
-msgid "# Inspect or validate the workspace architecture"
-msgstr "# 检查或验证工作空间架构"
 
 #: src/contributing/crate-policy.md:104
 msgid ""
@@ -80826,7 +82038,8 @@ msgstr ""
 "时,才安装匹配响声."
 
 #: src/contributing/building.md:32
-msgid "# Build the default product and its dependency closure"
+#, fuzzy
+msgid "# Build the default product and its dependency closure\n"
 msgstr "# 构建默认产品及其依赖关闭"
 
 #: src/contributing/building.md:37
@@ -80942,7 +82155,8 @@ msgstr ""
 "`sccache`,然后运行Cargo通过包装:"
 
 #: src/contributing/building.md:74
-msgid "# Slim, optimized developer CLI"
+#, fuzzy
+msgid "# Slim, optimized developer CLI\n"
 msgstr "# 精简,优化的开发者 CLI"
 
 #: src/contributing/building.md:80
@@ -80972,22 +82186,27 @@ msgid "Build Specific Crates"
 msgstr "构建特定 crate"
 
 #: src/contributing/building.md:93
-msgid "# Runtime only (must rebuild stdlib too!)"
+#, fuzzy
+msgid "# Runtime only (must rebuild stdlib too!)\n"
 msgstr "# 只有运行时间 (还必须重建stdlib!)"
 
 #: src/contributing/building.md:95
+#, fuzzy
 msgid ""
-"# The .a static archives are emitted by separate wrapper crates (#5422), so a"
+"# The .a static archives are emitted by separate wrapper crates (#5422), so "
+"a\n"
 msgstr "# 静态档案由单独的包装盒 (#5422) 发出,因此"
 
 #: src/contributing/building.md:97
+#, fuzzy
 msgid ""
 "# explicitly when you need libperry_runtime.a / libperry_stdlib.a (e.g. to "
-"link"
+"link\n"
 msgstr "# 当你需要libperry_runtime.a / libperry_stdlib.a (e.g. 进行链接时"
 
 #: src/contributing/building.md:101
-msgid "# Codegen only"
+#, fuzzy
+msgid "# Codegen only\n"
 msgstr "# 只有Codegen"
 
 #: src/contributing/building.md:106
@@ -81030,15 +82249,19 @@ msgid "Run Tests"
 msgstr "运行测试"
 
 #: src/contributing/building.md:126
-msgid "# Product unit targets"
+#, fuzzy
+msgid "# Product unit targets\n"
 msgstr "# 产品单位目标"
 
 #: src/contributing/building.md:128
-msgid "# Inspect the nightly CI test scope (all Linux-compatible test crates)"
+#, fuzzy
+msgid ""
+"# Inspect the nightly CI test scope (all Linux-compatible test crates)\n"
 msgstr "# 检查夜间CI测试范围 (所有兼容Linux的测试盒)"
 
 #: src/contributing/building.md:131
-msgid "# Specific crate"
+#, fuzzy
+msgid "# Specific crate\n"
 msgstr "# 特定的盒子"
 
 #: src/contributing/building.md:137
@@ -81046,11 +82269,13 @@ msgid "Compile and Run TypeScript"
 msgstr "编译并运行 TypeScript"
 
 #: src/contributing/building.md:140
-msgid "# Compile a TypeScript file"
+#, fuzzy
+msgid "# Compile a TypeScript file\n"
 msgstr "# 编译一个 TypeScript 文件"
 
 #: src/contributing/building.md:143
-msgid "# Debug: print HIR"
+#, fuzzy
+msgid "# Debug: print HIR\n"
 msgstr "# 调试:打印HIR"
 
 #: src/contributing/building.md:148
@@ -81112,19 +82337,23 @@ msgstr ""
 "或任何公共注册表 shasum不同,则拒绝标记."
 
 #: src/contributing/releasing.md:16
-msgid "# Confirm the checkout is current and clean."
+#, fuzzy
+msgid "# Confirm the checkout is current and clean.\n"
 msgstr "# 确认结账是最新的和干净的."
 
 #: src/contributing/releasing.md:18
-msgid "# must print 0"
+#, fuzzy
+msgid "# must print 0\n"
 msgstr "# 必须打印0"
 
 #: src/contributing/releasing.md:19
-msgid "# must print nothing"
+#, fuzzy
+msgid "# must print nothing\n"
 msgstr "# 没有任何印刷"
 
 #: src/contributing/releasing.md:20
-msgid "# Fast policy and script checks."
+#, fuzzy
+msgid "# Fast policy and script checks.\n"
 msgstr "# 快速的政策和脚本检查."
 
 #: src/contributing/releasing.md:23
@@ -81132,7 +82361,9 @@ msgid "origin/main"
 msgstr "origin/main"
 
 #: src/contributing/releasing.md:28
-msgid "# Host-runnable behavioral checks. These improve turnaround, but do not"
+#, fuzzy
+msgid ""
+"# Host-runnable behavioral checks. These improve turnaround, but do not\n"
 msgstr "# 通过主机进行行为检查. 这些提高了转换率,但并没有"
 
 #: src/contributing/releasing.md:38
@@ -81153,7 +82384,8 @@ msgstr ""
 "的合并过程找到新的版本."
 
 #: src/contributing/releasing.md:47
-msgid "# Substitute the version already present in Cargo.toml."
+#, fuzzy
+msgid "# Substitute the version already present in Cargo.toml.\n"
 msgstr "# 取代已经存在于 Cargo.toml 中的版本."
 
 #: src/contributing/releasing.md:48
@@ -81173,7 +82405,8 @@ msgid "'[0-9]*.md'"
 msgstr "\"[0-9]*.md\""
 
 #: src/contributing/releasing.md:52
-msgid "\"refs/tags/v$VERSION\"  # must print nothing"
+#, fuzzy
+msgid "\"refs/tags/v$VERSION\"  # must print nothing\n"
 msgstr "\"refs/tags/v$VERSION\"#不能打印任何东西"
 
 #: src/contributing/releasing.md:53 src/contributing/releasing.md:54
@@ -81267,9 +82500,10 @@ msgid "allowed action: **`npm publish`**"
 msgstr "允许的行动: **`npm publish`**"
 
 #: src/contributing/releasing.md:101
+#, fuzzy
 msgid ""
 "npm permits only one trusted publisher per package. The canonical identity "
-"is the existing `release-packages.yml` workflow above, with direct **`npm  "
+"is the existing `release-packages.yml` workflow above, with direct **`npm "
 "publish`** enabled. Do not configure `npm-stage-publish.yml` as a second "
 "publisher and do not add an environment name that the other packages do not "
 "use."
@@ -81296,20 +82530,15 @@ msgstr ""
 "次提供该包名,然后配置上面的可信发布者字段. 释放管道故意拒绝部分集."
 
 #: src/contributing/releasing.md:120
-msgid "# one Release Packages run: exact-SHA gates/builds,"
-msgstr "# 一个发布包运行:exact-SHA gates/builds,"
-
-#: src/contributing/releasing.md:120
 msgid ""
-"                            # publish + verify all 9 via OIDC, then create"
-msgstr "                            # 通过OIDC发布+验证所有9个,然后创建"
-
-#: src/contributing/releasing.md:121
-msgid "                            # v0.x.y + the GitHub Release last"
-msgstr "                            # v0.x.y + GitHub 最后发布"
+"# one Release Packages run: exact-SHA gates/builds,\n"
+"                            # publish + verify all 9 via OIDC, then create\n"
+"                            # v0.x.y + the GitHub Release last\n"
+msgstr ""
 
 #: src/contributing/releasing.md:125
-msgid "# inspect the commit/run/package/Socket receipt"
+#, fuzzy
+msgid "# inspect the commit/run/package/Socket receipt\n"
 msgstr "# 检查commit/run/package/Socket收据"
 
 #: src/contributing/releasing.md:128
@@ -81517,11 +82746,13 @@ msgstr ""
 "结合`xcrun simctl`来验证一个doc-示例运行没有人:"
 
 #: src/contributing/releasing.md:174
-msgid "# Compile for the simulator"
+#, fuzzy
+msgid "# Compile for the simulator\n"
 msgstr "# 编译模拟器"
 
 #: src/contributing/releasing.md:176
-msgid "# Boot a device (one-time; reuse the UDID across runs)"
+#, fuzzy
+msgid "# Boot a device (one-time; reuse the UDID across runs)\n"
 msgstr "# 启动设备 (一次性;在运行中重复使用UDID)"
 
 #: src/contributing/releasing.md:178
@@ -81529,20 +82760,9 @@ msgid "\"iPhone 15\""
 msgstr "\"iPhone 15\""
 
 #: src/contributing/releasing.md:180
-msgid "# Install + launch with test mode"
+#, fuzzy
+msgid "# Install + launch with test mode\n"
 msgstr "# 安装 + 启动测试模式"
-
-#: src/contributing/releasing.md:184 src/contributing/releasing.md:277
-msgid "500"
-msgstr "500"
-
-#: src/contributing/releasing.md:185
-msgid "\"$PWD/counter-ios.png\""
-msgstr "\"$PWD/counter-ios.png\""
-
-#: src/contributing/releasing.md:187
-msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
-msgstr "# 染后的应用程序输出0;屏幕截图登陆于反-ios.png"
 
 #: src/contributing/releasing.md:191
 msgid ""
@@ -81791,6 +83011,10 @@ msgid "patch distance"
 msgstr "补丁距离"
 
 #: src/contributing/releasing.md:277
+msgid "500"
+msgstr "500"
+
+#: src/contributing/releasing.md:277
 msgid ""
 "every merge bumps the workspace patch, so this is a commit count in "
 "disguise. A backstop for a cadence spike inside an unexpired age budget — "
@@ -81822,15 +83046,18 @@ msgstr ""
 "粘性问题,并更新它;它关闭自己一旦注册表赶上了."
 
 #: src/contributing/releasing.md:284
-msgid "# proves it can fail"
+#, fuzzy
+msgid "# proves it can fail\n"
 msgstr "# 证明它可以失败"
 
 #: src/contributing/releasing.md:285
-msgid "# offline"
+#, fuzzy
+msgid "# offline\n"
 msgstr "# offline"
 
 #: src/contributing/releasing.md:286
-msgid "# real registry, no issue writes"
+#, fuzzy
+msgid "# real registry, no issue writes\n"
 msgstr "# 真正的登记,没有问题写"
 
 #: src/contributing/releasing.md:289
@@ -81880,6 +83107,351 @@ msgstr ""
 "**标签后分发失败**:重新运行失败的工作流程. 要重新尝试旧的发布包分发脚,请使用"
 "`existing_tag=vX.Y.Z`发送;只有当idempotent npm脚本身也需要重新尝试时,添加"
 "`publish_npm=true`."
+
+#~ msgid "# Arch"
+#~ msgstr "# Arch"
+
+#~ msgid "'pdfium-render = \"0.8\"'"
+#~ msgstr "\"pdfium-render = \"0.8\" 这个字符号"
+
+#~ msgid "# Edit src/lib.rs — add your `js_*` functions, all using only"
+#~ msgstr "# 编辑 src/lib.rs 添加您的 `js_*` 函数,所有只使用"
+
+#~ msgid "# Edit src/index.ts — declare the TS surface user code imports"
+#~ msgstr "# 编辑 src/index.ts 声明 TS 表面用户代码进口"
+
+#~ msgid "# Edit package.json — list every js_* export in the"
+#~ msgstr "# 编辑package.json 列出每个js_*出口"
+
+#~ msgid "# Verify"
+#~ msgstr "# Verify"
+
+#~ msgid "# ✅ manifest matches the staticlib"
+#~ msgstr "# ✅公示表与静态表匹配"
+
+#~ msgid "# Publish"
+#~ msgstr "# Publish"
+
+#~ msgid "# the scaffolded release.yml"
+#~ msgstr "# 架式的release.yml"
+
+#~ msgid ""
+#~ "                                    # builds prebuilts for all targets"
+#~ msgstr "                                    # 为所有目标构建预先构建"
+
+#~ msgid ""
+#~ "                                    # and attaches them to the release"
+#~ msgstr "                                    # 然后,我把它们绑在子上,"
+
+#~ msgid "\"Native bindings for <upstream crate>\""
+#~ msgstr "\"<upstream crate> 的本地绑定\""
+
+#~ msgid "'<crate-name> = \"<version>\"'"
+#~ msgstr "'<crate-name> = \"<version>\"'"
+
+#~ msgid "/// `pdf.parse(buf) -> string` — extract text from a PDF buffer."
+#~ msgstr "/// `pdf.parse(buf) -> string` 从PDF缓冲区中提取文本."
+
+#~ msgid "///"
+#~ msgstr "///"
+
+#~ msgid "/// # Safety"
+#~ msgstr "#安全性"
+
+#~ msgid ""
+#~ "/// `buf_ptr` must be null or valid for `buf_len` bytes. Perry passes"
+#~ msgstr "/// `buf_ptr`必须为 `buf_len`字节为 null 或有效. 通过Perry"
+
+#~ msgid "/// this pair from a `buffer+len` manifest parameter."
+#~ msgstr "这对来自一个`buffer+len`显示参数."
+
+#~ msgid "// worker.js"
+#~ msgstr "// worker.js"
+
+#~ msgid "// const result = await spawn(() => heavyComputation(inputData));"
+#~ msgstr "// const结果 = 等待spawn(() => heavyComputation(inputData));"
+
+#~ msgid "`widgetSetEdgeInsets`"
+#~ msgstr "`widgetSetEdgeInsets`"
+
+#~ msgid "Padding and Insets"
+#~ msgstr "Padding 与 Insets"
+
+#~ msgid "target/aarch64-apple-watchos/release"
+#~ msgstr "target/aarch64-apple-watchos/release"
+
+#~ msgid "target/arm64_32-apple-watchos/release"
+#~ msgstr "target/arm64_32-apple-watchos/release"
+
+#~ msgid "_perry_user_main"
+#~ msgstr "_perry_user_main"
+
+#~ msgid ".../arm64_32-apple-watchos/release"
+#~ msgstr ".../arm64_32-apple-watchos/release"
+
+#~ msgid "# 2. arm64 slice (default device target)"
+#~ msgstr "# 2. arm64切片 (默认设备目标)"
+
+#~ msgid ".../aarch64-apple-watchos/release"
+#~ msgstr ".../aarch64-apple-watchos/release"
+
+#~ msgid "# 3. align minos + fuse"
+#~ msgstr "# 3. 调整子 + 安全"
+
+#~ msgid "# => arm64_32 arm64"
+#~ msgstr "# => arm64_32 arm64 没有"
+
+#~ msgid "\"Container.app/Watch/WatchApp.app\""
+#~ msgstr "\"Container.app/Watch/WatchApp.app\""
+
+#~ msgid "\"platforms;android-35\" \"build-tools;35.0.0\""
+#~ msgstr "\"平台;安卓-35\" \"构建工具;35.0.0\""
+
+#~ msgid "\"ndk;28.2.13676358\""
+#~ msgstr "\"ndk;28.2.13676358\""
+
+#~ msgid "\"system-images;android-34;android-wear;arm64-v8a\""
+#~ msgstr "\"系统图像;安卓-34;安卓穿戴;ARM64-V8A\""
+
+#~ msgid "# 4. The Rust cross target"
+#~ msgstr "# 4. 交叉目标Rust"
+
+#~ msgid "# 5. Create + boot a Wear OS emulator (round watch)"
+#~ msgstr "# 5. 创建 + 启动一个 Wear OS 模拟器 (全程观看)"
+
+#~ msgid ""
+#~ "Additional npm packages and Node.js APIs supported by Perry. All listed "
+#~ "here are wired through Perry's well-known native bindings registry (#466) "
+#~ "and compile to native code with no JavaScript runtime involvement."
+#~ msgstr ""
+#~ "Perry 支持的其他 npm 包和 Node.js API。此处列出的所有项均通过 Perry 的 "
+#~ "well-known 原生绑定注册表（#466）接入，并编译为原生代码，不涉及 "
+#~ "JavaScript 运行时。"
+
+#~ msgid "# …"
+#~ msgstr "# …"
+
+#~ msgid ""
+#~ "# 3) Sanity-check the signature locally before uploading the manifest —"
+#~ msgstr "# 在上传公告之前,"
+
+#~ msgid "#    here predicts a passing verify on the client."
+#~ msgstr "#    这里预测一个通过验证客户."
+
+#~ msgid "'<base64 from step 2>'"
+#~ msgstr "'<base64 from step 2>'"
+
+#~ msgid "'<public_key from kp.json>'"
+#~ msgstr "'<public_key from kp.json>'"
+
+#~ msgid ""
+#~ "# 4) Release CI signs the CLI manifest, binding its archive URL, platform,"
+#~ msgstr "# 4) 发布CI签署了CLI宣言,绑定其档案URL,平台,"
+
+#~ msgid ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+#~ msgstr ""
+#~ "'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-"
+#~ "x86_64.tar.gz'"
+
+#~ msgid "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+#~ msgstr "\"$PERRY_CLI_UPDATE_SIGNING_KEY\""
+
+#~ msgid ""
+#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK"
+#~ msgstr "// 检测目标:aarch64-apple-ios → arm64-apple-ios16.0,iPhoneOS SDK"
+
+#~ msgid ""
+#~ "// Compile: swiftc -emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+#~ msgstr ""
+#~ "//编译:快速编译-emit-library -static -target ... -sdk ... -framework "
+#~ "StoreKit"
+
+#~ msgid "// Link:    cargo:rustc-link-lib=static=review_bridge"
+#~ msgstr "//链接:货物:rustc-link-lib=static=review_bridge"
+
+#~ msgid "'Content-Type: application/json'"
+#~ msgstr "\"内容类型:application/json\""
+
+#~ msgid "'{\"text\":\"hello world\"}'"
+#~ msgstr "您可以在下面的页面上查看"
+
+#~ msgid "'{\"value\":0.75}'"
+#~ msgstr "\"{\"值\":0.75}\""
+
+#~ msgid "'{\"value\":42}'"
+#~ msgstr "\"{\"价值\":42}\""
+
+#~ msgid "'{\"shortcut\":\"s\"}'"
+#~ msgstr "现在,我们可以在这个问题上做些什么"
+
+#~ msgid "'{\"x\":0,\"y\":200}'"
+#~ msgstr "'{\"x\":0,\"y\":200}'"
+
+#~ msgid "'{\"interval_ms\":200}'"
+#~ msgstr "'{\"interval_ms\":200}'"
+
+#~ msgid "'s IP:"
+#~ msgstr "的IP:"
+
+#~ msgid "$(curl -sf http://127.0.0.1:7676/widgets)"
+#~ msgstr "$(curl -sf http://127.0.0.1:7676/widgets)"
+
+#~ msgid "'{\"interval_ms\":50}'"
+#~ msgstr "'{\"interval_ms\":50}'"
+
+#~ msgid "# Let it run for 30 seconds"
+#~ msgstr "# 让它运行30秒钟"
+
+#~ msgid "# Check stats"
+#~ msgstr "# 检查统计数据"
+
+#~ msgid "# {\"running\":true,\"events_fired\":600,\"uptime_secs\":30}"
+#~ msgstr "# 现在我们要做些什么events_fired\"六百\",uptime_secs没有人知道"
+
+#~ msgid "# Take a screenshot to see final state"
+#~ msgstr "# 截图以查看最终状态"
+
+#~ msgid "# Stop chaos"
+#~ msgstr "# 停止混乱"
+
+#~ msgid "# Check the app is still alive"
+#~ msgstr "# 检查应用程序是否还在使用"
+
+#~ msgid "jobs"
+#~ msgstr "jobs"
+
+#~ msgid "# ["
+#~ msgstr "# ["
+
+#~ msgid "# ]"
+#~ msgstr "# ]"
+
+#~ msgid "# Build for iOS (cross-compile)"
+#~ msgstr "# 为 iOS 构建 (交叉编译)"
+
+#~ msgid "'.workflow_runs[].id'"
+#~ msgstr "\".workflow_runs[].id\""
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs/$id/jobs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"in_progress\") | (.labels|join(\",\"))'"
+#~ msgstr "\"就业\" | select(.status==\"in_progress\") | (标签|join(\",\"))'"
+
+#~ msgid "# How deep the queue is, and on which pools:"
+#~ msgstr "# 排队的深度,以及哪些池:"
+
+#~ msgid "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+#~ msgstr "\"repos/PerryTS/perry/actions/runs?per_page=100\""
+
+#~ msgid "'.jobs[] | select(.status==\"queued\") | (.labels|join(\",\"))'"
+#~ msgstr "\"就业\" | select(.status==\"queued\") | (标签|join(\",\"))'"
+
+#~ msgid "schedule"
+#~ msgstr "schedule"
+
+#~ msgid "push"
+#~ msgstr "push"
+
+#~ msgid "workflow_dispatch"
+#~ msgstr "workflow_dispatch"
+
+#~ msgid "\"Native bindings for libfoo\""
+#~ msgstr "\"本地绑定libfoo\""
+
+#~ msgid "'libfoo = \"1.0\"'"
+#~ msgstr "\"libfoo = \"1.0\""
+
+#~ msgid "'opencode-web-ui.gen.ts=../app/dist'"
+#~ msgstr "'opencode-web-ui.gen.ts=../app/dist'"
+
+#~ msgid "env"
+#~ msgstr "env"
+
+#~ msgid ""
+#~ "Perry ships **two independent opt-in channels** for sending data home — "
+#~ "nothing leaves your machine without an explicit `enabled = true` or `on` "
+#~ "in `~/.perry/config.toml`. Both honour `PERRY_NO_TELEMETRY=1` and "
+#~ "`CI=true`."
+#~ msgstr ""
+#~ "Perry 船舶 **两个独立的选择道** 为了将数据发回家  没有任何东西离开你的机器"
+#~ "没有一个明确的`enabled = true`或`on`在`~/.perry/config.toml`. 它们都尊重"
+#~ "`PERRY_NO_TELEMETRY=1`和`CI=true`."
+
+#~ msgid "emit human-readable collector diagnostics"
+#~ msgstr "发出人类可读的收集器诊断"
+
+#~ msgid "# NATIVE (PERRY_RS4GC=1): the default everywhere else. Anchors on"
+#~ msgstr "# 本地 (PERRY_RS4GC=1):其他地方的默认. 着"
+
+#~ msgid "\"gc-live\""
+#~ msgstr "\"gc-live\""
+
+#~ msgid ""
+#~ "# `ptr addrspace(1)` root allocas and LLVM inserts the safepoints later, "
+#~ "so the"
+#~ msgstr "# `ptr addrspace(1)` 根配置,并 LLVM 插入后的安全点,所以"
+
+#~ msgid "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+#~ msgstr "'s/.*@([A-Za-z0-9_.$]+)\\($/\\1/'"
+
+#~ msgid ""
+#~ "// GC_STORE_AUDIT(BARRIERED): the slot write is unconditional; the barrier"
+#~ msgstr "// GC_STORE_AUDIT(BARRIERED): 插槽写作是无条件的; 屏障"
+
+#~ msgid ""
+#~ "// below is guarded only by a live test that the stored bits carry no heap"
+#~ msgstr "// 在下面只通过实时测试来保护存储的位没有堆"
+
+#~ msgid "// pointer, which is the barrier's own first test."
+#~ msgstr "//指针,这是屏障的第一个测试."
+
+#~ msgid "/// Borrows the emitter immutably. Not Clone, not Copy."
+#~ msgstr "/// 借用发射器不变. 没有克隆,没有复制."
+
+#~ msgid ""
+#~ "/// a slot index. Freely clonable, no lifetime, no borrow of the emitter."
+#~ msgstr "一个插槽指数. 无需使用发射器."
+
+#~ msgid "// ERROR: obj borrows e,"
+#~ msgstr "//错误:obj借用了e,"
+
+#~ msgid "//        which is mutably"
+#~ msgstr "// 这是一个可变的"
+
+#~ msgid "//        borrowed above"
+#~ msgstr "// 在上面借来的"
+
+#~ msgid "\"${excluded[@]}\""
+#~ msgstr "\"${excluded[@]}\""
+
+#~ msgid "\"$package\""
+#~ msgstr "\"$包装\""
+
+#~ msgid "\"${cargo_args[@]}\""
+#~ msgstr "\"${cargo_args[@]}\""
+
+#~ msgid "# Inspect or validate the workspace architecture"
+#~ msgstr "# 检查或验证工作空间架构"
+
+#~ msgid "# one Release Packages run: exact-SHA gates/builds,"
+#~ msgstr "# 一个发布包运行:exact-SHA gates/builds,"
+
+#~ msgid ""
+#~ "                            # publish + verify all 9 via OIDC, then create"
+#~ msgstr "                            # 通过OIDC发布+验证所有9个,然后创建"
+
+#~ msgid "                            # v0.x.y + the GitHub Release last"
+#~ msgstr "                            # v0.x.y + GitHub 最后发布"
+
+#~ msgid "\"$PWD/counter-ios.png\""
+#~ msgstr "\"$PWD/counter-ios.png\""
+
+#~ msgid "# App exits 0 after rendering; screenshot lands at counter-ios.png"
+#~ msgstr "# 染后的应用程序输出0;屏幕截图登陆于反-ios.png"
 
 #~ msgid ""
 #~ "The scalar aliases currently establish representation inside a `pod` "
@@ -82843,9 +84415,6 @@ msgstr ""
 #~ msgid "`LANG` / `LC_ALL` / `LC_MESSAGES` env vars"
 #~ msgstr "`LANG` / `LC_ALL` / `LC_MESSAGES` 环境变量"
 
-#~ msgid "Compile-Time Validation"
-#~ msgstr "编译期校验"
-
 #~ msgid "Perry validates parameters across all locales during compilation:"
 #~ msgstr "Perry 在编译期跨所有区域设置校验参数:"
 
@@ -82926,17 +84495,6 @@ msgstr ""
 #~ msgstr "对特定边缘应用内边距："
 
 #~ msgid ""
-#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
-#~ "    // Compile: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
-#~ msgstr ""
-#~ "// Detect target: aarch64-apple-ios → arm64-apple-ios16.0, iphoneos SDK\n"
-#~ "    // Compile: swiftc -emit-library -static -target ... -sdk ... "
-#~ "-framework StoreKit\n"
-#~ "    // Link:    cargo:rustc-link-lib=static=review_bridge\n"
-
-#~ msgid ""
 #~ "Uses [`SKStoreReviewController.requestReview(in:)`](https://"
 #~ "developer.apple.com/documentation/storekit/skstorereviewcontroller/"
 #~ "requestreview(in:)) from StoreKit."
@@ -82950,23 +84508,6 @@ msgstr ""
 
 #~ msgid "`SKStoreReviewController.requestReview()`"
 #~ msgstr "`SKStoreReviewController.requestReview()`"
-
-#~ msgid ""
-#~ "'s IP:\n"
-#~ "curl http://192.168.1.42:7676/widgets\n"
-#~ msgstr ""
-#~ "'s IP:\n"
-#~ "curl http://192.168.1.42:7676/widgets\n"
-
-#~ msgid "\"$WIDGETS\""
-#~ msgstr "\"$WIDGETS\""
-
-#~ msgid ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
-#~ msgstr ""
-#~ "# GitHub Actions example\n"
-#~ "jobs"
 
 #~ msgid "Produce object file only, skip linking"
 #~ msgstr "仅生成目标文件，跳过链接"

--- a/docs/src/ui/layout.md
+++ b/docs/src/ui/layout.md
@@ -6,8 +6,8 @@ platform's native layout system. Every snippet below is excerpted from
 CI compiles and runs it on every PR.
 
 Layout helpers are free functions: `widgetAddChild(parent, child)`,
-`stackSetAlignment(stack, value)`, `widgetSetEdgeInsets(w, top, left, bottom,
-right)`, etc. Stack constructors take a numeric spacing followed by a child
+`stackSetAlignment(stack, value)`, `setPadding(w, top, left, bottom, right)`,
+etc. Stack constructors take a numeric spacing followed by a child
 array; everything else (alignment, distribution, padding, sizing) is applied
 post-construction via the free functions on the widget handle.
 
@@ -198,7 +198,7 @@ The user can drag the divider to resize panes. On macOS this maps to
 ## Stacks with Built-in Padding
 
 Create a stack with padding in a single call. The order is **top, left,
-bottom, right** (CSS-shorthand-style), not top/right/bottom/left:
+bottom, right**, matching the per-side `setPadding` overload:
 
 ```typescript
 {{#include ../../examples/ui/layout/snippets.ts:insets-stack}}
@@ -206,7 +206,7 @@ bottom, right** (CSS-shorthand-style), not top/right/bottom/left:
 
 `HStackWithInsets(spacing, top, left, bottom, right)` is the horizontal
 counterpart. Equivalent to creating a stack and then calling
-`widgetSetEdgeInsets`, but more concise. Children are added via
+`setPadding`, but more concise. Children are added via
 `widgetAddChild` rather than the constructor array.
 
 ## Detaching Hidden Views

--- a/docs/src/ui/overview.md
+++ b/docs/src/ui/overview.md
@@ -14,7 +14,7 @@ perry app.ts -o app && ./app
 
 ## Mental Model
 
-Perry's UI follows the same model as SwiftUI and Flutter: you compose native widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), control alignment and distribution, and style widgets via free functions that take the widget handle as their first argument (`textSetColor(label, r, g, b, a)`, `widgetSetEdgeInsets(stack, ...)`, etc.). If you're coming from web development, the key shift is:
+Perry's UI follows the same model as SwiftUI and Flutter: you compose native widgets using stack-based layout containers (`VStack`, `HStack`, `ZStack`), control alignment and distribution, and style widgets via free functions that take the widget handle as their first argument (`textSetColor(label, r, g, b, a)`, `setPadding(stack, ...)`, etc.). If you're coming from web development, the key shift is:
 
 - **Layout** is controlled by stack alignment, distribution, and spacers — not CSS properties. See [Layout](layout.md).
 - **Styling** is applied directly to widgets — not through stylesheets. See [Styling](styling.md).

--- a/docs/src/ui/styling.md
+++ b/docs/src/ui/styling.md
@@ -32,7 +32,7 @@ for the full file.
 | `borderColor` | string \| PerryColor | `widgetSetBorderColor` |
 | `borderWidth` | number | `widgetSetBorderWidth` |
 | `borderRadius` | number | `setCornerRadius` |
-| `padding` | number \| `{ top, right, bottom, left }` | `widgetSetEdgeInsets` |
+| `padding` | number \| `{ top, right, bottom, left }` | `setPadding` |
 | `opacity` | number (0..=1) | `widgetSetOpacity` |
 | `shadow` | `{ color, blur, offsetX, offsetY }` | `widgetSetShadow` |
 | `textDecoration` | `"none" \| "underline" \| "strikethrough"` | `textSetDecoration` |
@@ -149,11 +149,16 @@ Use `"monospaced"` for the system monospaced font.
 {{#include ../../examples/ui/styling/snippets.ts:borders}}
 ```
 
-### Padding and Insets
+### Padding
 
 ```typescript
 {{#include ../../examples/ui/styling/snippets.ts:padding}}
 ```
+
+Use `setPadding(widget, value)` for uniform padding, or
+`setPadding(widget, top, left, bottom, right)` for individual sides.
+The old `widgetSetEdgeInsets` name is deprecated and remains an alias during
+the deprecation window.
 
 ### Sizing
 

--- a/docs/src/ui/widgets.md
+++ b/docs/src/ui/widgets.md
@@ -453,7 +453,7 @@ Every widget handle accepts these:
 | `widgetSetOnClick(w, cb)` | Click handler |
 | `widgetSetOnHover(w, cb)` | Hover enter/leave (desktop only) |
 | `widgetSetOnDoubleClick(w, cb)` | Double-click handler |
-| `widgetSetEdgeInsets(w, top, left, bottom, right)` | Padding around contents |
+| `setPadding(w, value)` / `setPadding(w, top, left, bottom, right)` | Padding around contents |
 | `widgetSetBorderColor(w, r, g, b, a)` / `widgetSetBorderWidth(w, n)` | Border |
 | `widgetAddChild(parent, child)` | Attach a child to a container |
 | `widgetSetContextMenu(w, menu)` | Right-click menu |

--- a/packages/perry-solid/src/index.ts
+++ b/packages/perry-solid/src/index.ts
@@ -48,7 +48,7 @@ const driver: NativeDriver = {
       case "cornerRadius": setCornerRadius(widget, numeric(value, 0)); return;
       case "padding": {
         const amount = numeric(value, 0);
-        setPadding(widget, amount, amount, amount, amount);
+        setPadding(widget, amount);
         return;
       }
       case "fontSize":

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -15,6 +15,10 @@ export interface WidgetMethods {
     addChild(child: Widget): void;
     /** Remove every child widget. Equivalent to `widgetClearChildren(this)`. */
     removeAllChildren(): void;
+    /** Set the same padding on all four sides. */
+    setPadding(value: number): void;
+    /** Set per-side padding in top, left, bottom, right order. */
+    setPadding(top: number, left: number, bottom: number, right: number): void;
     /**
      * Animate the widget's opacity to `target` over `durationSecs` seconds.
      * The animation starts from the widget's current opacity.
@@ -163,7 +167,7 @@ export interface StyleProps {
 
     /** Padding. A single number applies to all four sides; an object
      *  picks per-side (top / right / bottom / left). Maps to
-     *  `widgetSetEdgeInsets`. */
+     *  `setPadding`. */
     padding?: number | {
         top?: number;
         right?: number;
@@ -1080,6 +1084,10 @@ export function richTextToggleBold(widget: Widget): void;
 export function richTextToggleItalic(widget: Widget): void;
 export function richTextToggleUnderline(widget: Widget): void;
 export function widgetSetControlSize(widget: Widget, size: number): void;
+/**
+ * @deprecated Use `setPadding(widget, value)` or
+ * `setPadding(widget, top, left, bottom, right)` instead.
+ */
 export function widgetSetEdgeInsets(widget: Widget, top: number, left: number, bottom: number, right: number): void;
 export function widgetSetBorderColor(widget: Widget, r: number, g: number, b: number, a: number): void;
 export function widgetSetBorderWidth(widget: Widget, width: number): void;
@@ -1164,7 +1172,10 @@ export function widgetAnimateOpacity(widget: Widget, target: number, durationSec
 /** Animate position by `(dx, dy)` pixels over `durationSecs` seconds. */
 export function widgetAnimatePosition(widget: Widget, dx: number, dy: number, durationSecs: number): void;
 
-/** Set padding (edge insets) on a widget. */
+/** Set the same padding on all four sides of a widget. */
+export function setPadding(widget: Widget, value: number): void;
+
+/** Set per-side padding in top, left, bottom, right order. */
 export function setPadding(widget: Widget, top: number, left: number, bottom: number, right: number): void;
 
 /** Set corner radius on a widget. */


### PR DESCRIPTION
Fixes #9955.

## What changed

- makes `setPadding` the canonical API across native, web, WASM, and HarmonyOS
- supports both `(widget, value)` and `(widget, top, left, bottom, right)`, including widget instance calls
- keeps `widgetSetEdgeInsets` as a deprecated compatibility alias
- fixes asymmetric inline padding passing left/right in the wrong native ABI slots
- updates examples, API docs, Perry Solid, and all gettext catalogs

This complements #9960, which makes the underlying Apple setters effective on leaf widgets.

## Validation

- `cargo check -p perry-codegen -p perry-codegen-js -p perry-codegen-wasm -p perry-codegen-arkts -p perry-dispatch`
- `cargo test -p perry-dispatch`
- `cargo test -p perry-codegen-arkts padding -- --nocapture`
- `cargo test -p perry-codegen-js -p perry-codegen-wasm`
- native compiler smoke covering uniform/four-side free and instance calls
- Node runtime checks for uniform/four-side/legacy-alias CSS output on web and WASM
- styling doc cross-compile: 18/18 web/WASM targets passed
- docs navigation/link checks, TypeScript fence lint, and `msgfmt` checks passed
- gettext extraction/sync is reproducible with CI's mdBook 0.5.4
- `./scripts/pre-tag-check.sh --quick` passed all relevant checks; its only failure is the pre-existing stale public benchmark artifact

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `setPadding` supports uniform padding with one value or independent top, left, bottom, and right values.
  - Padding behavior and edge ordering are consistent across supported platforms.

- **Bug Fixes**
  - Corrected asymmetric padding application so each edge receives the intended value.
  - Uniform padding expressions are evaluated only once.

- **Documentation**
  - Updated UI examples and guides to use `setPadding`.
  - Clarified supported padding forms and edge ordering.

- **Deprecation**
  - `widgetSetEdgeInsets` remains available as a deprecated alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->