### PR TITLE
Merge train 153: record JSON template fix in release metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1526
+**Current Version:** 0.5.1527
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,7 +5695,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "cc",
  "libc",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5875,14 +5875,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "serde",
  "serde_json",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1526"
+version = "0.5.1527"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "clap",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "block2",
  "objc2",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "chrono",
  "cron",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6026,14 +6026,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6126,7 +6126,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "bson",
  "futures-util",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "fancy-regex",
  "notify",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6257,7 +6257,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "brotli",
  "flate2",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6554,14 +6554,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6570,7 +6570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.9",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1526"
+version = "0.5.1527"
 
 [[package]]
 name = "perry-ui-test"
@@ -6674,11 +6674,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1526"
+version = "0.5.1527"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "block2",
  "libc",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1526"
+version = "0.5.1527"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1526"
+version = "0.5.1527"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/10026-json-template-shape-ownership.md
+++ b/changelog.d/10026-json-template-shape-ownership.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Preserve the reusable JSON object template's shape descriptor across full
+  garbage collections, including when the ordinary parse-shape cache no longer
+  owns it. Repeated parsing can then safely create a fresh object from the
+  retained template. Regression coverage verifies descriptor ownership with
+  the redundant cache removed and checks template relocation during evacuation.
+
+This fragment backfills the release note omitted from #10026. Version 0.5.1527
+records that already-landed fix for the next release.


### PR DESCRIPTION
The JSON template shape-ownership fix in #10026 landed without its required
release note or patch-version increment. Backfill its PR-keyed changelog
fragment and advance the workspace to 0.5.1527 so the fix is recorded in the
next release.

The 78 Cargo.lock package changes are exclusively inherited workspace version
updates. Runtime/compiler source and registry dependencies are unchanged.

Validation on e1fb060408341b0591219915c4104fe204c27cdf:

- Full lint: 79/80 passed, two CI-context checks skipped. Only the inherited
  public benchmark artifact freshness failure remains; both API-doc checks,
  product/workspace warnings, Clippy, and structural gates pass.
- Standalone stdlib defaults, runtime regex-engine tests, and runtime wasm-host
  tests compile successfully.
- Coherent release compiler, runtime/static archives, and extensions build.
- Release tests pass with RUST_TEST_THREADS=1: runtime 3,512; codegen 1,959;
  HIR 639; stdlib 134; zero failures.

CI attribution: #10026's missing-fragment failure was new. Its Linux native-stack
test failure and all seven gap regressions also occur on the preceding main
commit, as shown by [the preceding-main run](https://github.com/PerryTS/perry/actions/runs/34349945102)
and [the #10026 run](https://github.com/PerryTS/perry/actions/runs/34355364261).

No closing issue references. The fragment deliberately names the repaired
original PR, as allowed for changelog backfills.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reusable JSON object templates could lose their shape information after garbage collection, ensuring repeated parsing continues to create objects safely.

* **Documentation**
  * Added a changelog entry describing the JSON template parsing fix.

* **Chores**
  * Updated the project version to 0.5.1527.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->