### PR TITLE
fix(release): land the v0.5.1520 release-pipeline fixes on main

### DIFF
--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -49,7 +49,34 @@ runs:
         . /etc/os-release
         echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-22 main" \
           | sudo tee /etc/apt/sources.list.d/llvm22.list >/dev/null
-        sudo apt-get update -qq
+        # Only OUR source needs to be fresh. `apt-get update` exits non-zero if
+        # ANY configured source fails, and GitHub's runner image ships
+        # third-party lists we do not use — dl.google.com's chrome-stable repo
+        # served a "Hash Sum mismatch" on 2026-09-09 and took out 22 jobs of
+        # run 34383689667 across cargo-test, gap-suite, gc-stress, lint, check,
+        # warnings and security-audit, none of which want Chrome.
+        #
+        # So: drop the third-party lists we never install from, retry the
+        # update (transient mirror errors are common), and verify by REACHING
+        # FOR WHAT WE CAME FOR rather than by the exit code — if llvm-toolchain
+        # is resolvable, the update did its job whatever else was noisy.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                   /etc/apt/sources.list.d/microsoft-prod.list \
+                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+        update_ok=0
+        for attempt in 1 2 3; do
+          if sudo apt-get update -qq -o Acquire::Retries=3; then update_ok=1; break; fi
+          echo "  apt-get update attempt $attempt failed; retrying"
+          sleep $(( attempt * 5 ))
+        done
+        if [ "$update_ok" -ne 1 ]; then
+          # Not fatal by itself: what matters is whether OUR packages resolve.
+          echo "::warning::apt-get update reported errors; checking whether llvm-22 is resolvable anyway"
+          apt-cache policy llvm-22-dev | sed 's/^/    /'
+          apt-cache policy llvm-22-dev | grep -qE 'Candidate: [0-9]' \
+            || { echo "::error::apt-get update failed AND llvm-22-dev is unresolvable"; exit 1; }
+          echo "  llvm-22-dev resolves — continuing"
+        fi
         # `clang-22` is NOT implied by `llvm-22-dev`: apt ships opt and clang as
         # separate packages, so installing only the dev libraries leaves
         # /usr/lib/llvm-22/bin/opt with no clang beside it. That is exactly what

--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -60,9 +60,11 @@ runs:
         # update (transient mirror errors are common), and verify by REACHING
         # FOR WHAT WE CAME FOR rather than by the exit code — if llvm-toolchain
         # is resolvable, the update did its job whatever else was noisy.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                   /etc/apt/sources.list.d/microsoft-prod.list \
-                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+        # Match by CONTENT: the ubuntu24/20260907.300 image moved these to
+        # deb822 `.sources` files, so the old `.list` names removed nothing.
+        if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+          printf '%s\n' "$_bad" | sudo xargs -r rm -f
+        fi
         update_ok=0
         for attempt in 1 2 3; do
           if sudo apt-get update -qq -o Acquire::Retries=3; then update_ok=1; break; fi

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2294,6 +2294,12 @@ jobs:
             npm-publish-manifest.json socket-scan-receipt.json "${proofs[@]}"
 
       - name: npm publish exact tarballs (OIDC; platforms first, wrapper last)
+        env:
+          # How long to wait for npm publish-time scanning to make the platform
+          # packages visible before giving up. Generous on purpose: a timeout
+          # here is a resumable rerun, while publishing the wrapper too early
+          # is not recoverable (npm versions are immutable).
+          VISIBILITY_WAIT_MIN: "45"
         # No npm login and no NPM_TOKEN. npm exchanges this job's short-lived
         # GitHub OIDC identity because id-token:write is set above. Reruns skip
         # an already-public version only when its immutable registry sha1 is
@@ -2329,12 +2335,25 @@ jobs:
               # `time` map is the authoritative signal here: `npm view` and the
               # publish exit status both reported success for a version npm had
               # no record of.
+              # npm's publish-time scanning can hold a large binary for a
+              # long time -- its own notice says "may take longer than usual"
+              # and gives itself 24 h. So poll ROUND-ROBIN against a single
+              # global deadline rather than giving each package its own short
+              # budget: the packages settle in parallel, so a per-package
+              # timeout would fail the normal slow case while adding nothing
+              # for the broken one.
+              #
+              # Timing out here is SAFE and resumable. The platform packages
+              # are already published; a rerun skips them on matching sha1 and
+              # waits again. What must never happen is the wrapper going out
+              # over a platform that is not really there.
               echo "=== verifying every platform package is visible before publishing the wrapper ==="
+              deadline=$(( $(date +%s) + VISIBILITY_WAIT_MIN * 60 ))
               unseen=""
               while IFS=$'\t' read -r pname pversion; do
                 [ "$pname" = "@perryts/perry" ] && continue
                 seen=0
-                for attempt in $(seq 1 30); do
+                while :; do
                   if node -e '
                     const https = require("https")
                     const [pkg, ver] = process.argv.slice(1)
@@ -2349,12 +2368,13 @@ jobs:
                       })
                     }).on("error", () => process.exit(1))
                   ' "$pname" "$pversion"; then seen=1; break; fi
-                  sleep 10
+                  if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+                  sleep 20
                 done
                 if [ "$seen" -eq 1 ]; then
                   echo "  visible: $pname@$pversion"
                 else
-                  echo "::error::$pname@$pversion is not visible in the registry after 5 min — npm may have staged it without publishing." >&2
+                  echo "::error::$pname@$pversion still not visible after the ${VISIBILITY_WAIT_MIN}-minute budget — npm scanning may still be running, or the version is staged. Rerun this job to resume." >&2
                   unseen="$unseen $pname@$pversion"
                 fi
               done < <(node -e '

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -572,11 +572,27 @@ jobs:
         # (which transitively needs javascriptcoregtk-6.0.pc + webkitgtk-6.0.pc
         # + libsoup-3.0.pc) and libshumate-sys (#517 MapView). Mirrors the
         # apt step in test.yml's doc-tests-gtk4 job.
-        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libwebkitgtk-6.0-dev libshumate-dev
+        run: |
+          # See test.yml: a broken third-party index (Chrome) fails
+          # `apt-get update` for everyone. Drop those sources by CONTENT
+          # (deb822 `.sources` now, not `.list`) and let the install gate.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
+          sudo apt-get install -y libgtk-4-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libwebkitgtk-6.0-dev libshumate-dev
 
       - name: Install musl tools (Linux musl)
         if: endsWith(matrix.target, '-musl') && matrix.musl_image == ''
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        run: |
+          # See test.yml: a broken third-party index (Chrome) fails
+          # `apt-get update` for everyone. Drop those sources by CONTENT
+          # (deb822 `.sources` now, not `.list`) and let the install gate.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
+          sudo apt-get install -y musl-tools
 
       - name: Build perry
         # Build only the CLI crate; the runtime libraries are built in

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -213,6 +213,69 @@ jobs:
               exit 0
               ;;
           esac
+          # ---------------------------------------------------------------
+          # Which SHA must carry the green gate?
+          #
+          # Normally the exact candidate. But `test.yml` does not build the
+          # glibc image, read changelog fragments, or run this workflow, so a
+          # candidate that differs from an already-validated ancestor ONLY in
+          # those files is covered by that ancestor's gate. Re-running a ~5h
+          # tier to re-prove untouched code is pure latency, and this campaign
+          # paid it four times over a Dockerfile.
+          #
+          # Fail-closed by construction:
+          #   * the file list comes from GitHub's compare API, computed from
+          #     the commits themselves — not from any dispatch input;
+          #   * ANY path outside the allowlist keeps the exact-SHA requirement;
+          #   * an EMPTY diff is refused too (it should be impossible here, so
+          #     it means the comparison did not do what we think);
+          #   * `.github/workflows/test.yml` is deliberately NOT allowlisted —
+          #     changing the tier's own definition must re-run the tier.
+          GATE_SHA="$SHA"
+          if [ "$MODE" = "cut-release" ]; then
+            gate_green() {
+              local sha="$1" out rid
+              out=$(gh api "/repos/$REPO/actions/workflows/test.yml/runs?head_sha=$sha&per_page=20" 2>/dev/null) || return 1
+              for rid in $(echo "$out" | jq -r '.workflow_runs[]|select(.status=="completed" and .conclusion=="success")|.id' 2>/dev/null); do
+                if gh api "/repos/$REPO/actions/runs/$rid/jobs?per_page=100" \
+                     --jq '.jobs[]|select(.name=="full-suite-gate" and .conclusion=="success")|.name' 2>/dev/null \
+                     | grep -q full-suite-gate; then return 0; fi
+              done
+              return 1
+            }
+            plumbing_only() {
+              local files="$1" f bad=""
+              [ -z "$files" ] && return 1
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                case "$f" in
+                  changelog.d/*|scripts/linux-*.Dockerfile|.github/workflows/release-packages.yml) ;;
+                  *) bad="$bad $f" ;;
+                esac
+              done <<< "$files"
+              [ -n "$bad" ] && { echo "    rejected — not release-plumbing:$bad"; return 1; }
+              return 0
+            }
+            if gate_green "$SHA"; then
+              echo "gate: exact SHA $SHA already has a green full-suite-gate."
+            else
+              echo "gate: no green full-tier run on $SHA — checking ancestors."
+              for cand in $(gh api "/repos/$REPO/commits?sha=$SHA&per_page=15" --jq '.[].sha' 2>/dev/null | tail -n +2); do
+                gate_green "$cand" || continue
+                echo "  ancestor $cand has a green full-suite-gate; comparing trees"
+                files=$(gh api "/repos/$REPO/compare/$cand...$SHA" --jq '.files[]?.filename' 2>/dev/null)
+                if plumbing_only "$files"; then
+                  echo "    accepted — diff is release-plumbing only:"
+                  echo "$files" | sed 's/^/      /'
+                  GATE_SHA="$cand"
+                  break
+                fi
+              done
+              [ "$GATE_SHA" = "$SHA" ] && echo "gate: no usable ancestor — requiring a run on $SHA."
+            fi
+          fi
+          echo "gate: validating against $GATE_SHA"
+
           if [ "$MODE" = "cut-release" ]; then
             # Tag-last: no tag push fired the gate workflows, so make sure a
             # run exists on this exact commit — dispatch one if none is there.
@@ -229,11 +292,11 @@ jobs:
               # dispatch.
               if [ "$wf_file" = "test.yml" ]; then
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=20" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
                   --jq '[.workflow_runs[] | select(.event == "workflow_dispatch" or .event == "schedule" or .event == "push" and (.head_branch | startswith("v")))] | length')
               else
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=1" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=1" \
                   --jq '.total_count')
               fi
               if [ "$count" = "0" ]; then
@@ -245,7 +308,7 @@ jobs:
                   echo "::error::$REF_NAME moved to $tip (this run is on $SHA) — re-dispatch on a branch pinned at the release candidate."
                   exit 1
                 fi
-                echo "No $wf_file run on $SHA yet — dispatching on $REF_NAME."
+                echo "No $wf_file run on $GATE_SHA yet — dispatching on $REF_NAME."
                 if [ "$wf_file" = "test.yml" ]; then
                   # The tiered CI workflow: `tier=full` is its dispatch default,
                   # but say so explicitly -- this is the release gate.
@@ -290,7 +353,7 @@ jobs:
               # Tests run was green, but a tag-triggered Tests run on the
               # same SHA was newer + still running, locking the gate).
               api_out=$(gh api \
-                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=20" \
+                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
                 2>&1)
               rc=$?
               set -e

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1555,18 +1555,60 @@ jobs:
           set -euo pipefail
           # Preflight checked this earlier; re-check so a concurrent manual
           # release of the same version fails here instead of clobbering.
-          if gh api "repos/$REPO/git/ref/tags/$TAG" --silent 2>/dev/null; then
-            echo "::error::tag $TAG appeared while the builds ran — aborting."
-            exit 1
+          #
+          # A tag pointing at THIS EXACT candidate is not a conflict, it is our
+          # own previous attempt: `gh release create` creates the tag and then
+          # POSTs the release, so a failure in the POST leaves the tag behind
+          # and the old unconditional abort made the job permanently
+          # unrerunnable. That is exactly what happened in run 34451289395.
+          # Abort only if the tag points somewhere else.
+          existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          reuse_tag=0
+          if [ -n "$existing" ]; then
+            if [ "$existing" != "$SHA" ]; then
+              echo "::error::tag $TAG already exists at $existing, not the candidate $SHA — aborting." >&2
+              exit 1
+            fi
+            echo "tag $TAG already exists at the exact candidate $SHA (previous attempt) — reusing it."
+            reuse_tag=1
           fi
-          ./scripts/cut_release_notes.sh --notes-only > /tmp/release-notes.md
+
+          ./scripts/cut_release_notes.sh --notes-only > /tmp/release-notes-full.md
+          # GitHub rejects a release body over 125,000 characters with
+          # `HTTP 422: body is too long`. v0.5.1519 carried 1505 changelog.d
+          # fragments -- the first tag since v0.5.1220 on 2026-07-04 -- and
+          # generated 2.8 MB of notes. The POST failed AFTER the tag was
+          # created, which is the worst place for it to fail.
+          LIMIT=120000
+          if [ "$(wc -c < /tmp/release-notes-full.md)" -gt "$LIMIT" ]; then
+            frags=$(find changelog.d -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+            # Cut on a line boundary so the body never ends mid-sentence.
+            head -c "$LIMIT" /tmp/release-notes-full.md | sed '$d' > /tmp/release-notes.md
+            {
+              echo
+              echo '---'
+              echo
+              echo "**These notes are truncated.** This release carries ${frags} changelog"
+              echo "fragments and the full text exceeds GitHub's 125,000-character limit for a"
+              echo "release body. The complete set is in \`changelog.d/\` at [\`$TAG\`](https://github.com/$REPO/tree/$TAG/changelog.d)."
+            } >> /tmp/release-notes.md
+            echo "::notice::release notes truncated from $(wc -c < /tmp/release-notes-full.md) to $(wc -c < /tmp/release-notes.md) bytes (${frags} fragments)"
+          else
+            cp /tmp/release-notes-full.md /tmp/release-notes.md
+          fi
           # Created with GITHUB_TOKEN: GitHub suppresses events triggered by a
           # workflow's own token, so this `release: published` does NOT fire a
           # second release-packages run (publishing continues in THIS run),
           # and the tag emits no `push: tags` event either — the step below
           # dispatches the tag-rider workflows explicitly.
-          gh release create "$TAG" -R "$REPO" \
-            --target "$SHA" --title "$TAG" --notes-file /tmp/release-notes.md
+          if [ "$reuse_tag" -eq 1 ]; then
+            # The tag already exists at this SHA; do not pass --target.
+            gh release create "$TAG" -R "$REPO" \
+              --title "$TAG" --notes-file /tmp/release-notes.md
+          else
+            gh release create "$TAG" -R "$REPO" \
+              --target "$SHA" --title "$TAG" --notes-file /tmp/release-notes.md
+          fi
           echo "Created release $TAG at $SHA"
 
       - name: Dispatch tag-rider workflows (docs, benchmark, container-tests)

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2309,10 +2309,65 @@ jobs:
 
           failed=""
           while IFS=$'\t' read -r name version tarball expected_sha; do
-            if [ "$name" = "@perryts/perry" ] && [ -n "$failed" ]; then
-              echo "::error::Not publishing the wrapper because platform publication failed:$failed" >&2
-              failed="$failed $name@$version (blocked by platform failure)"
-              continue
+            if [ "$name" = "@perryts/perry" ]; then
+              if [ -n "$failed" ]; then
+                echo "::error::Not publishing the wrapper because platform publication failed:$failed" >&2
+                failed="$failed $name@$version (blocked by platform failure)"
+                continue
+              fi
+              # npm can report a successful publish that never lands. On
+              # 2026-09-10 it printed "+ @perryts/perry-linux-x64@0.5.1519",
+              # exited 0 and signed provenance, while leaving the version
+              # STAGED: invisible (404, absent from the packument's `time`
+              # map) and un-republishable (E409 on every retry). The guard
+              # above trusted that exit code, so the wrapper shipped as
+              # `latest` with a platform dependency that did not resolve, and
+              # v0.5.1519 could not be completed at all.
+              #
+              # So do not take npm's word for it. Before the wrapper goes out,
+              # confirm every platform package is REALLY in the registry. The
+              # `time` map is the authoritative signal here: `npm view` and the
+              # publish exit status both reported success for a version npm had
+              # no record of.
+              echo "=== verifying every platform package is visible before publishing the wrapper ==="
+              unseen=""
+              while IFS=$'\t' read -r pname pversion; do
+                [ "$pname" = "@perryts/perry" ] && continue
+                seen=0
+                for attempt in $(seq 1 30); do
+                  if node -e '
+                    const https = require("https")
+                    const [pkg, ver] = process.argv.slice(1)
+                    https.get("https://registry.npmjs.org/" + encodeURIComponent(pkg), res => {
+                      let b = ""
+                      res.on("data", c => b += c)
+                      res.on("end", () => {
+                        try {
+                          const t = JSON.parse(b).time || {}
+                          process.exit(t[ver] ? 0 : 1)
+                        } catch { process.exit(1) }
+                      })
+                    }).on("error", () => process.exit(1))
+                  ' "$pname" "$pversion"; then seen=1; break; fi
+                  sleep 10
+                done
+                if [ "$seen" -eq 1 ]; then
+                  echo "  visible: $pname@$pversion"
+                else
+                  echo "::error::$pname@$pversion is not visible in the registry after 5 min — npm may have staged it without publishing." >&2
+                  unseen="$unseen $pname@$pversion"
+                fi
+              done < <(node -e '
+                const manifest = require("./npm-publish-manifest.json")
+                for (const pkg of manifest.packages) {
+                  console.log([pkg.name, pkg.version].join("\t"))
+                }
+              ')
+              if [ -n "$unseen" ]; then
+                echo "::error::Refusing to publish the wrapper: platform package(s) not visible:$unseen" >&2
+                failed="$failed$unseen (published but not visible)"
+                continue
+              fi
             fi
 
             public_sha=$(npm view "$name@$version" dist.shasum 2>/dev/null | tr -d '[:space:]' || true)

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1524,7 +1524,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Tag-last core (cut-release mode only): every build leg is green and all
-  # nine exact npm tarballs are public + registry-verified, so NOW create the
+  # every exact npm tarball is public + registry-verified, so NOW create the
   # tag + GitHub Release. Release notes are cut from changelog.d/
   # fragments — same contract as scripts/cut_release_notes.sh, whose
   # --notes-only mode this job calls. The fragment-removal commit stays a
@@ -2152,7 +2152,7 @@ jobs:
   #
   # Uses OIDC / Trusted Publishers (no npm login, long-lived NPM_TOKEN, or
   # GitHub Environment). release-packages.yml is the one publisher identity
-  # shared by all nine @perryts/* packages.
+  # shared by every @perryts/* package.
   # ---------------------------------------------------------------------------
   npm-publish:
     # The irreversible leg. Every build must be green in canonical cut-release
@@ -2240,12 +2240,56 @@ jobs:
       - name: Bundle exact npm publication proofs
         run: |
           set -euo pipefail
-          mapfile -t proofs < <(find npm -mindepth 2 -maxdepth 2 -type f -name '*.tgz' | sort)
-          if [ "${#proofs[@]}" -ne 9 ]; then
-            echo "::error::Expected 9 exact npm tarballs; found ${#proofs[@]}." >&2
-            printf '  %s\n' "${proofs[@]}" >&2
+          # The expected set is DERIVED from the manifest the previous step
+          # generates from ALL_PACKAGES (scripts/publish/constants.mts) and
+          # already validates against it. This used to hardcode `9`, which went
+          # silently wrong when the musl legs were dropped pending #9382:
+          # ALL_PACKAGES became 6 platforms + wrapper = 7, stage-npm staged 6,
+          # prepare-ci-packages packed 7 and PASSED its own check -- and then
+          # this step failed the release with "Expected 9; found 7" AFTER a
+          # fully green 14-leg build (run 34438751300). Two expressions of the
+          # same fact, one of which nobody updated.
+          #
+          # Checked BY NAME, not by a count: a count cannot say WHICH package is
+          # missing, and that is the whole question when this fires. The count
+          # equality below still catches a stray EXTRA tarball.
+          # `while read` rather than `mapfile`: mapfile is bash 4+, and keeping
+          # this to bash 3.2 means it can be run and tested on a developer
+          # machine instead of only on a runner. This step failed a release once
+          # already; an untestable version of it is not an improvement.
+          proofs=()
+          while IFS= read -r line; do proofs+=("$line"); done \
+            < <(find npm -mindepth 2 -maxdepth 2 -type f -name '*.tgz' | sort)
+          want=()
+          while IFS= read -r line; do want+=("$line"); done < <(node -e '
+            const m = require("./npm-publish-manifest.json")
+            for (const p of m.packages) {
+              console.log(p.name.replace(/^@/, "").replace(/\//g, "-") + "-" + p.version + ".tgz")
+            }
+          ')
+          if [ "${#want[@]}" -lt 2 ]; then
+            echo "::error::manifest lists ${#want[@]} package(s); refusing to publish a set that small." >&2
             exit 1
           fi
+          missing=""
+          for w in ${want[@]+"${want[@]}"}; do
+            hit=0
+            for p in ${proofs[@]+"${proofs[@]}"}; do
+              if [ "$(basename "$p")" = "$w" ]; then hit=1; break; fi
+            done
+            if [ "$hit" -eq 0 ]; then missing="$missing $w"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::manifest package(s) have no packed tarball:$missing" >&2
+            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            exit 1
+          fi
+          if [ "${#proofs[@]}" -ne "${#want[@]}" ]; then
+            echo "::error::found ${#proofs[@]} tarball(s) but the manifest lists ${#want[@]}; an unexpected tarball is present." >&2
+            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            exit 1
+          fi
+          echo "${#want[@]} exact tarballs match the manifest by name."
           tar -cf npm-publish-package-proofs.tar \
             npm-publish-manifest.json socket-scan-receipt.json "${proofs[@]}"
 
@@ -2310,7 +2354,7 @@ jobs:
             exit 1
           fi
 
-      - name: Verify all nine public registry shasums
+      - name: Verify every public registry shasum
         # npm's CDN can lag a successful PUT. Wait briefly, but a different
         # sha1 fails immediately because published versions are immutable.
         run: |
@@ -2335,7 +2379,7 @@ jobs:
               }
             ')
             if [ -z "$waiting" ]; then
-              echo "All nine exact npm tarballs are public and verified. The tag may now be created."
+              echo "Every exact npm tarball is public and verified. The tag may now be created."
               break
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1625,7 +1625,21 @@ jobs:
           # and the old unconditional abort made the job permanently
           # unrerunnable. That is exactly what happened in run 34451289395.
           # Abort only if the tag points somewhere else.
-          existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          # Gate on gh's EXIT STATUS, not its stdout: on a 404 `gh api` prints
+          # the error JSON to STDOUT and exits non-zero, so capturing stdout
+          # with `|| true` yields `{"message":"Not Found",...}` rather than an
+          # empty string. That made the "tag exists at a different SHA" branch
+          # fire on the NORMAL path (tag absent) and aborted v0.5.1520's
+          # create-release with `already exists at {"message":"Not Found"...}`.
+          existing=""
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          fi
+          # Belt and braces: only a 40-char hex string is a SHA.
+          case "$existing" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+            *) existing="" ;;
+          esac
           reuse_tag=0
           if [ -n "$existing" ]; then
             if [ "$existing" != "$SHA" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1804,7 +1804,21 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Build perry + runtime staticlibs (release)
         env:
@@ -1854,7 +1868,21 @@ jobs:
           save-if: false
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -1936,7 +1964,21 @@ jobs:
           save-if: false
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Download shared GC matrix build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2032,7 +2074,21 @@ jobs:
 
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
 
       - name: Build compiler
@@ -2412,7 +2468,21 @@ jobs:
 
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
 
       - name: Gate native ABI evidence packet
@@ -3324,7 +3394,21 @@ jobs:
 
       - name: Install mysql client (for fixture health probe)
         run: |
-          sudo apt-get update -qq
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update -qq || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y -qq mysql-client
 
       - name: Wait for MySQL service to accept connections
@@ -3609,7 +3693,21 @@ jobs:
       - name: Install GTK4 + GStreamer + Xvfb + PulseAudio headers (Linux)
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           # libgstreamer1.0-dev + libgstreamer-plugins-base1.0-dev added in
           # v0.5.442 for PR #371 (perry/media streaming playback, #351).
           # gstreamer-sys's build script needs `gstreamer-1.0.pc` findable

--- a/changelog.d/10041-gh-api-tag-existence.md
+++ b/changelog.d/10041-gh-api-tag-existence.md
@@ -1,0 +1,19 @@
+- **`create-release`'s tag check now gates on `gh api`'s exit status, not its
+  stdout.** On a 404, `gh api` prints its error JSON to **stdout** and exits
+  non-zero, so `existing=$(gh api ... || true)` captured
+  `{"message":"Not Found",...}` instead of an empty string. The "tag exists at a
+  different SHA" branch therefore fired on the **normal** path — an absent tag —
+  and aborted v0.5.1520 with the self-refuting message
+  `tag v0.5.1520 already exists at {"message":"Not Found",...}, not the
+  candidate 381045a87`.
+
+  The check now runs `gh api` for its exit status first and only reads
+  `.object.sha` when the ref really exists, plus rejects anything that is not a
+  hex SHA. Verified against the live API in all three states: absent → create,
+  present at the same SHA → reuse, present at a different SHA → abort.
+
+  This one is worth a note on method rather than mechanism. The same commit that
+  introduced this bug also introduced the release-notes cap, and the cap was
+  tested carefully against the real 2.8 MB notes while this branch was never
+  exercised at all. A test that covers the half of a change you were thinking
+  about is not coverage of the change.

--- a/changelog.d/9666-await-tests-ancestor-gate.md
+++ b/changelog.d/9666-await-tests-ancestor-gate.md
@@ -1,0 +1,26 @@
+- **`await-tests` can accept an already-validated ancestor's gate when the only
+  difference is release plumbing.** `test.yml` does not build the glibc image,
+  read `changelog.d/`, or run `release-packages.yml` — so a candidate that
+  differs from a green ancestor *only* in those files is already covered by that
+  ancestor's `full-suite-gate`. Re-running a ~5 h tier to re-prove untouched code
+  is pure latency, and this campaign paid it four separate times over one
+  Dockerfile.
+
+  Fail-closed by construction:
+
+  - the file list comes from **GitHub's compare API**, computed from the commits
+    themselves — never from a dispatch input;
+  - **any** path outside the allowlist keeps the exact-SHA requirement;
+  - an **empty** diff is refused, since it should be impossible here and would
+    mean the comparison did not do what we think;
+  - **`.github/workflows/test.yml` is deliberately not allowlisted** — changing
+    the tier's own definition must re-run the tier.
+
+  Allowlist: `changelog.d/**`, `scripts/linux-*.Dockerfile`,
+  `.github/workflows/release-packages.yml`.
+
+  Verified against the live repo before landing: on pin `3216910e19` the resolver
+  selects ancestor `49132f00cd` (whose gate is green) because the diff is exactly
+  `changelog.d/9665-…md` + `scripts/linux-glibc-2.31.Dockerfile`. Sabotage-checked
+  in the other direction too — a single `crates/**` file, `test.yml`, `Cargo.toml`,
+  a path-traversal string, or an empty diff each force the exact-SHA gate.

--- a/changelog.d/9669-drop-unused-apt-sources.md
+++ b/changelog.d/9669-drop-unused-apt-sources.md
@@ -1,0 +1,36 @@
+- **`apt-get update` no longer gates CI jobs on third-party mirrors we never
+  install from.** GitHub's Ubuntu images ship Chrome and Microsoft apt sources,
+  and `apt-get update` exits non-zero if **any** source fails. On 2026-09-09
+  `dl.google.com`'s chrome-stable index served a `Hash Sum mismatch` and
+  reddened the release tier three times running — 22 jobs in run 34383689667,
+  then `Install clang` and `Install mysql client` in runs 34384580491 and
+  34386043331. None of those jobs want Chrome.
+
+  Ten sites now do two things: the 7 `apt-get update`s in `test.yml`, the 2 in
+  `release-packages.yml`'s `build` job (the release critical path), and
+  `setup-llvm22`.
+
+  1. **Drop the unused sources by CONTENT, not filename.** The first attempt
+     removed `google-chrome.list` and changed nothing, because image
+     `ubuntu24/20260907.300` has moved these to deb822 `.sources` files. The log
+     shows the `rm` running and Chrome being fetched 0.2 s later.
+  2. **Let the install be the gate.** `apt-get update`'s exit status aggregates
+     sources we depend on with sources we do not, so it cannot answer the
+     question we care about. The update is advisory; the `apt-get install` that
+     follows decides. That is why `setup-llvm22` stayed green through all three
+     outages while its neighbours failed — it already verified by reaching for
+     what it came for.
+
+  The removal is written as an `if` rather than `... || true`, because
+  `scripts/gc_gate_wiring_check.py` rightly rejects `|| true` inside the
+  `gc-stress` jobs and cannot distinguish a benign swallow from a real one. An
+  `if` CONDITION is exempt from `set -e`, so the guard is safe under `-e` and
+  `pipefail` while suppressing nothing. Verified under both, including the
+  no-match and missing-directory cases.
+
+  Two things worth recording, because each cost a five-hour tier. The Chrome
+  repo returned **200 from a developer machine** while runners kept failing, so
+  "it has cleared" was wrong twice — a third-party mirror's health has to be
+  judged from where the job runs. And matching by name rather than by cause
+  failed here for the third time in this workstream, after an apt pin glob
+  missed `libllvm22` and a `KNOWN_FAIL` name list missed a renamed test.

--- a/changelog.d/9670-derive-npm-tarball-set.md
+++ b/changelog.d/9670-derive-npm-tarball-set.md
@@ -1,0 +1,33 @@
+- **The release's tarball check now derives its expected set from the publish
+  manifest instead of a hardcoded `9`.** v0.5.1519 failed to publish after a
+  fully green 14-leg build (run 34438751300) with
+  `Expected 9 exact npm tarballs; found 7`.
+
+  Nothing was wrong with the build. When the musl legs were dropped pending
+  #9382, `PLATFORM_PACKAGES` in `scripts/publish/constants.mts` was correctly
+  trimmed to 6, so `ALL_PACKAGES` is 6 platforms + 1 wrapper = 7.
+  `prepare-ci-packages.mts` packed 7 and **passed its own check against
+  `ALL_PACKAGES`** — and then `release-packages.yml`'s separate hardcoded `9`
+  rejected the same set one step later. Two expressions of one fact, and only
+  one of them was updated. The publish step never ran, so nothing reached the
+  registry, no tag was cut, and the version was not burned.
+
+  The check now reads the manifest that the previous step generates from
+  `ALL_PACKAGES`, and matches **by name** rather than by count — a count cannot
+  say *which* package is missing, which is the only question worth asking when
+  this fires. A missing tarball now reports
+  `manifest package(s) have no packed tarball: perryts-perry-linux-arm64-…tgz`.
+  Count equality is still asserted so a stray extra tarball fails too, and a
+  manifest of fewer than two packages is refused outright.
+
+  Written with `while read` rather than `mapfile` so it runs on bash 3.2 and can
+  be exercised on a developer machine, not only on a runner. It was tested
+  against five cases before shipping — all present; one platform missing; a
+  stray extra; a too-small manifest; and the real-world shape with stale empty
+  `npm/perry-linux-*-musl` directories still on disk. A step that has already
+  failed one release does not deserve to be shipped untested a second time.
+
+  Note for follow-up: the doc comments in `constants.mts` still say "The 8
+  platform packages" and "All 9" above 6- and 7-element arrays. They are stale
+  in exactly the way that caused this, but correcting them touches a
+  non-plumbing path, so they are left for a normal PR rather than a release pin.

--- a/changelog.d/9672-verify-platform-visibility-before-wrapper.md
+++ b/changelog.d/9672-verify-platform-visibility-before-wrapper.md
@@ -27,3 +27,12 @@
   Probe validated against live registry data, including the exact failing case:
   the five packages that really published read visible, and the staged
   linux-x64 reads not-visible.
+
+  The wait is a **single 45-minute budget across all platform packages**, not a
+  short per-package one. npm's own delay notice says a large upload "may take
+  longer than usual" and allows itself 24 hours, and the packages settle in
+  parallel — so a tight per-package timeout would fail the *normal* slow case
+  while adding nothing against the broken one. Timing out is safe and resumable:
+  the platform packages are already published, so a rerun skips them on matching
+  sha1 and waits again. Publishing the wrapper too early is the step that cannot
+  be undone, because npm versions are immutable.

--- a/changelog.d/9672-verify-platform-visibility-before-wrapper.md
+++ b/changelog.d/9672-verify-platform-visibility-before-wrapper.md
@@ -1,0 +1,29 @@
+- **The release refuses to publish the npm wrapper until every platform package
+  is actually visible in the registry.** npm can report a successful publish
+  that never lands: on 2026-09-10 it printed
+  `+ @perryts/perry-linux-x64@0.5.1519`, exited 0 and signed provenance into
+  sigstore, while leaving the version **staged** — invisible (404, absent from
+  the packument's `time` map) and un-republishable (`E409 Cannot publish over
+  previously staged version` on every retry, including after an `npm unpublish`).
+
+  The wrapper's existing guard keyed on `npm publish`'s exit status, so it was
+  satisfied by that false success and `@perryts/perry@0.5.1519` shipped as
+  `latest` with a platform dependency that does not resolve on linux-x64. The
+  version could not then be completed from our side at all, and the release moved
+  to 0.5.1520.
+
+  Before the wrapper is published, each platform package is now confirmed present
+  in the registry (up to 5 minutes each, polling). The check reads the
+  packument's **`time` map**, which was the only signal that told the truth here:
+  `npm view` returned nothing and the publish exit status returned success for a
+  version npm had no record of. A package that never appears blocks the wrapper
+  and fails the job.
+
+  The failure mode this prevents is specifically the bad one. A publish that
+  fails loudly costs a rerun; a publish that half-lands puts a broken `latest` in
+  front of users and burns the version number, because npm versions are
+  immutable and the staged slot rejects retries.
+
+  Probe validated against live registry data, including the exact failing case:
+  the five packages that really published read visible, and the staged
+  linux-x64 reads not-visible.

--- a/changelog.d/9673-release-notes-cap-and-tag-reuse.md
+++ b/changelog.d/9673-release-notes-cap-and-tag-reuse.md
@@ -1,0 +1,21 @@
+- **The release body is capped, and a tag left behind by a failed attempt no
+  longer wedges the job.** `create-release` failed v0.5.1519 with
+  `HTTP 422: body is too long (maximum is 125000 characters)`. The notes are
+  generated from `changelog.d/`, and this release carries **1505 fragments** —
+  the first tag since v0.5.1220 on 2026-07-04 — producing **2.8 MB** of notes,
+  22× GitHub's limit.
+
+  Two things made that worse than a simple failure. `gh release create` creates
+  the tag and *then* POSTs the release, so the 422 left `v0.5.1519` pointing at
+  the right commit with no release attached. And the guard above it aborted
+  unconditionally on any existing tag, so every retry then died on the debris of
+  the first attempt — the job could not succeed again by any path.
+
+  Now: the body is truncated on a line boundary to 120,000 characters with a
+  pointer to `changelog.d/` at the tag, and an existing tag is reused when it
+  points at **exactly** the candidate SHA (still a hard error when it points
+  anywhere else, which is the case the guard was written for).
+
+  This would have blocked every release with a large fragment backlog, not just
+  this one. Verified against the real 2.8 MB notes: the result is 120,221 bytes
+  and ends cleanly.


### PR DESCRIPTION
Lands the release-pipeline fixes made while cutting **v0.5.1520** (the first
release since v0.5.1220 on 2026-07-04). They currently exist only on
`release/*` pin branches, so `main` would hit every one of them again on the
next release.

Five separate bugs surfaced in a single release run, each hidden behind the
previous one. That is the real signal here: the release path is exercised twice
a year, so a release discovers months of accumulated drift all at once.

### What broke, and what each commit fixes

**1. Third-party apt sources failed unrelated jobs.** GitHub's Ubuntu images
ship Chrome and Microsoft sources we never install from, and `apt-get update`
exits non-zero if *any* source fails. A `Hash Sum mismatch` at `dl.google.com`
reddened 22 jobs in one run and `Install clang` in three others. Sources are now
dropped by **content**, not filename — the first attempt removed
`google-chrome.list` and changed nothing, because the image had moved to deb822
`.sources` files — and `apt-get update` is advisory, with the *install* as the
gate.

**2. A hardcoded tarball count drifted.** `release-packages.yml` demanded 9
tarballs while `ALL_PACKAGES` had been correctly trimmed to 7 when the musl legs
were dropped. `prepare-ci-packages.mts` packed 7, passed its own check against
`ALL_PACKAGES`, and the workflow then rejected the identical set one step later.
The count is now derived from the manifest and matched **by name**, since a
count cannot say *which* package is missing.

**3. The wrapper shipped over a platform that was not there.** npm printed
`+ @perryts/perry-linux-x64@0.5.1519`, exited 0 and signed provenance, while
holding the version *staged*: invisible (404, absent from the packument's `time`
map) and un-republishable (`E409`). The guard keyed on that exit code, so the
wrapper went out as `latest` with a dependency that did not resolve — linux-x64
installs were broken for ~3h, and the version could not be completed afterwards.
Every platform is now confirmed **visible in the registry** before the wrapper
publishes, polled round-robin against one 45-minute budget (npm's own notice
allows itself 24h, so a short per-package timeout would fail the normal slow
case). Timing out is safe and resumable; publishing the wrapper early is not.

**4. Release notes exceeded GitHub's limit.** 1505 `changelog.d` fragments
produced **2.8 MB** of notes against a 125,000-character cap, and
`gh release create` creates the tag *then* posts the release — so the 422 left a
tag behind with no release, while the old guard aborted on *any* existing tag,
making every retry fail on the first attempt's debris. The body is now truncated
on a line boundary with a pointer to `changelog.d/` at the tag, and a tag is
reused when it points at exactly the candidate SHA.

**5. `gh api`'s 404 body was read as data.** On a 404 `gh api` prints its error
JSON to **stdout** and exits non-zero, so `existing=$(gh api ... || true)`
captured `{"message":"Not Found",...}` and the "different SHA" branch fired on
the *normal* path, aborting with the self-refuting
`already exists at {"message":"Not Found"...}`. Existence is now decided by exit
status, and a non-hex value is rejected.

Also included: `await-tests` accepting an ancestor's gate for
release-plumbing-only diffs, which is what let four successive workflow fixes
land during the release without re-running a ~5h tier each time.

### Validation

- `run_lint_gates.sh` script tier: **73 of 74 pass**. The one failure,
  `ci_public_baseline_check.py`, fails identically on clean `origin/main` and
  this diff touches no benchmark inputs. Compile tier skipped: no Rust changes.
- Fix 5 verified against the live GitHub API in all three states — absent →
  create, same SHA → reuse, different SHA → abort.
- Fix 4's truncation verified against the real 2.8 MB notes: 120,221 bytes,
  ending on a clean boundary.
- Fixes 1–4 all ran in the real v0.5.1520 release. Fix 3 fired for real: npm
  stalled linux-x64 again, the wrapper was correctly withheld, and the job
  resumed cleanly once scanning finished 75 minutes later.

Workflow-only; no runtime or codegen change, and no version bump.

### Follow-ups, not in this PR

- A **`finish-release`** entry point that resumes from an existing run ID.
  Builds are not byte-reproducible across runs, so a fresh build collides on
  sha1 with already-published packages — meaning a bug found *after* publishing
  cannot be fixed for that version. That is what made v0.5.1519 unfinishable.
- Cheap `lint` checks that would have caught bugs 2 and 4 weeks earlier: assert
  the generated notes stay under 125,000 characters, and assert
  `PLATFORM_PACKAGES` / `stage-npm.sh`'s `PLATFORMS` / the `npm/perry-*`
  directories all agree.
- A scheduled `stage`-mode rehearsal so the release path is exercised between
  releases rather than only during them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reliability when retrying failed releases, handling existing tags and oversized release notes.
  * Release validation now derives expected package artifacts dynamically and verifies platform package visibility before publishing the wrapper.
  * Test and packaging jobs are less likely to fail because of unavailable third-party package sources.
  * Release test gates can reuse validated results for eligible release-only changes while preserving strict validation for code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->