### PR TITLE
fix(fastify): recycle context handles at outer pump ticks

### DIFF
--- a/changelog.d/10002-fastify-handle-recycling.md
+++ b/changelog.d/10002-fastify-handle-recycling.md
@@ -1,0 +1,8 @@
+Long-running Fastify servers now recycle completed request-context handles.
+The extension dropped one registry handle after every response, but only the
+HTTP server pump drained the registry's one-tick quarantine. Fastify therefore
+exhausted the 262,143-id common band under sustained traffic. The process event
+pump now promotes retired FFI handles once at the beginning of an outer tick,
+before any runtime, stdlib, or extension callback can retire another handle.
+This covers every extension while preserving the same-tick ABA quarantine when
+several extension pumps run sequentially.

--- a/crates/perry-ext-http/src/server/server.rs
+++ b/crates/perry-ext-http/src/server/server.rs
@@ -1508,13 +1508,6 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     // hazard: a handler that returned before `res.end()` leaves a stale `res`
     // (a bare tagged handle id) outstanding, and recycling its id immediately
     // would let the next request re-occupy it and a microtask-deferred
-    // `res.write`/`res.end` corrupt the new request's response. Holding the id
-    // in quarantine for a full tick lets those stale calls spend themselves
-    // against an empty slot first. (A write deferred MORE than a tick past
-    // finalization is a write-after-end use error and out of scope — see
-    // `perry_ffi::drain_quarantined_handles`.)
-    perry_ffi::drain_quarantined_handles();
-
     // Settle `Bun.serve` fetch/error promises before the ordinary in-flight
     // reaper observes their ServerResponse handles.
     count += crate::server::bun_server::process_pending_promises();

--- a/crates/perry-ffi/src/event_pump.rs
+++ b/crates/perry-ffi/src/event_pump.rs
@@ -31,6 +31,9 @@
 //! pushing so the main loop wakes promptly instead of waiting on the
 //! heartbeat cap.
 
+#[cfg(any(not(test), feature = "runtime-link"))]
+use std::sync::Once;
+
 extern "C" {
     /// Wake the main thread from `js_wait_for_event`.
     ///
@@ -39,17 +42,40 @@ extern "C" {
     /// one wake — the main-loop tick drains every queue each pass
     /// regardless.
     fn js_notify_main_thread();
+    #[cfg(any(not(test), feature = "runtime-link"))]
+    fn js_register_aux_tick_begin(f: extern "C" fn());
     fn js_register_aux_pump(f: extern "C" fn() -> i32);
     fn js_register_aux_has_active(f: extern "C" fn() -> i32);
+}
+
+#[cfg(any(not(test), feature = "runtime-link"))]
+static HANDLE_TICK_HOOK_REGISTRATION: Once = Once::new();
+
+/// Install handle recycling before the registry can allocate its first id.
+/// The runtime registration is itself idempotent, while `Once` keeps the hot
+/// allocation path to a single atomic check after initialization.
+pub(crate) fn ensure_handle_tick_hook_registered() {
+    // Standalone perry-ffi unit tests do not link the runtime symbol. Product
+    // binaries always resolve it when the compiler links libperry_runtime.
+    #[cfg(any(not(test), feature = "runtime-link"))]
+    HANDLE_TICK_HOOK_REGISTRATION.call_once(|| unsafe {
+        js_register_aux_tick_begin(drain_handle_quarantine_at_tick_begin);
+    });
 }
 
 /// Register an extension event pump and activity probe with the runtime.
 /// Registration is idempotent for each function pointer.
 pub fn register_aux_event_pump(pump: extern "C" fn() -> i32, has_active: extern "C" fn() -> i32) {
+    ensure_handle_tick_hook_registered();
     unsafe {
         js_register_aux_pump(pump);
         js_register_aux_has_active(has_active);
     }
+}
+
+#[cfg(any(not(test), feature = "runtime-link"))]
+extern "C" fn drain_handle_quarantine_at_tick_begin() {
+    crate::handle::drain_quarantined_handles();
 }
 
 /// Wake the main thread so it picks up a pending event the calling

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -483,6 +483,7 @@ impl<'a> GcRootVisitor<'a> {
 /// across threads (tokio workers may resolve promises that touch
 /// handle data while the main thread is also touching it).
 pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
+    crate::event_pump::ensure_handle_tick_hook_registered();
     ensure_handle_exists_probe_registered();
     // Reuse a reclaimed id when one is parked, else mint a fresh one. A
     // recycled id was removed from `HANDLES` before being parked, so inserting
@@ -521,6 +522,7 @@ pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
 /// under it — `0` is the "no handle" value — so the guard turns exhaustion into
 /// a caught error at the boundary, never a phantom id-0 entry.
 pub fn reserve_handle_id() -> Handle {
+    crate::event_pump::ensure_handle_tick_hook_registered();
     pop_free_handle()
         .or_else(next_fresh_handle_id)
         .unwrap_or(INVALID_HANDLE)

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -114,6 +114,11 @@ struct ExceptionState {
     /// `call_method_depth_*`). Indexed by try-depth, in lockstep with
     /// `jump_buffers`.
     call_method_depths: Box<[u32]>,
+    /// Re-entrant stdlib-pump depth at handler entry. A callback can throw
+    /// across `js_run_stdlib_pump`, skipping its `PumpDepthGuard`; restore the
+    /// counter so the next top-level pump still runs tick-begin lifecycle
+    /// hooks such as the native-handle quarantine drain.
+    pump_depths: Box<[u32]>,
     /// Active Set/Map `forEach` walks. Their normal epilogues re-enable
     /// backing-store compaction, but a caught throw skips those epilogues.
     set_foreach_depths: Box<[usize]>,
@@ -166,6 +171,7 @@ impl ExceptionState {
             shadow_savepoints: vec![ShadowSavepoint::EMPTY; MAX_TRY_DEPTH].into_boxed_slice(),
             runtime_handle_savepoints: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
             call_method_depths: vec![0u32; MAX_TRY_DEPTH].into_boxed_slice(),
+            pump_depths: vec![0u32; MAX_TRY_DEPTH].into_boxed_slice(),
             set_foreach_depths: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
             map_foreach_depths: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
             prototype_resolution_depths: vec![0usize; MAX_TRY_DEPTH].into_boxed_slice(),
@@ -239,6 +245,7 @@ fn try_push_with_kind(kind: HandlerKind) -> *mut i32 {
         // this `try` can restore it — `longjmp` skips the `CallMethodDepthGuard`
         // `Drop`s of the method frames it unwinds (#5591).
         (*s).call_method_depths[depth] = crate::object::call_method_depth_savepoint();
+        (*s).pump_depths[depth] = crate::stdlib_pump::pump_depth_savepoint();
         (*s).set_foreach_depths[depth] = crate::set::set_foreach_stack_savepoint();
         (*s).map_foreach_depths[depth] = crate::map::map_foreach_stack_savepoint();
         (*s).prototype_resolution_depths[depth] =
@@ -476,6 +483,7 @@ pub extern "C-unwind" fn js_throw(value: f64) -> ! {
         // otherwise caught throws wrap the counter below zero and wedge every
         // later method call into the depth-guard fallback (#5591).
         crate::object::call_method_depth_restore((*s).call_method_depths[depth]);
+        crate::stdlib_pump::pump_depth_restore((*s).pump_depths[depth]);
         crate::set::set_foreach_stack_restore((*s).set_foreach_depths[depth]);
         crate::map::map_foreach_stack_restore((*s).map_foreach_depths[depth]);
         crate::object::prototype_chain::resolution_stack_restore(
@@ -853,6 +861,8 @@ pub(crate) fn test_unwind_innermost_shadow_restore() {
         let depth = (*s).try_depth - 1;
         shadow_stack_restore((*s).shadow_savepoints[depth]);
         runtime_handle_stack_restore((*s).runtime_handle_savepoints[depth]);
+        crate::object::call_method_depth_restore((*s).call_method_depths[depth]);
+        crate::stdlib_pump::pump_depth_restore((*s).pump_depths[depth]);
         crate::set::set_foreach_stack_restore((*s).set_foreach_depths[depth]);
         crate::map::map_foreach_stack_restore((*s).map_foreach_depths[depth]);
         crate::object::prototype_chain::resolution_stack_restore(

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -392,8 +392,9 @@ mod ext_pump {
 // Stdlib pump registration — allows perry-ui-macos pump timer to call
 // js_stdlib_process_pending without a hard link dependency on perry-stdlib.
 pub(crate) mod stdlib_pump {
+    use std::cell::Cell;
     use std::ptr::null_mut;
-    use std::sync::atomic::{AtomicPtr, Ordering};
+    use std::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
     use std::sync::Mutex;
 
     static STDLIB_PUMP_FN: AtomicPtr<()> = AtomicPtr::new(null_mut());
@@ -402,6 +403,89 @@ pub(crate) mod stdlib_pump {
     /// Kept as a function pointer for the same reason as `STDLIB_PUMP_FN`: the
     /// runtime must not hard-link perry-stdlib into runtime-only binaries.
     static STDLIB_NEXT_WAKE_FN: AtomicPtr<()> = AtomicPtr::new(null_mut());
+
+    /// Number of OS threads currently executing an outer pump. JS normally
+    /// runs on one owning thread, but platform background-task callbacks can
+    /// enter the pump from a system queue. Treat overlapping entries as one
+    /// process-wide tick so lifecycle hooks never run while another pump is
+    /// dispatching callbacks.
+    static ACTIVE_OUTER_PUMPS: AtomicU32 = AtomicU32::new(0);
+    /// Serializes the zero-to-one transition with the tick-begin hooks. Once
+    /// the count is non-zero, other threads may join the same logical tick.
+    static OUTER_PUMP_ENTRY: Mutex<()> = Mutex::new(());
+
+    crate::perry_thread_local! {
+        /// `await` inside a pump callback can synchronously re-enter the host
+        /// pump. Lifecycle hooks belong to the outer tick only.
+        static PUMP_DEPTH: Cell<u32> = const { Cell::new(0) };
+    }
+
+    struct PumpDepthGuard {
+        depth_before: u32,
+        entered_outer_pump: bool,
+    }
+
+    impl PumpDepthGuard {
+        fn enter() -> (Self, bool) {
+            PUMP_DEPTH.with(|depth| {
+                let current = depth.get();
+                depth.set(current.saturating_add(1));
+                let entered_outer_pump = current == 0;
+                if entered_outer_pump {
+                    begin_outer_pump();
+                }
+                (
+                    Self {
+                        depth_before: current,
+                        entered_outer_pump,
+                    },
+                    entered_outer_pump,
+                )
+            })
+        }
+    }
+
+    impl Drop for PumpDepthGuard {
+        fn drop(&mut self) {
+            PUMP_DEPTH.with(|depth| {
+                let current = depth.get();
+                // `js_throw` eagerly restores this counter before choosing
+                // longjmp or system unwinding. The latter subsequently runs
+                // Rust cleanups, so a guard already covered by that restore
+                // must not decrement the enclosing pump's depth a second
+                // time. This mirrors CallMethodDepthGuard.
+                if current > self.depth_before {
+                    depth.set(current - 1);
+                    if self.entered_outer_pump {
+                        end_outer_pump();
+                    }
+                }
+            });
+        }
+    }
+
+    /// Capture the re-entrant stdlib-pump depth at `try` entry. A caught JS
+    /// throw can longjmp past `PumpDepthGuard::drop`; exception handling uses
+    /// this savepoint to keep the next top-level pump recognizable as a new
+    /// tick (and therefore run its lifecycle hooks).
+    pub(crate) fn pump_depth_savepoint() -> u32 {
+        PUMP_DEPTH.with(|depth| depth.get())
+    }
+
+    /// Restore a pump-depth savepoint for guards skipped by JS exception
+    /// transport. Guards remember their entry depths, making their later
+    /// system-unwinder cleanup idempotent after this eager restore.
+    pub(crate) fn pump_depth_restore(depth: u32) {
+        PUMP_DEPTH.with(|current| {
+            let before = current.replace(depth);
+            // Only a restore across this thread's outermost pump removes its
+            // process-wide active-pump contribution. A later Rust guard drop
+            // sees the restored TLS depth and therefore remains idempotent.
+            if depth == 0 && before > 0 {
+                end_outer_pump();
+            }
+        });
+    }
 
     // Runtime-internal reactor pumps (child_process, node-pty) register here
     // when their first live handle appears, mirroring `STDLIB_PUMP_FN`. The
@@ -480,6 +564,7 @@ pub(crate) mod stdlib_pump {
     // drains and queries them without either side naming the other's symbols,
     // which also lets out-of-tree extensions participate. Registration is
     // idempotent for each function pointer.
+    static AUX_TICK_BEGIN_HOOKS: Mutex<Vec<extern "C" fn()>> = Mutex::new(Vec::new());
     static AUX_PUMPS: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
     static AUX_HAS_ACTIVE: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
 
@@ -494,6 +579,48 @@ pub(crate) mod stdlib_pump {
                 pumps.push(f);
             }
         }
+    }
+
+    /// Register work that must run once at the beginning of an outer host
+    /// pump tick, before any runtime, stdlib, or extension callback can free
+    /// resources during that tick. Registration is idempotent per function
+    /// pointer.
+    #[no_mangle]
+    pub extern "C" fn js_register_aux_tick_begin(f: extern "C" fn()) {
+        if let Ok(mut hooks) = AUX_TICK_BEGIN_HOOKS.lock() {
+            if !hooks.contains(&f) {
+                hooks.push(f);
+            }
+        }
+    }
+
+    fn run_aux_tick_begin_hooks() {
+        let fns: Vec<extern "C" fn()> = match AUX_TICK_BEGIN_HOOKS.lock() {
+            Ok(g) => g.clone(),
+            Err(_) => return,
+        };
+        for f in fns {
+            f();
+        }
+    }
+
+    /// Join the process-wide pump tick. The entry mutex keeps another thread
+    /// from dispatching pump callbacks until the thread that transitions the
+    /// count from zero to one has completed every tick-begin hook.
+    fn begin_outer_pump() {
+        let _entry = OUTER_PUMP_ENTRY
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = ACTIVE_OUTER_PUMPS.fetch_add(1, Ordering::AcqRel);
+        let begins_tick = previous == 0;
+        if begins_tick {
+            run_aux_tick_begin_hooks();
+        }
+    }
+
+    fn end_outer_pump() {
+        let previous = ACTIVE_OUTER_PUMPS.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "outer pump activity counter underflow");
     }
 
     /// Register an auxiliary has-active callback (a `perry-ext-*` crate's
@@ -571,6 +698,16 @@ pub(crate) mod stdlib_pump {
     /// is not linked (no-op in that case).
     #[no_mangle]
     pub extern "C" fn js_run_stdlib_pump() {
+        let (_depth_guard, outermost) = PumpDepthGuard::enter();
+        // This is the process-wide outer pump boundary. Run lifecycle hooks
+        // before any callback in this tick can release resources. In
+        // particular, perry-ffi promotes handles quarantined during the
+        // previous tick here, rather than inside one extension pump where a
+        // later extension could reuse a handle in the same outer tick.
+        // `PumpDepthGuard::enter` already ran the hook while holding the
+        // process-wide entry gate. This branch documents the lifecycle point
+        // and keeps the result live for debug assertions/tests.
+        debug_assert!(!outermost || ACTIVE_OUTER_PUMPS.load(Ordering::Acquire) > 0);
         crate::promise::js_native_async_process_pending();
         #[cfg(feature = "node-api-host")]
         crate::node_api_host::process_pending();
@@ -698,9 +835,89 @@ pub(crate) mod stdlib_pump {
         use std::sync::atomic::{AtomicI32, Ordering as AtomicOrdering};
 
         static PUMP_CALLS: AtomicI32 = AtomicI32::new(0);
+        static TICK_BEGIN_CALLS: AtomicI32 = AtomicI32::new(0);
         extern "C" fn counting_pump() -> i32 {
             PUMP_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
             0
+        }
+
+        extern "C" fn counting_tick_begin() {
+            TICK_BEGIN_CALLS.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+
+        #[test]
+        fn pump_depth_identifies_only_the_outer_tick() {
+            let (outer_guard, outermost) = PumpDepthGuard::enter();
+            assert!(outermost);
+            let (inner_guard, outermost) = PumpDepthGuard::enter();
+            assert!(!outermost, "a re-entrant pump is still the same outer tick");
+            drop(inner_guard);
+            let (second_inner_guard, outermost) = PumpDepthGuard::enter();
+            assert!(!outermost);
+            drop(second_inner_guard);
+            drop(outer_guard);
+            let (_next_tick_guard, outermost) = PumpDepthGuard::enter();
+            assert!(outermost, "a later top-level pump starts a new tick");
+        }
+
+        #[test]
+        fn caught_throw_restores_pump_depth_and_guard_drops_are_idempotent() {
+            let base_depth = pump_depth_savepoint();
+            let base_try = crate::exception::test_try_depth();
+            let _jb = crate::exception::js_try_push();
+
+            let (outer_guard, outermost) = PumpDepthGuard::enter();
+            assert_eq!(outermost, base_depth == 0);
+            let (inner_guard, outermost) = PumpDepthGuard::enter();
+            assert!(!outermost);
+            assert_eq!(pump_depth_savepoint(), base_depth + 2);
+
+            // Replay js_throw's eager savepoint restores without performing
+            // the non-returning longjmp. System unwinding may then run both
+            // guards, so their Drops must leave the restored depth alone.
+            crate::exception::test_unwind_innermost_shadow_restore();
+            assert_eq!(pump_depth_savepoint(), base_depth);
+            drop(inner_guard);
+            drop(outer_guard);
+            assert_eq!(pump_depth_savepoint(), base_depth);
+
+            crate::exception::js_try_end();
+            assert_eq!(crate::exception::test_try_depth(), base_try);
+        }
+
+        #[test]
+        fn real_longjmp_does_not_leak_pump_depth() {
+            let base_depth = pump_depth_savepoint();
+            assert_eq!(base_depth, 0, "test thread began inside a pump");
+            let thrown = f64::from_bits(0x7FFD_0000_0000_99F1);
+
+            let outcome = crate::exception::catch_js_throw(|| -> () {
+                let (_skipped_guard, outermost) = PumpDepthGuard::enter();
+                assert!(outermost);
+                crate::exception::js_throw(thrown);
+            });
+            match outcome {
+                Err(value) => assert_eq!(value.to_bits(), thrown.to_bits()),
+                Ok(()) => panic!("throw unexpectedly returned normally"),
+            }
+            assert_eq!(pump_depth_savepoint(), base_depth);
+
+            let (_next_tick_guard, outermost) = PumpDepthGuard::enter();
+            assert!(
+                outermost,
+                "the next pump after a caught throw is a new tick"
+            );
+        }
+
+        #[test]
+        fn aux_tick_begin_registration_is_idempotent() {
+            js_register_aux_tick_begin(counting_tick_begin);
+            js_register_aux_tick_begin(counting_tick_begin);
+            js_register_aux_tick_begin(counting_tick_begin);
+            let before = TICK_BEGIN_CALLS.load(AtomicOrdering::SeqCst);
+            run_aux_tick_begin_hooks();
+            let after = TICK_BEGIN_CALLS.load(AtomicOrdering::SeqCst);
+            assert_eq!(after - before, 1);
         }
 
         /// #9416: the symbol the generated event loop calls must itself


### PR DESCRIPTION
Fastify drops one FFI context handle after every response. Its binaries did not initialize the `node:http` pump that previously owned quarantine draining, so completed handles remained quarantined. At 262,143 requests, `register_handle` exhausted the common ID band and aborted the server.

Move quarantine promotion to an outer-pump lifecycle hook and install it idempotently before the first FFI handle allocation. Thread-local depth keeps nested awaited-handler pump calls in the current tick. A process-wide active-pump count and serialized zero-to-one transition group overlapping platform callbacks into one logical tick, so no OS thread can promote handles while another pump is dispatching callbacks. Exception savepoints restore both the nested depth and the process-wide contribution after caught JS throws. The HTTP-local drain is removed because the lifecycle hook now covers every FFI handle user.

This is the focused extraction of the Fastify handle-recycling fix from #9998, whose broader release branch currently conflicts with `main`.

Validation:
- `cargo test --release -p perry-runtime stdlib_pump::tests --lib` (8 passed)
- `cargo test --release -p perry-ext-fastify --lib` (32 passed)
- `cargo test --release -p perry-ffi --lib` (33 passed)
- `cargo check --release -p perry-ffi --features runtime-link`
- Release Fastify stress run: 350,000 requests, 0 incorrect responses, server remained alive after crossing the old 262,143-ID ceiling
- `cargo fmt --all -- --check`
- `python3 scripts/check_thread_locals.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability for long-running Fastify servers under sustained traffic, preventing resource exhaustion that could interrupt request handling.
  - Improved event-loop processing reliability when callbacks and promise handling are nested or re-entered.
  - Fixed exception recovery scenarios that could leave subsequent runtime processing in an inconsistent state.

- **Reliability**
  - Improved cleanup timing across server and runtime event processing, supporting more consistent behavior during extended workloads.
  - Improved handle reuse across extensions during ongoing event-loop activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->