### PR TITLE
feat(codegen): resume completed LLVM units after interrupted builds

### DIFF
--- a/changelog.d/9997-llvm-unit-checkpoints.md
+++ b/changelog.d/9997-llvm-unit-checkpoints.md
@@ -1,0 +1,3 @@
+### Added
+
+- Atomically checkpoint completed native units under the driver's full object-cache identity and a fingerprint of each frozen LLVM input. Treat missing, truncated, corrupt or unwritable records as cache misses.

--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -71,6 +71,7 @@ pub(crate) mod type_analysis_net;
 pub mod typed_feedback_profile;
 pub(crate) mod typed_shape;
 pub mod types;
+pub mod unit_cache;
 
 pub use codegen::{
     compile_module, namespace_member_class_key, namespace_member_func_key,

--- a/crates/perry-codegen/src/native_emit.rs
+++ b/crates/perry-codegen/src/native_emit.rs
@@ -169,6 +169,40 @@ struct FrozenUnit {
     function_count: usize,
 }
 
+impl FrozenUnit {
+    /// Guard against unit-layout or lowering-order changes even when the
+    /// driver's full module cache identity matches. Hash the exact input, not
+    /// just the function names. Reuse one line buffer rather than materializing
+    /// a second whole-unit text representation.
+    fn fingerprint(&self, target: &str, args: &[String], native_roots: bool) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hash = std::collections::hash_map::DefaultHasher::new();
+        target.hash(&mut hash);
+        args.hash(&mut hash);
+        native_roots.hash(&mut hash);
+        self.skeleton.hash(&mut hash);
+        let mut line = String::new();
+        for function in &self.functions {
+            function.name.hash(&mut hash);
+            function.header.hash(&mut hash);
+            function.items.len().hash(&mut hash);
+            for item in &function.items {
+                std::mem::discriminant(item).hash(&mut hash);
+                match item {
+                    FrozenItem::Label(text) | FrozenItem::Text(text) => text.hash(&mut hash),
+                    FrozenItem::Blank => {}
+                    FrozenItem::Inst(inst) => {
+                        line.clear();
+                        inst.render_into(&mut line);
+                        line.hash(&mut hash);
+                    }
+                }
+            }
+        }
+        hash.finish()
+    }
+}
+
 /// Apply a typed pre- or post-RS4GC budget request to the lowering-owned functions
 /// that produced a module/unit. The request is expected to make progress for
 /// every named function; otherwise retrying would either preserve the refusal
@@ -471,10 +505,30 @@ pub fn compile_module_units_native(
     // `LlModule::skeleton_ir`; cross-unit declarations with their actual
     // signatures already live in each part's filtered `pre`.
     let llvm_started = std::time::Instant::now();
+    let unit_cache = crate::unit_cache::UnitCache::current();
     #[cfg(test)]
     let test_budget = crate::inprocess::test_rs4gc_budget_cap();
     let compile_one = |i: usize, unit: &FrozenUnit| -> Result<Vec<u8>> {
         let started = std::time::Instant::now();
+        let (effective_target, args) = crate::linker::native_plan_args(target, native_roots);
+        let checkpoint = unit_cache.as_ref().map(|cache| {
+            (
+                cache,
+                unit.fingerprint(&effective_target, &args, native_roots),
+            )
+        });
+        if let Some((cache, key)) = checkpoint {
+            if let Some(bytes) = cache.load(i, unit_total, key) {
+                if show_progress {
+                    eprintln!(
+                        "[perry] codegen: {module_prefix}: reused checkpoint for LLVM unit {}/{}",
+                        i + 1,
+                        unit_total
+                    );
+                }
+                return Ok(bytes);
+            }
+        }
         let context = Context::create();
         let module =
             crate::inprocess::parse_ir_text(&context, &unit.skeleton, "perry_native_module")
@@ -482,7 +536,6 @@ pub fn compile_module_units_native(
         let (t, r) = stream_frozen_functions(&context, &module, &unit.functions)
             .with_context(|| format!("unit {i}"))?;
         debug_dump(&module, &format!("{module_prefix}.unit{i}"));
-        let (effective_target, args) = crate::linker::native_plan_args(target, native_roots);
         let mut stats = crate::inprocess::UnitCodegenStats::default();
         let stats_out = unit_timings.then_some(&mut stats);
         let optimize = || {
@@ -525,6 +578,9 @@ pub fn compile_module_units_native(
         }
         let obj = crate::linker::finish_native_emission(unit_bytes, &effective_target, &args)
             .with_context(|| format!("unit {i}"))?;
+        if let Some((cache, key)) = checkpoint {
+            cache.store(i, unit_total, key, &obj);
+        }
         log::debug!(
             "perry-codegen: native unit {i}: {} fns, {t} typed + {r} raw insts, {:.3}s",
             unit.function_count,

--- a/crates/perry-codegen/src/unit_cache.rs
+++ b/crates/perry-codegen/src/unit_cache.rs
@@ -1,0 +1,182 @@
+//! Checkpoints for completed LLVM units of an otherwise unfinished module.
+//!
+//! The driver supplies a directory namespaced by its full object-cache key
+//! (compiler executable, HIR, target, options and codegen environment). Native
+//! emission additionally fingerprints each unit's actual frozen input. Neither
+//! a unit index alone nor a source-file name is a sufficient cache identity.
+
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+thread_local! {
+    static DIRECTORY: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+/// Scope checkpoints to one module compilation on the calling thread. `None`
+/// disables them (including inside an outer scope). The directory MUST include
+/// the driver's complete object-cache identity; it is not just a cache root.
+/// Workers receive an owned snapshot, never another worker's thread-local state.
+pub fn with_module_cache<T>(directory: Option<PathBuf>, compile: impl FnOnce() -> T) -> T {
+    struct Restore(Option<PathBuf>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            DIRECTORY.with(|directory| directory.replace(self.0.take()));
+        }
+    }
+    let _restore = Restore(DIRECTORY.with(|slot| slot.replace(directory)));
+    compile()
+}
+
+#[derive(Clone)]
+pub(crate) struct UnitCache(PathBuf);
+
+fn checksum(bytes: &[u8]) -> u64 {
+    let mut hash = DefaultHasher::new();
+    hash.write(bytes);
+    hash.finish()
+}
+
+impl UnitCache {
+    pub(crate) fn current() -> Option<Self> {
+        DIRECTORY.with(|directory| directory.borrow().clone().map(Self))
+    }
+
+    fn path(&self, index: usize, total: usize, input: u64) -> PathBuf {
+        self.0.join(format!("{index}-{total}-{input:016x}.puc"))
+    }
+
+    pub(crate) fn load(&self, index: usize, total: usize, input: u64) -> Option<Vec<u8>> {
+        let mut bytes = std::fs::read(self.path(index, total, input)).ok()?;
+        // A single atomically published record prevents torn object/metadata
+        // pairs. Reject truncation and corruption as misses, never as objects.
+        if bytes.len() <= 24 || &bytes[..8] != b"PERRYUC1" {
+            return None;
+        }
+        let length = u64::from_le_bytes(bytes[8..16].try_into().ok()?);
+        let digest = u64::from_le_bytes(bytes[16..24].try_into().ok()?);
+        if length != (bytes.len() - 24) as u64 || checksum(&bytes[24..]) != digest {
+            return None;
+        }
+        bytes.drain(..24);
+        Some(bytes)
+    }
+
+    pub(crate) fn store(&self, index: usize, total: usize, input: u64, bytes: &[u8]) {
+        // Caching is best effort: disk-full/read-only caches must not change
+        // compilation semantics. Unique create_new files also permit parallel
+        // invocations compiling the same module without publishing partial data.
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        if bytes.is_empty() || std::fs::create_dir_all(&self.0).is_err() {
+            return;
+        }
+        let temporary = self.0.join(format!(
+            ".unit-{}-{}.tmp",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        let Ok(mut file) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+        else {
+            return;
+        };
+        let written = (|| -> std::io::Result<()> {
+            file.write_all(b"PERRYUC1")?;
+            file.write_all(&(bytes.len() as u64).to_le_bytes())?;
+            file.write_all(&checksum(bytes).to_le_bytes())?;
+            file.write_all(bytes)?;
+            file.sync_all()
+        })();
+        drop(file);
+        if written.is_err() || std::fs::rename(&temporary, self.path(index, total, input)).is_err()
+        {
+            let _ = std::fs::remove_file(&temporary);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> UnitCache {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "perry-unit-cache-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir(&path).unwrap();
+        UnitCache(path)
+    }
+
+    #[test]
+    fn incomplete_module_retains_only_completed_matching_units() {
+        let cache = fixture();
+        cache.store(0, 3, 42, b"finished object");
+        let resumed = UnitCache(cache.0.clone());
+        assert_eq!(resumed.load(0, 3, 42).unwrap(), b"finished object");
+        assert!(resumed.load(1, 3, 42).is_none());
+        assert!(resumed.load(0, 4, 42).is_none());
+        assert!(resumed.load(0, 3, 43).is_none());
+        assert!(UnitCache(cache.0.join("different-compiler"))
+            .load(0, 3, 42)
+            .is_none());
+        std::fs::remove_dir_all(cache.0).unwrap();
+    }
+
+    #[test]
+    fn corrupt_or_truncated_checkpoints_are_misses() {
+        let cache = fixture();
+        cache.store(0, 2, 42, b"finished object");
+        let path = cache.path(0, 2, 42);
+        let original = std::fs::read(&path).unwrap();
+        for length in 0..original.len() {
+            std::fs::write(&path, &original[..length]).unwrap();
+            assert!(cache.load(0, 2, 42).is_none());
+        }
+        let mut corrupt = original;
+        corrupt[24] ^= 1;
+        std::fs::write(&path, corrupt).unwrap();
+        assert!(cache.load(0, 2, 42).is_none());
+        cache.store(0, 2, 42, b"recompiled object");
+        assert_eq!(cache.load(0, 2, 42).unwrap(), b"recompiled object");
+        std::fs::remove_dir_all(cache.0).unwrap();
+    }
+
+    #[test]
+    fn scope_is_nested_disabled_and_thread_local() {
+        let cache = fixture();
+        assert!(UnitCache::current().is_none());
+        with_module_cache(Some(cache.0.clone()), || {
+            assert_eq!(UnitCache::current().unwrap().0, cache.0);
+            with_module_cache(None, || assert!(UnitCache::current().is_none()));
+            assert_eq!(UnitCache::current().unwrap().0, cache.0);
+            std::thread::spawn(|| assert!(UnitCache::current().is_none()))
+                .join()
+                .unwrap();
+        });
+        assert!(UnitCache::current().is_none());
+        std::fs::remove_dir_all(cache.0).unwrap();
+    }
+
+    #[test]
+    fn unwinding_restores_scope_and_unwritable_cache_is_nonfatal() {
+        let cache = fixture();
+        let _ = std::panic::catch_unwind(|| {
+            with_module_cache(Some(cache.0.clone()), || panic!("fixture"));
+        });
+        assert!(UnitCache::current().is_none());
+        let path = cache.0.join("not-a-directory");
+        std::fs::write(&path, b"file").unwrap();
+        let unusable = UnitCache(path);
+        unusable.store(0, 2, 42, b"object");
+        assert!(unusable.load(0, 2, 42).is_none());
+        std::fs::remove_dir_all(cache.0).unwrap();
+    }
+}

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -5649,7 +5649,15 @@ pub fn run_with_parse_cache(
             let compiled = if let Some(session) = &typed_feedback {
                 super::typed_feedback_profile::compile(session, hir_module, opts, path, perry_version)
             } else {
-                perry_codegen::compile_module(hir_module, opts)
+                let unit_cache_dir = cache_key.map(|key| {
+                    ctx.cache_dir
+                        .join("codegen-units-v1")
+                        .join(cache_target_dir)
+                        .join(format!("{key:016x}"))
+                });
+                perry_codegen::unit_cache::with_module_cache(unit_cache_dir, || {
+                    perry_codegen::compile_module(hir_module, opts)
+                })
             };
             let object_code = compiled.map_err(|e| {
                 perry_codegen::ext_registry::take_module_capture();

--- a/crates/perry/tests/llvm_unit_checkpoints.rs
+++ b/crates/perry/tests/llvm_unit_checkpoints.rs
@@ -1,0 +1,20 @@
+//! CI-visible entry point for the bounded standalone native regression.
+use std::{path::Path, process::Command};
+
+#[test]
+fn standalone_regression() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new("node")
+        .arg(root.join("scripts/test-codegen-unit-resume.mjs"))
+        .arg(env!("CARGO_BIN_EXE_perry"))
+        .env("PERRY_WORKSPACE_ROOT", &root)
+        .current_dir(&root)
+        .output()
+        .expect("run bounded Node regression driver");
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/scripts/test-codegen-unit-resume.mjs
+++ b/scripts/test-codegen-unit-resume.mjs
@@ -1,0 +1,49 @@
+// Independent CLI regression: complete native units survive a missing module
+// object; a missing unit is regenerated; cold, resumed and uncached output agree.
+// Usage: node scripts/test-codegen-unit-resume.mjs /absolute/path/to/perry
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const compiler = path.resolve(process.argv[2]);
+const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const fixture = path.join(sourceRoot, 'tests/modules/codegen_unit_resume/main.ts');
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'perry-unit-resume-'));
+const cache = path.join(scratch, 'cache');
+console.log(`Artifacts: ${scratch}`);
+const env = {
+  ...process.env,
+  PERRY_LL_OPT_LEVEL: 's', PERRY_RS4GC: '0', PERRY_SHADOW_STACK: '1',
+  PERRY_INLINE_SHADOW_SLOT: '0', PERRY_FULL_OUTLINE_IC: '1',
+  PERRY_LLVM_INPROCESS: 'native', PERRY_CODEGEN_UNITS: '4',
+  PERRY_CODEGEN_UNIT_JOBS: '2', PERRY_CODEGEN_PROGRESS: '1',
+};
+function run(label, extra = []) {
+  const output = path.join(scratch, `${label}.o`);
+  const result = spawnSync(compiler, ['compile', fixture, '-o', output,
+    '--cache-dir', cache, '--no-link', '--no-auto-optimize', '--no-color', ...extra],
+  { cwd: scratch, env, encoding: 'utf8', timeout: 120_000, maxBuffer: 16 * 1024 * 1024 });
+  const log = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  fs.writeFileSync(path.join(scratch, `${label}.log`), log);
+  assert.equal(result.status, 0, `${label} failed: ${result.error ?? log}`);
+  return { bytes: fs.readFileSync(output), log };
+}
+const cold = run('cold');
+assert(!cold.log.includes('reused checkpoint'));
+const relative = fs.readdirSync(cache, { recursive: true }).filter(p => p.endsWith('.puc'));
+assert.equal(relative.length, 4, 'fixture must exercise four native LLVM units');
+// Model interruption before the final module object was stored, and before
+// one unit completed. Keep the original files recoverable for investigation.
+fs.renameSync(path.join(cache, 'objects'), path.join(scratch, 'completed-objects'));
+fs.renameSync(path.join(cache, relative[0]), path.join(scratch, 'missing-unit.puc'));
+const resumed = run('resumed');
+assert.equal((resumed.log.match(/reused checkpoint/g) ?? []).length, 3);
+assert.deepEqual(resumed.bytes, cold.bytes, 'resumed object differs from cold output');
+assert(fs.existsSync(path.join(cache, relative[0])), 'missing unit was not saved');
+const disabled = run('uncached', ['--no-cache']);
+assert(!disabled.log.includes('reused checkpoint'));
+assert.deepEqual(disabled.bytes, cold.bytes, 'checkpointing changed object output');
+console.log('PASS: 3 units reused, 1 regenerated; cold/resumed/uncached objects identical');

--- a/tests/modules/codegen_unit_resume/main.ts
+++ b/tests/modules/codegen_unit_resume/main.ts
@@ -1,0 +1,15 @@
+function a(n: number) { return { value: n + 1 }; }
+function b(n: number) { return { value: n + 2 }; }
+function c(n: number) { return { value: n + 3 }; }
+function d(n: number) { return { value: n + 4 }; }
+function e(n: number) { return { value: n + 5 }; }
+function f(n: number) { return { value: n + 6 }; }
+function g(n: number) { return { value: n + 7 }; }
+function h(n: number) { return { value: n + 8 }; }
+const functions = [a, b, c, d, e, f, g, h];
+let sum = 0;
+for (let i = 0; i < functions.length; i++) {
+    sum += functions[i](i).value;
+}
+if (sum !== 64) throw new Error('split unit result changed');
+console.log('PASS: split units', sum);


### PR DESCRIPTION
## Change

Atomically checkpoint completed native units under the driver's full object-cache identity and a fingerprint of each frozen LLVM input. Treat missing, truncated, corrupt or unwritable records as cache misses.

## Independent regression

Unit tests cover input isolation, corruption, nesting, unwinding and best-effort writes. Bounded CLI regression removes one of four completed units and the final module object, then requires 3 reused/1 rebuilt and byte-identical cold/resumed/uncached objects.

The branch starts directly from main and contains its own synthetic fixtures. No proprietary application sources, credentials, account or investigation artifacts are needed.

## Validation completed

All four checkpoint unit tests passed. The bounded native driver proved 3 reused units/1 regenerated unit and identical cold/resumed/uncached objects. On unchanged main it found 0 of the required 4 checkpoints.

For transparency: the local before/after native and unit validation used main `8d88e481c` and an integration checkout containing the nine audited patches together. Compiler and all nine runtime/extension archives had matching source identities. Each published branch is separate and passes its own CI warnings/check compilation jobs.

Local gate run: all applicable script gates passed except the already-stale public benchmark artifact; product/host warnings and Clippy passed. The all-in-one run reached its 10-minute cap in the API-doc rebuild; both API outputs were then independently verified byte-for-byte with the matching built compiler (no drift).

## Existing CI failures / landing note

- Main already has the same [public benchmark freshness failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350897) and [Linux custom thread-stack test failure](https://github.com/PerryTS/perry/actions/runs/34232917409/job/102083350807). Neither is changed or suppressed here.
- The existing parallel `typed_feedback` test race encountered by the scoped codegen suites is fixed separately in #9999. Please include that test-only fix in the landing batch.
- Scoped CI may still be running or show those recorded failures; this is not a claim that every CI job is green.

Ready for the maintainer landing workflow. The full application will be rebuilt only after the required production changes are verified on main.
