### PR TITLE
test: cover outer-pump handle lifecycle (train148, v0.5.1523)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1522
+**Current Version:** 0.5.1523
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5718,7 +5718,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "cc",
  "libc",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5849,7 +5849,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5869,7 +5869,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5898,14 +5898,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "serde",
  "serde_json",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1522"
+version = "0.5.1523"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "clap",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "block2",
  "objc2",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5958,7 +5958,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5991,7 +5991,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "chrono",
  "cron",
@@ -6009,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6049,14 +6049,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6119,7 +6119,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6140,7 +6140,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "bson",
  "futures-util",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6224,7 +6224,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "fancy-regex",
  "notify",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6280,7 +6280,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6300,7 +6300,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "brotli",
  "flate2",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6411,7 +6411,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -6474,14 +6474,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6577,14 +6577,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6593,7 +6593,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.0",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6686,7 +6686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1522"
+version = "0.5.1523"
 
 [[package]]
 name = "perry-ui-test"
@@ -6697,11 +6697,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1522"
+version = "0.5.1523"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "block2",
  "libc",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6768,7 +6768,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6797,7 +6797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1522"
+version = "0.5.1523"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1522"
+version = "0.5.1523"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/10002-pump-lifecycle-regression.md
+++ b/changelog.d/10002-pump-lifecycle-regression.md
@@ -1,4 +1,5 @@
 ### Fixed
 
-- Verify native handle recycling through the public extension registration and actual runtime pump, including same-tick re-entry and the next outer tick, in an isolated bounded test process.
+- Verify native handle recycling through allocation-only hook registration, public extension registration, and the actual runtime pump, including same-tick re-entry and the next outer tick, in an isolated bounded test process.
+- Check that overlapping outer guards share one lifecycle tick and that eager depth restoration releases only the current thread's contribution.
 - Clarify that HTTP callbacks rely on the outer tick's quarantine promotion.

--- a/changelog.d/10002-pump-lifecycle-regression.md
+++ b/changelog.d/10002-pump-lifecycle-regression.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Verify native handle recycling through the public extension registration and actual runtime pump, including same-tick re-entry and the next outer tick, in an isolated bounded test process.
+- Clarify that HTTP callbacks rely on the outer tick's quarantine promotion.

--- a/crates/perry-ext-http/src/server/server.rs
+++ b/crates/perry-ext-http/src/server/server.rs
@@ -1502,12 +1502,9 @@ pub extern "C" fn js_node_http_server_has_active() -> i32 {
 pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     let mut count = 0i32;
 
-    // Promote ids freed on PRIOR ticks from quarantine to the reusable
-    // freelist — at the top of the tick, before this tick's finalizations
-    // quarantine fresh ids. The one-tick deferral closes the same-tick ABA
-    // hazard: a handler that returned before `res.end()` leaves a stale `res`
-    // (a bare tagged handle id) outstanding, and recycling its id immediately
-    // would let the next request re-occupy it and a microtask-deferred
+    // The runtime's outer-pump tick-begin hook promotes prior-tick handle
+    // quarantine before any extension callback runs. Do not drain it again
+    // here: nested pumps and later extensions still belong to the same tick.
     // Settle `Bun.serve` fetch/error promises before the ordinary in-flight
     // reaper observes their ServerResponse handles.
     count += crate::server::bun_server::process_pending_promises();

--- a/crates/perry-ffi/src/event_pump.rs
+++ b/crates/perry-ffi/src/event_pump.rs
@@ -95,6 +95,109 @@ pub fn notify_main_thread() {
 #[cfg(all(test, feature = "runtime-link"))]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+
+    extern "C" {
+        fn js_run_stdlib_pump();
+    }
+
+    static LIFECYCLE_PHASE: AtomicUsize = AtomicUsize::new(0);
+    static CALLBACK_HANDLE: AtomicI64 = AtomicI64::new(0);
+    static NESTED_HANDLE: AtomicI64 = AtomicI64::new(0);
+    static CALLBACK_DROPPED: AtomicBool = AtomicBool::new(false);
+
+    extern "C" fn lifecycle_probe() -> i32 {
+        // Record observations, then assert outside the C callback boundary.
+        match LIFECYCLE_PHASE.fetch_add(1, Ordering::SeqCst) {
+            0 => {
+                let handle = crate::register_handle(30_u64);
+                CALLBACK_HANDLE.store(handle, Ordering::SeqCst);
+                CALLBACK_DROPPED.store(crate::drop_handle(handle), Ordering::SeqCst);
+                // A callback re-entering the real runtime pump remains in
+                // the same outer tick, so its newly retired id stays parked.
+                unsafe { js_run_stdlib_pump() };
+            }
+            1 => {
+                NESTED_HANDLE.store(crate::register_handle(40_u64), Ordering::SeqCst);
+            }
+            _ => {}
+        }
+        0
+    }
+
+    extern "C" fn lifecycle_idle() -> i32 {
+        0
+    }
+
+    #[test]
+    fn outer_ticks_recycle_handles_before_callbacks_without_http() {
+        const CHILD: &str = "PERRY_TEST_OUTER_TICK_LIFECYCLE_CHILD";
+        if std::env::var_os(CHILD).as_deref() != Some(std::ffi::OsStr::new("1")) {
+            // Other handle tests share the process-wide freelist. A fresh
+            // test process makes the exact reuse observations deterministic
+            // and starts with no HTTP pump or auxiliary registry entries.
+            let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "event_pump::tests::outer_ticks_recycle_handles_before_callbacks_without_http",
+                ])
+                .env(CHILD, "1")
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            let mut timed_out = false;
+            while child.try_wait().unwrap().is_none() {
+                if std::time::Instant::now() >= deadline {
+                    timed_out = true;
+                    let _ = child.kill();
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                !timed_out && output.status.success(),
+                "pump lifecycle child timed_out={timed_out}, status={}\n{}\n{}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return;
+        }
+
+        // Exercise the public FFI registration seam and the actual runtime
+        // entry point. Never call drain_quarantined_handles directly here.
+        register_aux_event_pump(lifecycle_probe, lifecycle_idle);
+        let prior_tick = crate::register_handle(10_u64);
+        assert!(crate::drop_handle(prior_tick));
+        let held = crate::register_handle(20_u64);
+        assert_ne!(held, prior_tick, "retired ids wait for the next outer tick");
+
+        unsafe { js_run_stdlib_pump() };
+        assert_eq!(LIFECYCLE_PHASE.load(Ordering::SeqCst), 2);
+        assert_eq!(CALLBACK_HANDLE.load(Ordering::SeqCst), prior_tick);
+        assert!(CALLBACK_DROPPED.load(Ordering::SeqCst));
+        let nested = NESTED_HANDLE.load(Ordering::SeqCst);
+        assert_ne!(
+            nested, prior_tick,
+            "nested pumps must not promote this tick's ids"
+        );
+        assert_eq!(*crate::get_handle::<u64>(nested).unwrap(), 40);
+
+        unsafe { js_run_stdlib_pump() };
+        assert_eq!(LIFECYCLE_PHASE.load(Ordering::SeqCst), 3);
+        let next_tick = crate::register_handle(50_u64);
+        assert_eq!(
+            next_tick, prior_tick,
+            "a later outer tick makes the id reusable"
+        );
+        for handle in [held, nested, next_tick] {
+            assert!(crate::drop_handle(handle));
+        }
+        unsafe { js_run_stdlib_pump() };
+    }
 
     #[test]
     fn notify_main_thread_does_not_panic() {

--- a/crates/perry-ffi/src/event_pump.rs
+++ b/crates/perry-ffi/src/event_pump.rs
@@ -167,14 +167,23 @@ mod tests {
             return;
         }
 
-        // Exercise the public FFI registration seam and the actual runtime
-        // entry point. Never call drain_quarantined_handles directly here.
-        register_aux_event_pump(lifecycle_probe, lifecycle_idle);
+        // Allocation must install the lifecycle hook even when no extension
+        // event pump has been initialized. Never drain the quarantine directly.
         let prior_tick = crate::register_handle(10_u64);
         assert!(crate::drop_handle(prior_tick));
         let held = crate::register_handle(20_u64);
         assert_ne!(held, prior_tick, "retired ids wait for the next outer tick");
+        unsafe { js_run_stdlib_pump() };
+        let allocation_only = crate::register_handle(15_u64);
+        assert_eq!(
+            allocation_only, prior_tick,
+            "allocation installs the tick hook"
+        );
+        assert!(crate::drop_handle(allocation_only));
 
+        // Now exercise the public extension registration seam and actual
+        // callback dispatch, including re-entry within an outer tick.
+        register_aux_event_pump(lifecycle_probe, lifecycle_idle);
         unsafe { js_run_stdlib_pump() };
         assert_eq!(LIFECYCLE_PHASE.load(Ordering::SeqCst), 2);
         assert_eq!(CALLBACK_HANDLE.load(Ordering::SeqCst), prior_tick);

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -861,6 +861,54 @@ pub(crate) mod stdlib_pump {
         }
 
         #[test]
+        fn overlapping_outer_guards_share_a_tick_and_restore_one_contribution() {
+            use std::sync::mpsc;
+            use std::time::Duration;
+
+            assert_eq!(pump_depth_savepoint(), 0);
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 0);
+            js_register_aux_tick_begin(counting_tick_begin);
+            let ticks_before = TICK_BEGIN_CALLS.load(AtomicOrdering::SeqCst);
+            let (outer, is_outer) = PumpDepthGuard::enter();
+            assert!(is_outer);
+            let (joined_tx, joined_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let worker = std::thread::spawn(move || {
+                // Only exercise lifecycle bookkeeping on this thread, not
+                // runtime callbacks or thread-owned GC state.
+                let (guard, is_outer) = PumpDepthGuard::enter();
+                joined_tx.send(is_outer).unwrap();
+                release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+                drop(guard);
+            });
+            assert!(joined_rx.recv_timeout(Duration::from_secs(5)).unwrap());
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 2);
+            assert_eq!(
+                TICK_BEGIN_CALLS.load(AtomicOrdering::SeqCst),
+                ticks_before + 1
+            );
+
+            // Eager exception restoration removes this thread's contribution,
+            // but cannot end the other thread's still-active logical tick.
+            pump_depth_restore(0);
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 1);
+            drop(outer);
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 1);
+            release_tx.send(()).unwrap();
+            worker.join().unwrap();
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 0);
+
+            let (next, is_outer) = PumpDepthGuard::enter();
+            assert!(is_outer);
+            assert_eq!(
+                TICK_BEGIN_CALLS.load(AtomicOrdering::SeqCst),
+                ticks_before + 2
+            );
+            drop(next);
+            assert_eq!(ACTIVE_OUTER_PUMPS.load(Ordering::Acquire), 0);
+        }
+
+        #[test]
         fn caught_throw_restores_pump_depth_and_guard_drops_are_idempotent() {
             let base_depth = pump_depth_savepoint();
             let base_try = crate::exception::test_try_depth();


### PR DESCRIPTION
## Summary

Audit follow-up to #10002: add real pump-lifecycle regression coverage, repair
its unfinished HTTP comment, and bump the workspace to **0.5.1523**.

Another actor already merged #10002 as 03d12cc3cc6e62dd596b7a2f939df0aa9cd5ed76.
Its author head d7edb34ad250e6706bd0afb9f6ac8bbd3debcd97 is byte-identical to that
main commit. This follow-up does not claim or duplicate the original merge.
Draft #9998 remains out of scope.

Candidate: 2a7837d2a09b3eae208e1fc96335347f4dee606f.
Validated tree: 69d36152f67e25826d56489908c5cdd1bb57c099.

## Changes

- Isolated, bounded FFI test exercises allocation-only hook registration and the
  actual runtime pump without HTTP initialization. It checks prior-tick reuse,
  retention during callback re-entry, and reuse on the next outer tick.
  Observations are asserted outside the C callback boundary.
- Two-thread bookkeeping test proves overlapping outer guards share one tick;
  eager restoration releases only its thread's contribution. The worker does
  not run runtime callbacks or GC operations.
- Replace the unfinished HTTP comment with the outer-tick responsibility.
- Maintainer version/changelog update. No additional production behavior change.

The FFI regression actually ran with runtime-link; default-feature FFI results
are not substituted for that execution.

## Validation

| Suite | Passed | Cargo exit |
|---|---:|---:|
| Runtime | 3488 | 0 |
| Codegen, including integration/doc tests | 1959 | 0 |
| HIR | 639 | 0 |
| Stdlib | 132 | 0 |
| FFI, runtime-link | 60 | 0 |
| FFI, default features | 33 | 0 |
| Fastify | 32 | 0 |
| HTTP | 87 | 0 |

**6430 Rust tests passed, zero failures.** Runtime/stdlib and the other suites
ran with RUST_TEST_THREADS=1. The new overlap and real-pump fixtures passed.
Native Fastify smoke: **12 checks passed, exit 0**, including routing, request
bodies, sync/async throws and continued service afterward.

The compiler/core/both static wrappers/seven providers were built coherently at
the candidate commit. The native Fastify smoke used its supported automatic
build path: runtime/stdlib wrappers and Fastify in one Cargo invocation with
external-fastify-pump. The successful build stamp and all three nonempty
archives were verified. No high-volume stress claim is substituted for these
local checks.

Full lint: **79/80 pass**, two CI-only commands skipped; exit 1 only for the
established public benchmark freshness failure. All four warning/Clippy scopes
and both API-doc checks pass. Standalone stdlib-default, runtime regex-tests,
and runtime wasm-host checks each exit 0. These source-tree checks ran at
459fb703916015cc1bea2381dbd929129e5bbccc, whose tree is byte-identical to the
candidate after reassembly on externally advanced main (git diff exit 0).
The raw-handle no-raise ratchet was additionally rerun against current main: 0.

Validation logs and actual exit-code sidecars are retained as v148b_* and
v148c_* in /tmp/p9176. The first native attempt used unsupported
PERRY_NO_AUTO_OPTIMIZE and exited 2 before generating/running the server;
the original release driver therefore exited 1. Its supported-mode retry
exited 0. The compiler guard was not changed or bypassed.

## CI and issue hygiene

Author-head CI34270347188: cargo job102214176171 reports3469pass/1fail/4ignore,
only the previously established native_stack.rs:53/60 custom-thread bound.
Lint job102214176222 reports stale benchmark inputs; check/warnings pass.
The green e2e-scoped job102214176371 selected no integration suite. Gap/GC jobs
were still active during classification; no result is claimed for those jobs.
Our additional fixtures are not in the author-head logs.

#10002 has no closing-issue reference or closing keyword; it is already MERGED
and will not be closed again. Umbrella #9202 remains open. After this follow-up
lands, fresh-fetch main and verify exact equality with the validated tree.

Inherited OWNER worktree edit remains uncommitted. Only session-owned completed
cache/test executables were cleaned up under disk pressure, with ownership,
exact-file checks and announcements; source, compiler/libraries and logs remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native handle lifecycle management so retired handles are recycled at the correct event-loop tick.
  * Fixed recycling behavior across nested and overlapping event-pump activity, reducing the risk of stale or prematurely reused handles.
  * Improved HTTP callback handling during lifecycle transitions.

* **Documentation**
  * Added changelog coverage for lifecycle regression scenarios.

* **Chores**
  * Updated the application version to 0.5.1523.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->