### PR TITLE
fix(codegen): prefer imported bindings over unrelated class names

### DIFF
--- a/changelog.d/9992-imported-value-class-collision.md
+++ b/changelog.d/9992-imported-value-class-collision.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Keep named and namespace imports authoritative when another module has same-named class metadata, across property, computed, spread and method-call lowering; retain rooted receiver/argument evaluation.

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -379,7 +379,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // the non-spread path, so element-call semantics are unchanged.
             if let Expr::IndexGet { object, index } = callee.as_ref() {
                 let object_is_class_ref = matches!(object.as_ref(), Expr::ClassRef(_))
-                    || matches!(object.as_ref(), Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name));
+                    || matches!(object.as_ref(), Expr::ExternFuncRef { name, .. }
+                        if !ctx.imported_vars.contains(name) && !ctx.namespace_imports.contains(name)
+                            && ctx.class_ids.contains_key(name));
                 if !(crate::type_analysis::is_numeric_expr(ctx, index) && !object_is_class_ref) {
                     let recv_box = lower_expr(ctx, object)?;
                     let key_box = lower_expr(ctx, index)?;

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -790,7 +790,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `Object.prototype.hasOwnProperty.call(ImportedClass, sym)`
             // always returned false because the receiver was a closure-pointer
             // NaN-box (POINTER_TAG) rather than a class-ref (INT32_TAG).
-            if let Some(&cid) = ctx.class_ids.get(name) {
+            // Class metadata also includes classes that are not lexical
+            // imports (for cross-module return-type dispatch). An unrelated
+            // class with the same name must not shadow an imported variable.
+            if let Some(&cid) = ctx.class_ids.get(name).filter(|_| {
+                !ctx.imported_vars.contains(name) && !ctx.namespace_imports.contains(name)
+            }) {
                 let bits = crate::nanbox::INT32_TAG | (cid as u64 & 0xFFFF_FFFF);
                 return Ok(double_literal(f64::from_bits(bits)));
             }

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -610,7 +610,11 @@ fn is_async_dispose_symbol_index(index: &Expr) -> bool {
 pub(crate) fn index_object_is_class_or_proto_ref(ctx: &FnCtx<'_>, object: &Expr) -> bool {
     match object {
         Expr::ClassRef(_) => true,
-        Expr::ExternFuncRef { name, .. } => ctx.class_ids.contains_key(name),
+        Expr::ExternFuncRef { name, .. } => {
+            !ctx.imported_vars.contains(name)
+                && !ctx.namespace_imports.contains(name)
+                && ctx.class_ids.contains_key(name)
+        }
         Expr::LocalGet(id) => ctx
             .local_id_to_name
             .get(id)

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -781,7 +781,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // namespace dispatcher below; treating it as the equal-named
                 // imported class makes `Sharding.layer` read a static field on
                 // the class and return undefined.
-                if !ctx.namespace_imports.contains(name) {
+                if !ctx.namespace_imports.contains(name) && !ctx.imported_vars.contains(name) {
                     let key = (name.clone(), property.clone());
                     if let Some(global_name) = ctx.static_field_globals.get(&key).cloned() {
                         let g_ref = format!("@{}", global_name);
@@ -803,7 +803,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // undefined.
             let is_class_ref_object = matches!(object.as_ref(), Expr::ClassRef(_))
                 || matches!(object.as_ref(), Expr::ExternFuncRef { name, .. }
-                    if !ctx.namespace_imports.contains(name) && ctx.class_ids.contains_key(name));
+                    if !ctx.namespace_imports.contains(name) && !ctx.imported_vars.contains(name)
+                        && ctx.class_ids.contains_key(name));
             if is_class_ref_object {
                 let obj_box = lower_expr(ctx, object)?;
                 let key_idx = ctx.strings.intern(property);

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -23,6 +23,50 @@ fn downgrade_unknown_call_args(ctx: &mut FnCtx<'_>, args: &[Expr]) {
     }
 }
 
+fn lower_imported_value_method(
+    ctx: &mut FnCtx<'_>,
+    name: &str,
+    method: &str,
+    args: &[Expr],
+) -> Result<String> {
+    let receiver = Expr::ExternFuncRef {
+        name: name.to_string(),
+        param_types: vec![],
+        return_type: HirType::Any,
+    };
+    let mut operands = vec![&receiver];
+    operands.extend(args.iter());
+    crate::rooting::with_operands_rooted(ctx, &operands, |ctx, values| {
+        let (recv_box, lowered_args) = values.split_first().expect("receiver operand");
+        let (args_ptr, args_len) = if lowered_args.is_empty() {
+            ("null".to_string(), "0".to_string())
+        } else {
+            let buf = ctx.func.alloca_entry_array(DOUBLE, lowered_args.len());
+            let blk = ctx.block();
+            for (i, value) in lowered_args.iter().enumerate() {
+                let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                blk.store(DOUBLE, value, &slot);
+            }
+            (buf, lowered_args.len().to_string())
+        };
+        let method_idx = ctx.strings.intern(method);
+        let entry = ctx.strings.entry(method_idx);
+        let bytes_global = format!("@{}", entry.bytes_global);
+        let name_len = entry.byte_len.to_string();
+        Ok(ctx.block().call(
+            DOUBLE,
+            "js_native_call_method",
+            &[
+                (DOUBLE, recv_box),
+                (PTR, &bytes_global),
+                (I64, &name_len),
+                (PTR, &args_ptr),
+                (I64, &args_len),
+            ],
+        ))
+    })
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::StaticMethodCall {
@@ -31,6 +75,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             args,
         } => {
             downgrade_unknown_call_args(ctx, args);
+            // HIR may classify an uppercase object import as a static call.
+            // Lexical variable imports win over unrelated same-named class
+            // metadata, including when that class has this static method.
+            if ctx.imported_vars.contains(class_name) {
+                return lower_imported_value_method(ctx, class_name, method_name, args);
+            }
             // Built-in static methods that the runtime provides directly.
             if class_name == "AbortSignal" && method_name == "timeout" {
                 let ms = if !args.is_empty() {
@@ -457,47 +507,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if ctx.import_function_prefixes.contains_key(class_name)
                 || ctx.class_ids.contains_key(class_name)
             {
-                let recv_box = lower_expr(
-                    ctx,
-                    &Expr::ExternFuncRef {
-                        name: class_name.clone(),
-                        param_types: vec![],
-                        return_type: HirType::Any,
-                    },
-                )?;
-                let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
-                for a in args {
-                    lowered_args.push(lower_expr(ctx, a)?);
-                }
-                let (args_ptr, args_len) = if lowered_args.is_empty() {
-                    ("null".to_string(), "0".to_string())
-                } else {
-                    let n = lowered_args.len();
-                    let buf = ctx.func.alloca_entry_array(DOUBLE, n);
-                    {
-                        let blk = ctx.block();
-                        for (i, value) in lowered_args.iter().enumerate() {
-                            let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
-                            blk.store(DOUBLE, value, &slot);
-                        }
-                    }
-                    (buf, n.to_string())
-                };
-                let method_idx = ctx.strings.intern(method_name);
-                let entry = ctx.strings.entry(method_idx);
-                let bytes_global = format!("@{}", entry.bytes_global);
-                let name_len = entry.byte_len.to_string();
-                return Ok(ctx.block().call(
-                    DOUBLE,
-                    "js_native_call_method",
-                    &[
-                        (DOUBLE, &recv_box),
-                        (PTR, &bytes_global),
-                        (I64, &name_len),
-                        (PTR, &args_ptr),
-                        (I64, &args_len),
-                    ],
-                ));
+                return lower_imported_value_method(ctx, class_name, method_name, args);
             }
             for a in args {
                 let _ = lower_expr(ctx, a)?;

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -1258,6 +1258,49 @@ mod tests {
     }
 
     #[test]
+    fn cross_module_imported_static_receiver_stays_in_source_module() {
+        // HIR also uses StaticMethodCall for uppercase imported object values.
+        // #9023 deliberately keeps class-bearing calls at their source, where
+        // the receiver import is available; do not require the old localizer
+        // strategy merely because it also avoided the dangling receiver.
+        let mut source = Module::new("/accessor.js");
+        source.imports.push(perry_hir::Import {
+            source: "/state.js".to_string(),
+            specifiers: vec![ImportSpecifier::Named {
+                imported: "Settings".to_string(),
+                local: "Registry".to_string(),
+            }],
+            is_native: false,
+            module_kind: ModuleKind::NativeCompiled,
+            resolved_path: Some("/state.js".to_string()),
+            type_only: false,
+            runtime_erased: false,
+            is_dynamic: false,
+            is_dynamic_target: false,
+            is_deferred_require: false,
+            is_adopted_require: false,
+        });
+        let mut root = function(
+            1,
+            vec![Stmt::Return(Some(Expr::StaticMethodCall {
+                class_name: "Registry".to_string(),
+                method_name: "of".to_string(),
+                args: vec![Expr::Object(Vec::new())],
+            }))],
+        );
+        root.name = "store".to_string();
+        root.is_exported = true;
+        source.functions.push(root);
+        source.exported_functions.push(("store".to_string(), 1));
+        assert!(gather_cross_module_functions(&source).is_empty());
+        assert!(matches!(
+            &source.functions[0].body[0],
+            Stmt::Return(Some(Expr::StaticMethodCall { class_name, .. }))
+                if class_name == "Registry"
+        ));
+    }
+
+    #[test]
     fn cross_module_free_function_cycle_is_rejected() {
         let mut source = Module::new("/src/cycle.ts");
         let call = |id| {

--- a/crates/perry/tests/imported_value_class_collision.rs
+++ b/crates/perry/tests/imported_value_class_collision.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-imported-value-class-collision.mjs"))
+        .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/scripts/test-imported-value-class-collision.mjs
+++ b/scripts/test-imported-value-class-collision.mjs
@@ -1,0 +1,45 @@
+// Standalone linked regression: no application sources or credentials.
+// PERRY_BIN=/path/to/perry PERRY_RUNTIME_DIR=/matching/runtime node scripts/test-imported-value-class-collision.mjs
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-imported-value-class-collision-'));
+let passed = false;
+try {
+  for (const fixture of ["imported_value_class_collision","xmod_imported_static_receiver"]) {
+    const source = path.join(root, 'tests/modules', fixture, 'main.js');
+    const oracle = spawnSync(process.execPath, ['--expose-gc', source], {
+      encoding: 'utf8', timeout: 15_000,
+    });
+    if (oracle.status !== 0) throw new Error('Node oracle failed: ' + oracle.stderr);
+    for (const opt of (process.env.PERRY_TEST_OPT_LEVELS ?? '0,s,z').split(',')) {
+      const output = path.join(work, fixture + '-' + opt);
+      const compile = spawnSync(compiler, ['compile', source, '-o', output,
+        '--cache-dir', path.join(work, 'cache-' + fixture + '-' + opt),
+        '--no-auto-optimize', '--no-color',
+        
+        ...(process.env.PERRY_TEST_WASM === '1' ? ['--enable-wasm-runtime'] : [])], {
+        cwd: work, env: { ...process.env, PERRY_LL_OPT_LEVEL: opt },
+        encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
+      });
+      fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
+      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
+      fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
+      if (run.status !== 0 || run.stdout !== oracle.stdout) {
+        throw new Error('Native regression failed: ' + (run.error ?? run.status) + '\n' +
+          (run.stdout ?? '') + (run.stderr ?? ''));
+      }
+      console.log('PASS O' + opt + ': ' + fixture);
+    }
+  }
+  passed = true;
+} finally {
+  if (passed) fs.rmSync(work, { recursive: true });
+  else console.error('Retained regression diagnostics: ' + work);
+}

--- a/tests/modules/imported_value_class_collision/keys.js
+++ b/tests/modules/imported_value_class_collision/keys.js
@@ -1,0 +1,5 @@
+const Shared = {
+  label: 'object',
+  state: (id) => ({ namespace: 'state', id }),
+};
+export { Shared };

--- a/tests/modules/imported_value_class_collision/main.js
+++ b/tests/modules/imported_value_class_collision/main.js
@@ -1,0 +1,24 @@
+import { Shared } from './keys.js';
+import { touch, OtherClass, makeInstance, ClassValue } from './types.js';
+import { checkReverseOrder } from './reverse.js';
+import { checkNamespace } from './namespace.js';
+
+if (touch() !== 'loaded' || new OtherClass().value() !== 42) throw new Error('class import failed');
+const key = Shared.state('settings');
+if (key.namespace !== 'state' || key.id !== 'settings') throw new Error('object import failed');
+if (Shared.label !== 'object') throw new Error('static field shadowed imported object');
+const copy = Shared;
+if (copy !== Shared || copy.state('copy').namespace !== 'state') throw new Error('imported value failed');
+const method = Shared.state;
+if (method('detached').namespace !== 'state') throw new Error('method value failed');
+const computed = ['state'][0];
+if (Shared[computed]('computed').namespace !== 'state') throw new Error('computed call failed');
+if (Shared[computed](...['spread']).namespace !== 'state') throw new Error('spread call failed');
+if (OtherClass.label !== 'class' || OtherClass.state('real').namespace !== 'wrong-class') {
+  throw new Error('genuine imported class failed');
+}
+if (makeInstance().value() !== 42) throw new Error('factory return class metadata failed');
+if (ClassValue.state('variable-class').namespace !== 'wrong-class') throw new Error('class-valued import failed');
+checkReverseOrder();
+checkNamespace();
+console.log('PASS imported object is not shadowed by another module class');

--- a/tests/modules/imported_value_class_collision/namespace.js
+++ b/tests/modules/imported_value_class_collision/namespace.js
@@ -1,0 +1,8 @@
+import * as Shared from './types.js';
+
+export function checkNamespace() {
+  const namespace = Shared;
+  if (namespace.touch() !== 'loaded' || Shared.OtherClass.state('namespace').namespace !== 'wrong-class') {
+    throw new Error('class metadata shadowed namespace import');
+  }
+}

--- a/tests/modules/imported_value_class_collision/reverse.js
+++ b/tests/modules/imported_value_class_collision/reverse.js
@@ -1,0 +1,9 @@
+import { touch, OtherClass } from './types.js';
+import { Shared } from './keys.js';
+
+export function checkReverseOrder() {
+  if (touch() !== 'loaded' || new OtherClass().value() !== 42) throw new Error('reverse class import');
+  if (Shared.state('reverse').namespace !== 'state' || Shared.label !== 'object') {
+    throw new Error('reverse object import');
+  }
+}

--- a/tests/modules/imported_value_class_collision/types.js
+++ b/tests/modules/imported_value_class_collision/types.js
@@ -1,0 +1,9 @@
+class Shared {
+  static label = 'class';
+  static state(id) { return { namespace: 'wrong-class', id }; }
+  value() { return 42; }
+}
+export { Shared as OtherClass };
+export function touch() { return 'loaded'; }
+export function makeInstance() { return new Shared(); }
+export const ClassValue = Shared;

--- a/tests/modules/xmod_imported_static_receiver/README.md
+++ b/tests/modules/xmod_imported_static_receiver/README.md
@@ -1,0 +1,26 @@
+# Cross-module imported static receiver regression
+
+This fixture has no Claude Code source or Bun-specific dependency. An exported
+accessor calls a method on an uppercase named import, and a third module imports
+only that accessor. Perry represents the receiver in `StaticMethodCall.class_name`,
+not as an expression child. Its import must remain available: current main's
+#9023 fix keeps this class-bearing call in its original module. An alternative
+inliner may propagate and rename the import, but must never drop the receiver.
+
+Before the fix, the localized accessor loses the receiver binding and codegen
+silently returns numeric `0`. The native test fails with `lost factory result`;
+Node prints `PASS: transitive imported static receiver`.
+
+Run the native regression with a compiler and matching runtime archives:
+
+```sh
+PERRY_BIN=/absolute/path/to/perry PERRY_RUNTIME_DIR=/absolute/path/to/runtime \
+  node scripts/test-xmod-imported-static-receiver.mjs
+```
+
+The transform unit tests assert that the imported static call remains in its
+source module, alongside upstream's transitive class-dependency coverage.
+Run them with `cargo test -p perry-transform --lib cross_module`.
+
+If using runtime archives built with `perry-runtime/wasm-host`, also set
+`PERRY_TEST_WASM=1` and provide their matching `libperry_wasm_host.a`.

--- a/tests/modules/xmod_imported_static_receiver/accessor.js
+++ b/tests/modules/xmod_imported_static_receiver/accessor.js
@@ -1,0 +1,2 @@
+import { Settings as Registry, context } from './state.js';
+export function store() { return Registry.of(context().host); }

--- a/tests/modules/xmod_imported_static_receiver/main.js
+++ b/tests/modules/xmod_imported_static_receiver/main.js
@@ -1,0 +1,9 @@
+import { store } from './accessor.js';
+// The consumer deliberately does not import Registry/Settings. Its inlined
+// accessor must carry that dependency across the second module boundary.
+const first = store();
+console.log('store type', typeof first);
+if (typeof first !== 'object' || first === null) throw new Error('lost factory result');
+first.perSource.set('fixture', 42);
+if (store().perSource.get('fixture') !== 42) throw new Error('lost store identity');
+console.log('PASS: transitive imported static receiver');

--- a/tests/modules/xmod_imported_static_receiver/state.js
+++ b/tests/modules/xmod_imported_static_receiver/state.js
@@ -1,0 +1,17 @@
+class PerOwner {
+  #factory;
+  #values = new WeakMap();
+  constructor(factory) { this.#factory = factory; }
+  of(owner) {
+    const existing = this.#values.get(owner);
+    if (existing !== undefined) return existing;
+    const value = this.#factory();
+    this.#values.set(owner, value);
+    return value;
+  }
+}
+class Store { perSource = new Map(); }
+const Settings = new PerOwner(() => new Store());
+const host = {};
+export function context() { return { host }; }
+export { Settings };


### PR DESCRIPTION
## Change

Keep named and namespace imports authoritative when another module has same-named class metadata, across property, computed, spread and method-call lowering; retain rooted receiver/argument evaluation.

## Independent regression

Standalone native/Node fixtures cover both import orders, detached/computed/spread calls, true classes, class-valued variables, factories, and source-owned receiver behavior. Includes transform regression.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

Both standalone fixtures matched Node at O0/Os/Oz and shadow-stack Oz: imported value/class-name collisions and source-owned imported receivers.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.
