### PR TITLE
fix(ios): use cross-thread promise pin lifecycle

### DIFF
--- a/changelog.d/9963-ios-foundation-model-promise.md
+++ b/changelog.d/9963-ios-foundation-model-promise.md
@@ -1,0 +1,4 @@
+**iOS Foundation Models:** restore `perry-ui-ios` cross-compilation by removing
+an orphaned call to the old manual Promise-pinning API. Foundation Models now
+relies on `js_promise_new_cross_thread`, which owns the non-moving allocation
+and pin/unpin lifecycle through settlement.

--- a/crates/perry-ui-ios/src/foundation_models.rs
+++ b/crates/perry-ui-ios/src/foundation_models.rs
@@ -102,10 +102,9 @@ pub extern "C" fn perry_ios_foundation_model_respond(session: f64, prompt_ptr: i
     };
 
     // The Swift task can outlive every JS reference to the returned promise.
-    // Force malloc-space allocation and pin it until its owner-agent queue
-    // drains the result; this is the same protocol used by spawn/waitAsync.
+    // The cross-thread constructor allocates in non-moving malloc space and
+    // pins the promise until resolve/reject drains on its owner agent.
     let promise = perry_runtime::promise::js_promise_new_cross_thread();
-    unsafe { perry_runtime::thread::pin_promise(promise) };
     perry_runtime::thread::thread_job_begin();
     let context = promise as i64;
     lock_pending().insert(context, perry_runtime::agent::current_agent());


### PR DESCRIPTION
Fixes #9961.

`perry_ios_foundation_model_respond` already creates its Promise with
`js_promise_new_cross_thread()`. Since #9552 that constructor allocates in
non-moving malloc space, takes the native pin, and records it for automatic
release on resolve/reject. The additional call to the removed
`thread::pin_promise` API was stale and redundant, and prevented the iOS crate
from compiling for a real iOS target.

The existing required iOS workflows already build `perry-ui-ios` for
`aarch64-apple-ios-sim` (and the simctl workflow also builds the device target),
so no new CI step is needed; those jobs will exercise this fix directly.

Validation:

- reproduced the E0425 failure on `aarch64-apple-ios` before the change
- `cargo check -p perry-ui-ios --target aarch64-apple-ios`
- `cargo check -p perry-ui-ios --target aarch64-apple-ios-sim`
- `cargo test -p perry-runtime cross_thread_promise --lib -- --nocapture`
- `cargo fmt --all -- --check`

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored iOS cross-compilation support for Foundation Models.
  - Improved promise lifecycle handling during cross-thread Foundation Models responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->