### PR TITLE
fix(hir): register exported local storage by binding

### DIFF
--- a/changelog.d/9991-exported-local-storage.md
+++ b/changelog.d/9991-exported-local-storage.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Register local variable exports after all module statements are lowered, independent of declaration order or initializer expression kind; remove the initializer whitelist.

--- a/changelog.d/9991-exported-local-storage.md
+++ b/changelog.d/9991-exported-local-storage.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - Register local variable exports after all module statements are lowered, independent of declaration order or initializer expression kind; remove the initializer whitelist.
+- Match the exported module binding's LocalId so shadowing declarations inside try/catch/finally blocks cannot reclassify imported or function exports as local variables.

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -1680,6 +1680,8 @@ pub fn lower_module_full_with_platform_globals(
         module.init = implicit_globals;
     }
 
+    module_decl::register_exported_local_variables(&mut module);
+
     // Populate exported_native_instances by matching native_instances with exports
     for (local_name, module_name, class_name) in &ctx.native_instances {
         // Check if this native instance is exported

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -1680,7 +1680,7 @@ pub fn lower_module_full_with_platform_globals(
         module.init = implicit_globals;
     }
 
-    module_decl::register_exported_local_variables(&mut module);
+    module_decl::register_exported_local_variables(&ctx, &mut module);
 
     // Populate exported_native_instances by matching native_instances with exports
     for (local_name, module_name, class_name) in &ctx.native_instances {

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -34,12 +34,12 @@ pub(super) use static_import_bindings::{
 /// have the same module storage/getters as literals or generic calls (#9778).
 /// Run after lowering the complete module so `export { x }; const x = ...`
 /// and declarations without initializers work too.
-pub(super) fn register_exported_local_variables(module: &mut Module) {
-    fn collect_names<'a>(stmts: &'a [Stmt], names: &mut std::collections::HashSet<&'a str>) {
+pub(super) fn register_exported_local_variables(ctx: &LoweringContext, module: &mut Module) {
+    fn collect_bindings(stmts: &[Stmt], bindings: &mut std::collections::HashSet<LocalId>) {
         for stmt in stmts {
             match stmt {
-                Stmt::Let { name, .. } => {
-                    names.insert(name);
+                Stmt::Let { id, .. } => {
+                    bindings.insert(*id);
                 }
                 // Array-pattern declarations put their bindings inside the
                 // IteratorClose scaffolding; mirror module_globals_emit's
@@ -49,12 +49,12 @@ pub(super) fn register_exported_local_variables(module: &mut Module) {
                     catch,
                     finally,
                 } => {
-                    collect_names(body, names);
+                    collect_bindings(body, bindings);
                     if let Some(catch) = catch {
-                        collect_names(&catch.body, names);
+                        collect_bindings(&catch.body, bindings);
                     }
                     if let Some(finally) = finally {
-                        collect_names(finally, names);
+                        collect_bindings(finally, bindings);
                     }
                 }
                 _ => {}
@@ -62,12 +62,18 @@ pub(super) fn register_exported_local_variables(module: &mut Module) {
         }
     }
     let mut locals = std::collections::HashSet::new();
-    collect_names(&module.init, &mut locals);
+    collect_bindings(&module.init, &mut locals);
     let mut registered: std::collections::HashSet<String> =
         module.exported_objects.iter().cloned().collect();
     for export in &module.exports {
         if let Export::Named { local, exported } = export {
-            if locals.contains(local.as_str()) {
+            // A user-authored try block may declare the same spelling as an
+            // imported binding or function. Only the binding visible in the
+            // restored module scope can own this export's variable storage.
+            if ctx
+                .lookup_local(local)
+                .is_some_and(|id| locals.contains(&id))
+            {
                 // Both names are consumed by existing importer/getter paths;
                 // codegen derives storage ownership from Export::Named.local.
                 for name in [local, exported] {

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -29,6 +29,57 @@ pub(super) use static_import_bindings::{
     import_is_runtime_erased, pre_register_static_import_bindings,
 };
 
+/// Exporting a local variable depends on the binding, not its initializer.
+/// In particular, specialized HIR such as SetNewFromArray and Binary must
+/// have the same module storage/getters as literals or generic calls (#9778).
+/// Run after lowering the complete module so `export { x }; const x = ...`
+/// and declarations without initializers work too.
+pub(super) fn register_exported_local_variables(module: &mut Module) {
+    fn collect_names<'a>(stmts: &'a [Stmt], names: &mut std::collections::HashSet<&'a str>) {
+        for stmt in stmts {
+            match stmt {
+                Stmt::Let { name, .. } => {
+                    names.insert(name);
+                }
+                // Array-pattern declarations put their bindings inside the
+                // IteratorClose scaffolding; mirror module_globals_emit's
+                // storage walk without descending into closures or loops.
+                Stmt::Try {
+                    body,
+                    catch,
+                    finally,
+                } => {
+                    collect_names(body, names);
+                    if let Some(catch) = catch {
+                        collect_names(&catch.body, names);
+                    }
+                    if let Some(finally) = finally {
+                        collect_names(finally, names);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut locals = std::collections::HashSet::new();
+    collect_names(&module.init, &mut locals);
+    let mut registered: std::collections::HashSet<String> =
+        module.exported_objects.iter().cloned().collect();
+    for export in &module.exports {
+        if let Export::Named { local, exported } = export {
+            if locals.contains(local.as_str()) {
+                // Both names are consumed by existing importer/getter paths;
+                // codegen derives storage ownership from Export::Named.local.
+                for name in [local, exported] {
+                    if registered.insert(name.clone()) {
+                        module.exported_objects.push(name.clone());
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn lower_module_decl(
     ctx: &mut LoweringContext,
     module: &mut Module,
@@ -1552,126 +1603,8 @@ pub(crate) fn lower_module_decl(
                             }
                         }
 
-                        // Check if the variable is a closure or other exportable object
-                        // by looking through init statements. For #460: also catch let
-                        // bindings whose init is a function-reference value
-                        // (`const _await = core.deferredAwait`) — without this branch
-                        // the renamed export `_await as await` produces no backing
-                        // global / getter at all and `_perry_fn_<mod>__await` link-fails.
-                        for stmt in &module.init {
-                            if let Stmt::Let {
-                                name,
-                                init: Some(init_expr),
-                                ..
-                            } = stmt
-                            {
-                                if name == &local {
-                                    let is_exportable = matches!(
-                                        init_expr,
-                                        Expr::Closure { .. }
-                                            | Expr::Object(_)
-                                            | Expr::Array(_)
-                                            | Expr::SetNew
-                                            | Expr::SetNewFromArray(_)
-                                            | Expr::Call { .. }
-                                            | Expr::New { .. }
-                                            | Expr::JsNew { .. }
-                                            | Expr::LocalGet(_)
-                                            | Expr::FuncRef(_)
-                                            | Expr::ExternFuncRef { .. }
-                                            | Expr::PropertyGet { .. }
-                                            // A const aliasing a class STATIC field value
-                                            // (`const stringType = ZodString.create;
-                                            // export { stringType as string }`) lowers its
-                                            // init to `StaticFieldGet`. Like `PropertyGet`
-                                            // above it must flow through `exported_objects`
-                                            // so the importer reads the const's value via the
-                                            // module getter instead of link-failing to a
-                                            // nonexistent `perry_fn_<src>__<name>` symbol
-                                            // (which made the call return `undefined`). zod's
-                                            // `z.string`/`z.number`/… are all this shape.
-                                            | Expr::StaticFieldGet { .. }
-                                            // #421 fix (v0.5.574): primitive literals must
-                                            // also flow through `exported_objects` so the
-                                            // importing module's `imported_vars` set picks
-                                            // them up — without this, `var X = "literal";
-                                            // export { X };` (the shape hono / drizzle /
-                                            // any prebundled JS uses for string / number
-                                            // constants) gets imported as a closure-pointer
-                                            // wrapper instead of the actual value, and
-                                            // `typeof X` returns "function" + `X.toString`
-                                            // prints `[object Object]`.
-                                            | Expr::String(_)
-                                            | Expr::Number(_)
-                                            | Expr::Bool(_)
-                                            | Expr::BigInt(_)
-                                            | Expr::Null
-                                            | Expr::Undefined
-                                            // #7964: renamed RegExp literals are values too.
-                                            // Zod exports `_null as null` and `_undefined as
-                                            // undefined`; omitting these from exported_objects
-                                            // leaves the namespace populator calling getters
-                                            // that the producer never emits.
-                                            | Expr::RegExp { .. }
-                                            // Refs #420 (drizzle): `const entityKind = Symbol.for(...)`
-                                            // followed by `export { entityKind }` must register the
-                                            // local as an exported variable so importing modules
-                                            // pick it up via `imported_vars` (and route through the
-                                            // getter, not as a closure pointer).
-                                            | Expr::SymbolFor(_)
-                                            // Plain `const X = Symbol(); export { X }` — same as
-                                            // SymbolFor above, but for unregistered symbols. Without
-                                            // this the local isn't promoted to a shared module global,
-                                            // so an importer gets a DIFFERENT symbol than the defining
-                                            // module's binding and `imported === X` is false. Hono's
-                                            // RegExpRouter does exactly this with `PATH_ERROR`, so its
-                                            // `e === PATH_ERROR` route-fallback check failed and a bare
-                                            // Symbol escaped `app.fetch`.
-                                            | Expr::SymbolNew(_)
-                                            // Issue #923: `const pool = mysql.createPool(...)`
-                                            // followed by `export { pool }` lowers the init to
-                                            // `Expr::NativeMethodCall` (not `Expr::Call`) because
-                                            // `mysql` is a registered native-module alias and the
-                                            // factory call resolves to the stdlib FFI dispatch.
-                                            // Without this branch, `pool` never lands in
-                                            // `exported_objects`, the producer-side getter
-                                            // `perry_fn_<src>__pool` is never emitted, and the
-                                            // consumer-side `ExternFuncRef { name: "pool" }` falls
-                                            // through to the closure-wrapper path
-                                            // (`__perry_wrap_perry_fn_<src>__pool`) which #836's
-                                            // Sub-bug B emits as a no-op returning undefined. End
-                                            // result: link succeeds but `typeof pool === "function"`
-                                            // and `pool.execute(...)` segfaults. Mirroring the
-                                            // inline-export shape (`export const pool = ...` at
-                                            // line ~5087) makes both export forms equivalent.
-                                            //
-                                            // Covers every stdlib factory pattern: `mysql2/promise`
-                                            // `createPool` / `createConnection`, `net.createConnection`,
-                                            // `http.createServer`, `pg.connect`, `ioredis`
-                                            // constructors, `tls.connect`, and any other
-                                            // factory the codegen already lowers to a
-                                            // `NativeMethodCall` via lookup_native_module.
-                                            | Expr::NativeMethodCall { .. }
-                                    );
-                                    if is_exportable {
-                                        module.exported_objects.push(exported.clone());
-                                        // Ensure the LOCAL name also surfaces as
-                                        // exported — that's what gates the global
-                                        // emission in codegen (`exported_var_names`
-                                        // is built from `exported_objects`).
-                                        // Without the local entry, `_await`'s id
-                                        // is never registered in `module_globals`,
-                                        // so even the local-name getter is missing
-                                        // and call sites that resolve through the
-                                        // local name fall through to undefined.
-                                        if !module.exported_objects.contains(&local) {
-                                            module.exported_objects.push(local.clone());
-                                        }
-                                    }
-                                    break;
-                                }
-                            }
-                        }
+                        // Variable exports are registered after all declarations
+                        // are lowered, independently of their initializer shape.
                     }
                 }
             }

--- a/crates/perry-hir/tests/exported_local_variables.rs
+++ b/crates/perry-hir/tests/exported_local_variables.rs
@@ -72,3 +72,22 @@ fn imports_functions_and_types_are_not_local_variable_exports() {
     );
     assert!(names.is_empty(), "{names:?}");
 }
+
+#[test]
+fn block_bindings_do_not_reclassify_import_or_function_exports() {
+    for shadow in [
+        "try { const remote = 1; } finally {}",
+        "try {} finally { const remote = 1; }",
+        "try { throw 1; } catch (error) { const remote = 1; }",
+        "try { const [remote] = [1]; } finally {}",
+    ] {
+        for declaration in [
+            "import { remote } from './remote';",
+            "function remote() { return 42; }",
+        ] {
+            let source = format!("{declaration} {shadow} export {{ remote as REMOTE }};");
+            let names = exported_variables(&source);
+            assert!(names.is_empty(), "{source}: {names:?}");
+        }
+    }
+}

--- a/crates/perry-hir/tests/exported_local_variables.rs
+++ b/crates/perry-hir/tests/exported_local_variables.rs
@@ -1,0 +1,74 @@
+use perry_hir::lower_module;
+use perry_parser::parse_typescript;
+
+fn exported_variables(source: &str) -> Vec<String> {
+    let parsed = parse_typescript(source, "exports.ts").expect("parse");
+    lower_module(&parsed, "exports", "exports.ts")
+        .expect("lower")
+        .exported_objects
+}
+
+#[test]
+fn local_exports_do_not_depend_on_initializer_shape() {
+    for init in [
+        "new Set()",
+        "new Set(['doctor'])",
+        "new Map()",
+        "new Map([['doctor', true]])",
+        "1 + 2",
+        "true ? 1 : 2",
+        "!false",
+        "new Date(0)",
+        "42",
+        "undefined",
+        "() => 42",
+    ] {
+        for declaration in ["var", "let", "const"] {
+            for forward in [false, true] {
+                let decl = format!("{declaration} commands = {init};");
+                let export = "export { commands as COMMANDS };";
+                let source = if forward {
+                    format!("{export} {decl}")
+                } else {
+                    format!("{decl} {export}")
+                };
+                let names = exported_variables(&source);
+                for name in ["commands", "COMMANDS"] {
+                    assert!(
+                        names.iter().any(|n| n == name),
+                        "missing {name}: {source}: {names:?}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn uninitialized_and_destructured_local_exports_get_storage() {
+    for source in [
+        "let value; export { value as publicValue };",
+        "export { value as publicValue }; var value;",
+        "const [value] = [42]; export { value as publicValue };",
+        "export { value as publicValue }; const { value } = { value: 42 };",
+        "const value = new Set(); export { value };",
+    ] {
+        let names = exported_variables(source);
+        assert!(names.iter().any(|n| n == "value"), "{source}: {names:?}");
+    }
+}
+
+#[test]
+fn imports_functions_and_types_are_not_local_variable_exports() {
+    let names = exported_variables(
+        r#"
+        import { remote } from './remote';
+        function declared() { return 42; }
+        type Shape = { value: number };
+        export { remote as REMOTE, declared as DECLARED };
+        export type { Shape };
+        function hidden() { const local = 42; return local; }
+    "#,
+    );
+    assert!(names.is_empty(), "{names:?}");
+}

--- a/crates/perry/tests/exported_local_storage.rs
+++ b/crates/perry/tests/exported_local_storage.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-exported-local-storage.mjs"))
+        .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/scripts/test-exported-local-storage.mjs
+++ b/scripts/test-exported-local-storage.mjs
@@ -1,0 +1,45 @@
+// Standalone linked regression: no application sources or credentials.
+// PERRY_BIN=/path/to/perry PERRY_RUNTIME_DIR=/matching/runtime node scripts/test-exported-local-storage.mjs
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-exported-local-storage-'));
+let passed = false;
+try {
+  for (const fixture of ["exported_local_variables"]) {
+    const source = path.join(root, 'tests/modules', fixture, 'main.js');
+    const oracle = spawnSync(process.execPath, ['--expose-gc', source], {
+      encoding: 'utf8', timeout: 15_000,
+    });
+    if (oracle.status !== 0) throw new Error('Node oracle failed: ' + oracle.stderr);
+    for (const opt of (process.env.PERRY_TEST_OPT_LEVELS ?? '0,s,z').split(',')) {
+      const output = path.join(work, fixture + '-' + opt);
+      const compile = spawnSync(compiler, ['compile', source, '-o', output,
+        '--cache-dir', path.join(work, 'cache-' + fixture + '-' + opt),
+        '--no-auto-optimize', '--no-color',
+        
+        ...(process.env.PERRY_TEST_WASM === '1' ? ['--enable-wasm-runtime'] : [])], {
+        cwd: work, env: { ...process.env, PERRY_LL_OPT_LEVEL: opt },
+        encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
+      });
+      fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
+      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
+      fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
+      if (run.status !== 0 || run.stdout !== oracle.stdout) {
+        throw new Error('Native regression failed: ' + (run.error ?? run.status) + '\n' +
+          (run.stdout ?? '') + (run.stderr ?? ''));
+      }
+      console.log('PASS O' + opt + ': ' + fixture);
+    }
+  }
+  passed = true;
+} finally {
+  if (passed) fs.rmSync(work, { recursive: true });
+  else console.error('Retained regression diagnostics: ' + work);
+}

--- a/tests/modules/exported_local_variables/main.js
+++ b/tests/modules/exported_local_variables/main.js
@@ -1,0 +1,12 @@
+import { COMMANDS as staticCommands, TOTAL as staticTotal } from './values.js';
+
+async function main() {
+  const { COMMANDS, LOOKUP, TOTAL, EMPTY, checkArgs } = await import('./values.js');
+  if (typeof COMMANDS !== 'object' || !COMMANDS.has('doctor')) throw new Error('Set export');
+  if (typeof LOOKUP !== 'object' || LOOKUP.get('doctor') !== true) throw new Error('Map export');
+  if (TOTAL !== 42 || EMPTY !== undefined) throw new Error('primitive export');
+  if (!checkArgs(['doctor'])) throw new Error('function alias');
+  if (staticCommands !== COMMANDS || staticTotal !== TOTAL) throw new Error('static/dynamic identity');
+  console.log('PASS: local variable exports');
+}
+main();

--- a/tests/modules/exported_local_variables/values.js
+++ b/tests/modules/exported_local_variables/values.js
@@ -1,0 +1,9 @@
+// #9778: export lists refer to bindings, irrespective of initializer shape
+// or declaration order. Keep this fixture independent of bundled applications.
+export { commands as COMMANDS, lookup as LOOKUP, total as TOTAL, empty as EMPTY };
+var commands = new Set(['doctor']);
+let lookup = new Map([['doctor', true]]);
+const total = 40 + 2;
+let empty;
+function check(args) { return args.includes('doctor'); }
+export { check as checkArgs };


### PR DESCRIPTION
## Change

Register local variable exports after all module statements are lowered, independent of declaration order or initializer expression kind; remove the initializer whitelist.

## Independent regression

Standalone HIR matrix and native/Node comparison cover forward exports, Set/Map, arithmetic, uninitialized bindings, destructuring and aliases.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

All three HIR tests passed (including the 66-case initializer/order matrix). Exact native/Node output matched at O0/Os/Oz and shadow-stack Oz.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed local variable exports so they work consistently regardless of declaration order, declaration type, initializer, destructuring, or whether they are initialized.
  - Corrected exported local values across static and dynamic imports.
  - Ensured functions, imports, and type-only exports are handled correctly and are not mistakenly treated as local variable exports.

- **Tests**
  - Added regression coverage across optimization levels and runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->