### PR TITLE
fix(runtime): make spread push scale linearly

### DIFF
--- a/changelog.d/10072-linear-push-spread.md
+++ b/changelog.d/10072-linear-push-spread.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Made repeated `array.push(...chunk)` scale linearly by updating array layout
+  metadata and write barriers only for newly appended slots. A one-million-item
+  fixed-chunk benchmark that previously timed out after 60 seconds now completes
+  in 41.6 ms, while preserving iterator overrides, sparse-array semantics,
+  self-aliasing, generic receivers, and old-to-young references under moving GC.

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -663,11 +663,10 @@ fn lower_array_push_spread_spec_order(
         let cur_bits = blk.bitcast_double_to_i64(&cur_box);
         let still_bound = blk.icmp_eq(I64, &cur_bits, &recv_bits);
         let dst_handle = unbox_to_i64(blk, &recv_box);
-        let src_handle = unbox_to_i64(blk, &src_box);
         let new_handle = blk.call(
             I64,
-            "js_array_concat",
-            &[(I64, &dst_handle), (I64, &src_handle)],
+            "js_array_spread_append",
+            &[(I64, &dst_handle), (DOUBLE, &src_box)],
         );
         let new_box = nanbox_pointer_inline(blk, &new_handle);
 
@@ -1491,12 +1490,9 @@ fn lower_inner(ctx: &mut FnCtx<'_>, expr: &Expr, value_discarded: bool) -> Resul
         // `arr.push(...src)` — HIR variant carrying the destination
         // array's LocalId and the source expression (any iterable, in
         // practice an array or Set). Mirrors `Expr::ArrayPush` above:
-        // load the destination from its slot, unbox both pointers, call
-        // the runtime's `js_array_concat` (which walks the source and
-        // calls `js_array_push_f64` per element + already handles
-        // Set sources via SET_REGISTRY), NaN-box the realloc-aware
-        // return pointer, and write back to whichever storage backs
-        // `array_id`. Issue #248.
+        // load the destination from its slot, call the runtime's iterator-aware
+        // `js_array_spread_append`, NaN-box the realloc-aware return pointer,
+        // and write back to whichever storage backs `array_id`. Issue #248.
         Expr::ArrayPushSpread { array_id, source } => {
             let array_expr = Expr::LocalGet(*array_id);
             // #7634, same as `Expr::ArrayPush`: spec order is only observable
@@ -1520,11 +1516,10 @@ fn lower_inner(ctx: &mut FnCtx<'_>, expr: &Expr, value_discarded: bool) -> Resul
             rooting::with_operands_rooted(ctx, &[source.as_ref(), &array_expr], |ctx, vals| {
                 let blk = ctx.block();
                 let dst_handle = unbox_to_i64(blk, &vals[1]);
-                let src_handle = unbox_to_i64(blk, &vals[0]);
                 let new_handle = blk.call(
                     I64,
-                    "js_array_concat",
-                    &[(I64, &dst_handle), (I64, &src_handle)],
+                    "js_array_spread_append",
+                    &[(I64, &dst_handle), (DOUBLE, &vals[0])],
                 );
                 let new_box = nanbox_pointer_inline(blk, &new_handle);
                 emit_push_writeback(ctx, *array_id, &new_box, "ArrayPushSpread")?;

--- a/crates/perry-runtime/src/array/concat_reverse.rs
+++ b/crates/perry-runtime/src/array/concat_reverse.rs
@@ -1,7 +1,6 @@
 //! concat / reverse / fill.
 use super::*;
 use crate::JSValue;
-use std::ptr;
 
 fn fill_to_number(value: f64) -> f64 {
     let jsval = JSValue::from_bits(value.to_bits());
@@ -122,42 +121,103 @@ pub extern "C" fn js_array_concat(
             return dest;
         }
 
-        let src_elements = (src as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-
-        // Bulk-copy fast path: pre-grow once to fit dest_len+src_len,
-        // then memcpy the source elements into the dest tail and update
-        // length once. Replaces N individual `js_array_push_f64` calls
-        // (each doing a forwarding-chain follow + capacity check). The
-        // alias case (dest == src) is rare but possible — fall back to
-        // the per-element loop for that, since growing dest invalidates
-        // the src_elements pointer.
         let dest_resolved = clean_arr_ptr_mut(dest);
-        if !dest_resolved.is_null() && !std::ptr::eq(dest_resolved, src) {
-            let dest_len = (*dest_resolved).length;
-            let new_len = dest_len + src_len;
-            let result = if new_len > (*dest_resolved).capacity {
-                js_array_grow(dest_resolved, new_len)
-            } else {
-                dest_resolved
-            };
-            let dst_elements =
-                (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-            // GC_STORE_AUDIT(BARRIERED): concat bulk copy is followed by exact layout/barrier rebuild.
-            ptr::copy_nonoverlapping(
-                src_elements,
-                dst_elements.add(dest_len as usize),
-                src_len as usize,
-            );
-            (*result).length = new_len;
-            rebuild_array_layout_exact(result);
+
+        // `a.push(...a)` reads the original prefix while growing the same
+        // array. Re-resolve the rooted source for every read because a push
+        // can replace the backing allocation and leave `src` as a forwarding
+        // stub. The captured `src_len` keeps the newly appended suffix out of
+        // the iteration, matching spread's pre-call argument materialization.
+        if !dest_resolved.is_null() && std::ptr::eq(dest_resolved, src) {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let source_handle = scope.root_raw_const_ptr(src);
+            let mut result = dest_resolved;
+            for i in 0..src_len as usize {
+                let source = clean_arr_ptr(source_handle.get_raw_const_ptr::<ArrayHeader>());
+                if source.is_null() {
+                    break;
+                }
+                let source_elements =
+                    (source as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+                let source_value = *source_elements.add(i);
+                let value = if source_value.to_bits() == crate::value::TAG_HOLE {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                } else {
+                    source_value
+                };
+                result = js_array_push_f64(result, value);
+            }
             return result;
         }
 
-        // Fallback: per-element push (handles aliasing + null dest).
-        let mut result = dest;
+        // A statically array-shaped receiver can still be a Proxy or an
+        // object-backed Array subclass. Preserve the public push dispatch for
+        // those receivers so setters/traps and subclass storage remain live.
+        if dest_resolved.is_null() {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let source_handle = scope.root_raw_const_ptr(src);
+            let mut result = if dest.is_null() {
+                js_array_alloc(src_len)
+            } else {
+                dest
+            };
+            for i in 0..src_len as usize {
+                let source = clean_arr_ptr(source_handle.get_raw_const_ptr::<ArrayHeader>());
+                if source.is_null() {
+                    break;
+                }
+                let source_elements =
+                    (source as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+                let source_value = *source_elements.add(i);
+                let value = if source_value.to_bits() == crate::value::TAG_HOLE {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                } else {
+                    source_value
+                };
+                result = js_array_push_f64(result, value);
+            }
+            return result;
+        }
+
+        // Grow once, then publish only the newly appended slots through the
+        // ordinary array store protocol. The destination's existing layout
+        // and remembered-set coverage survive `js_array_grow`; rebuilding the
+        // layout from slot zero after every fixed-size append made repeated
+        // `push(...chunk)` scan the complete accumulated prefix and therefore
+        // grow quadratically. Advancing `length` one slot at a time keeps the
+        // all-pointer and homogeneous-element append proofs exact, while each
+        // new edge receives its layout note and write barrier.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let source_handle = scope.root_raw_const_ptr(src);
+        let dest_handle = scope.root_raw_mut_ptr(dest_resolved);
+        let dest_len = (*dest_resolved).length;
+        let new_len = dest_len + src_len;
+        let result = if new_len > (*dest_resolved).capacity {
+            js_array_grow(dest_handle.get_raw_mut_ptr::<ArrayHeader>(), new_len)
+        } else {
+            dest_handle.get_raw_mut_ptr::<ArrayHeader>()
+        };
+        let source = clean_arr_ptr(source_handle.get_raw_const_ptr::<ArrayHeader>());
+        if source.is_null() || result.is_null() {
+            return result;
+        }
+        let source_elements =
+            (source as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         for i in 0..src_len as usize {
-            let element = *src_elements.add(i);
-            result = js_array_push_f64(result, element);
+            let source_value = *source_elements.add(i);
+            // Array iteration observes a hole as `undefined`; the internal
+            // TAG_HOLE sentinel must not escape into the destination.
+            let value = if source_value.to_bits() == crate::value::TAG_HOLE {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            } else {
+                source_value
+            };
+            crate::string::js_string_addref_if_heap_string(value);
+            let index = (*result).length as usize;
+            // GC_STORE_AUDIT(BARRIERED): note_array_slot records layout and
+            // emits the write barrier before the slot becomes reachable.
+            note_array_slot(result, index, value.to_bits());
+            (*result).length += 1;
         }
         result
     }

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -1217,8 +1217,17 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
 
 #[no_mangle]
 pub extern "C" fn js_array_spread_append(dest: *mut ArrayHeader, source: f64) -> *mut ArrayHeader {
-    let arr = array_from_spread_value(source);
-    js_array_concat(dest, arr)
+    // Materializing an intercepted iterator can allocate and move the
+    // destination. Keep it rooted across that protocol walk and re-read it
+    // before appending. Ordinary dense arrays need no temporary: the same
+    // guard used by `[...array]` proves their iterator is unobservable.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let dest_handle = scope.root_raw_mut_ptr(dest);
+    let arr = match crate::array::dense_spread_source(source) {
+        Some(arr) => arr as *mut ArrayHeader,
+        None => array_from_spread_value(source),
+    };
+    js_array_concat(dest_handle.get_raw_mut_ptr::<ArrayHeader>(), arr)
 }
 
 /// `true` when `raw_ptr` is a heap `GC_TYPE_OBJECT` whose class id is one of the

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -1006,42 +1006,38 @@ pub extern "C" fn js_array_push_spread_f64(
     if source.is_null() {
         return target;
     }
-    // #7542: call-spread (`f(...arr)`) is `GetIterator(arr)` + drain, so a
-    // patched `Array.prototype[Symbol.iterator]` decides how many arguments the
-    // callee receives. The element copy below never consults the protocol, so
-    // `f(...[1,2,3])` passed 3 arguments where node passes whatever the patched
-    // iterator yields (1).
-    //
-    // Materialize through the protocol and copy THAT, rather than concatenating:
-    // this helper appends into `target` in place and returns it, and callers
-    // rely on that identity. `js_array_clone_for_spread` is the same entry point
-    // `[...arr]` uses, so the two spread forms cannot disagree.
-    let source = if crate::array::array_proto_iterator_modified() {
-        let boxed = crate::value::js_nanbox_pointer(source as i64);
-        let materialized = crate::array::js_array_clone_for_spread(boxed);
-        if materialized.is_null() {
-            return target;
-        }
-        materialized as *const ArrayHeader
-    } else {
-        source
-    };
+    // Use the shared dense-source proof and iterator materializer so
+    // own/prototype overrides, accessors, holes and abrupt completion cannot
+    // diverge from the typed-local path. Keep pushing through the public
+    // helper because a generic receiver may be a Proxy or object-backed Array
+    // subclass rather than a plain dense Array.
     let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_raw_mut_ptr(target);
+    let boxed = crate::value::js_nanbox_pointer(source as i64);
+    let source = match crate::array::dense_spread_source(boxed) {
+        Some(source) => source,
+        None => crate::array::js_array_clone_for_spread(boxed) as *const ArrayHeader,
+    };
+    if source.is_null() {
+        return target_handle.get_raw_mut_ptr::<ArrayHeader>();
+    }
     let source_handle = scope.root_raw_const_ptr(source);
     unsafe {
         let src_len = (*source).length;
-        if src_len == 0 {
-            return target;
-        }
-        let mut current = target;
-        for i in 0..src_len {
+        let mut current = target_handle.get_raw_mut_ptr::<ArrayHeader>();
+        for i in 0..src_len as usize {
             let source = clean_arr_ptr(source_handle.get_raw_const_ptr::<ArrayHeader>());
             if source.is_null() {
                 break;
             }
-            let src_elements_ptr =
+            let elements =
                 (source as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-            let value = *src_elements_ptr.add(i as usize);
+            let source_value = *elements.add(i);
+            let value = if source_value.to_bits() == crate::value::TAG_HOLE {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            } else {
+                source_value
+            };
             current = js_array_push_f64(current, value);
         }
         current

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -1202,6 +1202,44 @@ fn test_numeric_array_layout_bulk_rebuild_preserves_and_downgrades() {
 }
 
 #[test]
+fn concat_repeated_fixed_chunks_preserves_numeric_layout_and_order() {
+    let values: Vec<f64> = (0..32).map(|value| value as f64).collect();
+    let chunk = js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let empty = js_array_alloc(0);
+    let mut result = js_array_concat(empty, js_array_alloc(0));
+    assert_eq!(result, empty, "an empty chunk must preserve array identity");
+
+    for _ in 0..1_024 {
+        result = js_array_concat(result, chunk);
+    }
+
+    assert_eq!(js_array_length(result), 32 * 1_024);
+    assert_eq!(js_array_is_numeric_f64_layout(result), 1);
+    for index in [0, 31, 32, 16_383, 32_767] {
+        assert_eq!(
+            js_array_numeric_get_f64_unboxed(result, index),
+            (index % 32) as f64
+        );
+    }
+}
+
+#[test]
+fn concat_source_destination_alias_uses_only_the_original_prefix() {
+    let values: Vec<f64> = (1..=20).map(|value| value as f64).collect();
+    let original = js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let result = js_array_concat(original, original);
+
+    assert_eq!(clean_arr_ptr(original) as usize, result as usize);
+    assert_eq!(js_array_length(result), 40);
+    for index in 0..40 {
+        assert_eq!(
+            js_array_numeric_get_f64_unboxed(result, index),
+            values[index as usize % values.len()]
+        );
+    }
+}
+
+#[test]
 fn test_array_slice_value_index_coercion() {
     let values = [1.0, 2.0, 3.0, 4.0];
     let src = js_array_from_f64(values.as_ptr(), values.len() as u32);

--- a/crates/perry/tests/issue_10058_push_spread_scaling.rs
+++ b/crates/perry/tests/issue_10058_push_spread_scaling.rs
@@ -1,0 +1,164 @@
+//! Regression coverage for #10058: repeated fixed-size spread pushes must do
+//! work proportional to the appended tail while preserving iterator and GC
+//! semantics.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::Once;
+
+const GC_ENV_OVERRIDES: &[&str] = &[
+    "PERRY_GEN_GC",
+    "PERRY_GEN_GC_EVACUATE",
+    "PERRY_GC_SCAVENGE",
+    "PERRY_GC_SCAVENGE_NURSERY_MB",
+    "PERRY_GC_MOVING_SAFEPOINT",
+    "PERRY_GC_MOVING_LOOP_POLLS",
+    "PERRY_GC_FORCE_EVACUATE",
+    "PERRY_GC_VERIFY_EVACUATION",
+    "PERRY_CONSERVATIVE_STACK_SCAN",
+    "PERRY_WRITE_BARRIERS",
+    "PERRY_GC_INCREMENTAL",
+    "PERRY_GC_HEAP_LIMIT",
+];
+
+fn remove_gc_env_overrides(command: &mut Command) {
+    for key in GC_ENV_OVERRIDES {
+        command.env_remove(key);
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn fixture() -> PathBuf {
+    workspace_root().join("test-files/fixtures/issue_10058_push_spread/main.ts")
+}
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn target_debug_dir() -> PathBuf {
+    if let Some(runtime) = std::env::var_os("PERRY_TEST_RUNTIME_DIR") {
+        return PathBuf::from(runtime);
+    }
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    target.join("debug")
+}
+
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let runtime_dir = target_debug_dir();
+        if runtime_dir.join("libperry_runtime.a").is_file()
+            && runtime_dir.join("libperry_stdlib.a").is_file()
+        {
+            return;
+        }
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let mut command = Command::new(cargo);
+        command
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static");
+        let output = command.output().expect("build static runtime archives");
+        assert_success("static runtime build", &output);
+    });
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn compile(dir: &Path) -> (PathBuf, String) {
+    ensure_runtime_archive();
+    let output = dir.join("main.bin");
+    let mut command = Command::new(perry_bin());
+    command
+        .current_dir(dir)
+        .arg("compile")
+        .arg(fixture())
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_LLVM_KEEP_IR", "1")
+        .env("PERRY_RUNTIME_DIR", target_debug_dir());
+    remove_gc_env_overrides(&mut command);
+    let compiled = command.output().expect("compile fixture");
+    assert_success("perry compile", &compiled);
+    (
+        output,
+        String::from_utf8_lossy(&compiled.stderr).into_owned(),
+    )
+}
+
+fn run(binary: &Path, moving_gc: bool) -> Output {
+    let mut command = Command::new(binary);
+    remove_gc_env_overrides(&mut command);
+    if moving_gc {
+        command
+            .env("PERRY_GC_SCAVENGE", "1")
+            .env("PERRY_GC_SCAVENGE_NURSERY_MB", "1")
+            .env("PERRY_GC_FORCE_EVACUATE", "1")
+            .env("PERRY_GC_VERIFY_EVACUATION", "1")
+            .env("PERRY_GC_INCREMENTAL", "0");
+    }
+    command.output().expect("run compiled fixture")
+}
+
+fn run_node() -> Output {
+    Command::new("node")
+        .arg("--expose-gc")
+        .arg("--experimental-strip-types")
+        .arg(fixture())
+        .output()
+        .expect("run Node oracle")
+}
+
+#[test]
+fn spread_push_is_iterator_correct_and_gc_safe_on_reused_destinations() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (binary, compile_stderr) = compile(temp.path());
+    let ir_path = compile_stderr
+        .lines()
+        .find_map(|line| line.split("kept LLVM IR: ").nth(1))
+        .map(str::trim)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            panic!("PERRY_LLVM_KEEP_IR did not report an IR path\n{compile_stderr}")
+        });
+    let ir = std::fs::read_to_string(ir_path).expect("read kept LLVM IR");
+    assert!(
+        ir.contains("call i64 @js_array_spread_append("),
+        "typed-local spread push must retain the iterator-aware runtime entry\n{ir}"
+    );
+
+    let node = run_node();
+    assert_success("Node oracle", &node);
+    for moving_gc in [false, true] {
+        let perry = run(&binary, moving_gc);
+        assert_success("compiled fixture", &perry);
+        assert_eq!(
+            perry.stdout,
+            node.stdout,
+            "spread-push parity failed with moving_gc={moving_gc}\nPerry stderr:\n{}",
+            String::from_utf8_lossy(&perry.stderr)
+        );
+    }
+}

--- a/test-files/fixtures/issue_10058_push_spread/benchmark.ts
+++ b/test-files/fixtures/issue_10058_push_spread/benchmark.ts
@@ -1,0 +1,93 @@
+let seed = 0x12345678;
+
+function rnd(): number {
+  seed ^= seed << 13;
+  seed ^= seed >>> 17;
+  seed ^= seed << 5;
+  return (seed >>> 0) / 4294967296;
+}
+
+function hashArray(a: number[]): number {
+  let h = a.length;
+  for (let i = 0; i < a.length; i++) h = (h * 31 + a[i]) % 1000000007;
+  return h;
+}
+
+function setup(n: number): number[][] {
+  const chunks: number[][] = [];
+  for (let i = 0; i < n; i += 32) {
+    const chunk: number[] = [];
+    for (let j = i; j < Math.min(n, i + 32); j++) {
+      chunk.push(Math.floor(rnd() * 1000000));
+    }
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+function run(chunks: number[][]): number {
+  const a: number[] = [];
+  for (let i = 0; i < chunks.length; i++) a.push(...chunks[i]);
+  return hashArray(a);
+}
+
+const n = Number(process.argv[process.argv.length - 1]);
+if (!(n > 0)) throw new Error("Expected a positive size argument");
+
+function benchmarkMain(): void {
+  seed = 0x12345678;
+  const preparedInput = setup(n);
+  let checksum = 0;
+  let seen = false;
+  let warmMs = 0;
+  let warmRuns = 0;
+  while (warmMs < 200 || warmRuns < 5) {
+    seed = 0x12345678;
+    const start = performance.now();
+    const value = run(preparedInput);
+    const elapsed = performance.now() - start;
+    if (!(elapsed >= 0)) throw new Error("Invalid monotonic timer");
+    warmMs += elapsed;
+    warmRuns++;
+    if (seen && value !== checksum) throw new Error("CORRECTNESS: unstable checksum during warmup");
+    checksum = value;
+    seen = true;
+  }
+  const samples: number[] = [];
+  let runs = 0;
+  for (let sample = 0; sample < 7; sample++) {
+    let elapsed = 0;
+    let count = 0;
+    while (elapsed < 20) {
+      seed = 0x12345678;
+      const start = performance.now();
+      const value = run(preparedInput);
+      const duration = performance.now() - start;
+      if (!(duration >= 0)) throw new Error("Invalid monotonic timer");
+      elapsed += duration;
+      count++;
+      if (value !== checksum) throw new Error("CORRECTNESS: unstable checksum during sampling");
+    }
+    samples.push(elapsed / count);
+    runs += count;
+  }
+  for (let i = 1; i < samples.length; i++) {
+    const value = samples[i];
+    let j = i - 1;
+    while (j >= 0 && samples[j] > value) {
+      samples[j + 1] = samples[j];
+      j--;
+    }
+    samples[j + 1] = value;
+  }
+  console.log(JSON.stringify({
+    name: "array-push-spread-chunk",
+    category: "arrays",
+    n,
+    ms_per_run: samples[3],
+    runs,
+    checksum,
+  }));
+}
+
+benchmarkMain();

--- a/test-files/fixtures/issue_10058_push_spread/main.ts
+++ b/test-files/fixtures/issue_10058_push_spread/main.ts
@@ -1,0 +1,107 @@
+declare function gc(): void;
+
+function values(a: any[]): string {
+  return a.map((value) => value === undefined ? "undefined" : String(value)).join(",");
+}
+
+const chunked: number[] = [];
+const chunkedAlias = chunked;
+let returnedLength = chunked.push(...[]);
+for (let start = 0; start < 101; start += 32) {
+  const chunk: number[] = [];
+  for (let i = start; i < Math.min(101, start + 32); i++) chunk.push(i);
+  returnedLength = chunked.push(...chunk);
+}
+console.log("chunked", chunked === chunkedAlias, returnedLength, chunked.length,
+  chunked[0], chunked[31], chunked[32], chunked[100]);
+
+const self = Array.from({ length: 20 }, (_, i) => i + 1);
+const selfAlias = self;
+const selfLength = self.push(...self);
+console.log("self", self === selfAlias, selfLength, self.length,
+  self[0], self[19], self[20], self[39]);
+
+const own: any[] = [1, 2, 3];
+own[Symbol.iterator] = function*(): Generator<number> {
+  yield 7;
+  yield 8;
+};
+const ownOut: number[] = [6];
+console.log("own", ownOut.push(...own), values(ownOut));
+
+const savedIterator = Array.prototype[Symbol.iterator];
+Array.prototype[Symbol.iterator] = function*(): Generator<number> {
+  yield 41;
+};
+const prototypeOut: number[] = [40];
+const prototypeLength = prototypeOut.push(...[1, 2, 3]);
+Array.prototype[Symbol.iterator] = savedIterator;
+console.log("prototype", prototypeLength, values(prototypeOut));
+
+const holey = [1, , 3];
+const holeyOut: any[] = [];
+holeyOut.push(...holey);
+console.log("holes", holeyOut.length, 1 in holeyOut, values(holeyOut));
+
+const accessor: any[] = [1, 2, 3];
+Object.defineProperty(accessor, "0", {
+  configurable: true,
+  get(): number {
+    accessor[1] = 20;
+    accessor.length = 2;
+    return 10;
+  },
+});
+const accessorOut: any[] = [];
+console.log("accessor", accessorOut.push(...accessor), values(accessorOut));
+
+const mutatedDestination: number[] = [1];
+const mutatingSource: any[] = [0];
+mutatingSource[Symbol.iterator] = function*(): Generator<number> {
+  mutatedDestination.push(2);
+  yield 3;
+};
+console.log("mutation", mutatedDestination.push(...mutatingSource), values(mutatedDestination));
+
+const generic: any = [];
+const mixedChunk: any[] = [1, { id: 2 }, "three"];
+console.log("generic", generic.push(...mixedChunk), generic[0], generic[1].id, generic[2]);
+
+const concatSource = [1, 2];
+const concatResult = concatSource.concat([3, 4]);
+console.log("concat", values(concatSource), values(concatResult), concatSource !== concatResult);
+
+const throwing: any[] = [1];
+throwing[Symbol.iterator] = function(): any {
+  return {
+    next(): any {
+      throw new Error("iterator-boom");
+    },
+  };
+};
+try {
+  const never: any[] = [];
+  never.push(...throwing);
+  console.log("throw", "missing");
+} catch (error: any) {
+  console.log("throw", error.message);
+}
+
+// Promote a reused destination, then append freshly allocated pointer-bearing
+// chunks. Forced-moving runs verify that every new old-to-young edge survives.
+const oldDestination: any[] = [];
+for (let i = 0; i < 2300; i++) oldDestination.push({ id: -i });
+gc();
+for (let round = 0; round < 40; round++) {
+  const youngChunk: any[] = [];
+  for (let i = 0; i < 7; i++) youngChunk.push({ id: round * 7 + i });
+  oldDestination.push(...youngChunk);
+  const churn: any[] = [];
+  for (let i = 0; i < 2000; i++) churn.push({ i, pad: "x" + i });
+  gc();
+}
+let live = 0;
+for (let i = 2300; i < oldDestination.length; i++) {
+  if (oldDestination[i].id === i - 2300) live++;
+}
+console.log("old-young", oldDestination.length, live);


### PR DESCRIPTION
## Summary

Repeated `array.push(...chunk)` rebuilt GC layout metadata for the complete accumulated destination after every append, making fixed-size chunk growth nearly quadratic. This updates only the appended tail, while routing spread pushes through the iterator-aware runtime path so observable iteration, aliasing, and GC behavior remain correct.

## Changes

- Preserve the destination's existing array layout and apply layout notes/write barriers only to newly appended slots.
- Root source and destination arrays across iterator materialization and reallocations, including `array.push(...array)`.
- Use the shared dense-spread proof for the fast path and retain public push dispatch for generic receivers.
- Add runtime and end-to-end coverage for empty and short chunks, identity and return values, self-aliasing, iterator overrides, holes, accessors, mutation, abrupt completion, generic targets, concat behavior, and old-to-young references under forced moving GC.
- Add the issue benchmark as a reproducible fixture.

## Related issue

Fixes #10058

## Test plan

- `cargo fmt --all -- --check`
- `cargo check --locked -p perry-runtime -p perry-codegen -p perry`
- `cargo build --locked -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test --locked -p perry-runtime concat_ -- --test-threads=1`
- `cargo test --locked -p perry-runtime gc::tests::layout_trace::array_layout -- --test-threads=1`
- `cargo test --locked -p perry --test issue_10058_push_spread_scaling -- --test-threads=1`
- `cargo test --locked -p perry --test issue_8772_short_packed_spread -- --test-threads=1`
- `cargo test --locked -p perry-codegen receiver_order -- --test-threads=1`
- `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release --locked -p perry -p perry-runtime-static -p perry-stdlib-static`

- [x] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output

Benchmark from the issue, measured as median milliseconds per run on the same machine. The baseline is `origin/main` at `603b074`; the final build is this branch. Checksums match Node at every size.

| elements | Perry before | Perry after | Node |
| ---: | ---: | ---: | ---: |
| 100 | 0.00360 ms | 0.00391 ms | 0.00269 ms |
| 1,000 | 0.0669 ms | 0.0386 ms | 0.0284 ms |
| 10,000 | 6.96 ms | 0.416 ms | 0.314 ms |
| 100,000 | 2,016.5 ms | 4.18 ms | 3.20 ms |
| 1,000,000 | >60,000 ms (timeout) | 41.6 ms | 32.4 ms |

The Perry log-log slope falls from 1.926 on the four baseline-completing sizes to 1.012 on the same sizes, and is 1.009 across all five final sizes. A separate ordinary single-element `push` control remains linear.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
