### PR TITLE
fix(array): describe partial species results before callbacks

### DIFF
--- a/changelog.d/9983-array-species-result-slots.md
+++ b/changelog.d/9983-array-species-result-slots.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Keep partially filled `slice` and `splice` result arrays' reference-slot
+  descriptions current when an indexed source getter interrupts the copy.

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -101,9 +101,20 @@ pub extern "C" fn js_array_splice(
             (*deleted).length = actual_delete;
             let deleted_elements =
                 (deleted as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            // Hole reads also consult recorded custom prototypes, which are
+            // not covered by array_iteration_is_exotic's canonical-proto flags.
+            let src_exotic = crate::array::array_iteration_is_exotic(arr)
+                || crate::object::prototype_chain::array_static_proto_recorded();
             for i in 0..actual_delete as usize {
-                // GC_STORE_AUDIT(BARRIERED): deleted-array init is followed by layout/barrier rebuild.
-                ptr::write(deleted_elements.add(i), spec_read(i));
+                let value = spec_read(i);
+                if src_exotic {
+                    // Publish before the next getter can collect or throw,
+                    // leaving the species result reachable with a partial copy.
+                    note_array_slot(deleted, i, value.to_bits());
+                } else {
+                    // GC_STORE_AUDIT(BARRIERED): no source callbacks; layout/barrier rebuild follows the copy.
+                    ptr::write(deleted_elements.add(i), value);
+                }
             }
             rebuild_array_layout(deleted);
         } else {
@@ -274,10 +285,16 @@ pub extern "C" fn js_array_slice(
                         f64::from_bits(crate::value::TAG_HOLE)
                     }
                 } else {
-                    // GC_STORE_AUDIT(BARRIERED): slice result init is followed by layout/barrier rebuild.
                     ptr::read(src_elements.add(src_idx))
                 };
-                ptr::write(dst_elements.add(i), v);
+                if src_exotic {
+                    // Publish before the next getter can collect or throw,
+                    // leaving the species result reachable with a partial copy.
+                    note_array_slot(result, i, v.to_bits());
+                } else {
+                    // GC_STORE_AUDIT(BARRIERED): raw source reads cannot call out; rebuild follows the copy.
+                    ptr::write(dst_elements.add(i), v);
+                }
             }
             rebuild_array_layout(result);
         } else {

--- a/test-files/test_gap_array_side_mask_covers_a_pointer_stored_at_a_late_index.ts
+++ b/test-files/test_gap_array_side_mask_covers_a_pointer_stored_at_a_late_index.ts
@@ -25,35 +25,46 @@ function array_side_mask_covers_a_pointer_stored_at_a_late_index(
 
   const late = { label: operation + "-late" };
   const source: any[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, late, ,];
-  const sourcePrototype = Object.create(Array.prototype);
-  Object.defineProperty(sourcePrototype, "11", {
+  // Perry's array_iteration_is_exotic predicate observes indexed properties
+  // on the canonical Array prototype. Put the inherited getter there so the
+  // public slice path is forced through its observable-read loop as well as
+  // splice's hole lookup. Restore the prior descriptor in finally.
+  const previousIndex11 = Object.getOwnPropertyDescriptor(Array.prototype, "11");
+  Object.defineProperty(Array.prototype, "11", {
     configurable: true,
     get() {
       throw new Error(operation + "-stop");
     },
   });
-  Object.setPrototypeOf(source, sourcePrototype);
 
   function SpeciesResult(): any[] {
     return destination;
   }
   (source as any).constructor = { [Symbol.species]: SpeciesResult };
 
-  let caught = "none";
   try {
-    if (operation === "slice") {
-      source.slice(0, 12);
-    } else {
-      source.splice(0, 12);
+    let caught = "none";
+    try {
+      if (operation === "slice") {
+        source.slice(0, 12);
+      } else {
+        source.splice(0, 12);
+      }
+    } catch (error) {
+      caught = (error as Error).message;
     }
-  } catch (error) {
-    caught = (error as Error).message;
-  }
 
-  // The throw skips the deferred rebuild. The value itself is observable;
-  // the diagnostic must also find that the collector walk lists its slot.
-  console.log(operation + ":" + caught + ":" + destination[10].label);
-  forceFullGc();
+    // The throw skips the deferred rebuild. Keep destination observably live
+    // across the collection, then verify the value after the diagnostic ran.
+    forceFullGc();
+    console.log(operation + ":" + caught + ":" + destination[10].label);
+  } finally {
+    if (previousIndex11 === undefined) {
+      delete (Array.prototype as any)[11];
+    } else {
+      Object.defineProperty(Array.prototype, "11", previousIndex11);
+    }
+  }
 }
 
 array_side_mask_covers_a_pointer_stored_at_a_late_index("slice");

--- a/test-files/test_gap_array_side_mask_covers_a_pointer_stored_at_a_late_index.ts
+++ b/test-files/test_gap_array_side_mask_covers_a_pointer_stored_at_a_late_index.ts
@@ -1,0 +1,60 @@
+// #9983: slice/splice must describe each result slot before a later inherited
+// getter can throw and leave a custom-species result reachable. Run the Perry
+// binary with PERRY_GC_VERIFY_MARK=1; the manual gc() after each caught throw
+// makes the existing mask-free array verifier inspect the partially written
+// result. The required pre-fix check is an UNENUMERATED report at index 10.
+declare function gc(): void;
+
+function forceFullGc(): void {
+  if (typeof gc === "function") {
+    gc();
+  }
+}
+
+function array_side_mask_covers_a_pointer_stored_at_a_late_index(
+  operation: "slice" | "splice",
+): void {
+  // Establish a mixed twelve-slot destination whose old description lists
+  // index 0 but not index 10. The custom species keeps this exact array
+  // reachable even when the source getter aborts the operation.
+  const destination: any[] = new Array(12);
+  destination[0] = { old: true };
+  for (let i = 1; i < 12; i++) {
+    destination[i] = i;
+  }
+
+  const late = { label: operation + "-late" };
+  const source: any[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, late, ,];
+  const sourcePrototype = Object.create(Array.prototype);
+  Object.defineProperty(sourcePrototype, "11", {
+    configurable: true,
+    get() {
+      throw new Error(operation + "-stop");
+    },
+  });
+  Object.setPrototypeOf(source, sourcePrototype);
+
+  function SpeciesResult(): any[] {
+    return destination;
+  }
+  (source as any).constructor = { [Symbol.species]: SpeciesResult };
+
+  let caught = "none";
+  try {
+    if (operation === "slice") {
+      source.slice(0, 12);
+    } else {
+      source.splice(0, 12);
+    }
+  } catch (error) {
+    caught = (error as Error).message;
+  }
+
+  // The throw skips the deferred rebuild. The value itself is observable;
+  // the diagnostic must also find that the collector walk lists its slot.
+  console.log(operation + ":" + caught + ":" + destination[10].label);
+  forceFullGc();
+}
+
+array_side_mask_covers_a_pointer_stored_at_a_late_index("slice");
+array_side_mask_covers_a_pointer_stored_at_a_late_index("splice");


### PR DESCRIPTION
A custom Array species can return an existing plain array. During `slice` or `splice`, Perry wrote result elements directly and rebuilt the result's reference-slot description only after the complete copy. If a later indexed source getter interrupted that copy, previously written reference slots were absent from the description.

This change records each result slot immediately on source paths that can invoke indexed access behavior. Ordinary dense copies keep the existing raw-write loop and one final rebuild. The description threshold and custom-species dispatch are unchanged.

A regression fixture covers public `slice` and `splice` with a twelve-element result, a reference at index 10, and an index-11 getter that interrupts the operation. The pre-change Linux diagnostic reported `UNENUMERATED ... index=10 length=12` twice. With this branch composed onto the same diagnostic, both full reports are `OK`, `INDEX10_UNENUMERATED=0`, and `ALL_UNENUMERATED=0`; program output is unchanged.

Validation: pinned Node fixture, rustfmt, static inventory checks, Linux release runtime build, and the pre/post diagnostic gate. The full local CI ladder remains pending, so this PR starts as draft.

Closes #9983

Claude-Session: https://claude.ai/code/session_011dhBmdn4vGgNibjo3oZqTo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `slice` and `splice` so partially copied result arrays retain valid references when a source getter interrupts the operation.
  * Improved handling of custom-species arrays and inherited getters during interrupted copies.

* **Tests**
  * Added regression coverage for objects stored at later array indexes when `slice` or `splice` encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->