### PR TITLE
Merge train 152: retain JSON template shape ownership

### DIFF
--- a/crates/perry-runtime/src/gc/tests/json_parse_scalar.rs
+++ b/crates/perry-runtime/src/gc/tests/json_parse_scalar.rs
@@ -185,11 +185,32 @@ fn json_small_object_template_survives_evacuation() {
     let first = input.with_const_ptr(|input| unsafe { crate::json::js_json_parse(input) });
     let first = scope.root_nanbox_u64(first.bits());
 
+    // The bounded parse-shape cache usually carries the same descriptor as
+    // the reusable object template. Remove that redundant owner and rebuild
+    // transient carrier bits as a full trace does: the template must retain
+    // its own ShapeId even when it is the sole metadata publisher.
+    let first_object =
+        crate::JSValue::from_bits(first.get_nanbox_u64()).as_pointer::<crate::ObjectHeader>();
+    let template_shape = unsafe { crate::object::shapes::object_shape_stamp(first_object) };
+    crate::json::PARSE_SHAPE_CACHE.with(|cache| cache.borrow_mut().clear());
+    crate::object::shape_carriers::recompute_after_full_trace();
+    assert!(
+        crate::object::shapes::shape_descriptor_by_id(template_shape)
+            .is_some_and(|descriptor| descriptor.cache_carrier),
+        "the reusable object template must rebuild ownership of its ShapeId"
+    );
+
     let _ = gc_collect_minor_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct));
     assert_ne!(
         input_before,
         input.with_const_ptr(|input: *const crate::StringHeader| input as usize),
         "the test must exercise template-key rewriting"
+    );
+    assert!(
+        input.with_const_ptr(|input| {
+            crate::json::test_parse_object_template_matches(input, text.len())
+        }),
+        "the template source slot must be rewritten with its rooted input"
     );
     let second = input.with_const_ptr(|input| unsafe { crate::json::js_json_parse(input) });
     assert_ne!(first.get_nanbox_u64(), second.bits());

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -530,6 +530,7 @@ pub(crate) fn note_parse_shape_cache_carriers() {
     if empty != 0 {
         crate::object::shape_carriers::note_shape_id(empty);
     }
+    parse_reuse::note_shape_carrier();
 }
 
 #[inline]

--- a/crates/perry-runtime/src/json/parse_reuse.rs
+++ b/crates/perry-runtime/src/json/parse_reuse.rs
@@ -418,6 +418,22 @@ pub(super) fn scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     });
 }
 
+/// Rebuild ShapeId ownership for the object template after a full trace.
+///
+/// `keys_array` is a traced root, but tracing that array does not visit the
+/// separate descriptor table entry named by `shape_id`. The ordinary parse
+/// shape cache usually owns the same id; once that bounded cache is full,
+/// however, this template can be the only metadata publisher left. Re-note it
+/// before uncarried descriptors are pruned so a later template hit cannot
+/// stamp a retired id into a fresh object.
+pub(super) fn note_shape_carrier() {
+    PARSE_OBJECT_TEMPLATE.with(|cache| {
+        if let Some(entry) = cache.borrow().as_ref() {
+            crate::object::shape_carriers::note_shape_id(entry.shape_id);
+        }
+    });
+}
+
 #[cfg(test)]
 pub(super) fn clear_caches() {
     PARSE_STRING_CACHE.with(|cache| *cache.borrow_mut() = None);


### PR DESCRIPTION
## Merge train 152

Audit repair for independently merged #10022.

### Audit finding

- The reusable JSON object template stored a `ShapeId`, but the post-full-trace
  carrier rebuild only re-noted the ordinary parse-shape cache and the empty
  object cache. Once the bounded ordinary cache was absent/full, the template
  could be the descriptor's sole metadata publisher and later stamp a retired
  id into a fresh object.
- Re-note the template's shape during carrier reconstruction. The regression
  test clears the redundant ordinary cache, recomputes carrier ownership, and
  verifies both descriptor retention and template-source relocation.
- Negative control: removing the production re-note makes the strengthened
  test fail at the carrier-ownership assertion (exit 101); restoring it passes.
- #10022's body has `Related issue: n/a` and contains no Perry
  closing-keyword issue reference. The #9202 umbrella remains open.

### Validation

- `run_lint_gates.sh`: 79/80 green, 2 CI-only skipped. The sole red is the
  public benchmark evidence freshness failure already present on `main`;
  API-doc regeneration/drift, product and host-wide `-D warnings`, Clippy, and
  all structural/GC/shape/debt gates pass.
- Standalone configurations pass: `perry-stdlib` default features;
  `perry-runtime --tests --features regex-engine`; and
  `perry-runtime --tests --features wasm-host`.
- Release suites pass with `RUST_TEST_THREADS=1`: runtime 3,512; codegen 1,959;
  HIR 639; stdlib 134; zero failures.
- Exact coherent compiler/runtime/static-extension release build passes.
- An exact compiler/runtime build of the JSON benchmark worker passes all 150
  semantic oracle rows: 50 operations each in Perry, Node 26.5.1, and Bun
  1.3.14, with matching output hashes and zero process failures.

Version: 0.5.1526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing reliability during garbage collection and memory compaction.
  * Reusable object templates now retain valid shape information, preventing invalid metadata from being applied to newly parsed objects.
  * Added coverage for parsing scenarios involving cache clearing, full tracing, and minor collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->