### PR TITLE
fix(codegen): initialize missing cells in reused boxed declarations

### DIFF
--- a/changelog.d/10049-generator-continuation-preallocation.md
+++ b/changelog.d/10049-generator-continuation-preallocation.md
@@ -1,11 +1,11 @@
 Fix captured local callbacks becoming undefined after `yield*` inside an async
-generator loop (#10048). Each emitted preallocation directive now initializes
-its own control-flow path, reusing an existing local slot without confusing
-emitted storage with an executed initialization. Scope re-entry gets a fresh
-cell while retained closures keep their original cells. Module-global
-precedence, TDZ initialization, and specialized async control cells are kept.
+generator loop (#10048). The reused boxed-declaration path now initializes a
+missing cell before evaluating its initializer, without confusing an existing
+stack slot with an executed box allocation. Existing live cells are retained,
+preserving shared hoisted-var bindings. Module globals and preallocated cells
+remain on their existing paths; specialized async control cell types are kept.
 
-Adds fail-before/pass-after codegen coverage for ordinary and TDZ continuation
+Adds codegen coverage for initialized and uninitialized boxed declaration
 copies, plus independent native parity fixtures for delegated loops, retained
 iteration callbacks, empty delegates, ordinary yield/await, recursion, TDZ,
 and shared hoisted-var bindings.

--- a/changelog.d/10049-generator-continuation-preallocation.md
+++ b/changelog.d/10049-generator-continuation-preallocation.md
@@ -1,0 +1,11 @@
+Fix captured local callbacks becoming undefined after `yield*` inside an async
+generator loop (#10048). Each emitted preallocation directive now initializes
+its own control-flow path, reusing an existing local slot without confusing
+emitted storage with an executed initialization. Scope re-entry gets a fresh
+cell while retained closures keep their original cells. Module-global
+precedence, TDZ initialization, and specialized async control cells are kept.
+
+Adds fail-before/pass-after codegen coverage for ordinary and TDZ continuation
+copies, plus independent native parity fixtures for delegated loops, retained
+iteration callbacks, empty delegates, ordinary yield/await, recursion, TDZ,
+and shared hoisted-var bindings.

--- a/crates/perry-codegen/src/stmt/boxed_continuation_tests.rs
+++ b/crates/perry-codegen/src/stmt/boxed_continuation_tests.rs
@@ -1,27 +1,43 @@
-//! #10048: emitting an earlier branch does not initialize a sibling branch.
+//! #10048: a boxed Let's earlier emitted copy may never execute on this path.
 use perry_hir::types::Type;
 use perry_hir::{Expr, Function, Module, Param, Stmt};
 
-fn branch(tdz: bool) -> Vec<Stmt> {
+fn branch(initialized: bool) -> Vec<Stmt> {
     vec![
-        if tdz {
-            Stmt::PreallocateTdzBoxes(vec![101])
-        } else {
-            Stmt::PreallocateBoxes(vec![101])
-        },
         Stmt::Let {
             id: 101,
             name: "callback".into(),
             ty: Type::Any,
             mutable: true,
-            init: Some(Expr::Integer(40)),
+            init: initialized.then_some(Expr::Integer(40)),
+        },
+        Stmt::Let {
+            id: 102,
+            name: "writer".into(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Closure {
+                func_id: 2,
+                params: Vec::new(),
+                return_type: Type::Any,
+                body: vec![Stmt::Expr(Expr::LocalSet(101, Box::new(Expr::Integer(42))))],
+                captures: vec![101],
+                mutable_captures: vec![101],
+                captures_this: false,
+                captures_new_target: false,
+                enclosing_class: None,
+                is_arrow: true,
+                is_async: false,
+                is_generator: false,
+                is_strict: true,
+            }),
         },
         Stmt::Return(Some(Expr::LocalGet(101))),
     ]
 }
 
-fn assert_each_continuation_allocates(tdz: bool) {
-    let mut module = Module::new("prealloc_continuation.ts");
+fn assert_each_continuation_allocates(initialized: bool) {
+    let mut module = Module::new("boxed_continuation.ts");
     module.functions.push(Function {
         id: 1,
         name: "resume".into(),
@@ -38,8 +54,8 @@ fn assert_each_continuation_allocates(tdz: bool) {
         return_type: Type::Any,
         body: vec![Stmt::If {
             condition: Expr::LocalGet(100),
-            then_branch: branch(tdz),
-            else_branch: Some(branch(tdz)),
+            then_branch: branch(initialized),
+            else_branch: Some(branch(initialized)),
         }],
         is_async: false,
         is_generator: false,
@@ -65,11 +81,11 @@ fn assert_each_continuation_allocates(tdz: bool) {
         2,
         "each continuation must allocate:\n{ir}"
     );
-    let seed = if tdz {
-        crate::nanbox::TAG_TDZ_I64
-    } else {
-        crate::nanbox::TAG_UNDEFINED_I64
-    };
+    let seed = crate::nanbox::TAG_UNDEFINED_I64;
+    assert!(
+        ir.contains("boxed.reuse.allocate"),
+        "missing-cell allocation must be conditional"
+    );
     let mut slots = Vec::new();
     for allocation in allocations {
         assert!(
@@ -101,11 +117,11 @@ fn assert_each_continuation_allocates(tdz: bool) {
 }
 
 #[test]
-fn each_plain_continuation_allocates_its_cell() {
-    assert_each_continuation_allocates(false);
+fn initialized_boxed_let_materializes_a_missing_cell() {
+    assert_each_continuation_allocates(true);
 }
 
 #[test]
-fn each_tdz_continuation_allocates_its_cell() {
-    assert_each_continuation_allocates(true);
+fn uninitialized_boxed_let_materializes_a_missing_cell() {
+    assert_each_continuation_allocates(false);
 }

--- a/crates/perry-codegen/src/stmt/boxed_local_init.rs
+++ b/crates/perry-codegen/src/stmt/boxed_local_init.rs
@@ -1,0 +1,40 @@
+//! A reused stack slot is not proof its boxed declaration executed (#10048).
+use crate::expr::FnCtx;
+use crate::types::{I32, I64};
+
+pub(super) fn ensure_reused_box_is_initialized(ctx: &mut FnCtx<'_>, id: u32) {
+    if !ctx.boxed_vars.contains(&id)
+        || ctx.prealloc_boxes.contains(&id)
+        || ctx.module_globals.contains_key(&id)
+    {
+        return;
+    }
+    let Some(slot) = ctx.locals.get(&id).cloned() else {
+        return;
+    };
+    let pointer = ctx.block().load(I64, &slot);
+    let missing = ctx
+        .block()
+        .icmp_eq(I64, &pointer, crate::nanbox::TAG_UNDEFINED_I64);
+    let allocate = ctx.new_block("boxed.reuse.allocate");
+    let ready = ctx.new_block("boxed.reuse.ready");
+    let allocate_label = ctx.block_label(allocate);
+    let ready_label = ctx.block_label(ready);
+    ctx.block().cond_br(&missing, &allocate_label, &ready_label);
+    ctx.current_block = allocate;
+    let cell = if crate::expr::is_compiler_private_async_i32_control_local(ctx, id) {
+        ctx.block().call(I64, "js_i32_box_alloc", &[(I32, "0")])
+    } else if crate::expr::is_compiler_private_async_i1_control_local(ctx, id) {
+        ctx.block().call(I64, "js_bool_box_alloc", &[(I32, "0")])
+    } else {
+        ctx.block().call(
+            I64,
+            "js_box_alloc_bits",
+            &[(I64, crate::nanbox::TAG_UNDEFINED_I64)],
+        )
+    };
+    ctx.block().store(I64, &cell, &slot);
+    super::record_boxed_slot_js_value_bits(ctx, id, &cell, "boxed_let.reused_missing_box");
+    ctx.block().br(&ready_label);
+    ctx.current_block = ready;
+}

--- a/crates/perry-codegen/src/stmt/boxed_local_init.rs
+++ b/crates/perry-codegen/src/stmt/boxed_local_init.rs
@@ -1,4 +1,6 @@
 //! A reused stack slot is not proof its boxed declaration executed (#10048).
+//! Generator continuations can emit the declaration on mutually exclusive paths.
+//! Preserve live var cells, but create a missing cell before a self-capturing init.
 use crate::expr::FnCtx;
 use crate::types::{I32, I64};
 

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -386,11 +386,7 @@ pub(crate) fn lower_let(
     // reuse guard must consider the rep map too, or a redeclaration would
     // re-run the allocation path and leave the local with two slots.
     if ctx.locals.contains_key(&id) || ctx.local_slot_reps.contains_key(&id) {
-        // #10048: a previous *emitted* boxed Let may belong to another
-        // generator continuation. Its entry-initialized pointer slot exists,
-        // but the allocation did not execute on this resumed path. Preserve
-        // live var cells while lazily materializing a missing declaration cell
-        // BEFORE evaluating the initializer (which may capture itself).
+        // #10048: materialize a missing continuation cell before its initializer.
         super::boxed_local_init::ensure_reused_box_is_initialized(ctx, id);
         if let Some(init_expr) = init {
             // The binding's OWN declaration ends its Temporal Dead Zone: the

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -386,6 +386,12 @@ pub(crate) fn lower_let(
     // reuse guard must consider the rep map too, or a redeclaration would
     // re-run the allocation path and leave the local with two slots.
     if ctx.locals.contains_key(&id) || ctx.local_slot_reps.contains_key(&id) {
+        // #10048: a previous *emitted* boxed Let may belong to another
+        // generator continuation. Its entry-initialized pointer slot exists,
+        // but the allocation did not execute on this resumed path. Preserve
+        // live var cells while lazily materializing a missing declaration cell
+        // BEFORE evaluating the initializer (which may capture itself).
+        super::boxed_local_init::ensure_reused_box_is_initialized(ctx, id);
         if let Some(init_expr) = init {
             // The binding's OWN declaration ends its Temporal Dead Zone: the
             // reused-slot write below (plain, unchecked) overwrites any TAG_TDZ

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -28,6 +28,8 @@ mod let_stmt_facts;
 mod loops;
 mod masked_window_region;
 #[cfg(test)]
+mod prealloc_continuation_tests;
+#[cfg(test)]
 mod prealloc_module_global_tests;
 pub(crate) mod stable_packed_accumulator;
 pub(crate) mod stable_packed_loop;
@@ -671,16 +673,11 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
         if ctx.module_globals.contains_key(id) {
             continue;
         }
-        if ctx.locals.contains_key(id) {
-            // A previous PreallocateBoxes (or an unusual nesting)
-            // already set this up -- skip to keep the existing slot.
-            ctx.prealloc_boxes.insert(*id);
-            ctx.boxed_vars.insert(*id);
-            if tdz {
-                ctx.tdz_boxes.insert(*id);
-            }
-            continue;
-        }
+        // #10048: `locals` describes emitted storage, not which initializers
+        // dominate this path. Generator lowering can clone a scope into
+        // mutually exclusive continuations. Each executed scope entry needs
+        // its own fresh cell, even when an earlier emitted copy owns the slot.
+        // Reuse only the alloca below, never omit this path's allocation.
         let is_i32_control = crate::expr::is_compiler_private_async_i32_control_local(ctx, *id);
         let is_i1_control = crate::expr::is_compiler_private_async_i1_control_local(ctx, *id);
         let blk = ctx.block();
@@ -721,7 +718,6 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
                 "jsvalue_box_cell",
             )
         };
-        let slot = ctx.func.alloca_entry(crate::types::I64);
         // perry#4926: PreallocateBoxes can sit nested inside an If/Try/Labeled
         // body (e.g. the async state-machine wrapper), so this block's
         // box-pointer store doesn't necessarily dominate every load of the
@@ -731,9 +727,15 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
         // the value, so it is TAG_UNDEFINED-initialized in both the TDZ and
         // non-TDZ cases -- the TAG_TDZ sentinel lives in the box cell, not the
         // slot.
-        let undef_bits = crate::nanbox::TAG_UNDEFINED_I64.to_string();
-        ctx.func
-            .entry_allocas_push_store(crate::types::I64, &undef_bits, &slot);
+        let slot = if let Some(slot) = ctx.locals.get(id) {
+            slot.clone()
+        } else {
+            let slot = ctx.func.alloca_entry(crate::types::I64);
+            let undef_bits = crate::nanbox::TAG_UNDEFINED_I64.to_string();
+            ctx.func
+                .entry_allocas_push_store(crate::types::I64, &undef_bits, &slot);
+            slot
+        };
         ctx.block().store(crate::types::I64, &box_ptr, &slot);
         record_boxed_slot_js_value_bits(ctx, *id, &box_ptr, "preallocate_boxes.box_ptr_slot");
         if cell_note != "jsvalue_box_cell" {

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -12,6 +12,9 @@ use crate::native_value::{LoweredValue, MaterializationReason};
 use crate::types::DOUBLE;
 
 #[cfg(test)]
+mod boxed_continuation_tests;
+mod boxed_local_init;
+#[cfg(test)]
 mod boxed_slot_no_root_tests;
 mod cached_field_index_return;
 #[cfg(test)]
@@ -27,8 +30,6 @@ mod let_stmt;
 mod let_stmt_facts;
 mod loops;
 mod masked_window_region;
-#[cfg(test)]
-mod prealloc_continuation_tests;
 #[cfg(test)]
 mod prealloc_module_global_tests;
 pub(crate) mod stable_packed_accumulator;
@@ -673,11 +674,16 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
         if ctx.module_globals.contains_key(id) {
             continue;
         }
-        // #10048: `locals` describes emitted storage, not which initializers
-        // dominate this path. Generator lowering can clone a scope into
-        // mutually exclusive continuations. Each executed scope entry needs
-        // its own fresh cell, even when an earlier emitted copy owns the slot.
-        // Reuse only the alloca below, never omit this path's allocation.
+        if ctx.locals.contains_key(id) {
+            // A previous PreallocateBoxes (or an unusual nesting)
+            // already set this up -- skip to keep the existing slot.
+            ctx.prealloc_boxes.insert(*id);
+            ctx.boxed_vars.insert(*id);
+            if tdz {
+                ctx.tdz_boxes.insert(*id);
+            }
+            continue;
+        }
         let is_i32_control = crate::expr::is_compiler_private_async_i32_control_local(ctx, *id);
         let is_i1_control = crate::expr::is_compiler_private_async_i1_control_local(ctx, *id);
         let blk = ctx.block();
@@ -718,6 +724,7 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
                 "jsvalue_box_cell",
             )
         };
+        let slot = ctx.func.alloca_entry(crate::types::I64);
         // perry#4926: PreallocateBoxes can sit nested inside an If/Try/Labeled
         // body (e.g. the async state-machine wrapper), so this block's
         // box-pointer store doesn't necessarily dominate every load of the
@@ -727,15 +734,9 @@ fn emit_preallocate_boxes(ctx: &mut FnCtx<'_>, ids: &[u32], tdz: bool) -> Result
         // the value, so it is TAG_UNDEFINED-initialized in both the TDZ and
         // non-TDZ cases -- the TAG_TDZ sentinel lives in the box cell, not the
         // slot.
-        let slot = if let Some(slot) = ctx.locals.get(id) {
-            slot.clone()
-        } else {
-            let slot = ctx.func.alloca_entry(crate::types::I64);
-            let undef_bits = crate::nanbox::TAG_UNDEFINED_I64.to_string();
-            ctx.func
-                .entry_allocas_push_store(crate::types::I64, &undef_bits, &slot);
-            slot
-        };
+        let undef_bits = crate::nanbox::TAG_UNDEFINED_I64.to_string();
+        ctx.func
+            .entry_allocas_push_store(crate::types::I64, &undef_bits, &slot);
         ctx.block().store(crate::types::I64, &box_ptr, &slot);
         record_boxed_slot_js_value_bits(ctx, *id, &box_ptr, "preallocate_boxes.box_ptr_slot");
         if cell_note != "jsvalue_box_cell" {

--- a/crates/perry-codegen/src/stmt/prealloc_continuation_tests.rs
+++ b/crates/perry-codegen/src/stmt/prealloc_continuation_tests.rs
@@ -1,0 +1,111 @@
+//! #10048: emitting an earlier branch does not initialize a sibling branch.
+use perry_hir::types::Type;
+use perry_hir::{Expr, Function, Module, Param, Stmt};
+
+fn branch(tdz: bool) -> Vec<Stmt> {
+    vec![
+        if tdz {
+            Stmt::PreallocateTdzBoxes(vec![101])
+        } else {
+            Stmt::PreallocateBoxes(vec![101])
+        },
+        Stmt::Let {
+            id: 101,
+            name: "callback".into(),
+            ty: Type::Any,
+            mutable: true,
+            init: Some(Expr::Integer(40)),
+        },
+        Stmt::Return(Some(Expr::LocalGet(101))),
+    ]
+}
+
+fn assert_each_continuation_allocates(tdz: bool) {
+    let mut module = Module::new("prealloc_continuation.ts");
+    module.functions.push(Function {
+        id: 1,
+        name: "resume".into(),
+        type_params: Vec::new(),
+        params: vec![Param {
+            id: 100,
+            name: "state".into(),
+            ty: Type::Any,
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        }],
+        return_type: Type::Any,
+        body: vec![Stmt::If {
+            condition: Expr::LocalGet(100),
+            then_branch: branch(tdz),
+            else_branch: Some(branch(tdz)),
+        }],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    });
+    let ir = String::from_utf8(
+        crate::compile_module(&module, super::prealloc_module_global_tests::ir_opts()).unwrap(),
+    )
+    .unwrap();
+    let allocations: Vec<_> = ir
+        .lines()
+        .filter(|line| line.contains("call i64 @js_box_alloc_bits("))
+        .collect();
+    // Both mutually exclusive copies initialize the same lexical binding.
+    // The pre-fix ctx.locals check only emitted the first allocation.
+    assert_eq!(
+        allocations.len(),
+        2,
+        "each continuation must allocate:\n{ir}"
+    );
+    let seed = if tdz {
+        crate::nanbox::TAG_TDZ_I64
+    } else {
+        crate::nanbox::TAG_UNDEFINED_I64
+    };
+    let mut slots = Vec::new();
+    for allocation in allocations {
+        assert!(
+            allocation.contains(seed),
+            "wrong initial cell value: {allocation}"
+        );
+        let result = allocation.trim().split(" = ").next().unwrap();
+        let store = ir
+            .lines()
+            .find(|line| {
+                line.trim()
+                    .starts_with(&format!("store i64 {result}, ptr "))
+            })
+            .expect("each allocated box must initialize its pointer slot");
+        slots.push(store.trim().split(", ptr ").nth(1).unwrap());
+    }
+    assert_eq!(
+        slots[0], slots[1],
+        "continuations must share the lexical slot"
+    );
+    assert!(
+        ir.contains(&format!(
+            "store i64 {}, ptr {}",
+            crate::nanbox::TAG_UNDEFINED_I64,
+            slots[0]
+        )),
+        "bypassed declarations still need the entry sentinel"
+    );
+}
+
+#[test]
+fn each_plain_continuation_allocates_its_cell() {
+    assert_each_continuation_allocates(false);
+}
+
+#[test]
+fn each_tdz_continuation_allocates_its_cell() {
+    assert_each_continuation_allocates(true);
+}

--- a/crates/perry-codegen/src/stmt/prealloc_module_global_tests.rs
+++ b/crates/perry-codegen/src/stmt/prealloc_module_global_tests.rs
@@ -39,7 +39,7 @@ use crate::{compile_module, AppMetadata, CompileOptions};
 use perry_hir::types::Type;
 use perry_hir::{Expr, Module, ModuleInitKind, Param, Stmt};
 
-fn ir_opts() -> CompileOptions {
+pub(super) fn ir_opts() -> CompileOptions {
     CompileOptions {
         target: None,
         is_entry_module: true,

--- a/test-files/test_gap_generator_delegated_local_capture.ts
+++ b/test-files/test_gap_generator_delegated_local_capture.ts
@@ -1,0 +1,19 @@
+// #10048: a delegated loop emits multiple copies of the resumed scope.
+// The callback's preallocated cell must be initialized in every copy.
+async function* delegate(value: number) { yield value; }
+async function* outer() {
+  let base = 40;
+  for (let index = 0; index < 2; index++) {
+    yield* delegate(index);
+    let getter = () => base + index;
+    let wrapper = () => getter();
+    yield wrapper();
+  }
+}
+async function main() {
+  const values: number[] = [];
+  for await (const value of outer()) values.push(value);
+  if (values.join(',') !== '0,40,1,41') throw new Error(values.join(','));
+  console.log('PASS: delegated loop captures local callable');
+}
+main().catch(error => { console.error(error); process.exit(1); });

--- a/test-files/test_gap_generator_preallocated_capture_controls.ts
+++ b/test-files/test_gap_generator_preallocated_capture_controls.ts
@@ -1,0 +1,80 @@
+// #10048 controls: fresh iteration cells, empty delegates, TDZ, var identity,
+// recursive closures, and captures made after ordinary yield/await.
+function check(label: string, actual: string, expected: string) {
+  if (actual !== expected) throw new Error(label + ': ' + actual + ' != ' + expected);
+  console.log(label + ': ' + actual);
+}
+async function* emptyDelegate() { if (false) yield -1; }
+async function* nonemptyDelegate(value: number) { yield value; }
+async function* emptyLoop() {
+  for (let index = 0; index < 2; index++) {
+    yield* emptyDelegate();
+    let getter = () => index + 40;
+    let wrapper = () => getter();
+    yield wrapper();
+  }
+}
+async function* yieldControl() {
+  yield 1;
+  let getter = () => 42;
+  let wrapper = () => getter();
+  yield wrapper();
+}
+async function awaitControl() {
+  await Promise.resolve(1);
+  let getter = () => 42;
+  let wrapper = () => getter();
+  return wrapper();
+}
+async function* retained(callbacks: Array<() => number>) {
+  for (let index = 0; index < 3; index++) {
+    yield* nonemptyDelegate(index);
+    let value = index + 10;
+    let getter = () => value;
+    let wrapper = () => getter();
+    callbacks.push(wrapper);
+    value += 100;
+    yield wrapper();
+  }
+}
+function tdzAndRecursion() {
+  const results: string[] = [];
+  for (let index = 0; index < 2; index++) {
+    let read = () => value;
+    try { read(); results.push('missing-tdz'); }
+    catch (error) { results.push(error instanceof ReferenceError ? 'tdz' : 'wrong-error'); }
+    let value: number;
+    results.push(String(read()));
+    value = index;
+    results.push(String(read()));
+    let recurse = (n: number): number => n === 0 ? value : recurse(n - 1);
+    results.push(String(recurse(2)));
+  }
+  return results.join(',');
+}
+function hoistedVar() {
+  const callbacks: Array<() => number> = [];
+  for (let index = 0; index < 3; index++) {
+    callbacks.push(read);
+    var value = index;
+    function read() { return value; }
+  }
+  return callbacks.map(callback => callback()).join(',');
+}
+async function collect(iterator: AsyncIterable<number>) {
+  const values: number[] = [];
+  for await (const value of iterator) values.push(value);
+  return values.join(',');
+}
+async function main() {
+  check('empty delegate', await collect(emptyLoop()), '40,41');
+  check('ordinary yield', await collect(yieldControl()), '1,42');
+  check('ordinary await', String(await awaitControl()), '42');
+  const callbacks: Array<() => number> = [];
+  check('retained yields', await collect(retained(callbacks)), '0,110,1,111,2,112');
+  check('retained callbacks', callbacks.map(callback => callback()).join(','), '110,111,112');
+  check('TDZ and recursion', tdzAndRecursion(), 'tdz,undefined,0,0,tdz,undefined,1,1');
+  check('hoisted var', hoistedVar(), '2,2,2');
+  console.log('PASS: preallocated capture controls');
+}
+main().catch(error => { console.error(error); process.exit(1); });

--- a/test-files/test_gap_generator_preallocated_capture_controls.ts
+++ b/test-files/test_gap_generator_preallocated_capture_controls.ts
@@ -37,19 +37,18 @@ async function* retained(callbacks: Array<() => number>) {
     yield wrapper();
   }
 }
-function tdzAndRecursion() {
+// Separate invocations: repeated-block TDZ reset already fails on main (#10051).
+function tdzAndRecursion(index: number) {
   const results: string[] = [];
-  for (let index = 0; index < 2; index++) {
-    let read = () => value;
-    try { read(); results.push('missing-tdz'); }
-    catch (error) { results.push(error instanceof ReferenceError ? 'tdz' : 'wrong-error'); }
-    let value: number;
-    results.push(String(read()));
-    value = index;
-    results.push(String(read()));
-    let recurse = (n: number): number => n === 0 ? value : recurse(n - 1);
-    results.push(String(recurse(2)));
-  }
+  let read = () => value;
+  try { read(); results.push('missing-tdz'); }
+  catch (error) { results.push(error instanceof ReferenceError ? 'tdz' : 'wrong-error'); }
+  let value: number;
+  results.push(String(read()));
+  value = index;
+  results.push(String(read()));
+  let recurse = (n: number): number => n === 0 ? value : recurse(n - 1);
+  results.push(String(recurse(2)));
   return results.join(',');
 }
 function hoistedVar() {
@@ -73,7 +72,7 @@ async function main() {
   const callbacks: Array<() => number> = [];
   check('retained yields', await collect(retained(callbacks)), '0,110,1,111,2,112');
   check('retained callbacks', callbacks.map(callback => callback()).join(','), '110,111,112');
-  check('TDZ and recursion', tdzAndRecursion(), 'tdz,undefined,0,0,tdz,undefined,1,1');
+  check('TDZ and recursion', tdzAndRecursion(0) + ',' + tdzAndRecursion(1), 'tdz,undefined,0,0,tdz,undefined,1,1');
   check('hoisted var', hoistedVar(), '2,2,2');
   console.log('PASS: preallocated capture controls');
 }


### PR DESCRIPTION
Closes #10048.

## Problem and fix

An async-generator delegated loop emits the local callback's declaration in
more than one continuation. The first emitted declaration allocates its box;
the ordinary existing-local / hoisted-var reuse guard routes later copies
straight through LocalSet. On a resumed path the stack slot exists but still
holds the entry undefined sentinel, so initialization and capture use no cell.

Before a reused, non-preallocated boxed declaration evaluates its initializer,
check whether the pointer slot still contains that sentinel. Materialize the
missing cell when needed and preserve an existing live cell unchanged. This
keeps hoisted-var/parameter binding identity and handles self-capturing
initializers. Module globals, preallocated cells, and ordinary unboxed slots
stay on their existing paths; specialized async control cell types are kept.
No environment switch or runtime ABI change is introduced.

Independent branch from main `603b074ac`. Neither #10042 nor #10046 nor any
application bundle, extraction, credentials, or network is needed for testing.

## Validation

- Pinned Node 26.5.1 passes both independent gap fixtures.
- Frozen before-fix native reproduction exits 1 with the callback TypeError.
- The initial preallocation-only candidate `eb52a581e` was rejected after
  native O0 failed under both default and compact GC. That implementation has
  been removed; the original PreallocateBoxes behavior is restored.
- The revised tests exercise the actual ordinary declaration reuse path,
  with and without an initializer, requiring conditional allocation into the
  same entry-initialized slot.
- **1,463 codegen unit tests pass, no failures, one ignored**, with the revised
  implementation: normal debug profile, one thread, 16.01s execution.
- **12 native cases pass**: both standalone fixtures at O0/Os/Oz under default
  and compact GC, Wasm host enabled, byte-for-byte against pinned Node.
  The compiler and all nine coherent provider archives are frozen at
  `81b47b47cace5b150edde32059ff272a3a19eca5`. Compiler build: 10m30s;
  runtime graph: 9m56s; each had a 15-minute bound.
- Current head `f56ef0f9638e333be994db6de8bdac00f90b587e` changes only Rust
  comments and test setup relative to that native toolchain. Its exact fixtures
  were rerun with the frozen pair (12 passes). This does not claim a newly built
  compiler at the test-only head. The compiler implementation is unchanged.
- The initial broad control exposed a separate **existing** repeated-loop TDZ
  failure, now independently reported with a reproducer in #10051. A six-case
  A/B reproduces identical failure at O0/Oz on old main `53df2c671`, pre-fix
  `f3e8d5d1a`, and fixed `81b47b47c`. This PR's TDZ/no-initializer/recursion
  control uses separate invocations; retained per-iteration callbacks and
  shared hoisted-var bindings remain covered. No failing behavior is claimed fixed.
- Final full script-tier lint: **75 pass, one proven base-main benchmark freshness
  failure, two CI-only skips**. Compile-tier lint is explicitly skipped locally.
  The two-line file-cap overflow has been corrected with a comment-only move
  (`let_stmt.rs`: 1,998 lines); formatting and file-cap checks pass.
- Additional local moving-GC witness passes at Oz under both rooting modes:
  insert an allocating synchronous loop between getter creation, wrapper
  capture, and later invocation. Each run verifies **224 loop polls, 231 copying
  minors, and 13,778 moved objects**, with from-space protection and evacuation
  verification enabled. This uses the same frozen `81b47b47c` toolchain; it is
  supplementary local evidence, not a claim that CI runs this extra witness.

## Completed current-head Linux CI

[Run 34576434651](https://github.com/PerryTS/perry/actions/runs/34576434651)
at exact head `f56ef0f9638e333be994db6de8bdac00f90b587e` is complete. Both new
generator fixtures executed and passed (shards 2 and 5). Check, warnings,
scoped E2E, gap shards 1/6, and GC stress passed. The GC matrix reports
**429 PASS / 159 UNVERIFIED / 0 FAIL**; unverified cells are not passes.

CI is **not all green**. A single attribution pass against the exact base-main
`603b074ace01464bc66fc07cc8d532f26ccf5a0f`
[push run 34565492075](https://github.com/PerryTS/perry/actions/runs/34565492075)
finds the same failures:

- Lint: inherited public benchmark freshness failure.
- Cargo-test: `native_stack::tests::stack_top_respects_custom_thread_stack_sizes`,
  the same `bound must belong to this worker` assertion at native_stack.rs:53
  and unwrap at :60; 3,504 passed / 1 failed / 4 ignored.
- Gap shards 2/3/4/5: all **10 printed failure verdicts and diagnostics** match
  base main, including the webcrypto threadpool timeout. Seven are snapshot
  regressions and three are already baseline-accepted parity failures. Comparison
  covers reported exit codes and first/last printed output lines, not full stdout.
- `pr-gate` is the fan-in of those failed jobs, not an additional test failure.

No baseline or tests were suppressed and no CI rerun was requested. This remains
ready for maintainer review; the separate full application rebuild is pending.

Native fixtures cover delegated loops, retained iteration callbacks, empty
delegates, ordinary yield/await, recursion, TDZ, and shared hoisted-var bindings.
This is not a claim that the full application works or meets its size target.
The merge train can perform the patch-version bump.
