### PR TITLE
fix(codegen): honor size optimization with LLVM function attributes

### DIFF
--- a/changelog.d/9996-llvm-size-attributes.md
+++ b/changelog.d/9996-llvm-size-attributes.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Apply optsize for Os and optsize+minsize for Oz consistently to text and native LLVM construction; leave speed levels unchanged.

--- a/crates/perry-codegen/src/dialect/mod.rs
+++ b/crates/perry-codegen/src/dialect/mod.rs
@@ -355,7 +355,9 @@ impl<'ctx, 'm> FnReader<'ctx, 'm> {
                 // than lingering as an untested branch (CLAUDE.md kill
                 // policy) — a corpus still carrying one is stale and must
                 // say so loudly.
-                "alwaysinline" | "inlinehint" | "noinline" => add_enum_attr(ctx, func, a),
+                "alwaysinline" | "inlinehint" | "noinline" | "optsize" | "minsize" => {
+                    add_enum_attr(ctx, func, a)
+                }
                 // String attributes: `"frame-pointer"="non-leaf"`, and the
                 // valueless `"key"` form LLVM also accepts.
                 other if other.starts_with('"') => {

--- a/crates/perry-codegen/src/function.rs
+++ b/crates/perry-codegen/src/function.rs
@@ -895,6 +895,7 @@ impl LlFunction {
         } else {
             ""
         };
+        let size_attrs = crate::linker::application_size_function_attrs();
         // The native-stack walker recovers frames through the x29 chain, so
         // every generated function must link one; without the attribute,
         // textual-IR input gets no frame-pointer default from the clang
@@ -928,13 +929,14 @@ impl LlFunction {
             None => String::new(),
         };
         format!(
-            "define {}{}{} @{}({}){}{}{}{} {{",
+            "define {}{}{} @{}({}){}{}{}{}{} {{",
             linkage,
             cconv,
             self.return_type,
             self.name,
             param_str,
             attrs,
+            size_attrs,
             frame_pointer,
             gc_strategy,
             personality

--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -367,6 +367,29 @@ fn application_opt_flag(explicit: Option<&str>, size_opt: Option<&str>) -> &'sta
     }
 }
 
+fn application_opt_flag_from_env() -> &'static str {
+    application_opt_flag(
+        env::var("PERRY_LL_OPT_LEVEL").ok().as_deref(),
+        env::var("PERRY_LL_SIZE_OPT").ok().as_deref(),
+    )
+}
+
+fn size_function_attrs_for_opt_flag(flag: &str) -> &'static str {
+    match flag {
+        "-Os" => " optsize",
+        "-Oz" => " optsize minsize",
+        _ => "",
+    }
+}
+
+/// LLVM's size-oriented pass pipeline does not add frontend function
+/// attributes. In particular, AArch64 machine outlining consults `minsize`,
+/// so selecting default<Oz> alone still emits speed-oriented machine code.
+/// Share the driver's exact option resolution with both IR renderers.
+pub(crate) fn application_size_function_attrs() -> &'static str {
+    size_function_attrs_for_opt_flag(application_opt_flag_from_env())
+}
+
 fn build_clang_compile_plan(
     clang: PathBuf,
     ll_path: PathBuf,
@@ -388,9 +411,7 @@ fn build_clang_compile_plan(
     // materially shrinks dense generated bundles. `PERRY_LL_SIZE_OPT=0` restores
     // `-O3`; the explicit `PERRY_LL_OPT_LEVEL` override wins over both. There is
     // no implicit module-size-driven policy change.
-    let size_opt = env::var("PERRY_LL_SIZE_OPT").ok();
-    let explicit_opt = env::var("PERRY_LL_OPT_LEVEL").ok();
-    let opt_flag = application_opt_flag(explicit_opt.as_deref(), size_opt.as_deref());
+    let opt_flag = application_opt_flag_from_env();
 
     // Compacting the stack map means going through assembly, because that is
     // where LLVM prints the map's function addresses as symbol *names* — the

--- a/crates/perry-codegen/src/linker_tests.rs
+++ b/crates/perry-codegen/src/linker_tests.rs
@@ -241,6 +241,30 @@ fn explicit_application_opt_level_overrides_the_size_default() {
 }
 
 #[test]
+fn size_function_attributes_follow_the_same_policy_as_the_pass_pipeline() {
+    for (explicit, size_opt, expected) in [
+        (None, None, " optsize"),
+        (None, Some("0"), ""),
+        (Some("s"), Some("0"), " optsize"),
+        (Some(" Os "), None, " optsize"),
+        (Some("z"), None, " optsize minsize"),
+        (Some("Oz"), Some("off"), " optsize minsize"),
+        (Some("0"), None, ""),
+        (Some("O1"), None, ""),
+        (Some("2"), None, ""),
+        (Some("O3"), None, ""),
+        (Some("unknown"), None, " optsize"),
+        (Some("unknown"), Some("0"), ""),
+    ] {
+        assert_eq!(
+            size_function_attrs_for_opt_flag(application_opt_flag(explicit, size_opt)),
+            expected,
+            "explicit={explicit:?}, size_opt={size_opt:?}"
+        );
+    }
+}
+
+#[test]
 fn compile_plan_skips_native_tuning_for_explicit_target() {
     let plan = build_clang_compile_plan(
         PathBuf::from("clang"),

--- a/crates/perry-codegen/tests/size_function_attributes.rs
+++ b/crates/perry-codegen/tests/size_function_attributes.rs
@@ -1,0 +1,51 @@
+use perry_codegen::module::LlModule;
+use perry_codegen::types::DOUBLE;
+
+// Run in separate processes for default, O0/O2/O3, Os and Oz. This avoids
+// changing process-global compiler settings while another test is lowering.
+#[test]
+fn size_attributes_survive_text_and_native_construction() {
+    let expected = std::env::var("PERRY_TEST_SIZE_ATTRIBUTES").unwrap_or_else(|_| "optsize".into());
+    let mut module = LlModule::new("arm64-apple-macosx15.0.0");
+    for (name, forced, hinted, noinline) in [
+        ("plain", false, false, false),
+        ("forced", true, false, false),
+        ("hinted", false, true, false),
+        ("boundary", false, false, true),
+    ] {
+        let function = module.define_function(name, DOUBLE, vec![(DOUBLE, "%value".to_string())]);
+        function.force_inline = forced;
+        function.inline_hint = hinted;
+        function.no_inline = noinline;
+        function.create_block("entry").ret(DOUBLE, "%value");
+        for external in [false, true] {
+            let header = function.define_header(external);
+            assert_eq!(
+                header.contains(" optsize"),
+                expected.contains("optsize"),
+                "{header}"
+            );
+            assert_eq!(
+                header.contains(" minsize"),
+                expected.contains("minsize"),
+                "{header}"
+            );
+        }
+    }
+    let text = perry_codegen::linker::compile_ll_to_object(
+        &module.to_ir(),
+        Some("arm64-apple-macosx15.0.0"),
+    )
+    .unwrap();
+    let native = perry_codegen::native_emit::compile_module_native(
+        &mut module,
+        Some("arm64-apple-macosx15.0.0"),
+        "size_attribute_fixture",
+    )
+    .unwrap();
+    assert!(!native.is_empty());
+    assert_eq!(
+        native, text,
+        "native/text size policy must produce the same object"
+    );
+}

--- a/scripts/ci_e2e_scope.py
+++ b/scripts/ci_e2e_scope.py
@@ -131,6 +131,7 @@ _CODEGEN_SUITES = [
     "native_proof_buffer_views",
     "padding_single_evaluation",
     "shadow_slot_hygiene",
+    "size_function_attributes",
     "typed_feedback",
     # #7506/#7245: held out until its one failing test was triaged. The
     # composition it guards had drifted from three named callees to three


### PR DESCRIPTION
## Change

Apply optsize for Os and optsize+minsize for Oz consistently to text and native LLVM construction; leave speed levels unchanged.

## Independent regression

Option-resolution matrix plus object-level comparison between text/native paths. No claim about final application size until measured.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

The native/text object comparison passed independently at levels 0/1/2/3/s/z. The 12-case policy-resolution unit matrix passed. The missing-attribute regression fails on unchanged main.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied size optimization attributes consistently across text-based and native LLVM output.
  * `Os` now applies size optimization, while `Oz` applies both size and minimum-size optimization attributes.
  * Speed-focused optimization levels remain unchanged.

* **Tests**
  * Added coverage verifying size attributes across function configurations and code generation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->