### PR TITLE
fix(cache): PERRY_SEGVIEW keys the build cache, PERRY_SEGVIEW_DIAG is a recorded diagnostic exclusion — fixes codegen_env_vars_are_build_cache_inputs on main

### DIFF
--- a/changelog.d/9971-segview-build-cache-input.md
+++ b/changelog.d/9971-segview-build-cache-input.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Register the segment-view lowering switch as a build-cache input so changing
+  `PERRY_SEGVIEW` cannot reuse a binary emitted under the opposite setting.
+  `PERRY_SEGVIEW_DIAG` remains diagnostic-only and is explicitly excluded from
+  the cache key.

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -177,6 +177,9 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     "PERRY_PTR_NUMARRAY_LOCALS",
     "PERRY_PTR_SHAPE_LOCALS",
     "PERRY_PTR_SHAPE_THIS",
+    // #9893: selects the segment-view lowering, which rewrites qualifying
+    // for-of loops to call the `js_segments_view_*` runtime entry points.
+    "PERRY_SEGVIEW",
     "PERRY_SPECIALIZED_ABI",
     "PERRY_SPECIALIZED_ABI_MAX",
     "PERRY_SPEC_PRESERVE_NONE",
@@ -232,6 +235,9 @@ const BUILD_CACHE_ENV_EXCLUSIONS: &[&str] = &[
     "PERRY_PACKED_LOOP_TRACE",
     // Entry outlining report output is observational only.
     "PERRY_OUTLINE_ENTRY_REPORT",
+    // Segment-view diagnostics only scan the final HIR and print counters;
+    // their checks inside the rewrite guard `eprintln!` calls only.
+    "PERRY_SEGVIEW_DIAG",
     // Only read on an already-fatal dialect-construction failure (a unit that
     // never parses); it writes a diagnostic IR dump to `<dir>/<name>.ll` for
     // triage and cannot affect the bytes of any build that actually succeeds.
@@ -865,19 +871,6 @@ fn eligibility(args: &CompileArgs, project_root: &Path) -> Result<(), String> {
     // measured zero.
     if std::env::var("PERRY_SEGVIEW_DIAG").is_ok() {
         return Err("segview-diag".to_string());
-    }
-    // #9843: `PERRY_SEGVIEW` is NOT a diagnostic — it changes the emitted
-    // code. It is not part of the build-cache fingerprint or any object-cache
-    // key, so without this a cached build can hand back a binary compiled with
-    // the OTHER setting: compile a file with the tier on, compile it again
-    // with the tier off, and the second can be served from the first. The
-    // A/B rig's whole shape is "one compiler binary, two compiles of one
-    // source differing only in this variable", which is exactly the collision.
-    // Excluded rather than keyed because the tier is experimental and default
-    // OFF; a cache key is the right fix when it ships on, and then a stale
-    // entry cannot silently become the measurement.
-    if std::env::var("PERRY_SEGVIEW").is_ok() {
-        return Err("segview-lowering".to_string());
     }
     if args.verify_native_regions || args.emit_attest || args.emit_sandbox {
         return Err("sidecar-or-verify".to_string());

--- a/crates/perry/tests/native_link_cache.rs
+++ b/crates/perry/tests/native_link_cache.rs
@@ -168,3 +168,44 @@ fn native_compile_skips_link_on_identical_second_build() {
     assert_codegen_cache(&missing_output, 2, 0, 2, 0, 0);
     assert!(output.exists());
 }
+
+#[test]
+fn segment_view_switch_misses_build_and_object_caches() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project = dir.path();
+    let output = project.join("app");
+    let entry = project.join("main.ts");
+    fs::write(
+        project.join("package.json"),
+        "{\"name\":\"segview-cache-test\"}\n",
+    )
+    .unwrap();
+    fs::write(
+        &entry,
+        r#"const segmenter = new Intl.Segmenter("en");
+for (const { segment } of segmenter.segment("ab")) {
+  console.log(segment);
+}
+"#,
+    )
+    .unwrap();
+
+    let disabled = compile_json_with_env(project, &entry, &output, &[("PERRY_SEGVIEW", "0")]);
+    assert_linked(&disabled);
+    assert_build_cache_miss(&disabled, "manifest-missing");
+    assert_codegen_cache(&disabled, 0, 1, 0, 1, 0);
+    assert_eq!(run_binary(&output), "a\nb\n");
+
+    // This must reach codegen and produce a distinct object. Sabotage:
+    // removing PERRY_SEGVIEW from BUILD_CACHE_ENV_VARS makes it an erroneous
+    // whole-build cache hit, so the assertions below fail before codegen.
+    let enabled = compile_json_with_env(project, &entry, &output, &[("PERRY_SEGVIEW", "1")]);
+    assert_linked(&enabled);
+    assert_build_cache_miss(&enabled, "env");
+    assert_codegen_cache(&enabled, 0, 1, 0, 1, 0);
+    assert_eq!(run_binary(&output), "a\nb\n");
+
+    let enabled_warm = compile_json_with_env(project, &entry, &output, &[("PERRY_SEGVIEW", "1")]);
+    assert_skipped(&enabled_warm);
+    assert_build_cache_hit(&enabled_warm);
+}


### PR DESCRIPTION
Small fix on `origin/main` for the one unit test that has been red in CI's `cargo-test` on main: `commands::compile::build_cache::tests::codegen_env_vars_are_build_cache_inputs`.

## Why
The segment-view lowering (#9893, landed via the merge train) reads two environment variables in codegen that were registered neither as build-cache key inputs nor as exclusions. `PERRY_SEGVIEW` selects the lowering, so a compile with a different value could be served a stale cached object — the same class of silent staleness the build-cache inventory test exists to prevent.

## What changes
- `PERRY_SEGVIEW` is a build-cache input (`crates/perry/src/commands/compile/build_cache.rs`); it is read in `crates/perry-codegen/src/collectors/segview.rs` and gates the lowering.
- `PERRY_SEGVIEW_DIAG` is an explicit diagnostic-only exclusion with its reason recorded; its read only toggles diagnostics and does not change emitted code.
- A real cache test in `crates/perry/tests/native_link_cache.rs`: compiling the same program with `PERRY_SEGVIEW=0` then `=1` must miss both the build and the object cache. Sabotage (registration removed) fails with an erroneous manifest match.
- Changelog fragment.

## Verified locally
Scoped build-cache units 4 passed; the `perry` binary's unit tests 1,089 passed; the new cache test passes; rustfmt and diff-check clean. (`perry` has no library target, so the gates ran as `--bin perry`.)

https://claude.ai/code/session_011dhBmdn4vGgNibjo3oZqTo
