### PR TITLE
Merge train158: release-pipeline hardening (v0.5.1532)

### DIFF
--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -49,7 +49,34 @@ runs:
         . /etc/os-release
         echo "deb http://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME}-22 main" \
           | sudo tee /etc/apt/sources.list.d/llvm22.list >/dev/null
-        sudo apt-get update -qq
+        # Only OUR source needs to be fresh. `apt-get update` exits non-zero if
+        # ANY configured source fails, and GitHub's runner image ships
+        # third-party lists we do not use — dl.google.com's chrome-stable repo
+        # served a "Hash Sum mismatch" on 2026-09-09 and took out 22 jobs of
+        # run 34383689667 across cargo-test, gap-suite, gc-stress, lint, check,
+        # warnings and security-audit, none of which want Chrome.
+        #
+        # So: drop the third-party lists we never install from, retry the
+        # update (transient mirror errors are common), and verify by REACHING
+        # FOR WHAT WE CAME FOR rather than by the exit code — if llvm-toolchain
+        # is resolvable, the update did its job whatever else was noisy.
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                   /etc/apt/sources.list.d/microsoft-prod.list \
+                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+        update_ok=0
+        for attempt in 1 2 3; do
+          if sudo apt-get update -qq -o Acquire::Retries=3; then update_ok=1; break; fi
+          echo "  apt-get update attempt $attempt failed; retrying"
+          sleep $(( attempt * 5 ))
+        done
+        if [ "$update_ok" -ne 1 ]; then
+          # Not fatal by itself: what matters is whether OUR packages resolve.
+          echo "::warning::apt-get update reported errors; checking whether llvm-22 is resolvable anyway"
+          apt-cache policy llvm-22-dev | sed 's/^/    /'
+          apt-cache policy llvm-22-dev | grep -qE 'Candidate: [0-9]' \
+            || { echo "::error::apt-get update failed AND llvm-22-dev is unresolvable"; exit 1; }
+          echo "  llvm-22-dev resolves — continuing"
+        fi
         # `clang-22` is NOT implied by `llvm-22-dev`: apt ships opt and clang as
         # separate packages, so installing only the dev libraries leaves
         # /usr/lib/llvm-22/bin/opt with no clang beside it. That is exactly what

--- a/.github/actions/setup-llvm22/action.yml
+++ b/.github/actions/setup-llvm22/action.yml
@@ -60,9 +60,11 @@ runs:
         # update (transient mirror errors are common), and verify by REACHING
         # FOR WHAT WE CAME FOR rather than by the exit code — if llvm-toolchain
         # is resolvable, the update did its job whatever else was noisy.
-        sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                   /etc/apt/sources.list.d/microsoft-prod.list \
-                   /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+        # Match by CONTENT: the ubuntu24/20260907.300 image moved these to
+        # deb822 `.sources` files, so the old `.list` names removed nothing.
+        if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+          printf '%s\n' "$_bad" | sudo xargs -r rm -f
+        fi
         update_ok=0
         for attempt in 1 2 3; do
           if sudo apt-get update -qq -o Acquire::Retries=3; then update_ok=1; break; fi

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2428,12 +2428,12 @@ jobs:
           done
           if [ -n "$missing" ]; then
             echo "::error::manifest package(s) have no packed tarball:$missing" >&2
-            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            printf '  on disk: %s\n' ${proofs[@]+"${proofs[@]}"} >&2
             exit 1
           fi
           if [ "${#proofs[@]}" -ne "${#want[@]}" ]; then
             echo "::error::found ${#proofs[@]} tarball(s) but the manifest lists ${#want[@]}; an unexpected tarball is present." >&2
-            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            printf '  on disk: %s\n' ${proofs[@]+"${proofs[@]}"} >&2
             exit 1
           fi
           echo "${#want[@]} exact tarballs match the manifest by name."

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2294,6 +2294,12 @@ jobs:
             npm-publish-manifest.json socket-scan-receipt.json "${proofs[@]}"
 
       - name: npm publish exact tarballs (OIDC; platforms first, wrapper last)
+        env:
+          # How long to wait for npm publish-time scanning to make the platform
+          # packages visible before giving up. Generous on purpose: a timeout
+          # here is a resumable rerun, while publishing the wrapper too early
+          # is not recoverable (npm versions are immutable).
+          VISIBILITY_WAIT_MIN: "45"
         # No npm login and no NPM_TOKEN. npm exchanges this job's short-lived
         # GitHub OIDC identity because id-token:write is set above. Reruns skip
         # an already-public version only when its immutable registry sha1 is
@@ -2329,12 +2335,25 @@ jobs:
               # `time` map is the authoritative signal here: `npm view` and the
               # publish exit status both reported success for a version npm had
               # no record of.
+              # npm's publish-time scanning can hold a large binary for a
+              # long time -- its own notice says "may take longer than usual"
+              # and gives itself 24 h. So poll ROUND-ROBIN against a single
+              # global deadline rather than giving each package its own short
+              # budget: the packages settle in parallel, so a per-package
+              # timeout would fail the normal slow case while adding nothing
+              # for the broken one.
+              #
+              # Timing out here is SAFE and resumable. The platform packages
+              # are already published; a rerun skips them on matching sha1 and
+              # waits again. What must never happen is the wrapper going out
+              # over a platform that is not really there.
               echo "=== verifying every platform package is visible before publishing the wrapper ==="
+              deadline=$(( $(date +%s) + VISIBILITY_WAIT_MIN * 60 ))
               unseen=""
               while IFS=$'\t' read -r pname pversion; do
                 [ "$pname" = "@perryts/perry" ] && continue
                 seen=0
-                for attempt in $(seq 1 30); do
+                while :; do
                   if node -e '
                     const https = require("https")
                     const [pkg, ver] = process.argv.slice(1)
@@ -2349,12 +2368,13 @@ jobs:
                       })
                     }).on("error", () => process.exit(1))
                   ' "$pname" "$pversion"; then seen=1; break; fi
-                  sleep 10
+                  if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
+                  sleep 20
                 done
                 if [ "$seen" -eq 1 ]; then
                   echo "  visible: $pname@$pversion"
                 else
-                  echo "::error::$pname@$pversion is not visible in the registry after 5 min — npm may have staged it without publishing." >&2
+                  echo "::error::$pname@$pversion still not visible after the ${VISIBILITY_WAIT_MIN}-minute budget — npm scanning may still be running, or the version is staged. Rerun this job to resume." >&2
                   unseen="$unseen $pname@$pversion"
                 fi
               done < <(node -e '

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -572,11 +572,27 @@ jobs:
         # (which transitively needs javascriptcoregtk-6.0.pc + webkitgtk-6.0.pc
         # + libsoup-3.0.pc) and libshumate-sys (#517 MapView). Mirrors the
         # apt step in test.yml's doc-tests-gtk4 job.
-        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libwebkitgtk-6.0-dev libshumate-dev
+        run: |
+          # See test.yml: a broken third-party index (Chrome) fails
+          # `apt-get update` for everyone. Drop those sources by CONTENT
+          # (deb822 `.sources` now, not `.list`) and let the install gate.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
+          sudo apt-get install -y libgtk-4-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libwebkitgtk-6.0-dev libshumate-dev
 
       - name: Install musl tools (Linux musl)
         if: endsWith(matrix.target, '-musl') && matrix.musl_image == ''
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        run: |
+          # See test.yml: a broken third-party index (Chrome) fails
+          # `apt-get update` for everyone. Drop those sources by CONTENT
+          # (deb822 `.sources` now, not `.list`) and let the install gate.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
+          sudo apt-get install -y musl-tools
 
       - name: Build perry
         # Build only the CLI crate; the runtime libraries are built in

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -213,6 +213,69 @@ jobs:
               exit 0
               ;;
           esac
+          # ---------------------------------------------------------------
+          # Which SHA must carry the green gate?
+          #
+          # Normally the exact candidate. But `test.yml` does not build the
+          # glibc image, read changelog fragments, or run this workflow, so a
+          # candidate that differs from an already-validated ancestor ONLY in
+          # those files is covered by that ancestor's gate. Re-running a ~5h
+          # tier to re-prove untouched code is pure latency, and this campaign
+          # paid it four times over a Dockerfile.
+          #
+          # Fail-closed by construction:
+          #   * the file list comes from GitHub's compare API, computed from
+          #     the commits themselves — not from any dispatch input;
+          #   * ANY path outside the allowlist keeps the exact-SHA requirement;
+          #   * an EMPTY diff is refused too (it should be impossible here, so
+          #     it means the comparison did not do what we think);
+          #   * `.github/workflows/test.yml` is deliberately NOT allowlisted —
+          #     changing the tier's own definition must re-run the tier.
+          GATE_SHA="$SHA"
+          if [ "$MODE" = "cut-release" ]; then
+            gate_green() {
+              local sha="$1" out rid
+              out=$(gh api "/repos/$REPO/actions/workflows/test.yml/runs?head_sha=$sha&per_page=20" 2>/dev/null) || return 1
+              for rid in $(echo "$out" | jq -r '.workflow_runs[]|select(.status=="completed" and .conclusion=="success")|.id' 2>/dev/null); do
+                if gh api "/repos/$REPO/actions/runs/$rid/jobs?per_page=100" \
+                     --jq '.jobs[]|select(.name=="full-suite-gate" and .conclusion=="success")|.name' 2>/dev/null \
+                     | grep -q full-suite-gate; then return 0; fi
+              done
+              return 1
+            }
+            plumbing_only() {
+              local files="$1" f bad=""
+              [ -z "$files" ] && return 1
+              while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                case "$f" in
+                  changelog.d/*|scripts/linux-*.Dockerfile|.github/workflows/release-packages.yml) ;;
+                  *) bad="$bad $f" ;;
+                esac
+              done <<< "$files"
+              [ -n "$bad" ] && { echo "    rejected — not release-plumbing:$bad"; return 1; }
+              return 0
+            }
+            if gate_green "$SHA"; then
+              echo "gate: exact SHA $SHA already has a green full-suite-gate."
+            else
+              echo "gate: no green full-tier run on $SHA — checking ancestors."
+              for cand in $(gh api "/repos/$REPO/commits?sha=$SHA&per_page=15" --jq '.[].sha' 2>/dev/null | tail -n +2); do
+                gate_green "$cand" || continue
+                echo "  ancestor $cand has a green full-suite-gate; comparing trees"
+                files=$(gh api "/repos/$REPO/compare/$cand...$SHA" --jq '.files[]?.filename' 2>/dev/null)
+                if plumbing_only "$files"; then
+                  echo "    accepted — diff is release-plumbing only:"
+                  echo "$files" | sed 's/^/      /'
+                  GATE_SHA="$cand"
+                  break
+                fi
+              done
+              [ "$GATE_SHA" = "$SHA" ] && echo "gate: no usable ancestor — requiring a run on $SHA."
+            fi
+          fi
+          echo "gate: validating against $GATE_SHA"
+
           if [ "$MODE" = "cut-release" ]; then
             # Tag-last: no tag push fired the gate workflows, so make sure a
             # run exists on this exact commit — dispatch one if none is there.
@@ -229,11 +292,11 @@ jobs:
               # dispatch.
               if [ "$wf_file" = "test.yml" ]; then
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=20" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
                   --jq '[.workflow_runs[] | select(.event == "workflow_dispatch" or .event == "schedule" or .event == "push" and (.head_branch | startswith("v")))] | length')
               else
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=1" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=1" \
                   --jq '.total_count')
               fi
               if [ "$count" = "0" ]; then
@@ -245,7 +308,7 @@ jobs:
                   echo "::error::$REF_NAME moved to $tip (this run is on $SHA) — re-dispatch on a branch pinned at the release candidate."
                   exit 1
                 fi
-                echo "No $wf_file run on $SHA yet — dispatching on $REF_NAME."
+                echo "No $wf_file run on $GATE_SHA yet — dispatching on $REF_NAME."
                 if [ "$wf_file" = "test.yml" ]; then
                   # The tiered CI workflow: `tier=full` is its dispatch default,
                   # but say so explicitly -- this is the release gate.
@@ -290,7 +353,7 @@ jobs:
               # Tests run was green, but a tag-triggered Tests run on the
               # same SHA was newer + still running, locking the gate).
               api_out=$(gh api \
-                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$SHA&per_page=20" \
+                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
                 2>&1)
               rc=$?
               set -e

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1555,18 +1555,60 @@ jobs:
           set -euo pipefail
           # Preflight checked this earlier; re-check so a concurrent manual
           # release of the same version fails here instead of clobbering.
-          if gh api "repos/$REPO/git/ref/tags/$TAG" --silent 2>/dev/null; then
-            echo "::error::tag $TAG appeared while the builds ran — aborting."
-            exit 1
+          #
+          # A tag pointing at THIS EXACT candidate is not a conflict, it is our
+          # own previous attempt: `gh release create` creates the tag and then
+          # POSTs the release, so a failure in the POST leaves the tag behind
+          # and the old unconditional abort made the job permanently
+          # unrerunnable. That is exactly what happened in run 34451289395.
+          # Abort only if the tag points somewhere else.
+          existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          reuse_tag=0
+          if [ -n "$existing" ]; then
+            if [ "$existing" != "$SHA" ]; then
+              echo "::error::tag $TAG already exists at $existing, not the candidate $SHA — aborting." >&2
+              exit 1
+            fi
+            echo "tag $TAG already exists at the exact candidate $SHA (previous attempt) — reusing it."
+            reuse_tag=1
           fi
-          ./scripts/cut_release_notes.sh --notes-only > /tmp/release-notes.md
+
+          ./scripts/cut_release_notes.sh --notes-only > /tmp/release-notes-full.md
+          # GitHub rejects a release body over 125,000 characters with
+          # `HTTP 422: body is too long`. v0.5.1519 carried 1505 changelog.d
+          # fragments -- the first tag since v0.5.1220 on 2026-07-04 -- and
+          # generated 2.8 MB of notes. The POST failed AFTER the tag was
+          # created, which is the worst place for it to fail.
+          LIMIT=120000
+          if [ "$(wc -c < /tmp/release-notes-full.md)" -gt "$LIMIT" ]; then
+            frags=$(find changelog.d -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+            # Cut on a line boundary so the body never ends mid-sentence.
+            head -c "$LIMIT" /tmp/release-notes-full.md | sed '$d' > /tmp/release-notes.md
+            {
+              echo
+              echo '---'
+              echo
+              echo "**These notes are truncated.** This release carries ${frags} changelog"
+              echo "fragments and the full text exceeds GitHub's 125,000-character limit for a"
+              echo "release body. The complete set is in \`changelog.d/\` at [\`$TAG\`](https://github.com/$REPO/tree/$TAG/changelog.d)."
+            } >> /tmp/release-notes.md
+            echo "::notice::release notes truncated from $(wc -c < /tmp/release-notes-full.md) to $(wc -c < /tmp/release-notes.md) bytes (${frags} fragments)"
+          else
+            cp /tmp/release-notes-full.md /tmp/release-notes.md
+          fi
           # Created with GITHUB_TOKEN: GitHub suppresses events triggered by a
           # workflow's own token, so this `release: published` does NOT fire a
           # second release-packages run (publishing continues in THIS run),
           # and the tag emits no `push: tags` event either — the step below
           # dispatches the tag-rider workflows explicitly.
-          gh release create "$TAG" -R "$REPO" \
-            --target "$SHA" --title "$TAG" --notes-file /tmp/release-notes.md
+          if [ "$reuse_tag" -eq 1 ]; then
+            # The tag already exists at this SHA; do not pass --target.
+            gh release create "$TAG" -R "$REPO" \
+              --title "$TAG" --notes-file /tmp/release-notes.md
+          else
+            gh release create "$TAG" -R "$REPO" \
+              --target "$SHA" --title "$TAG" --notes-file /tmp/release-notes.md
+          fi
           echo "Created release $TAG at $SHA"
 
       - name: Dispatch tag-rider workflows (docs, benchmark, container-tests)

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2309,10 +2309,65 @@ jobs:
 
           failed=""
           while IFS=$'\t' read -r name version tarball expected_sha; do
-            if [ "$name" = "@perryts/perry" ] && [ -n "$failed" ]; then
-              echo "::error::Not publishing the wrapper because platform publication failed:$failed" >&2
-              failed="$failed $name@$version (blocked by platform failure)"
-              continue
+            if [ "$name" = "@perryts/perry" ]; then
+              if [ -n "$failed" ]; then
+                echo "::error::Not publishing the wrapper because platform publication failed:$failed" >&2
+                failed="$failed $name@$version (blocked by platform failure)"
+                continue
+              fi
+              # npm can report a successful publish that never lands. On
+              # 2026-09-10 it printed "+ @perryts/perry-linux-x64@0.5.1519",
+              # exited 0 and signed provenance, while leaving the version
+              # STAGED: invisible (404, absent from the packument's `time`
+              # map) and un-republishable (E409 on every retry). The guard
+              # above trusted that exit code, so the wrapper shipped as
+              # `latest` with a platform dependency that did not resolve, and
+              # v0.5.1519 could not be completed at all.
+              #
+              # So do not take npm's word for it. Before the wrapper goes out,
+              # confirm every platform package is REALLY in the registry. The
+              # `time` map is the authoritative signal here: `npm view` and the
+              # publish exit status both reported success for a version npm had
+              # no record of.
+              echo "=== verifying every platform package is visible before publishing the wrapper ==="
+              unseen=""
+              while IFS=$'\t' read -r pname pversion; do
+                [ "$pname" = "@perryts/perry" ] && continue
+                seen=0
+                for attempt in $(seq 1 30); do
+                  if node -e '
+                    const https = require("https")
+                    const [pkg, ver] = process.argv.slice(1)
+                    https.get("https://registry.npmjs.org/" + encodeURIComponent(pkg), res => {
+                      let b = ""
+                      res.on("data", c => b += c)
+                      res.on("end", () => {
+                        try {
+                          const t = JSON.parse(b).time || {}
+                          process.exit(t[ver] ? 0 : 1)
+                        } catch { process.exit(1) }
+                      })
+                    }).on("error", () => process.exit(1))
+                  ' "$pname" "$pversion"; then seen=1; break; fi
+                  sleep 10
+                done
+                if [ "$seen" -eq 1 ]; then
+                  echo "  visible: $pname@$pversion"
+                else
+                  echo "::error::$pname@$pversion is not visible in the registry after 5 min — npm may have staged it without publishing." >&2
+                  unseen="$unseen $pname@$pversion"
+                fi
+              done < <(node -e '
+                const manifest = require("./npm-publish-manifest.json")
+                for (const pkg of manifest.packages) {
+                  console.log([pkg.name, pkg.version].join("\t"))
+                }
+              ')
+              if [ -n "$unseen" ]; then
+                echo "::error::Refusing to publish the wrapper: platform package(s) not visible:$unseen" >&2
+                failed="$failed$unseen (published but not visible)"
+                continue
+              fi
             fi
 
             public_sha=$(npm view "$name@$version" dist.shasum 2>/dev/null | tr -d '[:space:]' || true)

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1524,7 +1524,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Tag-last core (cut-release mode only): every build leg is green and all
-  # nine exact npm tarballs are public + registry-verified, so NOW create the
+  # every exact npm tarball is public + registry-verified, so NOW create the
   # tag + GitHub Release. Release notes are cut from changelog.d/
   # fragments — same contract as scripts/cut_release_notes.sh, whose
   # --notes-only mode this job calls. The fragment-removal commit stays a
@@ -2152,7 +2152,7 @@ jobs:
   #
   # Uses OIDC / Trusted Publishers (no npm login, long-lived NPM_TOKEN, or
   # GitHub Environment). release-packages.yml is the one publisher identity
-  # shared by all nine @perryts/* packages.
+  # shared by every @perryts/* package.
   # ---------------------------------------------------------------------------
   npm-publish:
     # The irreversible leg. Every build must be green in canonical cut-release
@@ -2240,12 +2240,56 @@ jobs:
       - name: Bundle exact npm publication proofs
         run: |
           set -euo pipefail
-          mapfile -t proofs < <(find npm -mindepth 2 -maxdepth 2 -type f -name '*.tgz' | sort)
-          if [ "${#proofs[@]}" -ne 9 ]; then
-            echo "::error::Expected 9 exact npm tarballs; found ${#proofs[@]}." >&2
-            printf '  %s\n' "${proofs[@]}" >&2
+          # The expected set is DERIVED from the manifest the previous step
+          # generates from ALL_PACKAGES (scripts/publish/constants.mts) and
+          # already validates against it. This used to hardcode `9`, which went
+          # silently wrong when the musl legs were dropped pending #9382:
+          # ALL_PACKAGES became 6 platforms + wrapper = 7, stage-npm staged 6,
+          # prepare-ci-packages packed 7 and PASSED its own check -- and then
+          # this step failed the release with "Expected 9; found 7" AFTER a
+          # fully green 14-leg build (run 34438751300). Two expressions of the
+          # same fact, one of which nobody updated.
+          #
+          # Checked BY NAME, not by a count: a count cannot say WHICH package is
+          # missing, and that is the whole question when this fires. The count
+          # equality below still catches a stray EXTRA tarball.
+          # `while read` rather than `mapfile`: mapfile is bash 4+, and keeping
+          # this to bash 3.2 means it can be run and tested on a developer
+          # machine instead of only on a runner. This step failed a release once
+          # already; an untestable version of it is not an improvement.
+          proofs=()
+          while IFS= read -r line; do proofs+=("$line"); done \
+            < <(find npm -mindepth 2 -maxdepth 2 -type f -name '*.tgz' | sort)
+          want=()
+          while IFS= read -r line; do want+=("$line"); done < <(node -e '
+            const m = require("./npm-publish-manifest.json")
+            for (const p of m.packages) {
+              console.log(p.name.replace(/^@/, "").replace(/\//g, "-") + "-" + p.version + ".tgz")
+            }
+          ')
+          if [ "${#want[@]}" -lt 2 ]; then
+            echo "::error::manifest lists ${#want[@]} package(s); refusing to publish a set that small." >&2
             exit 1
           fi
+          missing=""
+          for w in ${want[@]+"${want[@]}"}; do
+            hit=0
+            for p in ${proofs[@]+"${proofs[@]}"}; do
+              if [ "$(basename "$p")" = "$w" ]; then hit=1; break; fi
+            done
+            if [ "$hit" -eq 0 ]; then missing="$missing $w"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::manifest package(s) have no packed tarball:$missing" >&2
+            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            exit 1
+          fi
+          if [ "${#proofs[@]}" -ne "${#want[@]}" ]; then
+            echo "::error::found ${#proofs[@]} tarball(s) but the manifest lists ${#want[@]}; an unexpected tarball is present." >&2
+            printf '  on disk: %s\n' "${proofs[@]}" >&2
+            exit 1
+          fi
+          echo "${#want[@]} exact tarballs match the manifest by name."
           tar -cf npm-publish-package-proofs.tar \
             npm-publish-manifest.json socket-scan-receipt.json "${proofs[@]}"
 
@@ -2310,7 +2354,7 @@ jobs:
             exit 1
           fi
 
-      - name: Verify all nine public registry shasums
+      - name: Verify every public registry shasum
         # npm's CDN can lag a successful PUT. Wait briefly, but a different
         # sha1 fails immediately because published versions are immutable.
         run: |
@@ -2335,7 +2379,7 @@ jobs:
               }
             ')
             if [ -z "$waiting" ]; then
-              echo "All nine exact npm tarballs are public and verified. The tag may now be created."
+              echo "Every exact npm tarball is public and verified. The tag may now be created."
               break
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1625,7 +1625,21 @@ jobs:
           # and the old unconditional abort made the job permanently
           # unrerunnable. That is exactly what happened in run 34451289395.
           # Abort only if the tag points somewhere else.
-          existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          # Gate on gh's EXIT STATUS, not its stdout: on a 404 `gh api` prints
+          # the error JSON to STDOUT and exits non-zero, so capturing stdout
+          # with `|| true` yields `{"message":"Not Found",...}` rather than an
+          # empty string. That made the "tag exists at a different SHA" branch
+          # fire on the NORMAL path (tag absent) and aborted v0.5.1520's
+          # create-release with `already exists at {"message":"Not Found"...}`.
+          existing=""
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          fi
+          # Belt and braces: only a 40-char hex string is a SHA.
+          case "$existing" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+            *) existing="" ;;
+          esac
           reuse_tag=0
           if [ -n "$existing" ]; then
             if [ "$existing" != "$SHA" ]; then

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -244,17 +244,26 @@ jobs:
               return 1
             }
             plumbing_only() {
-              local files="$1" f bad=""
-              [ -z "$files" ] && return 1
-              while IFS= read -r f; do
-                [ -z "$f" ] && continue
-                case "$f" in
-                  changelog.d/*|scripts/linux-*.Dockerfile|.github/workflows/release-packages.yml) ;;
-                  *) bad="$bad $f" ;;
-                esac
-              done <<< "$files"
-              [ -n "$bad" ] && { echo "    rejected — not release-plumbing:$bad"; return 1; }
-              return 0
+              # The compare API caps files at 300, even with pagination. At
+              # that boundary completeness is unknown: require the exact SHA.
+              # A rename must also allow its OLD path, or moving code into
+              # changelog.d/ would hide its removal from the tested tree.
+              jq -e --arg base "$2" '
+                def allowed:
+                  type == "string" and
+                  (test("(^/|[\\\\\\r\\n]|(^|/)\\.\\.?(/|$)|//)") | not) and
+                  (test("^changelog[.]d/[^/]+.*$") or
+                   test("^scripts/linux-[^/]+[.]Dockerfile$") or
+                   . == ".github/workflows/release-packages.yml");
+                .status == "ahead" and .behind_by == 0 and
+                .base_commit.sha == $base and .merge_base_commit.sha == $base and
+                (.files | type == "array" and length > 0 and length < 300) and
+                all(.files[];
+                  (.filename | allowed) and
+                  (.status == "added" or .status == "modified" or
+                   .status == "removed" or
+                   (.status == "renamed" and (.previous_filename | allowed))))
+              ' <<< "$1" >/dev/null
             }
             if gate_green "$SHA"; then
               echo "gate: exact SHA $SHA already has a green full-suite-gate."
@@ -263,10 +272,10 @@ jobs:
               for cand in $(gh api "/repos/$REPO/commits?sha=$SHA&per_page=15" --jq '.[].sha' 2>/dev/null | tail -n +2); do
                 gate_green "$cand" || continue
                 echo "  ancestor $cand has a green full-suite-gate; comparing trees"
-                files=$(gh api "/repos/$REPO/compare/$cand...$SHA" --jq '.files[]?.filename' 2>/dev/null)
-                if plumbing_only "$files"; then
+                comparison=$(gh api "/repos/$REPO/compare/$cand...$SHA" 2>/dev/null) || continue
+                if plumbing_only "$comparison" "$cand"; then
                   echo "    accepted — diff is release-plumbing only:"
-                  echo "$files" | sed 's/^/      /'
+                  jq -r '.files[].filename | "      " + .' <<< "$comparison"
                   GATE_SHA="$cand"
                   break
                 fi
@@ -286,17 +295,24 @@ jobs:
             # nightly. The /release skill dispatches cut_release runs on a
             # pinned release/vX.Y.Z branch for exactly that reason.
             for wf_file in "test.yml" "simctl-tests.yml"; do
+              # Only test.yml may reuse the ancestor. Simulator tests still
+              # run on the candidate, which is where dispatch below runs them.
+              WF_SHA="$SHA"
+              if [ "$wf_file" = "test.yml" ]; then
+                WF_SHA="$GATE_SHA"
+                [ "$GATE_SHA" != "$SHA" ] && continue
+              fi
               # test.yml: only a FULL-tier run counts (see the poll below), so
               # look for one of those rather than any run on the SHA -- a
               # push-to-main sweep on the same commit must not suppress the
               # dispatch.
               if [ "$wf_file" = "test.yml" ]; then
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$WF_SHA&per_page=20" \
                   --jq '[.workflow_runs[] | select(.event == "workflow_dispatch" or .event == "schedule" or .event == "push" and (.head_branch | startswith("v")))] | length')
               else
                 count=$(gh api \
-                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=1" \
+                  "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$WF_SHA&per_page=1" \
                   --jq '.total_count')
               fi
               if [ "$count" = "0" ]; then
@@ -308,7 +324,7 @@ jobs:
                   echo "::error::$REF_NAME moved to $tip (this run is on $SHA) — re-dispatch on a branch pinned at the release candidate."
                   exit 1
                 fi
-                echo "No $wf_file run on $GATE_SHA yet — dispatching on $REF_NAME."
+                echo "No $wf_file run on $WF_SHA yet — dispatching on $REF_NAME."
                 if [ "$wf_file" = "test.yml" ]; then
                   # The tiered CI workflow: `tier=full` is its dispatch default,
                   # but say so explicitly -- this is the release gate.
@@ -331,6 +347,8 @@ jobs:
           # API error now gets one retry then fails the gate loudly instead
           # of burning the 45-min budget.
           for wf_file in "test.yml" "simctl-tests.yml"; do
+            WF_SHA="$SHA"
+            [ "$wf_file" = "test.yml" ] && WF_SHA="$GATE_SHA"
             echo "::group::Waiting for $wf_file"
             # 120-min budget per workflow.
             # - v0.5.876: 60 → 90 (Tests wall-time grew past 60).
@@ -353,7 +371,7 @@ jobs:
               # Tests run was green, but a tag-triggered Tests run on the
               # same SHA was newer + still running, locking the gate).
               api_out=$(gh api \
-                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$GATE_SHA&per_page=20" \
+                "/repos/$REPO/actions/workflows/$wf_file/runs?head_sha=$WF_SHA&per_page=20" \
                 2>&1)
               rc=$?
               set -e
@@ -1586,7 +1604,7 @@ jobs:
             perry-cross-${{ matrix.target }}.tar.gz.sha256
 
   # ---------------------------------------------------------------------------
-  # Tag-last core (cut-release mode only): every build leg is green and all
+  # Tag-last core (cut-release mode only): every build leg is green and
   # every exact npm tarball is public + registry-verified, so NOW create the
   # tag + GitHub Release. Release notes are cut from changelog.d/
   # fragments — same contract as scripts/cut_release_notes.sh, whose
@@ -1632,14 +1650,24 @@ jobs:
           # fire on the NORMAL path (tag absent) and aborted v0.5.1520's
           # create-release with `already exists at {"message":"Not Found"...}`.
           existing=""
-          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
-            existing=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null || true)
+          # One request, including status headers: only an actual 404 means
+          # absent. Authentication/server failures and malformed data must
+          # not fall through to a release write. Annotated tags fail closed.
+          if tag_response=$(gh api --include "repos/$REPO/git/ref/tags/$TAG" \
+               --jq '.object | select(.type == "commit") | .sha' 2>&1); then
+            existing="${tag_response##*$'\n'}"
+            existing="${existing%$'\r'}"
+            if [[ ! "$existing" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::tag $TAG returned no valid commit SHA — aborting." >&2
+              exit 1
+            fi
+          else
+            http_status="${tag_response%%$'\n'*}"
+            if [[ ! "$http_status" =~ ^HTTP/[0-9.]+\ 404([[:space:]]|$) ]]; then
+              echo "::error::could not determine whether tag $TAG exists — aborting." >&2
+              exit 1
+            fi
           fi
-          # Belt and braces: only a 40-char hex string is a SHA.
-          case "$existing" in
-            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
-            *) existing="" ;;
-          esac
           reuse_tag=0
           if [ -n "$existing" ]; then
             if [ "$existing" != "$SHA" ]; then
@@ -2467,44 +2495,9 @@ jobs:
               # waits again. What must never happen is the wrapper going out
               # over a platform that is not really there.
               echo "=== verifying every platform package is visible before publishing the wrapper ==="
-              deadline=$(( $(date +%s) + VISIBILITY_WAIT_MIN * 60 ))
-              unseen=""
-              while IFS=$'\t' read -r pname pversion; do
-                [ "$pname" = "@perryts/perry" ] && continue
-                seen=0
-                while :; do
-                  if node -e '
-                    const https = require("https")
-                    const [pkg, ver] = process.argv.slice(1)
-                    https.get("https://registry.npmjs.org/" + encodeURIComponent(pkg), res => {
-                      let b = ""
-                      res.on("data", c => b += c)
-                      res.on("end", () => {
-                        try {
-                          const t = JSON.parse(b).time || {}
-                          process.exit(t[ver] ? 0 : 1)
-                        } catch { process.exit(1) }
-                      })
-                    }).on("error", () => process.exit(1))
-                  ' "$pname" "$pversion"; then seen=1; break; fi
-                  if [ "$(date +%s)" -ge "$deadline" ]; then break; fi
-                  sleep 20
-                done
-                if [ "$seen" -eq 1 ]; then
-                  echo "  visible: $pname@$pversion"
-                else
-                  echo "::error::$pname@$pversion still not visible after the ${VISIBILITY_WAIT_MIN}-minute budget — npm scanning may still be running, or the version is staged. Rerun this job to resume." >&2
-                  unseen="$unseen $pname@$pversion"
-                fi
-              done < <(node -e '
-                const manifest = require("./npm-publish-manifest.json")
-                for (const pkg of manifest.packages) {
-                  console.log([pkg.name, pkg.version].join("\t"))
-                }
-              ')
-              if [ -n "$unseen" ]; then
-                echo "::error::Refusing to publish the wrapper: platform package(s) not visible:$unseen" >&2
-                failed="$failed$unseen (published but not visible)"
+              if ! node scripts/publish/platform-visibility.mjs npm-publish-manifest.json; then
+                echo "::error::Refusing to publish the wrapper: platform visibility verification failed. Rerun this job to resume." >&2
+                failed="$failed $name@$version (platform visibility failed)"
                 continue
               fi
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1804,7 +1804,21 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Build perry + runtime staticlibs (release)
         env:
@@ -1854,7 +1868,21 @@ jobs:
           save-if: false
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -1936,7 +1964,21 @@ jobs:
           save-if: false
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
       - name: Download shared GC matrix build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -2032,7 +2074,21 @@ jobs:
 
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
 
       - name: Build compiler
@@ -2412,7 +2468,21 @@ jobs:
 
       - name: Install clang
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y clang
 
       - name: Gate native ABI evidence packet
@@ -3324,7 +3394,21 @@ jobs:
 
       - name: Install mysql client (for fixture health probe)
         run: |
-          sudo apt-get update -qq
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update -qq || echo "::warning::apt-get update reported errors; the install below is the real gate"
           sudo apt-get install -y -qq mysql-client
 
       - name: Wait for MySQL service to accept connections
@@ -3609,7 +3693,21 @@ jobs:
       - name: Install GTK4 + GStreamer + Xvfb + PulseAudio headers (Linux)
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt-get update
+          # Third-party sources we never install from can fail `apt-get update`,
+          # which exits non-zero if ANY source fails -- a broken Chrome index has
+          # now reddened jobs that only want clang in three separate runs
+          # (34383689667, 34384580491, 34386043331). Two lessons are baked in here:
+          #
+          #   1. Match by CONTENT, not filename. The ubuntu24/20260907.300 image
+          #      moved these to deb822 `.sources` files, so removing
+          #      `google-chrome.list` removed nothing and the job still failed.
+          #   2. Let the INSTALL be the gate. `apt-get update`'s exit status
+          #      aggregates sources we care about with sources we do not; if the
+          #      packages we came for resolve, the update did its job.
+          if _bad=$(sudo grep -rlE 'dl\.google\.com|packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null); then
+            printf '%s\n' "$_bad" | sudo xargs -r rm -f
+          fi
+          sudo apt-get update || echo "::warning::apt-get update reported errors; the install below is the real gate"
           # libgstreamer1.0-dev + libgstreamer-plugins-base1.0-dev added in
           # v0.5.442 for PR #371 (perry/media streaming playback, #351).
           # gstreamer-sys's build script needs `gstreamer-1.0.pc` findable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,6 +213,11 @@ jobs:
       - name: Validate Windows LLVM runtime npm staging
         run: ./tests/test_stage_npm_windows_llvm.sh
 
+      - name: Release pipeline failure-path regressions
+        run: |
+          python3 tests/test_release_pipeline.py
+          node --test scripts/publish/platform-visibility.test.mjs
+
       - name: Install Rust toolchain
         run: rustup toolchain install nightly-2026-08-20 --profile minimal --component rustfmt --component clippy
       - uses: ./.github/actions/setup-llvm22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1531
+**Current Version:** 0.5.1532
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,7 +5695,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "cc",
  "libc",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "inkwell",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5875,14 +5875,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "serde",
  "serde_json",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1531"
+version = "0.5.1532"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5901,7 +5901,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "clap",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "block2",
  "objc2",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5960,7 +5960,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "chrono",
  "cron",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6026,14 +6026,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6051,7 +6051,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6117,7 +6117,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6126,7 +6126,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "bson",
  "futures-util",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "fancy-regex",
  "notify",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6240,7 +6240,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6249,7 +6249,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6257,7 +6257,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6268,7 +6268,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6306,7 +6306,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6337,7 +6337,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "brotli",
  "flate2",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6451,14 +6451,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6554,14 +6554,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6570,7 +6570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.9",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1531"
+version = "0.5.1532"
 
 [[package]]
 name = "perry-ui-test"
@@ -6674,11 +6674,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1531"
+version = "0.5.1532"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "block2",
  "libc",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6745,7 +6745,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1531"
+version = "0.5.1532"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1531"
+version = "0.5.1532"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/10041-gh-api-tag-existence.md
+++ b/changelog.d/10041-gh-api-tag-existence.md
@@ -1,0 +1,19 @@
+- **`create-release`'s tag check now gates on `gh api`'s exit status, not its
+  stdout.** On a 404, `gh api` prints its error JSON to **stdout** and exits
+  non-zero, so `existing=$(gh api ... || true)` captured
+  `{"message":"Not Found",...}` instead of an empty string. The "tag exists at a
+  different SHA" branch therefore fired on the **normal** path — an absent tag —
+  and aborted v0.5.1520 with the self-refuting message
+  `tag v0.5.1520 already exists at {"message":"Not Found",...}, not the
+  candidate 381045a87`.
+
+  The check now runs `gh api` for its exit status first and only reads
+  `.object.sha` when the ref really exists, plus rejects anything that is not a
+  hex SHA. Verified against the live API in all three states: absent → create,
+  present at the same SHA → reuse, present at a different SHA → abort.
+
+  This one is worth a note on method rather than mechanism. The same commit that
+  introduced this bug also introduced the release-notes cap, and the cap was
+  tested carefully against the real 2.8 MB notes while this branch was never
+  exercised at all. A test that covers the half of a change you were thinking
+  about is not coverage of the change.

--- a/changelog.d/10041-release-gate-audit.md
+++ b/changelog.d/10041-release-gate-audit.md
@@ -10,3 +10,5 @@
   both publication time and the expected immutable hash before releasing the
   wrapper. Failure-path tests run in lint, including an actually stalled local
   HTTP response and proof that failed visibility withholds wrapper publication.
+- Preserve missing-tarball diagnostics with an empty array on Bash 3.2, and
+  correct the historical description of the LLVM apt action's update handling.

--- a/changelog.d/10041-release-gate-audit.md
+++ b/changelog.d/10041-release-gate-audit.md
@@ -1,0 +1,12 @@
+- Harden the release-pipeline fixes during merge audit. Ancestor reuse rejects
+  comparisons at the API's 300-file completeness boundary, non-ancestor results,
+  unsafe paths, and renames whose old path is not release plumbing. Simulator
+  tests always dispatch and poll the candidate, even when the main full-suite
+  gate is reused from an ancestor.
+- Read tag state once, accept only a valid 40-character commit SHA, and treat
+  only HTTP 404 as absence; API failures cannot fall through to publication.
+- Bound each npm visibility request, including response-body reads, by the
+  remaining shared deadline. Poll unresolved packages round-robin and require
+  both publication time and the expected immutable hash before releasing the
+  wrapper. Failure-path tests run in lint, including an actually stalled local
+  HTTP response and proof that failed visibility withholds wrapper publication.

--- a/changelog.d/9666-await-tests-ancestor-gate.md
+++ b/changelog.d/9666-await-tests-ancestor-gate.md
@@ -1,0 +1,26 @@
+- **`await-tests` can accept an already-validated ancestor's gate when the only
+  difference is release plumbing.** `test.yml` does not build the glibc image,
+  read `changelog.d/`, or run `release-packages.yml` — so a candidate that
+  differs from a green ancestor *only* in those files is already covered by that
+  ancestor's `full-suite-gate`. Re-running a ~5 h tier to re-prove untouched code
+  is pure latency, and this campaign paid it four separate times over one
+  Dockerfile.
+
+  Fail-closed by construction:
+
+  - the file list comes from **GitHub's compare API**, computed from the commits
+    themselves — never from a dispatch input;
+  - **any** path outside the allowlist keeps the exact-SHA requirement;
+  - an **empty** diff is refused, since it should be impossible here and would
+    mean the comparison did not do what we think;
+  - **`.github/workflows/test.yml` is deliberately not allowlisted** — changing
+    the tier's own definition must re-run the tier.
+
+  Allowlist: `changelog.d/**`, `scripts/linux-*.Dockerfile`,
+  `.github/workflows/release-packages.yml`.
+
+  Verified against the live repo before landing: on pin `3216910e19` the resolver
+  selects ancestor `49132f00cd` (whose gate is green) because the diff is exactly
+  `changelog.d/9665-…md` + `scripts/linux-glibc-2.31.Dockerfile`. Sabotage-checked
+  in the other direction too — a single `crates/**` file, `test.yml`, `Cargo.toml`,
+  a path-traversal string, or an empty diff each force the exact-SHA gate.

--- a/changelog.d/9669-drop-unused-apt-sources.md
+++ b/changelog.d/9669-drop-unused-apt-sources.md
@@ -1,0 +1,36 @@
+- **`apt-get update` no longer gates CI jobs on third-party mirrors we never
+  install from.** GitHub's Ubuntu images ship Chrome and Microsoft apt sources,
+  and `apt-get update` exits non-zero if **any** source fails. On 2026-09-09
+  `dl.google.com`'s chrome-stable index served a `Hash Sum mismatch` and
+  reddened the release tier three times running — 22 jobs in run 34383689667,
+  then `Install clang` and `Install mysql client` in runs 34384580491 and
+  34386043331. None of those jobs want Chrome.
+
+  Ten sites now do two things: the 7 `apt-get update`s in `test.yml`, the 2 in
+  `release-packages.yml`'s `build` job (the release critical path), and
+  `setup-llvm22`.
+
+  1. **Drop the unused sources by CONTENT, not filename.** The first attempt
+     removed `google-chrome.list` and changed nothing, because image
+     `ubuntu24/20260907.300` has moved these to deb822 `.sources` files. The log
+     shows the `rm` running and Chrome being fetched 0.2 s later.
+  2. **Let the install be the gate.** `apt-get update`'s exit status aggregates
+     sources we depend on with sources we do not, so it cannot answer the
+     question we care about. The update is advisory; the `apt-get install` that
+     follows decides. That is why `setup-llvm22` stayed green through all three
+     outages while its neighbours failed — it already verified by reaching for
+     what it came for.
+
+  The removal is written as an `if` rather than `... || true`, because
+  `scripts/gc_gate_wiring_check.py` rightly rejects `|| true` inside the
+  `gc-stress` jobs and cannot distinguish a benign swallow from a real one. An
+  `if` CONDITION is exempt from `set -e`, so the guard is safe under `-e` and
+  `pipefail` while suppressing nothing. Verified under both, including the
+  no-match and missing-directory cases.
+
+  Two things worth recording, because each cost a five-hour tier. The Chrome
+  repo returned **200 from a developer machine** while runners kept failing, so
+  "it has cleared" was wrong twice — a third-party mirror's health has to be
+  judged from where the job runs. And matching by name rather than by cause
+  failed here for the third time in this workstream, after an apt pin glob
+  missed `libllvm22` and a `KNOWN_FAIL` name list missed a renamed test.

--- a/changelog.d/9669-drop-unused-apt-sources.md
+++ b/changelog.d/9669-drop-unused-apt-sources.md
@@ -17,9 +17,9 @@
   2. **Let the install be the gate.** `apt-get update`'s exit status aggregates
      sources we depend on with sources we do not, so it cannot answer the
      question we care about. The update is advisory; the `apt-get install` that
-     follows decides. That is why `setup-llvm22` stayed green through all three
-     outages while its neighbours failed — it already verified by reaching for
-     what it came for.
+     follows decides. `setup-llvm22` previously depended on
+     `sudo apt-get update -qq`; this change introduces its package-resolution
+     fallback when the update fails.
 
   The removal is written as an `if` rather than `... || true`, because
   `scripts/gc_gate_wiring_check.py` rightly rejects `|| true` inside the

--- a/changelog.d/9670-derive-npm-tarball-set.md
+++ b/changelog.d/9670-derive-npm-tarball-set.md
@@ -1,0 +1,33 @@
+- **The release's tarball check now derives its expected set from the publish
+  manifest instead of a hardcoded `9`.** v0.5.1519 failed to publish after a
+  fully green 14-leg build (run 34438751300) with
+  `Expected 9 exact npm tarballs; found 7`.
+
+  Nothing was wrong with the build. When the musl legs were dropped pending
+  #9382, `PLATFORM_PACKAGES` in `scripts/publish/constants.mts` was correctly
+  trimmed to 6, so `ALL_PACKAGES` is 6 platforms + 1 wrapper = 7.
+  `prepare-ci-packages.mts` packed 7 and **passed its own check against
+  `ALL_PACKAGES`** — and then `release-packages.yml`'s separate hardcoded `9`
+  rejected the same set one step later. Two expressions of one fact, and only
+  one of them was updated. The publish step never ran, so nothing reached the
+  registry, no tag was cut, and the version was not burned.
+
+  The check now reads the manifest that the previous step generates from
+  `ALL_PACKAGES`, and matches **by name** rather than by count — a count cannot
+  say *which* package is missing, which is the only question worth asking when
+  this fires. A missing tarball now reports
+  `manifest package(s) have no packed tarball: perryts-perry-linux-arm64-…tgz`.
+  Count equality is still asserted so a stray extra tarball fails too, and a
+  manifest of fewer than two packages is refused outright.
+
+  Written with `while read` rather than `mapfile` so it runs on bash 3.2 and can
+  be exercised on a developer machine, not only on a runner. It was tested
+  against five cases before shipping — all present; one platform missing; a
+  stray extra; a too-small manifest; and the real-world shape with stale empty
+  `npm/perry-linux-*-musl` directories still on disk. A step that has already
+  failed one release does not deserve to be shipped untested a second time.
+
+  Note for follow-up: the doc comments in `constants.mts` still say "The 8
+  platform packages" and "All 9" above 6- and 7-element arrays. They are stale
+  in exactly the way that caused this, but correcting them touches a
+  non-plumbing path, so they are left for a normal PR rather than a release pin.

--- a/changelog.d/9672-verify-platform-visibility-before-wrapper.md
+++ b/changelog.d/9672-verify-platform-visibility-before-wrapper.md
@@ -27,3 +27,12 @@
   Probe validated against live registry data, including the exact failing case:
   the five packages that really published read visible, and the staged
   linux-x64 reads not-visible.
+
+  The wait is a **single 45-minute budget across all platform packages**, not a
+  short per-package one. npm's own delay notice says a large upload "may take
+  longer than usual" and allows itself 24 hours, and the packages settle in
+  parallel — so a tight per-package timeout would fail the *normal* slow case
+  while adding nothing against the broken one. Timing out is safe and resumable:
+  the platform packages are already published, so a rerun skips them on matching
+  sha1 and waits again. Publishing the wrapper too early is the step that cannot
+  be undone, because npm versions are immutable.

--- a/changelog.d/9672-verify-platform-visibility-before-wrapper.md
+++ b/changelog.d/9672-verify-platform-visibility-before-wrapper.md
@@ -13,7 +13,7 @@
   to 0.5.1520.
 
   Before the wrapper is published, each platform package is now confirmed present
-  in the registry (up to 5 minutes each, polling). The check reads the
+  in the registry (one shared 45-minute budget, polling). The check reads the
   packument's **`time` map**, which was the only signal that told the truth here:
   `npm view` returned nothing and the publish exit status returned success for a
   version npm had no record of. A package that never appears blocks the wrapper

--- a/changelog.d/9672-verify-platform-visibility-before-wrapper.md
+++ b/changelog.d/9672-verify-platform-visibility-before-wrapper.md
@@ -1,0 +1,29 @@
+- **The release refuses to publish the npm wrapper until every platform package
+  is actually visible in the registry.** npm can report a successful publish
+  that never lands: on 2026-09-10 it printed
+  `+ @perryts/perry-linux-x64@0.5.1519`, exited 0 and signed provenance into
+  sigstore, while leaving the version **staged** — invisible (404, absent from
+  the packument's `time` map) and un-republishable (`E409 Cannot publish over
+  previously staged version` on every retry, including after an `npm unpublish`).
+
+  The wrapper's existing guard keyed on `npm publish`'s exit status, so it was
+  satisfied by that false success and `@perryts/perry@0.5.1519` shipped as
+  `latest` with a platform dependency that does not resolve on linux-x64. The
+  version could not then be completed from our side at all, and the release moved
+  to 0.5.1520.
+
+  Before the wrapper is published, each platform package is now confirmed present
+  in the registry (up to 5 minutes each, polling). The check reads the
+  packument's **`time` map**, which was the only signal that told the truth here:
+  `npm view` returned nothing and the publish exit status returned success for a
+  version npm had no record of. A package that never appears blocks the wrapper
+  and fails the job.
+
+  The failure mode this prevents is specifically the bad one. A publish that
+  fails loudly costs a rerun; a publish that half-lands puts a broken `latest` in
+  front of users and burns the version number, because npm versions are
+  immutable and the staged slot rejects retries.
+
+  Probe validated against live registry data, including the exact failing case:
+  the five packages that really published read visible, and the staged
+  linux-x64 reads not-visible.

--- a/changelog.d/9673-release-notes-cap-and-tag-reuse.md
+++ b/changelog.d/9673-release-notes-cap-and-tag-reuse.md
@@ -1,0 +1,21 @@
+- **The release body is capped, and a tag left behind by a failed attempt no
+  longer wedges the job.** `create-release` failed v0.5.1519 with
+  `HTTP 422: body is too long (maximum is 125000 characters)`. The notes are
+  generated from `changelog.d/`, and this release carries **1505 fragments** —
+  the first tag since v0.5.1220 on 2026-07-04 — producing **2.8 MB** of notes,
+  22× GitHub's limit.
+
+  Two things made that worse than a simple failure. `gh release create` creates
+  the tag and *then* POSTs the release, so the 422 left `v0.5.1519` pointing at
+  the right commit with no release attached. And the guard above it aborted
+  unconditionally on any existing tag, so every retry then died on the debris of
+  the first attempt — the job could not succeed again by any path.
+
+  Now: the body is truncated on a line boundary to 120,000 characters with a
+  pointer to `changelog.d/` at the tag, and an existing tag is reused when it
+  points at **exactly** the candidate SHA (still a hard error when it points
+  anywhere else, which is the case the guard was written for).
+
+  This would have blocked every release with a large fragment backlog, not just
+  this one. Verified against the real 2.8 MB notes: the result is 120,221 bytes
+  and ends cleanly.

--- a/scripts/publish/platform-visibility.mjs
+++ b/scripts/publish/platform-visibility.mjs
@@ -1,0 +1,86 @@
+// Read-only gate before the irreversible wrapper publication. A publish exit
+// status is insufficient: npm can hold a successful upload in scanning limbo.
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { setTimeout as sleep } from "node:timers/promises";
+
+export function platformPackages(manifest) {
+  const packages = manifest?.packages;
+  if (!Array.isArray(packages) || packages.length < 2 ||
+      packages.filter(p => p.name === "@perryts/perry").length !== 1 ||
+      new Set(packages.map(p => p.name)).size !== packages.length ||
+      packages.some(p => typeof p.name !== "string" ||
+        typeof p.version !== "string" || !p.version ||
+        !/^[0-9a-f]{40}$/.test(p.sha1))) {
+    throw new Error("Invalid npm publication manifest");
+  }
+  return packages.filter(p => p.name !== "@perryts/perry");
+}
+
+export async function waitForPlatforms(packages, {
+  budgetMs = 45 * 60_000,
+  requestMs = 15_000,
+  intervalMs = 20_000,
+  fetchImpl = fetch,
+  now = Date.now,
+  pause = sleep,
+  log = console.log,
+} = {}) {
+  if (!packages.length || !Number.isFinite(budgetMs) || budgetMs <= 0 ||
+      !Number.isFinite(requestMs) || requestMs <= 0 ||
+      !Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new Error("Invalid platform visibility budget or package set");
+  }
+  const deadline = now() + budgetMs;
+  let pending = [...packages];
+  while (pending.length && now() < deadline) {
+    const unseen = [];
+    for (const pkg of pending) {
+      const remaining = deadline - now();
+      if (remaining <= 0) {
+        unseen.push(pkg);
+        continue;
+      }
+      let visible = false;
+      try {
+        // Abort bounds the entire fetch AND body read, including a connected
+        // server that never finishes its response, not just socket inactivity.
+        const response = await fetchImpl(
+          "https://registry.npmjs.org/" + encodeURIComponent(pkg.name),
+          { signal: AbortSignal.timeout(Math.max(1, Math.floor(Math.min(requestMs, remaining)))) },
+        );
+        if (response.ok) {
+          const body = await response.json();
+          visible = Boolean(body.time?.[pkg.version]) &&
+            body.versions?.[pkg.version]?.dist?.shasum === pkg.sha1;
+        } else {
+          await response.body?.cancel();
+        }
+      } catch {
+        // A failed/aborted request is unseen, never permission to publish.
+      }
+      if (visible && now() <= deadline) log(`  visible: ${pkg.name}@${pkg.version}`);
+      else unseen.push(pkg);
+    }
+    pending = unseen;
+    if (pending.length && now() < deadline) {
+      await pause(Math.min(intervalMs, deadline - now()));
+    }
+  }
+  if (pending.length) {
+    throw new Error("Platform visibility budget expired: " +
+      pending.map(p => `${p.name}@${p.version}`).join(", "));
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const manifest = JSON.parse(await readFile(process.argv[2], "utf8"));
+    await waitForPlatforms(platformPackages(manifest), {
+      budgetMs: Number(process.env.VISIBILITY_WAIT_MIN ?? "45") * 60_000,
+    });
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/publish/platform-visibility.test.mjs
+++ b/scripts/publish/platform-visibility.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { platformPackages, waitForPlatforms } from "./platform-visibility.mjs";
+
+const a = { name: "@perryts/perry-a", version: "1", sha1: "a".repeat(40) };
+const b = { ...a, name: "@perryts/perry-b" };
+const wrapper = { ...a, name: "@perryts/perry" };
+const quiet = { log() {} };
+const visible = pkg => ({ ok: true, json: async () => ({
+  time: { [pkg.version]: "2026-09-11" },
+  versions: { [pkg.version]: { dist: { shasum: pkg.sha1 } } },
+}) });
+
+test("manifest refuses empty, duplicate, missing wrapper, and malformed sets", () => {
+  assert.deepEqual(platformPackages({ packages: [a, wrapper] }), [a]);
+  for (const packages of [[], [a], [a, a, wrapper], [a, b],
+    [{ ...a, sha1: "bad" }, wrapper]]) {
+    assert.throws(() => platformPackages({ packages }));
+  }
+});
+
+test("visible packages pass only with both timestamp and matching immutable hash", async () => {
+  const calls = [];
+  await waitForPlatforms([a, b], { ...quiet, fetchImpl: async url => {
+    calls.push(url);
+    return visible(a);
+  } });
+  assert.equal(calls.length, 2);
+  for (const body of [{}, { time: { 1: "published" } },
+    { versions: { 1: { dist: { shasum: a.sha1 } } } },
+    { time: { 1: "published" }, versions: { 1: { dist: { shasum: "wrong" } } } }]) {
+    let clock = 0;
+    await assert.rejects(waitForPlatforms([a], { ...quiet, budgetMs: 1,
+      now: () => clock, pause: async ms => { clock += ms; },
+      fetchImpl: async () => ({ ok: true, json: async () => body }),
+    }), /budget expired/);
+  }
+});
+
+test("polls round-robin under one shared deadline", async () => {
+  let clock = 0;
+  const calls = [];
+  await assert.rejects(waitForPlatforms([a, b], { ...quiet,
+    budgetMs: 25, intervalMs: 20, now: () => clock,
+    pause: async ms => { clock += ms; },
+    fetchImpl: async url => { calls.push(decodeURIComponent(url)); return { ok: false }; },
+  }), /perry-a@1, @perryts\/perry-b@1/);
+  assert.equal(clock, 25);
+  assert.deepEqual(calls.map(url => url.split("/").at(-1)), ["perry-a", "perry-b", "perry-a", "perry-b"]);
+});
+
+test("one slow package does not hide a visible sibling", async () => {
+  let clock = 0;
+  const calls = [];
+  await waitForPlatforms([a, b], { ...quiet, budgetMs: 50, intervalMs: 20,
+    now: () => clock, pause: async ms => { clock += ms; },
+    fetchImpl: async url => {
+      calls.push(url);
+      return url.endsWith("perry-a") && clock === 0 ? { ok: false } : visible(a);
+    },
+  });
+  assert.equal(calls.length, 3);
+});
+
+test("network failures and invalid budgets cannot permit publication", async () => {
+  for (const budgetMs of [0, -1, NaN, Infinity]) {
+    await assert.rejects(waitForPlatforms([a], { ...quiet, budgetMs }));
+  }
+  let clock = 0;
+  await assert.rejects(waitForPlatforms([a], { ...quiet, budgetMs: 1,
+    now: () => clock, pause: async ms => { clock += ms; },
+    fetchImpl: async () => { throw new Error("network"); },
+  }), /budget expired/);
+});
+
+test("a real stalled HTTP body is aborted inside the shared budget", async () => {
+  let requests = 0;
+  const server = createServer((req, res) => {
+    requests++;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.write('{"time":'); // Deliberately never complete the body.
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const start = Date.now();
+    await assert.rejects(waitForPlatforms([a], { ...quiet,
+      budgetMs: 300, requestMs: 80, intervalMs: 10,
+      fetchImpl: (_url, options) => fetch(`http://127.0.0.1:${server.address().port}`, options),
+    }), /budget expired/);
+    assert.ok(requests > 0, "the stalled server must actually be reached");
+    assert.ok(Date.now() - start < 2000, "request must not escape the deadline");
+  } finally {
+    server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+  }
+});

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -1,0 +1,200 @@
+"""Exercise the actual release workflow shell with read-only API/CLI doubles."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+JOBS = yaml.safe_load((ROOT / '.github/workflows/release-packages.yml').read_text())['jobs']
+SHA, BASE = 'a' * 40, 'b' * 40
+
+
+def step(job, name):
+    return next(s['run'] for s in JOBS[job]['steps'] if s.get('name', '').startswith(name))
+
+
+def shell(script, *args, cwd=ROOT, env=None):
+    return subprocess.run(['bash', '-euo', 'pipefail', '-c', script, 'test', *args],
+                          cwd=cwd, env={**os.environ, **(env or {})},
+                          capture_output=True, text=True, timeout=10)
+
+
+class ReleasePipeline(unittest.TestCase):
+    def test_ancestor_comparison_is_complete_and_safe(self):
+        source = step('await-tests', 'Wait for Tests')
+        function = source[source.index('  plumbing_only() {'):source.index('  if gate_green "$SHA";')]
+        good = dict(status='ahead', behind_by=0, base_commit={'sha': BASE},
+                    merge_base_commit={'sha': BASE},
+                    files=[dict(filename='changelog.d/fix.md', status='added')])
+        cases = [('good', good, True)]
+        for path in ['crates/runtime.rs', '.github/workflows/test.yml', 'Cargo.toml',
+                     'changelog.d/../crates/unsafe.rs', 'changelog.d//x',
+                     'changelog.d/x\ny', 'scripts/linux-x/y.Dockerfile']:
+            cases.append((path, {**good, 'files': [dict(filename=path, status='modified')]}, False))
+        for path in ['scripts/linux-glibc-2.31.Dockerfile', '.github/workflows/release-packages.yml']:
+            cases.append((path, {**good, 'files': [dict(filename=path, status='modified')]}, True))
+        for count in [0, 299, 300, 301]:
+            cases.append((str(count), {**good, 'files': good['files'] * count}, 0 < count < 300))
+        for old, allowed in [('crates/runtime.rs', False), ('changelog.d/old.md', True), (None, False)]:
+            cases.append(('rename ' + str(old), {**good, 'files': [dict(
+                filename='changelog.d/new.md', status='renamed', previous_filename=old)]}, allowed))
+        for patch in [dict(status='diverged'), dict(behind_by=1), dict(files=None),
+                      dict(base_commit={'sha': SHA}), dict(merge_base_commit={'sha': SHA}),
+                      dict(files=[dict(filename='changelog.d/x', status='unknown')])]:
+            cases.append((str(patch), {**good, **patch}, False))
+        for name, data, expected in cases:
+            with self.subTest(name=name):
+                result = shell(function + '\nplumbing_only "$1" "$2"', json.dumps(data), BASE)
+                self.assertEqual(result.returncode == 0, expected, result.stderr)
+        self.assertNotEqual(shell(function + '\nplumbing_only "$1" "$2"', '{bad', BASE).returncode, 0)
+
+    def test_tag_lookup_fails_closed(self):
+        source = step('create-release', 'Create tag')
+        fragment = source[source.index('existing=""'):source.index('./scripts/cut_release_notes.sh')]
+        stub = 'gh() { printf "%s\\n" "$RESPONSE"; return "$RC"; }\n'
+        cases = [(0, 'HTTP/2.0 200 OK\n\n' + SHA, 0, '1'),
+                 (0, 'HTTP/2.0 200 OK\n\n' + BASE, 1, None),
+                 (0, 'HTTP/2.0 200 OK\n\n12345678garbage', 1, None),
+                 (0, 'HTTP/2.0 200 OK\n\n', 1, None),
+                 (1, 'HTTP/2.0 404 Not Found\n\n{"message":"Not Found"}', 0, '0'),
+                 (1, 'HTTP/2.0 403 Forbidden', 1, None),
+                 (1, 'HTTP/2.0 500 Server Error', 1, None),
+                 (1, 'network failure', 1, None)]
+        for rc, response, expected, reuse in cases:
+            with self.subTest(response=response):
+                result = shell(stub + fragment + '\necho "REUSE=$reuse_tag"', env={
+                    'RC': str(rc), 'RESPONSE': response, 'SHA': SHA, 'TAG': 'v0.0.1', 'REPO': 'test/repo'})
+                self.assertEqual(result.returncode, expected, result.stderr)
+                if reuse is not None:
+                    self.assertIn('REUSE=' + reuse, result.stdout)
+
+    def test_ancestor_test_gate_keeps_simulator_on_candidate(self):
+        source = step('await-tests', 'Wait for Tests')
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / 'calls'
+            stub = r'''
+gh() {
+  printf '%s\n' "$*" >> "$CALLS"
+  case "$*" in
+    *'/commits?'*) printf '%s\n%s\n' "$SHA" "$BASE" ;;
+    *'/compare/'*) printf '{"status":"ahead","behind_by":0,"base_commit":{"sha":"%s"},"merge_base_commit":{"sha":"%s"},"files":[{"filename":"changelog.d/fix.md","status":"added"}]}' "$BASE" "$BASE" ;;
+    *'/jobs?'*) echo full-suite-gate ;;
+    *'/git/ref/heads/'*) echo "$SHA" ;;
+    'workflow run simctl-tests.yml'*) echo dispatched ;;
+    *'simctl-tests.yml/runs?'*'per_page=1'*) echo 0 ;;
+    *'simctl-tests.yml/runs?'*) echo '{"workflow_runs":[{"status":"completed","conclusion":"success","html_url":"sim-success"}]}' ;;
+    *"head_sha=$BASE"*) echo '{"workflow_runs":[{"id":42,"status":"completed","conclusion":"success","html_url":"test-success"}]}' ;;
+    *"head_sha=$SHA"*) echo '{"workflow_runs":[]}' ;;
+    *) echo "unexpected gh call: $*" >&2; return 1 ;;
+  esac
+}
+sleep() { echo 'unexpected wait' >&2; exit 99; }
+'''
+            result = shell(stub + source, env={'CALLS': str(log), 'SHA': SHA, 'BASE': BASE,
+                'MODE': 'cut-release', 'REF_NAME': 'release/test', 'REPO': 'test/repo'})
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            calls = log.read_text()
+            self.assertIn('workflow run simctl-tests.yml', calls)
+            self.assertNotIn('workflow run test.yml', calls)
+            sim_queries = [c for c in calls.splitlines() if 'simctl-tests.yml/runs?' in c]
+            self.assertEqual(len(sim_queries), 2)
+            self.assertTrue(all('head_sha=' + SHA in c for c in sim_queries), calls)
+
+    def test_tarball_set_matches_names_not_just_count(self):
+        source = step('npm-publish', 'Bundle exact npm')
+        for names, expected in [(['perryts-perry-a-1.tgz', 'perryts-perry-1.tgz'], 0),
+                                (['perryts-perry-a-1.tgz'], 1),
+                                (['perryts-perry-a-1.tgz', 'wrong-1.tgz'], 1),
+                                (['perryts-perry-a-1.tgz', 'perryts-perry-1.tgz', 'extra.tgz'], 1)]:
+            with self.subTest(names=names), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                package = root / 'npm' / 'fixture'
+                package.mkdir(parents=True)
+                for name in names:
+                    (package / name).touch()
+                (root / 'npm-publish-manifest.json').write_text(json.dumps({'packages': [
+                    {'name': '@perryts/perry-a', 'version': '1'}, {'name': '@perryts/perry', 'version': '1'}]}))
+                (root / 'socket-scan-receipt.json').write_text('{}')
+                result = shell(source, cwd=root)
+                self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+
+    def test_wrapper_is_withheld_when_visibility_fails(self):
+        source = step('npm-publish', 'npm publish exact')
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / 'npm-publish-manifest.json').write_text(json.dumps({'packages': [
+                {'name': '@perryts/perry-a', 'version': '1', 'path': 'platform.tgz', 'sha1': SHA},
+                {'name': '@perryts/perry', 'version': '1', 'path': 'wrapper.tgz', 'sha1': SHA}]}))
+            stub = r'''
+node() {
+  if [ "$1" = scripts/publish/platform-visibility.mjs ]; then return 1; fi
+  command node "$@"
+}
+npm() { printf '%s\n' "$*" >> "$CALLS"; }
+'''
+            result = shell(stub + source, cwd=root, env={'CALLS': str(root / 'calls'),
+                'NPM_TOKEN': '', 'NODE_AUTH_TOKEN': '', 'NPM_AUTH_TOKEN': '', 'DIST_TAG': 'test'})
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            calls = (root / 'calls').read_text()
+            self.assertIn('publish ./platform.tgz', calls)
+            self.assertNotIn('publish ./wrapper.tgz', calls)
+
+    def test_apt_install_still_gates_after_update_failure(self):
+        workflows = [JOBS, yaml.safe_load((ROOT / '.github/workflows/test.yml').read_text())['jobs']]
+        sources = [s['run'] for jobs in workflows for job in jobs.values()
+                   for s in job.get('steps', [])
+                   if 'sudo apt-get update' in s.get('run', '') and '_bad=' in s['run']]
+        action = yaml.safe_load((ROOT / '.github/actions/setup-llvm22/action.yml').read_text())
+        sources += [s['run'] for s in action['runs']['steps']
+                    if 'sudo apt-get update' in s.get('run', '')]
+        self.assertEqual(len(sources), 10, 'exercise every changed apt site')
+        for source in sources:
+            start = source.index('if _bad=')
+            lines = source[start:].splitlines()
+            end = next(i for i, line in enumerate(lines) if 'apt-get install' in line and 'sudo' in line)
+            while lines[end].rstrip().endswith('\\'):
+                end += 1
+            fragment = '\n'.join(lines[:end + 1])
+            for install_rc in [0, 42]:
+                with self.subTest(fragment=fragment, install_rc=install_rc):
+                    stub = r'''
+sudo() {
+  case "$*" in
+    'grep '*) return 1 ;;
+    'apt-get update'*) return 100 ;;
+    *'apt-get install'*) echo INSTALL_REACHED; return "$INSTALL_RC" ;;
+    *) echo "unexpected sudo: $*" >&2; return 99 ;;
+  esac
+}
+apt-cache() { echo 'Candidate: 22.1.4'; }
+sleep() { :; }
+'''
+                    result = shell(stub + fragment, env={'INSTALL_RC': str(install_rc)})
+                    self.assertEqual(result.returncode, install_rc, result.stdout + result.stderr)
+                    self.assertIn('INSTALL_REACHED', result.stdout)
+
+    def test_release_notes_cap_preserves_unicode_and_bounds(self):
+        source = step('create-release', 'Create tag')
+        fragment = source[source.index('LIMIT=120000'):source.index('# Created with GITHUB_TOKEN:')]
+        for body in ['short notes\n', 'Unicode: 日本語\n' * 100000, 'x' * 150000 + '\n']:
+            with self.subTest(size=len(body)), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                (root / 'changelog.d').mkdir()
+                (root / 'release-notes-full.md').write_text(body)
+                result = shell(fragment.replace('/tmp/', tmp + '/'), cwd=root,
+                               env={'TAG': 'v0.0.1', 'REPO': 'test/repo'})
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                actual = (root / 'release-notes.md').read_text()
+                self.assertLess(len(actual.encode()), 125000)
+                if len(body.encode()) > 120000:
+                    self.assertIn('These notes are truncated.', actual)
+                else:
+                    self.assertEqual(actual, body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -107,6 +107,7 @@ sleep() { echo 'unexpected wait' >&2; exit 99; }
     def test_tarball_set_matches_names_not_just_count(self):
         source = step('npm-publish', 'Bundle exact npm')
         for names, expected in [(['perryts-perry-a-1.tgz', 'perryts-perry-1.tgz'], 0),
+                                ([], 1),
                                 (['perryts-perry-a-1.tgz'], 1),
                                 (['perryts-perry-a-1.tgz', 'wrong-1.tgz'], 1),
                                 (['perryts-perry-a-1.tgz', 'perryts-perry-1.tgz', 'extra.tgz'], 1)]:
@@ -121,6 +122,11 @@ sleep() { echo 'unexpected wait' >&2; exit 99; }
                 (root / 'socket-scan-receipt.json').write_text('{}')
                 result = shell(source, cwd=root)
                 self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+                if expected:
+                    self.assertIn('  on disk:', result.stderr)
+                    self.assertNotIn('unbound variable', result.stderr)
+                    for name in names:
+                        self.assertIn('npm/fixture/' + name, result.stderr)
 
     def test_wrapper_is_withheld_when_visibility_fails(self):
         source = step('npm-publish', 'npm publish exact')

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -179,7 +179,7 @@ sleep() { :; }
 
     def test_release_notes_cap_preserves_unicode_and_bounds(self):
         source = step('create-release', 'Create tag')
-        fragment = source[source.index('LIMIT=120000'):source.index('# Created with GITHUB_TOKEN:')]
+        fragment = source[source.index('LIMIT='):source.index('# Created with GITHUB_TOKEN:')]
         for body in ['short notes\n', 'Unicode: 日本語\n' * 100000, 'x' * 150000 + '\n']:
             with self.subTest(size=len(body)), tempfile.TemporaryDirectory() as tmp:
                 root = Path(tmp)


### PR DESCRIPTION
## Scope

Audited merge train for #10041 (eight author commits, pinned at
`812682297dfb2c603f4bbb40cf9991e1b9de52b6`). Preserves their authorship via
cherry-pick and rebase merge. Version 0.5.1532; no compiler/runtime source changes.

Includes the apt mirror resilience, manifest-derived tarball set, visibility
guard before npm wrapper publication, capped release notes, same-SHA tag reuse,
and release-plumbing-only ancestor test-gate reuse.

## Merge-audit fixes

- Reject incomplete (300+ files), non-ancestor, malformed, or unsafe compare
  evidence; inspect both rename paths before allowing ancestor reuse.
  The completeness bound follows [GitHub's compare API documentation](https://docs.github.com/en/rest/commits/commits#compare-two-commits).
- Keep simulator dispatch AND polling on the candidate SHA while test.yml alone
  may reuse the validated ancestor.
- One tag lookup: validate the complete 40-hex commit SHA and treat only HTTP404
  as absence. API/authentication failures cannot fall through to a release write.
- Bound npm requests and body reads by the remaining shared deadline. Poll
  unresolved platforms round-robin and require publication time plus the expected
  immutable hash before the wrapper can publish.
- Wire focused failure-path regression tests into lint; correct stale wait prose.
- Preserve empty-tarball diagnostics on Bash 3.2 and correct the historical apt
  fallback description. Both final review findings were independently verified;
  the new empty-set assertion failed before the fix and passed afterward.

## Validation

- PASS: seven Python workflow tests covering extracted production shell, ten apt
  install sites, compare evidence/renames, API errors, simulator SHA selection,
  tarball name sets, wrapper withholding, Unicode/oversized notes.
- PASS: six Node visibility tests including a real unfinished loopback HTTP body
  with a live-request assertion and explicit socket cleanup.
- PASS: deliberate bypass controls for compare cap, rename provenance, simulator
  SHA, API errors, wrapper visibility, notes cap, visibility acceptance, request
  timeout. Sabotages never modified committed production source.
- PASS: live read-only tag API checks for absent/same/different SHA; actionlint
  syntax/expression validation; formatting, file cap, raw-handle no-raise check.
- PASS: four serial release suites: runtime 3524 passed (4 ignored), codegen
  1956 regular plus 3 doc tests passed (6 ignored), HIR 639 passed (3 ignored),
  stdlib 134 passed. Rust/Cargo inputs are unchanged by the final review fix.
- PASS: standalone default-feature stdlib check and runtime tests checked with
  both regex-engine and wasm-host features.
- Final full lint: 81/82 PASS; only the confirmed baseline benchmark-freshness
  failure. Product/host strict warning checks, Clippy, and both API-docs checks
  pass. Cargo exit codes were captured directly, not through pipelines.
- PASS: final matched release build of compiler, runtime, stdlib, both static
  wrappers, and all six extension packages with external-net-pump. Final native
  smoke links/runs successfully (runtime-only link path); archive hashes retained.
- Validated head `551deb22c654972e084eb35e52cbf1b22caa8f23`, clean committed tree
  `5afee2b5b4d70cf3c16891788b317f67b2d3d2b3`. All eight author patches are present.

## CI attribution

- Original lint: inherited public benchmark freshness failure.
- Original cargo-test: `native_stack::tests::stack_top_respects_custom_thread_stack_sizes`
  (`bound must belong to this worker`) also fails on exact base `1a9c0de6c`,
  run 34539173487/job 103077746917, same 3504 passed/1 failed/4 ignored.
- Original zizmor: same `dangerous-triggers` finding in `gate-failure-watch.yml`
  reproduced byte-for-byte with pinned zizmor1.28.0 offline against pristine
  base and train. No new offline high-severity finding.
- All eight failed original CheckRuns were attributed to exact-base evidence:
  the above three failures, four gap shards (seven identical named regressions
  and printed diagnostics), and their `pr-gate` fan-in.
- Final train head `551deb22c`: zizmor, lint and cargo-test failures are likewise
  attributed to the same exact-base evidence. Remaining checks are pending;
  no all-green claim, and skipped/queued work is not counted as test coverage.

No attached Fixes/Closes issues found in #10041 metadata, body, or commit bodies.
The original PR will be closed with a pointer after landing and content verification.
No npm publication, tag creation, or release dispatch was performed during audit.
