### PR TITLE
fix(linux): find npm archives for explicit host targets

### DIFF
--- a/changelog.d/9964-linux-npm-ui-link.md
+++ b/changelog.d/9964-linux-npm-ui-link.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Linux npm installs now find their bundled runtime, standard-library, and
+  GTK4 archives when the host target is spelled explicitly with `--target
+  linux`. Cross-architecture and cross-libc targets remain isolated to their
+  target-specific archive directories.

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1023,6 +1023,39 @@ fn apple_class_lib_name(name: &str, class: &str, is_sim: bool) -> String {
     }
 }
 
+/// Whether an explicit Linux target is the platform of this compiler binary.
+/// This distinguishes `--target linux` on a Linux x64 install from a genuine
+/// x64-to-arm64 or glibc-to-musl cross-compile, whose archive search must remain
+/// triple-only.
+#[cfg(target_os = "linux")]
+fn is_native_linux_target(target: Option<&str>) -> bool {
+    if cfg!(all(target_arch = "x86_64", target_env = "gnu")) {
+        matches!(target, Some("linux") | Some("linux-x86_64"))
+    } else if cfg!(all(target_arch = "aarch64", target_env = "gnu")) {
+        matches!(target, Some("linux-arm64") | Some("linux-aarch64"))
+    } else if cfg!(all(target_arch = "x86_64", target_env = "musl")) {
+        matches!(target, Some("linux-musl") | Some("linux-x86_64-musl"))
+    } else if cfg!(all(target_arch = "aarch64", target_env = "musl")) {
+        matches!(target, Some("linux-aarch64-musl"))
+    } else {
+        false
+    }
+}
+
+fn push_executable_relative_host_candidates(
+    candidates: &mut Vec<PathBuf>,
+    executable: &Path,
+    name: &str,
+) {
+    let Some(bin_dir) = executable.parent() else {
+        return;
+    };
+    candidates.push(bin_dir.join(name));
+    if let Some(prefix) = bin_dir.parent() {
+        candidates.push(prefix.join("lib").join(name));
+    }
+}
+
 pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
@@ -1052,7 +1085,7 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
             candidates.extend(winget_lib_candidates(name));
         }
         #[cfg(target_os = "linux")]
-        if matches!(target, Some("linux")) {
+        if is_native_linux_target(target) {
             candidates.push(PathBuf::from(format!("target/release/{}", name)));
             candidates.push(PathBuf::from(format!("target/debug/{}", name)));
         }
@@ -1100,6 +1133,15 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
                     .join("release")
                     .join(name);
                 candidates.push(source_target);
+
+                // npm installs place `perry` in `bin/` and the compressed
+                // archives in the sibling `lib/`. The target=None host path
+                // probes that layout, but the explicit `--target linux` path
+                // used to omit it and lose every bundled archive (#9953).
+                #[cfg(target_os = "linux")]
+                if is_native_linux_target(target) {
+                    push_executable_relative_host_candidates(&mut candidates, &exe, name);
+                }
 
                 // For Apple / HarmonyOS cross-compile targets, check the exe
                 // directory for libs with the platform-suffix naming convention:
@@ -1149,13 +1191,7 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
         candidates.push(PathBuf::from(format!("target/release/{}", name)));
         candidates.push(PathBuf::from(format!("target/debug/{}", name)));
         if let Ok(exe) = std::env::current_exe() {
-            if let Some(dir) = exe.parent() {
-                candidates.push(dir.join(name));
-                // Homebrew: libs installed in ../lib relative to bin
-                if let Some(prefix) = dir.parent() {
-                    candidates.push(prefix.join("lib").join(name));
-                }
-            }
+            push_executable_relative_host_candidates(&mut candidates, &exe, name);
         }
         // When cargo install'd, check the original source tree's target dir
         let source_target = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -1842,6 +1878,9 @@ mod llvm_tool_discovery_tests;
 // conservative triple-only search.
 #[cfg(all(test, target_os = "macos"))]
 mod macos_host_candidate_tests;
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_host_candidate_tests;
 
 #[cfg(all(test, target_os = "windows"))]
 mod windows_toolchain_tests;

--- a/crates/perry/src/commands/compile/library_search/linux_host_candidate_tests.rs
+++ b/crates/perry/src/commands/compile/library_search/linux_host_candidate_tests.rs
@@ -1,0 +1,34 @@
+use super::{is_native_linux_target, push_executable_relative_host_candidates};
+use std::path::{Path, PathBuf};
+
+#[test]
+fn native_linux_alias_matches_only_the_host_architecture_and_libc() {
+    if cfg!(all(target_arch = "x86_64", target_env = "gnu")) {
+        assert!(is_native_linux_target(Some("linux")));
+        assert!(is_native_linux_target(Some("linux-x86_64")));
+        assert!(!is_native_linux_target(Some("linux-arm64")));
+        assert!(!is_native_linux_target(Some("linux-musl")));
+    } else if cfg!(all(target_arch = "aarch64", target_env = "gnu")) {
+        assert!(is_native_linux_target(Some("linux-arm64")));
+        assert!(!is_native_linux_target(Some("linux")));
+        assert!(!is_native_linux_target(Some("linux-x86_64")));
+    }
+}
+
+#[test]
+fn npm_bin_layout_probes_the_sibling_lib_directory() {
+    let mut candidates = Vec::new();
+    push_executable_relative_host_candidates(
+        &mut candidates,
+        Path::new("/project/node_modules/@perryts/perry-linux-x64/bin/perry"),
+        "libperry_ui_gtk4.a",
+    );
+
+    assert_eq!(
+        candidates,
+        [
+            PathBuf::from("/project/node_modules/@perryts/perry-linux-x64/bin/libperry_ui_gtk4.a",),
+            PathBuf::from("/project/node_modules/@perryts/perry-linux-x64/lib/libperry_ui_gtk4.a",),
+        ]
+    );
+}

--- a/crates/perry/src/commands/compile/library_search/linux_host_candidate_tests.rs
+++ b/crates/perry/src/commands/compile/library_search/linux_host_candidate_tests.rs
@@ -12,6 +12,17 @@ fn native_linux_alias_matches_only_the_host_architecture_and_libc() {
         assert!(is_native_linux_target(Some("linux-arm64")));
         assert!(!is_native_linux_target(Some("linux")));
         assert!(!is_native_linux_target(Some("linux-x86_64")));
+        assert!(!is_native_linux_target(Some("linux-aarch64-musl")));
+    } else if cfg!(all(target_arch = "x86_64", target_env = "musl")) {
+        assert!(is_native_linux_target(Some("linux-musl")));
+        assert!(is_native_linux_target(Some("linux-x86_64-musl")));
+        assert!(!is_native_linux_target(Some("linux")));
+        assert!(!is_native_linux_target(Some("linux-aarch64-musl")));
+    } else if cfg!(all(target_arch = "aarch64", target_env = "musl")) {
+        assert!(is_native_linux_target(Some("linux-aarch64-musl")));
+        assert!(!is_native_linux_target(Some("linux-arm64")));
+        assert!(!is_native_linux_target(Some("linux-x86_64-musl")));
+        assert!(!is_native_linux_target(Some("linux")));
     }
 }
 


### PR DESCRIPTION
Fixes #9953.

`--target linux` resolves to a Rust triple, so library discovery entered the cross-target branch and stopped probing the installed compiler's normal host layout. npm puts the compiler in `bin/` and its compressed runtime, stdlib, and GTK archives in sibling `lib/`; `perry doctor` (host mode) found them, while `perry compile ... --target linux` did not. A UI program could therefore reach the system linker without the GTK provider and report the undefined `perry_ui_*` symbols from #9953.

Treat an explicit Linux target as host-native only when its architecture and libc match the compiler binary, and mirror the executable-relative host candidates in that case. Genuine architecture/libc cross-targets retain triple-only isolation.

Regression coverage pins native-vs-cross target classification and the npm `bin/../lib` layout.

Validation:
- Reproduced with `@perryts/perry@0.5.1220` on Ubuntu 24.04 using the documented counter and `--target linux`.
- Confirmed the packaged GTK archive exports the reported symbols and is selected once its directory is visible.
- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p perry --no-default-features --features compile-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Linux npm installations using `--target linux` now correctly locate bundled runtime, standard-library, and GTK4 archives.
  - Native Linux targets now support bundled archives in npm’s `bin/` and sibling `lib/` directory layouts.
  - Cross-architecture and cross-libc Linux targets continue using target-specific archive directories.

- **Tests**
  - Added coverage for native Linux target detection and npm package archive discovery across supported architectures, libc variants, and package layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->