### PR TITLE
fix(hir): preserve first-class import.meta.require values

### DIFF
--- a/changelog.d/9990-import-meta-require-value.md
+++ b/changelog.d/9990-import-meta-require-value.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Lower bare, computed and destructured import.meta.require to one module-owned createRequire(import.meta.url) value; retain the existing direct-call static graph path.

--- a/changelog.d/9990-import-meta-require-value.md
+++ b/changelog.d/9990-import-meta-require-value.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - Lower bare, computed and destructured import.meta.require to one module-owned createRequire(import.meta.url) value; retain the existing direct-call static graph path.
+- Build the standalone native regression's runtime and require-provider archives coherently, and include compiler diagnostics directly in failing CI output.

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -232,6 +232,7 @@ impl LoweringContext {
             is_external_module: false,
             optional_require_try_depth: 0,
             require_local_is_create_require: false,
+            import_meta_require_local: None,
             fn_ctor_env: super::fn_ctor_env::FnCtorEnv::default(),
             dynamic_function_subclasses: HashMap::new(),
             expr_lower_depth: 0,

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -256,13 +256,22 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // omitted — adding them would silently break code moving Perry → Node.
     if let ast::Expr::MetaProp(mp) = member.obj.as_ref() {
         if matches!(mp.kind, ast::MetaPropKind::ImportMeta) {
-            if let ast::MemberProp::Ident(prop_ident) = &member.prop {
+            let property = match &member.prop {
+                ast::MemberProp::Ident(ident) => Some(ident.sym.as_ref()),
+                ast::MemberProp::Computed(computed) => match computed.expr.as_ref() {
+                    ast::Expr::Lit(ast::Lit::Str(value)) => value.value.as_str(),
+                    _ => None,
+                },
+                _ => None,
+            };
+            if let Some(property) = property {
                 let (url, dirname, filename) = super::expr_misc::import_meta_paths(ctx);
-                return Ok(match prop_ident.sym.as_ref() {
+                return Ok(match property {
                     "url" => Expr::String(url),
                     "main" => Expr::Bool(ctx.is_entry_module),
                     "dirname" => Expr::String(dirname),
                     "filename" => Expr::String(filename),
+                    "require" => super::expr_misc::import_meta_require_value(ctx),
                     // Unknown property — undefined matches the spec'd
                     // "missing property on a frozen object" behavior of
                     // import.meta in Node / Bun.

--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -387,6 +387,7 @@ pub(super) fn lower_meta_prop(
                 ("main".to_string(), Expr::Bool(ctx.is_entry_module)),
                 ("dirname".to_string(), Expr::String(dirname)),
                 ("filename".to_string(), Expr::String(filename)),
+                ("require".to_string(), import_meta_require_value(ctx)),
             ]))
         }
         ast::MetaPropKind::NewTarget => {
@@ -416,11 +417,25 @@ pub(super) fn lower_meta_prop(
     }
 }
 
+/// Reuse one module-owned loader for first-class `import.meta.require` reads.
+/// Its initializer is prepended after lowering has discovered every use.
+pub(crate) fn import_meta_require_value(ctx: &mut LoweringContext) -> Expr {
+    let id = match ctx.import_meta_require_local {
+        Some(id) => id,
+        None => {
+            let id = ctx.next_local_id;
+            ctx.next_local_id += 1;
+            ctx.import_meta_require_local = Some(id);
+            id
+        }
+    };
+    Expr::LocalGet(id)
+}
+
 /// Issue #444: compute the `(url, dirname, filename)` triplet exposed via
 /// `import.meta`. Mirrors Node 20+ semantics — `url` is `file://<path>`,
 /// `filename` is the absolute file path, `dirname` is its parent directory.
-/// Used by both the bare-`import.meta` Object synthesis above and the
-/// member-access fast path in `expr_member::lower_member`.
+/// Used by both bare-object synthesis and the member-access fast path.
 pub(crate) fn import_meta_paths(ctx: &LoweringContext) -> (String, String, String) {
     let mut path = ctx.source_file_path.replace('\\', "/");
     // `dunce::canonicalize` keeps Windows' verbatim `\\?\` prefix for long

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -1680,6 +1680,28 @@ pub fn lower_module_full_with_platform_globals(
         module.init = implicit_globals;
     }
 
+    if let Some(id) = ctx.import_meta_require_local {
+        let (url, _, _) = super::expr_misc::import_meta_paths(&ctx);
+        // Reuse createRequire's synchronous builtin/compiled-module resolver,
+        // rooted in module storage and initialized before source statements.
+        module.init.insert(
+            0,
+            Stmt::Let {
+                id,
+                name: format!("__perry_import_meta_require_{id}"),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::NativeMethodCall {
+                    module: "module".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "createRequire".to_string(),
+                    args: vec![Expr::String(url)],
+                }),
+            },
+        );
+    }
+
     // Populate exported_native_instances by matching native_instances with exports
     for (local_name, module_name, class_name) in &ctx.native_instances {
         // Check if this native instance is exported

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -1067,6 +1067,8 @@ pub struct LoweringContext {
     /// strictly narrower than the pre-#8343 behavior, which ignored ALL
     /// local `require` bindings on this path.
     pub(crate) require_local_is_create_require: bool,
+    /// One module-owned loader shared by first-class import.meta.require reads.
+    pub(crate) import_meta_require_local: Option<LocalId>,
     /// Pre-scanned constant environment for `new Function` / `Function(...)`
     /// argument resolution (single-assignment module vars, `toString`-bearing
     /// object literals, counters). Built once per module in

--- a/crates/perry-hir/tests/import_meta_require_value.rs
+++ b/crates/perry-hir/tests/import_meta_require_value.rs
@@ -1,0 +1,67 @@
+use perry_hir::{lower_module, Expr, Stmt};
+use perry_parser::parse_typescript;
+
+#[test]
+fn import_meta_require_values_share_one_module_scoped_loader() {
+    let parsed = parse_typescript(
+        r#"
+        const load = import.meta.require;
+        const computed = import.meta['require'];
+        const { require: destructured } = import.meta;
+        function getLoader() { return import.meta.require; }
+        export { load, computed, destructured, getLoader };
+    "#,
+        "/tmp/owner/loader.js",
+    )
+    .unwrap();
+    let hir = lower_module(&parsed, "loader", "/tmp/owner/loader.js").unwrap();
+    let loaders: Vec<_> = hir
+        .init
+        .iter()
+        .filter_map(|stmt| match stmt {
+            Stmt::Let {
+                id,
+                init:
+                    Some(Expr::NativeMethodCall {
+                        module,
+                        method,
+                        args,
+                        ..
+                    }),
+                ..
+            } if module == "module" && method == "createRequire" => Some((*id, args)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(loaders.len(), 1);
+    let (loader, args) = loaders[0];
+    assert!(matches!(&args[0], Expr::String(url) if url == "file:///tmp/owner/loader.js"));
+    for name in ["load", "computed"] {
+        assert!(hir.init.iter().any(|stmt| matches!(stmt,
+            Stmt::Let { name: n, init: Some(Expr::LocalGet(id)), .. } if n == name && *id == loader)));
+    }
+    let get = hir
+        .functions
+        .iter()
+        .find(|f| f.name == "getLoader")
+        .unwrap();
+    assert!(get
+        .body
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::Return(Some(Expr::LocalGet(id))) if *id == loader)));
+}
+
+#[test]
+fn direct_import_meta_require_retains_static_graph_dispatch() {
+    let parsed = parse_typescript("import.meta.require('./leaf.js');", "entry.js").unwrap();
+    let hir = lower_module(&parsed, "entry", "entry.js").unwrap();
+    assert!(hir.init.iter().any(|stmt| matches!(
+        stmt,
+        Stmt::Expr(Expr::DynamicImport {
+            synchronous: true,
+            ..
+        })
+    )));
+    assert!(!hir.init.iter().any(|stmt| matches!(stmt,
+        Stmt::Let { init: Some(Expr::NativeMethodCall { method, .. }), .. } if method == "createRequire")));
+}

--- a/crates/perry/tests/import_meta_require_value.rs
+++ b/crates/perry/tests/import_meta_require_value.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-import-meta-require-value.mjs"))
+        .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/crates/perry/tests/import_meta_require_value.rs
+++ b/crates/perry/tests/import_meta_require_value.rs
@@ -8,6 +8,7 @@ fn standalone_regression() {
         .arg(root.join("scripts/test-import-meta-require-value.mjs"))
         .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
         .env("PERRY_WORKSPACE_ROOT", &root)
+        .env("PERRY_TEST_BUILD_RUNTIME", "1")
         .current_dir(&root)
         .output()
         .expect("run bounded Node regression driver");

--- a/scripts/test-import-meta-require-value.mjs
+++ b/scripts/test-import-meta-require-value.mjs
@@ -1,0 +1,42 @@
+// Standalone linked regression: no application sources or credentials.
+// PERRY_BIN=/path/to/perry PERRY_RUNTIME_DIR=/matching/runtime node scripts/test-import-meta-require-value.mjs
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-import-meta-require-value-'));
+let passed = false;
+try {
+  for (const fixture of ["import_meta_require_value"]) {
+    const source = path.join(root, 'tests/modules', fixture, 'main.js');
+    
+    for (const opt of (process.env.PERRY_TEST_OPT_LEVELS ?? '0,s,z').split(',')) {
+      const output = path.join(work, fixture + '-' + opt);
+      const compile = spawnSync(compiler, ['compile', source, '-o', output,
+        '--cache-dir', path.join(work, 'cache-' + fixture + '-' + opt),
+        '--no-auto-optimize', '--no-color',
+        '--platform', 'bun',
+        ...(process.env.PERRY_TEST_WASM === '1' ? ['--enable-wasm-runtime'] : [])], {
+        cwd: work, env: { ...process.env, PERRY_LL_OPT_LEVEL: opt },
+        encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
+      });
+      fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
+      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
+      fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
+      if (run.status !== 0 || !run.stdout?.includes('PASS: first-class import.meta.require')) {
+        throw new Error('Native regression failed: ' + (run.error ?? run.status) + '\n' +
+          (run.stdout ?? '') + (run.stderr ?? ''));
+      }
+      console.log('PASS O' + opt + ': ' + fixture);
+    }
+  }
+  passed = true;
+} finally {
+  if (passed) fs.rmSync(work, { recursive: true });
+  else console.error('Retained regression diagnostics: ' + work);
+}

--- a/scripts/test-import-meta-require-value.mjs
+++ b/scripts/test-import-meta-require-value.mjs
@@ -5,8 +5,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { prepareRequireRuntime } from './test-require-runtime.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+prepareRequireRuntime(root);
 const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
 const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-import-meta-require-value-'));
 let passed = false;
@@ -25,7 +27,10 @@ try {
         encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
       });
       fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
-      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      if (compile.error || compile.status !== 0) {
+        throw new Error('Compilation failed: ' + (compile.error ?? compile.status) + '\n' +
+          (compile.stdout ?? '') + (compile.stderr ?? ''));
+      }
       const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
       fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
       if (run.status !== 0 || !run.stdout?.includes('PASS: first-class import.meta.require')) {

--- a/scripts/test-require-runtime.mjs
+++ b/scripts/test-require-runtime.mjs
@@ -1,0 +1,63 @@
+// Runtime setup shared by the standalone require regressions. Cargo unifies
+// features per invocation: building a missing wrapper separately can create a
+// second Tokio runtime even when every archive has the same source stamp.
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export function prepareRequireRuntime(root) {
+  // Direct script users may supply their own verified, coherent archives.
+  // The CI-visible Rust entry points explicitly request the build below.
+  if (process.env.PERRY_TEST_BUILD_RUNTIME !== '1') return;
+  // perry-dev keeps panic=abort and avoids a second thin-LTO build inside
+  // cargo test. Release/dist remain available for optimization-sensitive runs.
+  const profile = process.env.PERRY_TEST_RUNTIME_PROFILE ?? 'perry-dev';
+  if (!['release', 'perry-dev', 'dist'].includes(profile)) {
+    throw new Error('Native require tests need a panic=abort runtime profile');
+  }
+  const packages = [
+    'perry-runtime', 'perry-stdlib', 'perry-runtime-static', 'perry-stdlib-static',
+    'perry-ext-events', 'perry-ext-http', 'perry-ext-net',
+    'perry-ext-typescript', 'perry-ext-ws', 'perry-ext-zlib',
+  ];
+  const args = ['build', '--locked', '--profile', profile,
+    ...packages.flatMap(name => ['-p', name])];
+  if (process.env.PERRY_TEST_WASM === '1') {
+    args.push('-p', 'perry-wasm-host', '--features', 'perry-runtime/wasm-host');
+  }
+  const buildEnv = { ...process.env };
+  // CI overrides target rustflags to disable lld. Such an override replaces
+  // .cargo/config.toml's unwind/frame-pointer flags rather than extending it.
+  // Preserve those native exception/stack-walking requirements in every
+  // override while keeping the caller's linker and other options intact.
+  for (const key of Object.keys(buildEnv)) {
+    if (key === 'RUSTFLAGS' || /^CARGO_TARGET_.+_RUSTFLAGS$/.test(key)) {
+      buildEnv[key] += ' -C force-unwind-tables=yes -C force-frame-pointers=yes';
+    }
+  }
+  if (buildEnv.CARGO_ENCODED_RUSTFLAGS !== undefined) {
+    buildEnv.CARGO_ENCODED_RUSTFLAGS += '\x1f-C\x1fforce-unwind-tables=yes' +
+      '\x1f-C\x1fforce-frame-pointers=yes';
+  }
+  console.log('Building coherent require-test runtime archives...');
+  const build = spawnSync(process.env.CARGO ?? 'cargo', args, {
+    cwd: root, env: buildEnv, encoding: 'utf8',
+    timeout: 600_000, killSignal: 'SIGKILL', maxBuffer: 8 * 1024 * 1024,
+  });
+  if (build.error || build.status !== 0) {
+    throw new Error('Coherent runtime build failed: ' + (build.error ?? build.status) +
+      '\n' + (build.stdout ?? '') + (build.stderr ?? ''));
+  }
+  const target = path.resolve(root, process.env.CARGO_TARGET_DIR ?? 'target');
+  const runtime = path.join(target, profile);
+  // Refuse a misleading successful Cargo invocation (e.g. a cross-target
+  // override) rather than falling back to an unrelated installed archive.
+  for (const name of ['runtime', 'stdlib', 'ext_events', 'ext_http', 'ext_net',
+    'ext_typescript', 'ext_ws', 'ext_zlib']) {
+    const filename = process.platform === 'win32' ? 'perry_' + name + '.lib' :
+      'libperry_' + name + '.a';
+    fs.accessSync(path.join(runtime, filename), fs.constants.R_OK);
+  }
+  process.env.PERRY_RUNTIME_DIR = runtime;
+  console.log('Using coherent require-test runtime: ' + runtime);
+}

--- a/tests/modules/import_meta_require_value/loader.js
+++ b/tests/modules/import_meta_require_value/loader.js
@@ -1,0 +1,6 @@
+const load = import.meta.require;
+const computed = import.meta['require'];
+const { require: destructured } = import.meta;
+function getLoader() { return import.meta.require; }
+const arrow = () => import.meta.require;
+export { load as requireFromModule, computed, destructured, getLoader, arrow };

--- a/tests/modules/import_meta_require_value/main.js
+++ b/tests/modules/import_meta_require_value/main.js
@@ -1,0 +1,18 @@
+import { requireFromModule, computed, destructured, getLoader, arrow } from './loader.js';
+
+function check(loader) {
+  if (typeof loader !== 'function') throw new Error('loader not callable');
+  if (typeof loader('util').inherits !== 'function') throw new Error('util missing');
+  if (typeof loader('stream').Stream !== 'function') throw new Error('stream missing');
+}
+
+if (requireFromModule !== computed || computed !== destructured ||
+    destructured !== getLoader() || getLoader() !== arrow()) {
+  throw new Error('module loader identity not stable');
+}
+check(requireFromModule);
+import('./loader.js').then(module => {
+  if (module.requireFromModule !== requireFromModule) throw new Error('export identity changed');
+  check(module.requireFromModule);
+  console.log('PASS: first-class import.meta.require');
+});


### PR DESCRIPTION
## Change

Lower bare, computed and destructured import.meta.require to one module-owned createRequire(import.meta.url) value; retain the existing direct-call static graph path.

## Independent regression

Standalone HIR and linked fixtures cover callability, builtins, identity, closure access and static/dynamic namespace exports.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

Both HIR tests passed. Native identity/callability/builtin/export checks passed at O0/Os/Oz and again with the application's shadow-stack Oz settings.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `import.meta.require` so direct, computed, destructured, and function-based access consistently share one module-scoped loader.
  - Added support for computed `import.meta` property access, such as `import.meta["url"]`.
  - Preserved direct-call behavior for synchronous module loading and static graph dispatch.

- **Tests**
  - Added coverage verifying loader identity, module-boundary behavior, built-in module loading, and runtime execution across optimization levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->