### PR TITLE
test(codegen): isolate the default feedback lane

### DIFF
--- a/changelog.d/9999-typed-feedback-test-isolation.md
+++ b/changelog.d/9999-typed-feedback-test-isolation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Isolate the default-lane closure-specialization regression from concurrent profiling environment changes and inherited profiling settings.

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -1118,6 +1118,11 @@ fn synthetic_arguments_only_method_uses_shape_guarded_direct_call() {
 
 #[test]
 fn typed_feedback_guards_direct_closure_call_specialization() {
+    // This test asserts the non-recording lane. Join the env-mutating tests'
+    // lock and pin that lane, including when the parent enables profiling.
+    let _lock = env_lock();
+    let _feedback = EnvVarGuard::set("PERRY_TYPED_FEEDBACK", None);
+    let _trace = EnvVarGuard::set("PERRY_TYPED_FEEDBACK_TRACE", None);
     let closure_ty = Type::Function(FunctionType {
         params: vec![("x".to_string(), Type::Number, false)],
         return_type: Box::new(Type::Number),


### PR DESCRIPTION
## Test-only fix

The closure-specialization test asserts that pure feedback recording calls are absent, but did not acquire the suite's environment lock or disable the profiling settings. Other tests in this same parallel suite temporarily enable those settings, causing scoped CI on unrelated codegen PRs to fail at typed_feedback.rs:1171.

Join the existing poison-tolerant lock and scoped environment guards. No production compiler/runtime behavior changes. Based directly on main; independent of the compatibility changes.

## Validation

- Deterministic before: PERRY_TYPED_FEEDBACK=1 makes the existing exact test fail at the same assertion as CI.
- After: the exact test passes with both PERRY_TYPED_FEEDBACK=1 and PERRY_TYPED_FEEDBACK_TRACE=1 inherited.
- The full 20-test suite passes with 8 test threads after the fix.
- Synthetic HIR only; no application artifacts required.

Baseline CI issues, independently confirmed in main run 34232917409: stale public benchmark evidence and native_stack::tests::stack_top_respects_custom_thread_stack_sizes. This PR does not alter or suppress either gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test reliability by isolating typed-feedback behavior from inherited profiling settings.
  - Prevented concurrent profiling configuration from affecting closure-specialization verification.

- **Documentation**
  - Added a changelog entry documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->