### PR TITLE
fix(hir): preserve spreads in static String calls

### DIFF
--- a/changelog.d/9994-string-static-spread.md
+++ b/changelog.d/9994-string-static-spread.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Retain spread boundaries and the String constructor receiver for fromCharCode, fromCodePoint and raw instead of sending spread operands through scalar-only intrinsic lowering.

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -958,16 +958,19 @@ pub(super) fn try_module_static_methods(
             // Check for String.methodName() static calls. #6677: computed form too.
             if obj_ident.sym.as_ref() == "String" {
                 if let Some(method_name) = super::static_call_prop_name(&member.prop) {
+                    // Scalar intrinsics receive flattened AST arguments, not
+                    // expanded values. Let CallSpread preserve every argument
+                    // boundary and invoke the reified variadic String static.
+                    // This also handles mixed spreads and iterable operands.
+                    if has_spread && matches!(method_name, "fromCharCode" | "fromCodePoint" | "raw")
+                    {
+                        return Ok(Err(args));
+                    }
                     match method_name {
                         "fromCharCode" => {
                             if args.is_empty() {
                                 // #2788: String.fromCharCode() -> "".
                                 return Ok(Ok(Expr::String(String::new())));
-                            }
-                            if has_spread && args.len() == 1 {
-                                return Ok(Ok(Expr::StringFromCharCodeSpread(Box::new(
-                                    args.into_iter().next().unwrap(),
-                                ))));
                             }
                             if args.len() == 1 {
                                 return Ok(Ok(Expr::StringFromCharCode(Box::new(

--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -304,11 +304,12 @@ pub(crate) fn lower_member_tail(
                             .unwrap_or(false);
                     // #4627: `String.fromCharCode` / `fromCodePoint` / `raw` are
                     // reified statics — value reads need the reified String
-                    // receiver for correct `.name`/`.length`. Explicit member
-                    // list (NOT the whole namespace) so only the reified statics
-                    // are rerouted.
-                    let outer_is_reified_string_static_value = !member_is_call_callee
-                        && property == "String"
+                    // receiver for correct `.name`/`.length`. Spread calls also
+                    // reach this path after declining the scalar intrinsics;
+                    // keep their receiver so CallSpread can invoke that same
+                    // variadic function. Non-spread calls are handled earlier.
+                    // Only the explicitly reified statics are rerouted.
+                    let outer_is_reified_string_static_value = property == "String"
                         && outer_static_member
                             .map(|member| {
                                 matches!(member, "fromCharCode" | "fromCodePoint" | "raw")

--- a/crates/perry-hir/tests/string_static_spread.rs
+++ b/crates/perry-hir/tests/string_static_spread.rs
@@ -1,0 +1,44 @@
+use perry_hir::{lower_module, CallArg, Expr, Stmt};
+use perry_parser::parse_typescript;
+
+#[test]
+fn string_static_spreads_keep_the_constructor_and_argument_boundaries() {
+    for method in ["fromCodePoint", "fromCharCode", "raw"] {
+        for property in [format!(".{method}"), format!("['{method}']")] {
+            for (args, spread) in [
+                ("...[65, 66]", vec![true]),
+                ("...[]", vec![true]),
+                (
+                    "64, ...[65, 66], 67, ...[68]",
+                    vec![false, true, false, true],
+                ),
+            ] {
+                let source = format!("const result = String{property}({args});");
+                let parsed = parse_typescript(&source, "string_spread.js").unwrap();
+                let module = lower_module(&parsed, "test", "string_spread.js").unwrap();
+                let result = module
+                    .init
+                    .iter()
+                    .find_map(|stmt| match stmt {
+                        Stmt::Let { name, init, .. } if name == "result" => init.as_ref(),
+                        _ => None,
+                    })
+                    .expect("result initializer");
+                let Expr::CallSpread { callee, args, .. } = result else {
+                    panic!("{source} lost spread: {result:?}");
+                };
+                assert_eq!(
+                    args.iter()
+                        .map(|arg| matches!(arg, CallArg::Spread(_)))
+                        .collect::<Vec<_>>(),
+                    spread
+                );
+                let debug = format!("{callee:?}");
+                assert!(
+                    debug.contains("\"String\"") && debug.contains(method),
+                    "{source} lost its String constructor receiver: {debug}"
+                );
+            }
+        }
+    }
+}

--- a/crates/perry/tests/string_static_spread.rs
+++ b/crates/perry/tests/string_static_spread.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-string-static-spread.mjs"))
+        .env("PERRY_BIN", env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/scripts/test-string-static-spread.mjs
+++ b/scripts/test-string-static-spread.mjs
@@ -1,0 +1,45 @@
+// Standalone linked regression: no application sources or credentials.
+// PERRY_BIN=/path/to/perry PERRY_RUNTIME_DIR=/matching/runtime node scripts/test-string-static-spread.mjs
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const compiler = process.env.PERRY_BIN ?? path.join(root, 'target/perry-dev/perry');
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-string-static-spread-'));
+let passed = false;
+try {
+  for (const fixture of ["string_static_spread"]) {
+    const source = path.join(root, 'tests/modules', fixture, 'main.js');
+    const oracle = spawnSync(process.execPath, ['--expose-gc', source], {
+      encoding: 'utf8', timeout: 15_000,
+    });
+    if (oracle.status !== 0) throw new Error('Node oracle failed: ' + oracle.stderr);
+    for (const opt of (process.env.PERRY_TEST_OPT_LEVELS ?? '0,s,z').split(',')) {
+      const output = path.join(work, fixture + '-' + opt);
+      const compile = spawnSync(compiler, ['compile', source, '-o', output,
+        '--cache-dir', path.join(work, 'cache-' + fixture + '-' + opt),
+        '--no-auto-optimize', '--no-color',
+        
+        ...(process.env.PERRY_TEST_WASM === '1' ? ['--enable-wasm-runtime'] : [])], {
+        cwd: work, env: { ...process.env, PERRY_LL_OPT_LEVEL: opt },
+        encoding: 'utf8', timeout: 120_000, maxBuffer: 8 * 1024 * 1024,
+      });
+      fs.writeFileSync(output + '-compile.log', (compile.stdout ?? '') + (compile.stderr ?? ''));
+      if (compile.status !== 0) throw new Error('Compilation failed: ' + (compile.error ?? compile.status));
+      const run = spawnSync(output, [], { cwd: work, encoding: 'utf8', timeout: 15_000 });
+      fs.writeFileSync(output + '-run.log', (run.stdout ?? '') + (run.stderr ?? ''));
+      if (run.status !== 0 || run.stdout !== oracle.stdout) {
+        throw new Error('Native regression failed: ' + (run.error ?? run.status) + '\n' +
+          (run.stdout ?? '') + (run.stderr ?? ''));
+      }
+      console.log('PASS O' + opt + ': ' + fixture);
+    }
+  }
+  passed = true;
+} finally {
+  if (passed) fs.rmSync(work, { recursive: true });
+  else console.error('Retained regression diagnostics: ' + work);
+}

--- a/tests/modules/string_static_spread/README.md
+++ b/tests/modules/string_static_spread/README.md
@@ -1,0 +1,22 @@
+# String constructor statics with spread arguments
+
+This self-contained JS fixture exercises direct, computed and detached
+`String.fromCodePoint` calls; empty and mixed spreads; array, typed-array and Set
+operands; evaluation order; invalid code points; and the equivalent spread paths
+for `String.fromCharCode` and `String.raw`.
+
+Run `node --expose-gc main.js` for the reference, then compile `main.js` with Perry
+and run the resulting executable. All 20 cases must pass, including 36 forced
+collections during spread-operand evaluation. No Claude Code files, Bun
+executable, credentials, network access, or generated assets are required.
+
+The original HIR static-call fast paths discarded spread markers. An array was
+passed as a scalar code point (throwing `RangeError: Invalid code point NaN`),
+mixed char-code arguments became NUL characters, and raw substitutions became
+comma-joined strings. Spread forms must use the reified variadic callable via
+`CallSpread`, keeping the `String` constructor receiver and each spread boundary.
+Do not make an ordinary array argument implicitly spread: the negative control
+`String.fromCodePoint([65, 66])` must continue to throw.
+
+The lowering contract is independently checked by
+`crates/perry-hir/tests/string_static_spread.rs` (18 AST forms).

--- a/tests/modules/string_static_spread/main.js
+++ b/tests/modules/string_static_spread/main.js
@@ -1,0 +1,61 @@
+// Independent regression: static String calls must retain spread boundaries.
+let failures = 0;
+function check(name, run, expected) {
+  try {
+    const actual = run();
+    if (actual !== expected) throw new Error('unexpected result: ' + actual);
+    console.log('PASS ' + name);
+  } catch (error) {
+    failures++;
+    console.log('FAIL ' + name + ': ' + error.message);
+  }
+}
+const points = [65, 66, 0x1f600];
+check('codepoint spread', () => String.fromCodePoint(...points), 'AB😀');
+check('codepoint empty', () => String.fromCodePoint(...[]), '');
+check('codepoint mixed', () => String.fromCodePoint(64, ...points, 67, ...[68]), '@AB😀CD');
+check('codepoint computed', () => String['fromCodePoint'](...points), 'AB😀');
+const fromCodePoint = String.fromCodePoint;
+check('codepoint detached', () => fromCodePoint(...points), 'AB😀');
+check('codepoint scalars', () => String.fromCodePoint(65, 66, 0x1f600), 'AB😀');
+check('codepoint typed array', () => String.fromCodePoint(...new Uint32Array([65, 0x1f600])), 'A😀');
+check('codepoint set', () => String.fromCodePoint(...new Set([65, 66])), 'AB');
+check('charcode spread', () => String.fromCharCode(...[65, 66]), 'AB');
+check('charcode empty', () => String.fromCharCode(...[]), '');
+check('charcode mixed', () => String.fromCharCode(64, ...[65, 66], 67, ...[68]), '@ABCD');
+check('charcode computed', () => String['fromCharCode'](64, ...[65, 66]), '@AB');
+check('charcode surrogate pair', () => String.fromCharCode(65, ...[0xd83d, 0xde00]), 'A😀');
+const template = { raw: ['a', 'b', 'c'] };
+check('raw spread substitutions', () => String.raw(template, ...[1, 2]), 'a1b2c');
+check('raw whole spread', () => String.raw(...[template, 1, 2]), 'a1b2c');
+check('raw mixed spread', () => String.raw(template, 1, ...[2]), 'a1b2c');
+check('codepoint evaluation order', () => {
+  let order = '';
+  function part(mark, value) { order += mark; return value; }
+  const result = String.fromCodePoint(part('a', 65), ...part('b', [66]), part('c', 67));
+  return order + ':' + result;
+}, 'abc:ABC');
+check('codepoint rejects invalid spread elements', () => {
+  let caught = 0;
+  for (const value of [-1, 1.5, 0x110000, NaN, Infinity]) {
+    try { String.fromCodePoint(...[65, value]); }
+    catch (error) { if (error.name === 'RangeError') caught++; }
+  }
+  return caught;
+}, 5);
+check('ordinary array argument is not spread', () => {
+  try { String.fromCodePoint([65, 66]); }
+  catch (error) { return error.name; }
+  return 'did not throw';
+}, 'RangeError');
+check('spread operands survive collection', () => {
+  function collect(value) { if (typeof globalThis.gc === 'function') globalThis.gc(); return value; }
+  let result = '';
+  for (let index = 0; index < 12; index++) {
+    result = String.fromCodePoint(...collect([65]), collect(66), ...collect([0x1f600]));
+    if (result !== 'AB😀') throw new Error('spread roots lost');
+  }
+  return result;
+}, 'AB😀');
+if (failures !== 0) throw new Error('String static spread failures: ' + failures);
+console.log('PASS String static spread regression');


### PR DESCRIPTION
## Change

Retain spread boundaries and the String constructor receiver for fromCharCode, fromCodePoint and raw instead of sending spread operands through scalar-only intrinsic lowering.

## Independent regression

HIR matrix and a 20-case native/Node regression cover computed/detached calls, multiple spreads, mixed arguments, Unicode, iterables, ordering, RangeError and GC.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

The HIR matrix passed. All 20 native cases matched Node at O0/Os/Oz and shadow-stack Oz, including forced GC.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed spread arguments for `String.fromCharCode`, `String.fromCodePoint`, and `String.raw`.
  - Preserved argument order and boundaries across mixed, empty, computed, detached, typed-array, and Set spreads.
  - Ensured invalid code points continue to raise `RangeError` and ordinary array arguments are not implicitly spread.

- **Tests**
  - Added comprehensive regression coverage across optimization levels and runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->