### PR TITLE
perf(runtime): bulk-copy Uint8Array/Buffer.prototype.set instead of per-byte view lookups (#10088)

### DIFF
--- a/changelog.d/10096-uint8array-set-bulk-copy.md
+++ b/changelog.d/10096-uint8array-set-bulk-copy.md
@@ -1,0 +1,17 @@
+Fixed `Uint8Array`/`Buffer.prototype.set(source, offset)` paying a view-registry
+lookup (and, for `Buffer`/`TypedArray` sources, an extra `Vec<u8>` copy) per
+byte instead of per call, reaching 171x Node at 100k bytes and 82x at 1M
+(#10088). `js_buffer_set_from_value` now resolves a `Buffer` source's view
+indirection once via `view::resolve_data_ptr` (already the codebase's
+established span resolver, used by `bun_ffi`/`DataView`) and, for a
+same-element-width (1-byte) `TypedArray` source (`Int8Array`, `Uint8Array`,
+`Uint8ClampedArray`), reads its raw byte span directly via
+`typedarray::data_ptr` — the stored byte already equals what `to_uint8` of the
+read element would give for all three kinds. The single resulting span is then
+copied straight into the target with `ptr::copy` (a memmove), which also
+correctly handles the case where the resolved source span physically overlaps
+the destination (e.g. `buf.set(buf.subarray(2), 0)`) without needing an
+intermediate buffer. `Array`/`Object` sources and wider or BigInt-kind
+`TypedArray` sources are untouched — they still need per-element
+coercion/property reads. 1M-byte `Uint8Array.set` measured ~1.2x Node locally,
+down from the issue's ~82x.

--- a/crates/perry-runtime/src/buffer/access.rs
+++ b/crates/perry-runtime/src/buffer/access.rs
@@ -171,6 +171,44 @@ unsafe fn collect_buffer_set_bytes(source: BufferSetSource, source_len: usize) -
     bytes
 }
 
+/// Resolve a raw byte span for sources whose elements need no per-index
+/// coercion: a `Buffer`/`Uint8Array` source, or a same-element-width
+/// (1-byte-per-element) `TypedArray` source (`Int8Array`, `Uint8Array`,
+/// `Uint8ClampedArray`) — for these kinds the stored byte already equals
+/// `to_uint8` of the read element (two's-complement reinterpretation for
+/// `Int8Array`, identity for the other two), so the underlying bytes can be
+/// copied directly. Returns `None` for `Array`/`Object` sources (need
+/// per-index `ToNumber`/property-read coercion) and for wider or BigInt
+/// `TypedArray` kinds (need per-element numeric coercion) — those fall back
+/// to [`collect_buffer_set_bytes`].
+///
+/// Resolving through [`super::view::resolve_data_ptr`] / [`crate::
+/// typedarray::data_ptr`] here (once) rather than through [`js_buffer_get`]
+/// / [`crate::typedarray::js_typed_array_get`] per byte (#10088) is what
+/// collapses the view-registry lookup from O(n) to O(1) per call.
+unsafe fn bulk_copy_source_ptr(source: BufferSetSource) -> Option<*const u8> {
+    match source {
+        BufferSetSource::Buffer(ptr) => {
+            if ptr.is_null() {
+                None
+            } else {
+                Some(super::view::resolve_data_ptr(ptr))
+            }
+        }
+        BufferSetSource::TypedArray(ptr) => {
+            let kind = crate::typedarray::lookup_typed_array_kind(ptr as usize)?;
+            matches!(
+                kind,
+                crate::typedarray::KIND_INT8
+                    | crate::typedarray::KIND_UINT8
+                    | crate::typedarray::KIND_UINT8_CLAMPED
+            )
+            .then(|| crate::typedarray::data_ptr(ptr))
+        }
+        BufferSetSource::Array(_) | BufferSetSource::Object(_) | BufferSetSource::Empty => None,
+    }
+}
+
 /// Read the byte at `index`, resolving a registered view to its ultimate
 /// backing buffer. Returns `None` for a null receiver or an out-of-range
 /// index (`index < 0` or `index >= length`). Shared by the native i32
@@ -345,16 +383,36 @@ pub extern "C" fn js_buffer_set_from_value(
             super::numeric::throw_out_of_range();
         }
 
-        let bytes = collect_buffer_set_bytes(source, source_len);
-        if !bytes.is_empty() {
-            let target_data = buffer_data_mut(target).add(offset);
-            ptr::copy_nonoverlapping(bytes.as_ptr(), target_data, bytes.len());
-            super::view::propagate_written_range_from_receiver(
-                target as usize,
-                offset as u32,
-                target_data,
-                bytes.len() as u32,
-            );
+        match bulk_copy_source_ptr(source) {
+            Some(src_data) if source_len > 0 => {
+                // `ptr::copy` (memmove) rather than `copy_nonoverlapping`:
+                // `src_data` can legitimately point into the same backing
+                // buffer `target` is a view of (or vice versa), e.g.
+                // `buf.set(buf.subarray(2))`, so source and destination
+                // ranges may overlap for real.
+                let target_data = buffer_data_mut(target).add(offset);
+                ptr::copy(src_data, target_data, source_len);
+                super::view::propagate_written_range_from_receiver(
+                    target as usize,
+                    offset as u32,
+                    target_data,
+                    source_len as u32,
+                );
+            }
+            Some(_) => {}
+            None => {
+                let bytes = collect_buffer_set_bytes(source, source_len);
+                if !bytes.is_empty() {
+                    let target_data = buffer_data_mut(target).add(offset);
+                    ptr::copy_nonoverlapping(bytes.as_ptr(), target_data, bytes.len());
+                    super::view::propagate_written_range_from_receiver(
+                        target as usize,
+                        offset as u32,
+                        target_data,
+                        bytes.len() as u32,
+                    );
+                }
+            }
         }
     }
 

--- a/test-files/test_gap_10088_uint8array_set_bulk_copy.ts
+++ b/test-files/test_gap_10088_uint8array_set_bulk_copy.ts
@@ -1,0 +1,142 @@
+// #10088 — Uint8Array/Buffer.prototype.set(source, offset) went through a
+// per-byte view-table lookup (and, for Buffer/TypedArray sources, an
+// intermediate Vec<u8>) instead of a bulk copy. The fix resolves the view
+// indirection once per call for Buffer and same-element-width (1-byte)
+// TypedArray sources and copies the raw span directly. This exercises every
+// source arm plus the overlap / view-coherency guarantees the bulk path must
+// preserve.
+
+// `instanceof`, not `e.constructor.name`: a pre-existing, unrelated gap in
+// the ERR_OUT_OF_RANGE error path (#buffer/numeric.rs's `throw_range_error_
+// code`) leaves `.constructor` undefined on that particular RangeError, so
+// asserting the class this way stays independent of that separate bug.
+function r(fn: () => unknown): string {
+    try {
+        return "ok:" + String(fn());
+    } catch (e: any) {
+        if (e instanceof RangeError) return "throw:RangeError";
+        if (e instanceof TypeError) return "throw:TypeError";
+        return "throw:" + (e && e.name ? e.name : String(e));
+    }
+}
+
+function show(a: Uint8Array): string {
+    return Array.from(a).join(",");
+}
+
+// ---- Buffer-to-Buffer (the bulk-copy fast path) ----
+{
+    const dest = Buffer.alloc(6);
+    const src = Buffer.from([10, 20, 30]);
+    dest.set(src, 2);
+    console.log("buffer-to-buffer:", show(dest));
+}
+
+// ---- Uint8Array-to-Uint8Array ----
+{
+    const dest = new Uint8Array(5);
+    const src = new Uint8Array([1, 2, 3]);
+    dest.set(src, 1);
+    console.log("u8-to-u8:", show(dest));
+}
+
+// ---- Int8Array source: negative values must wrap to the same byte a
+// two's-complement reinterpretation gives (-1 -> 255, -128 -> 128). ----
+{
+    const dest = new Uint8Array(4);
+    const src = new Int8Array([-1, -128, 127, 0]);
+    dest.set(src);
+    console.log("int8-source:", show(dest));
+}
+
+// ---- Uint8ClampedArray source: already-clamped bytes copy as-is. ----
+{
+    const dest = new Uint8Array(3);
+    const src = new Uint8ClampedArray([0, 128, 255]);
+    dest.set(src);
+    console.log("uint8clamped-source:", show(dest));
+}
+
+// ---- Multi-byte TypedArray source: still needs per-element ToNumber-style
+// coercion (NOT the bulk path) — Float64Array carrying fractional/huge/NaN
+// values. ----
+{
+    const dest = new Uint8Array(4);
+    const src = new Float64Array([300, -1, NaN, 3.9]);
+    dest.set(src);
+    console.log("float64-source:", show(dest));
+}
+
+// ---- Plain Array source needing ToUint8 wrapping. ----
+{
+    const dest = new Uint8Array(5);
+    dest.set([-1, 256, 300.9, NaN, Infinity]);
+    console.log("array-source:", show(dest));
+}
+
+// ---- Array-like Object source with index-named properties. ----
+{
+    const dest = new Uint8Array(3);
+    dest.set({ length: 3, 0: 7, 1: 8, 2: 9 } as any);
+    console.log("object-source:", show(dest));
+}
+
+// ---- Zero-length source: no-op, destination untouched. ----
+{
+    const dest = new Uint8Array([1, 2, 3]);
+    dest.set(new Uint8Array(0), 1);
+    console.log("zero-length-source:", show(dest));
+}
+
+// ---- Out-of-range offset: RangeError, target untouched. ----
+{
+    const dest = new Uint8Array(3);
+    console.log("out-of-range-offset:", r(() => dest.set(new Uint8Array(2), 5)));
+    console.log("out-of-range-offset target:", show(dest));
+}
+
+// ---- BigInt-kind source mixed with a Number-kind target must still throw
+// (unaffected by the bulk path — BigInt64/BigUint64 never take it). ----
+{
+    const dest = new Uint8Array(3);
+    console.log("bigint-mix:", r(() => dest.set(new BigInt64Array([1n, 2n]) as any)));
+}
+
+// ---- Overlap: forward shift (`buf.set(buf.subarray(2))`, dest offset < the
+// subarray's own start — reading must observe the ORIGINAL bytes throughout,
+// like memmove). ----
+{
+    const buf = new Uint8Array([1, 2, 3, 4, 5, 6]);
+    buf.set(buf.subarray(2), 0);
+    console.log("overlap-forward:", show(buf));
+}
+
+// ---- Overlap: backward shift (dest offset > source's own start). ----
+{
+    const buf = new Uint8Array([1, 2, 3, 4, 5, 6]);
+    buf.set(buf.subarray(0, 4), 2);
+    console.log("overlap-backward:", show(buf));
+}
+
+// ---- Overlap: source fully nested inside the destination's own window. ----
+{
+    const buf = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    buf.set(buf.subarray(2, 5), 3);
+    console.log("overlap-nested:", show(buf));
+}
+
+// ---- #1205 view coherency: a direct write to the BACKING buffer (the
+// codegen fast path for a statically-typed Buffer.alloc local) must still be
+// visible to a `set()` that reads through a registered view of it. ----
+{
+    const backing = Buffer.alloc(4);
+    backing[0] = 1;
+    backing[1] = 2;
+    backing[2] = 3;
+    backing[3] = 4;
+    const view = backing.subarray(1, 3);
+    backing[2] = 99; // direct write to the backing AFTER the view was created
+    const dest = Buffer.alloc(2);
+    dest.set(view);
+    console.log("view-coherency:", show(dest));
+}


### PR DESCRIPTION
## Summary

Fixes #10088. `Uint8Array`/`Buffer.prototype.set(source, offset)` materialized
its source into a `Vec<u8>` one byte at a time via `js_buffer_get`/
`js_typed_array_get` — each call paying a view-registry lookup (and, for a
`TypedArray` source, a per-element dispatch/coercion) — before copying that
`Vec` into the target a second time. At 1M bytes this measured 82x Node
(171x at 100k) in the issue.

For a `Buffer` source, or a same-element-width (1-byte) `TypedArray` source
(`Int8Array`/`Uint8Array`/`Uint8ClampedArray`, where the stored byte already
equals what `to_uint8` of the read element gives), the fix resolves the
source's raw byte span **once** via the existing `view::resolve_data_ptr` /
`typedarray::data_ptr` resolvers, and copies the whole span into the target
with `ptr::copy` (a memmove) instead of the byte loop + intermediate `Vec`.
`ptr::copy` rather than `copy_nonoverlapping` matters here: `resolve_data_ptr`
can legitimately hand back a pointer into the same backing buffer the target
is itself a view of (e.g. `buf.set(buf.subarray(2), 0)`), so source and
destination ranges can really overlap.

`Array`/`Object` sources and wider/BigInt `TypedArray` sources are untouched —
they still need per-element `ToNumber`/property-read coercion, so they keep
the existing `collect_buffer_set_bytes` path.

Locally, a 1M-byte `Uint8Array.set` now measures ~1.2x Node, down from the
issue's ~82x.

## Testing

- `test-files/test_gap_10088_uint8array_set_bulk_copy.ts` (new gap test):
  Buffer→Buffer, TypedArray→Buffer for all three 1-byte kinds (including
  Int8Array's negative-value wrap), a multi-byte TypedArray source (still
  per-element), an Array source needing ToUint8 wrapping, an array-like
  Object source, a zero-length source, an out-of-range offset, a BigInt-kind
  mismatch, three overlap shapes (forward/backward/nested subarray self-set),
  and a #1205 view-coherency case (direct write to the backing after a view
  was taken, read back through `.set()` on that view). Compiled and diffed
  byte-for-byte against `node 26.5.1` (the `.node-version` pin) — identical.
- `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime buffer:: typedarray::` — 74 passed, 0 failed.
- `cargo fmt --all -- --check`, `scripts/check_file_size.sh`,
  `scripts/addr_class_inventory.py` — all clean.

## Note: unrelated pre-existing bug found while testing

While comparing the out-of-range-offset `RangeError` against Node, I found
that `throw_range_error_code` (`crates/perry-runtime/src/buffer/numeric.rs`,
used for `ERR_OUT_OF_RANGE` throws including this one) builds its error via
`js_object_alloc` directly rather than the real `RangeError` constructor path,
so `.constructor` is `undefined` on it — the same class of bug
`throw_dataview_offset_out_of_bounds` right next to it was already fixed for
(see that function's comment). `instanceof RangeError` still holds. This is
unrelated to #10088 and out of scope for this PR (the gap test uses
`instanceof` to sidestep it, with a comment); happy to file a follow-up issue
if useful.

No version bump per request — this PR does not touch `Cargo.toml` or the
`CLAUDE.md` version line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved `Uint8Array` and `Buffer` bulk-copy operations for compatible byte-based sources.
  * Large transfers are significantly faster and now handle overlapping source and destination ranges safely.

* **Bug Fixes**
  * Improved consistency when copying data through shared or registered views.
  * Preserved correct coercion behavior for arrays, objects, wider typed arrays, and BigInt-based sources.
  * Added coverage for offsets, zero-length operations, range errors, and overlapping copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->