### PR TITLE
Merge train 151: Hono JSX fixture security update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1525
+**Current Version:** 0.5.1526
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,7 +5695,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "cc",
  "libc",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5875,14 +5875,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "serde",
  "serde_json",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1525"
+version = "0.5.1526"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "clap",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "block2",
  "objc2",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "chrono",
  "cron",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6026,14 +6026,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6126,7 +6126,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "bson",
  "futures-util",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "fancy-regex",
  "notify",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6257,7 +6257,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "brotli",
  "flate2",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6554,14 +6554,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6570,7 +6570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.9",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1525"
+version = "0.5.1526"
 
 [[package]]
 name = "perry-ui-test"
@@ -6674,11 +6674,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1525"
+version = "0.5.1526"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "block2",
  "libc",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1525"
+version = "0.5.1526"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1525"
+version = "0.5.1526"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/10021-hono-jsx-fixture.md
+++ b/changelog.d/10021-hono-jsx-fixture.md
@@ -1,0 +1,3 @@
+Update the compiled Hono JSX and streaming release fixture from 4.12.34 to
+4.13.7, including the 4.13.5 security fixes, while retaining native link and
+Node output parity coverage for the package's timer-backed hooks path.

--- a/tests/release/packages/hono-jsx-imports/package-lock.json
+++ b/tests/release/packages/hono-jsx-imports/package-lock.json
@@ -8,13 +8,13 @@
       "name": "perry-release-fixture-hono-jsx-imports",
       "version": "0.0.0",
       "dependencies": {
-        "hono": "^4.13.5"
+        "hono": "^4.13.7"
       }
     },
     "node_modules/hono": {
-      "version": "4.13.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
-      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tests/release/packages/hono-jsx-imports/package-lock.json
+++ b/tests/release/packages/hono-jsx-imports/package-lock.json
@@ -8,13 +8,13 @@
       "name": "perry-release-fixture-hono-jsx-imports",
       "version": "0.0.0",
       "dependencies": {
-        "hono": "^4.12.34"
+        "hono": "^4.13.5"
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/tests/release/packages/hono-jsx-imports/package.json
+++ b/tests/release/packages/hono-jsx-imports/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Tier-3 fixture (#1671): static imports from hono/jsx and hono/jsx/streaming must compile + link natively. hono/jsx/streaming transitively pulls in hono/jsx/hooks, whose `setTimeout(() => …)` 1-arg call previously fell through codegen's extern-func table to a bare `@setTimeout` and failed to link (`Undefined symbols: _setTimeout`). Imports only (no JSX syntax) so `node --experimental-strip-types` can run it for the expected.txt sanity check.",
   "dependencies": {
-    "hono": "^4.13.5"
+    "hono": "^4.13.7"
   },
   "perry": {
     "compilePackages": ["hono"],

--- a/tests/release/packages/hono-jsx-imports/package.json
+++ b/tests/release/packages/hono-jsx-imports/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Tier-3 fixture (#1671): static imports from hono/jsx and hono/jsx/streaming must compile + link natively. hono/jsx/streaming transitively pulls in hono/jsx/hooks, whose `setTimeout(() => …)` 1-arg call previously fell through codegen's extern-func table to a bare `@setTimeout` and failed to link (`Undefined symbols: _setTimeout`). Imports only (no JSX syntax) so `node --experimental-strip-types` can run it for the expected.txt sanity check.",
   "dependencies": {
-    "hono": "^4.12.34"
+    "hono": "^4.13.5"
   },
   "perry": {
     "compilePackages": ["hono"],


### PR DESCRIPTION
## Merge train 151

Audited and integrates #10021, preserving the Dependabot author commit and a
separate maintainer follow-up.

### Audit

- Updates the compiled `hono/jsx` + `hono/jsx/streaming` fixture from 4.12.34
  to current Hono 4.13.7, retaining the security fixes introduced in 4.13.5.
- `npm ci` verified the registry tarball/integrity; `npm audit` reports zero
  vulnerabilities, and the installed version is 4.13.7.
- Node's TypeScript execution matches `expected.txt`; Perry compiles all 22
  fixture modules, links against coherent train151 static archives, and the
  native output matches the same expectation.
- The only Cargo.lock churn is the required 0.5.1525 -> 0.5.1526 workspace
  version roll. No unrelated dependency changes are included.
- The original PR body contains no Perry closing-keyword issue reference.

### Validation

- `run_lint_gates.sh`: 79/80 green, 2 CI-only skipped. The sole red is the
  public benchmark evidence freshness failure already present on main; API-doc
  regeneration/drift, product and host-wide `-D warnings`, Clippy, and all
  structural gates pass.
- Standalone configurations pass: `perry-stdlib` default features;
  `perry-runtime --tests --features regex-engine`; and
  `perry-runtime --tests --features wasm-host`.
- Release suites pass with `RUST_TEST_THREADS=1`: runtime 3,502; codegen 1,959;
  HIR 639; stdlib 134; zero failures.
- Exact coherent release compiler/static-archive build passes.
- Hono fixture, Node oracle, lockfile install, registry-integrity check, and
  npm audit all pass.

Version: 0.5.1526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version to 0.5.1526.
  - Refreshed release validation fixtures for Hono JSX and streaming integrations to Hono 4.13.7, including coverage for recent security fixes.
  - Updated release documentation to reflect the refreshed fixture versions and compatibility coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->