### PR TITLE
fix(hir): preserve object-owned array-named methods

### DIFF
--- a/changelog.d/9993-object-array-methods.md
+++ b/changelog.d/9993-object-array-methods.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Do not select Array callback intrinsics for statically known object receivers simply because their property is named forEach/map/filter/etc.

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -430,6 +430,15 @@ pub(super) fn try_array_only_methods(
                             return Ok(Err(args));
                         }
                         let ty = ctx.lookup_local_type(&n);
+                        // A structural object is not an Array. The earlier
+                        // local-array pass already declines these receivers;
+                        // do not recapture them here merely because their own
+                        // method has an Array name. In particular,
+                        // `utility.forEach(items, callback)` must not treat
+                        // `items` as Array.prototype.forEach's callback.
+                        if matches!(ty, Some(Type::Object(_))) {
+                            return Ok(Err(args));
+                        }
                         let class_typed = ty
                             .as_ref()
                             .map(|t| {

--- a/crates/perry-hir/tests/object_array_method_names.rs
+++ b/crates/perry-hir/tests/object_array_method_names.rs
@@ -1,0 +1,50 @@
+use perry_hir::lower_module;
+use perry_parser::parse_typescript;
+
+#[test]
+fn local_object_callback_methods_are_not_array_builtins() {
+    for method in [
+        "forEach", "map", "filter", "some", "every", "reduce", "sort",
+    ] {
+        for args in ["[1, 2]", "[1, 2], (value) => value"] {
+            let source = format!(
+                "function impl(items, callback) {{ return items; }} \
+                 var facade = {{ {method}: impl }}; \
+                 facade.{method}({args});"
+            );
+            let parsed = parse_typescript(&source, "object_methods.js").unwrap();
+            let hir = format!(
+                "{:?}",
+                lower_module(&parsed, "test", "object_methods.js").unwrap()
+            );
+            for array_op in [
+                "ArrayLikeMethod",
+                "ArrayForEach",
+                "ArrayMap",
+                "ArrayFilter",
+                "ArraySome",
+                "ArrayEvery",
+                "ArrayReduce",
+                "ArraySort",
+            ] {
+                assert!(
+                    !hir.contains(array_op),
+                    "plain-object {method}({args}) became {array_op}: {hir}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn actual_arrays_keep_their_callback_lowering() {
+    let parsed = parse_typescript(
+        "const items = [1, 2]; items.forEach(value => value); \
+         items.map(value => value, {});",
+        "array.js",
+    )
+    .unwrap();
+    let hir = format!("{:?}", lower_module(&parsed, "test", "array.js").unwrap());
+    assert!(hir.contains("ArrayForEach"));
+    assert!(hir.contains("ArrayLikeMethod"));
+}

--- a/crates/perry/tests/object_array_methods.rs
+++ b/crates/perry/tests/object_array_methods.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-object-array-methods.mjs"))
+        .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/scripts/test-object-array-methods.mjs
+++ b/scripts/test-object-array-methods.mjs
@@ -1,0 +1,45 @@
+// Standalone linked regression: no application sources or credentials.
+// PERRY_BIN=/path/to/perry PERRY_RUNTIME_DIR=/matching/runtime node scripts/test-object-array-methods.mjs
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-object-array-methods-'));
+let passed = false;
+try {
+  for (const fixture of ["object_array_method_names"]) {
+    const source = path.join(root, 'tests/modules', fixture, 'main.js');
+    const oracle = spawnSync(process.execPath, ['--expose-gc', source], {
+      encoding: 'utf8', timeout: 15_000,
+    });
+    if (oracle.status !== 0) throw new Error('Node oracle failed: ' + oracle.stderr);
+    for (const opt of (process.env.PERRY_TEST_OPT_LEVELS ?? '0,s,z').split(',')) {
+      const output = path.join(work, fixture + '-' + opt);
+      const compile = spawnSync(compiler, ['compile', source, '-o', output,
+        '--cache-dir', path.join(work, 'cache-' + fixture + '-' + opt),
+        '--no-auto-optimize', '--no-color',
+        
+        ...(process.env.PERRY_TEST_WASM === '1' ? ['--enable-wasm-runtime'] : [])], {
+        cwd: work, env: { ...process.env, PERRY_LL_OPT_LEVEL: opt },
+        encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
+      });
+      fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
+      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
+      fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
+      if (run.status !== 0 || run.stdout !== oracle.stdout) {
+        throw new Error('Native regression failed: ' + (run.error ?? run.status) + '\n' +
+          (run.stdout ?? '') + (run.stderr ?? ''));
+      }
+      console.log('PASS O' + opt + ': ' + fixture);
+    }
+  }
+  passed = true;
+} finally {
+  if (passed) fs.rmSync(work, { recursive: true });
+  else console.error('Retained regression diagnostics: ' + work);
+}

--- a/tests/modules/object_array_method_names/main.js
+++ b/tests/modules/object_array_method_names/main.js
@@ -1,0 +1,8 @@
+function iterate(items, callback) {
+  for (let i = 0; i < items.length; i++) callback(items[i]);
+}
+var utility = { forEach: iterate };
+let output = '';
+utility.forEach(['get', 'post'], method => { output += method + ';'; });
+if (output !== 'get;post;') throw new Error('own forEach was bypassed: ' + output);
+console.log('PASS: object forEach method');


### PR DESCRIPTION
## Change

Do not select Array callback intrinsics for statically known object receivers simply because their property is named forEach/map/filter/etc.

## Independent regression

HIR tests retain true-array fast paths; standalone native/Node fixture exercises an object facade with its own forEach signature.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

Both HIR tests passed, preserving genuine-array lowering. Native/Node output matched at O0/Os/Oz and shadow-stack Oz.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object methods named `forEach`, `map`, or `filter` being incorrectly treated as built-in array methods.
  * Object-defined callbacks now execute their own implementations, while genuine array methods continue to work as expected.

* **Tests**
  * Added coverage across optimization levels and runtime configurations to verify correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->