### PR TITLE
perf(hir): skip the iterator protocol for proven-array destructuring

### DIFF
--- a/changelog.d/10112-array-destructuring-fast-path.md
+++ b/changelog.d/10112-array-destructuring-fast-path.md
@@ -1,0 +1,62 @@
+### Performance
+
+Array destructuring no longer drives the spec iterator protocol when the source
+is a spread-free array literal written in place or a value whose static type
+proves a plain `Array`. Both `[x, y] = [y, x]` and `const [a, b] = pair(i)`
+previously paid a `GetIterator` call, one `iteratorNextResult` per element —
+each allocating a `{ value, done }` result object — two property reads off that
+result, and an `IteratorClose`, none of which is observable for an array whose
+`Array.prototype[Symbol.iterator]` has not been replaced.
+
+The lowering now emits both arms and branches on the same runtime guard that
+`for…of` over a proven array uses (`Expr::ArrayIterationPatched`, a volatile
+read of the runtime's sticky `PERRY_ARRAY_PROTO_ITERATOR_PATCHED` byte); no
+runtime change was needed. For a literal source the fast arm spills the
+literal's elements into temps and never builds the array at all, so the swap
+loop's one GC allocation per iteration disappears — a 10,000,000-iteration
+`[a, b] = [b, a]` loop runs 7,952 collections before the change and 6 after,
+the same 6 it runs at 10,000 iterations. For a proven array it reads elements
+by index, re-reading `length` per element exactly as `IteratorStep` does.
+
+The branch is per element rather than around the whole pattern. A pattern
+DECLARES bindings, so lowering it twice would give each binding two `LocalId`s;
+per-element branching also preserves the spec's interleaving, which an eager
+"pull N values, then bind" arm would lose — `let [a = f(), b] = src` still
+evaluates `f()` between producing element 0 and element 1.
+
+Measured against Node 26.5.1 on an Apple M1 Max (host under heavy concurrent
+build load, so the absolute times are inflated; checksums matched at every
+size):
+
+| workload | n | before | after | speedup | before ÷ node | after ÷ node |
+|---|---:|---:|---:|---:|---:|---:|
+| `iteration-destructuring-swap` | 1,000 | 2.393 ms | 0.057 ms | 42.2x | 81.8x | 1.94x |
+| `iteration-destructuring-swap` | 100,000 | 334.6 ms | 7.38 ms | 45.3x | 104.1x | 2.30x |
+| `iteration-destructuring-swap` | 1,000,000 | 3071.9 ms | 105.0 ms | 29.3x | 102.6x | 3.51x |
+| `iteration-destructure-return` | 1,000 | 5.199 ms | 0.076 ms | 68.2x | 101.0x | 1.48x |
+| `iteration-destructure-return` | 100,000 | 457.0 ms | 7.70 ms | 59.3x | 61.5x | 1.04x |
+| `iteration-destructure-return` | 1,000,000 | 4673.5 ms | 191.3 ms | 24.4x | 90.7x | 3.71x |
+
+A rest element, a nested pattern, an empty pattern, a generator, a `Set` / `Map`
+/ string and any source without a static array proof keep the unguarded iterator
+lowering, statement-for-statement identical to before.
+
+### Fixed
+
+A `for…of` over a statically-proven array ignored a replaced
+`%ArrayIteratorPrototype%.next`, iterating the unpatched elements where Node
+iterates the patched ones — the half of the iteration protocol #7760's guard did
+not cover, because the runtime detects a replaced `next` per `.next()` call and
+an index loop never calls it.
+
+The exported guard byte (renamed `PERRY_ARRAY_ITERATION_NOT_PRISTINE`, since it
+no longer means only "`Array.prototype[Symbol.iterator]` was replaced") is now
+also set when the array-iterator prototype object escapes to user code through
+`Object.getPrototypeOf` / `Reflect.getPrototypeOf` — the only way to name that
+object in order to patch it. Setting it on escape rather than on the write is
+deliberate: the object is an ordinary object, so a precise hook would have to
+cover every mutation funnel and missing one fails silently toward a wrong
+answer, whereas over-approximating costs the index arm only in programs that
+introspect an array iterator. The Rust-side `ARRAY_PROTO_ITERATOR_MODIFIED` bool
+keeps its original narrow meaning, so the spread and `js_get_iterator`
+delegation paths are unchanged.

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -1208,7 +1208,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // predictable branch PER LOOP, never per iteration.
         Expr::ArrayIterationPatched => {
             let blk = ctx.block();
-            let flag = blk.load_volatile(crate::types::I8, "@PERRY_ARRAY_PROTO_ITERATOR_PATCHED");
+            let flag = blk.load_volatile(crate::types::I8, "@PERRY_ARRAY_ITERATION_NOT_PRISTINE");
             let widened = blk.zext(crate::types::I8, &flag, crate::types::I32);
             Ok(super::i32_bool_to_nanbox(blk, &widened))
         }

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -58,7 +58,7 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     // byte directly in the inline plain-array index guard.
     module.add_external_global("PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED", I8);
     // #7760: set when `Array.prototype[Symbol.iterator]` is replaced.
-    module.add_external_global("PERRY_ARRAY_PROTO_ITERATOR_PATCHED", I8);
+    module.add_external_global("PERRY_ARRAY_ITERATION_NOT_PRISTINE", I8);
     // Process-wide count of threads with an active incremental marking
     // barrier. Persistent shadow-slot updates use zero as an authoritative
     // fast skip before calling the TLS-backed root barrier.

--- a/crates/perry-hir/src/destructuring/array_fast.rs
+++ b/crates/perry-hir/src/destructuring/array_fast.rs
@@ -1,0 +1,330 @@
+//! #10086: the non-iterator arm of array destructuring.
+//!
+//! Both destructuring entry points (`[a, b] = rhs` as a statement and
+//! `const [a, b] = rhs`) lower an array pattern through the full spec iterator
+//! protocol: `GetIterator`, one `iteratorNextResult` per element (each of which
+//! allocates a `{ value, done }` result object), two property reads off that
+//! result, and `IteratorClose`. For a plain array that is the whole cost — the
+//! measured swap (`[x, y] = [y, x]`) spent 76x Node on machinery that is, for an
+//! unpatched `Array.prototype[Symbol.iterator]`, entirely unobservable.
+//!
+//! The patch is a RUNTIME fact and the choice of lowering is a COMPILE-TIME one,
+//! so — exactly as #7760 item 1 did for `for…of` over a proven array — the only
+//! correct answer is to emit both and branch on [`Expr::ArrayIterationPatched`],
+//! the volatile `i8` read of the runtime's sticky
+//! `PERRY_ARRAY_ITERATION_NOT_PRISTINE` byte.
+//!
+//! Two properties shaped this differently from the `for…of` guard:
+//!
+//!   * The branch is PER ELEMENT, not around the whole pattern. A destructuring
+//!     pattern DECLARES bindings (`const [a, b] = …`); lowering the pattern
+//!     twice would allocate two different `LocalId`s for `a`, and every use
+//!     after the `if` would resolve to whichever arm was lowered last.
+//!     Branching only where the element VALUE is produced keeps one binding per
+//!     leaf.
+//!   * Branching per element is also what keeps the lowering spec-exact. Both
+//!     arms interleave element production with the pattern's own work, so
+//!     `let [a = f(), b] = src` still evaluates `f()` between producing element
+//!     0 and producing element 1 — an eager "pull N values, then bind" fast arm
+//!     would not.
+//!
+//! The iterator arm is what the pre-existing lowering emitted apart from
+//! `GetIterator` moving behind the guard, so a patched iterator behaves exactly
+//! as it did before.
+//!
+//! The guard covers BOTH ways array iteration stops being the builtin protocol.
+//! A replaced or deleted `Array.prototype[Symbol.iterator]` already set that
+//! byte (#7760). A replaced `%ArrayIteratorPrototype%.next` did not: the runtime
+//! detects it per `.next()` call, which an arm that never calls `.next()` cannot
+//! observe. #10086 also publishes the byte when the array-iterator prototype
+//! object escapes to user code — the only way to name it in order to patch it —
+//! so both arms decline. That closed the same hole in the `for…of` index loop,
+//! which had it since #7760. Spread keeps its own Rust-side proof
+//! (`array::dense_spread_source`) and is unchanged.
+//!
+//! Element production on the fast arm comes in two shapes ([`FastElements`]):
+//! an index read for a statically-proven array, and — when the source is a
+//! spread-free array literal written in place — the literal's already-spilled
+//! element temps, which removes the array ALLOCATION as well (the swap's one GC
+//! allocation per iteration).
+
+use super::*;
+
+/// How one array pattern reaches its elements.
+pub(crate) enum ArraySource {
+    /// No proof that the source is a plain array — drive the spec iterator
+    /// protocol on this expression, unguarded. What every array pattern did
+    /// before #10086, and what a nested pattern, a rest element or an unproven
+    /// source still does.
+    Iterator(Expr),
+    /// The source admits the non-iterator arm: [`FastPlan`] carries both the
+    /// runtime guard and the fast element source.
+    Guarded(FastPlan),
+}
+
+impl ArraySource {
+    /// The initializer for the pattern's iterator local.
+    pub(crate) fn iter_init(&self) -> Expr {
+        match self {
+            ArraySource::Iterator(source) => Expr::GetIterator(Box::new(source.clone())),
+            ArraySource::Guarded(plan) => plan.guarded_get_iterator(),
+        }
+    }
+
+    /// Produce element `idx` into `value_id`. `iter_pull` is the caller's
+    /// existing iterator-step sequence, used verbatim on the protocol arm.
+    pub(crate) fn pull(&self, idx: usize, value_id: LocalId, iter_pull: Vec<Stmt>) -> Vec<Stmt> {
+        match self {
+            ArraySource::Iterator(_) => iter_pull,
+            ArraySource::Guarded(plan) => vec![plan.guarded_pull(idx, value_id, iter_pull)],
+        }
+    }
+
+    /// `IteratorClose`, run only where an iterator was actually created.
+    pub(crate) fn close(&self, close: Stmt) -> Stmt {
+        match self {
+            ArraySource::Iterator(_) => close,
+            ArraySource::Guarded(plan) => plan.guarded_close(close),
+        }
+    }
+}
+
+/// Where the fast arm reads element `i` from.
+pub(crate) enum FastElements {
+    /// A local holding a statically-proven plain Array. Element `i` is
+    /// `i < src.length ? src[i] : undefined` — the bounds test is what makes an
+    /// out-of-range element `undefined` (so a destructuring default still
+    /// fires) instead of whatever the backing store answers past its end.
+    /// `length` is re-read per element because the spec's `IteratorStep` does:
+    /// a default initializer that truncates the array must be visible to the
+    /// next element.
+    Indexed(LocalId),
+    /// One local per element of a spread-free array literal, spilled in source
+    /// order BEFORE the guard (so each element expression is evaluated exactly
+    /// once, whichever arm runs). Element `i` past the end is `undefined`, the
+    /// value the iterator would have produced once exhausted.
+    Scalars(Vec<LocalId>),
+}
+
+/// The guarded-pull plan for one array pattern.
+pub(crate) struct FastPlan {
+    /// Boolean local holding the once-evaluated [`Expr::ArrayIterationPatched`].
+    /// Read once per element; the branch is loop-invariant and perfectly
+    /// predicted.
+    use_iter: LocalId,
+    /// The expression the iterator arm calls `GetIterator` on. Evaluated ONLY on
+    /// that arm — for the `Scalars` shape it is the array literal rebuilt from
+    /// the spilled temps, so the fast arm allocates no array at all.
+    iter_source: Expr,
+    elements: FastElements,
+}
+
+impl FastPlan {
+    /// The fast arm's value for element `idx`.
+    fn value(&self, idx: usize) -> Expr {
+        match &self.elements {
+            FastElements::Scalars(temps) => match temps.get(idx) {
+                Some(id) => Expr::LocalGet(*id),
+                None => Expr::Undefined,
+            },
+            FastElements::Indexed(src) => Expr::Conditional {
+                condition: Box::new(Expr::Compare {
+                    op: CompareOp::Lt,
+                    left: Box::new(Expr::Number(idx as f64)),
+                    right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
+                        object: Box::new(Expr::LocalGet(*src)),
+                        property: "length".to_string(),
+                    }),
+                }),
+                then_expr: Box::new(Expr::IndexGet {
+                    object: Box::new(Expr::LocalGet(*src)),
+                    index: Box::new(Expr::Number(idx as f64)),
+                }),
+                else_expr: Box::new(Expr::Undefined),
+            },
+        }
+    }
+
+    /// `__use ? GetIterator(<source>) : undefined` — the iterator (and, for the
+    /// literal shape, the array it iterates) is materialized only when the
+    /// protocol is actually patched. A `Conditional` rather than a mutable
+    /// local written inside an `if` keeps the iterator binding an immutable
+    /// `Let`, the same shape the unguarded lowering emitted.
+    pub(crate) fn guarded_get_iterator(&self) -> Expr {
+        Expr::Conditional {
+            condition: Box::new(Expr::LocalGet(self.use_iter)),
+            then_expr: Box::new(Expr::GetIterator(Box::new(self.iter_source.clone()))),
+            else_expr: Box::new(Expr::Undefined),
+        }
+    }
+
+    /// `if (__use) { <iterator pull> } else { value = <fast element> }`.
+    /// `iter_pull` is the caller's existing per-element iterator sequence,
+    /// unchanged.
+    pub(crate) fn guarded_pull(&self, idx: usize, value_id: LocalId, iter_pull: Vec<Stmt>) -> Stmt {
+        Stmt::If {
+            condition: Expr::LocalGet(self.use_iter),
+            then_branch: iter_pull,
+            else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
+                value_id,
+                Box::new(self.value(idx)),
+            ))]),
+        }
+    }
+
+    /// `if (__use) { <IteratorClose> }` — there is nothing to close on the fast
+    /// arm, which never created an iterator.
+    pub(crate) fn guarded_close(&self, close: Stmt) -> Stmt {
+        Stmt::If {
+            condition: Expr::LocalGet(self.use_iter),
+            then_branch: vec![close],
+            else_branch: None,
+        }
+    }
+}
+
+fn fresh(ctx: &mut LoweringContext, ty: Type) -> (LocalId, String) {
+    let id = ctx.fresh_local();
+    let name = format!("__destruct_fast_{}", id);
+    ctx.locals.push((name.clone(), id, ty));
+    (id, name)
+}
+
+fn push_guard(ctx: &mut LoweringContext, out: &mut Vec<Stmt>) -> LocalId {
+    let (id, name) = fresh(ctx, Type::Boolean);
+    out.push(Stmt::Let {
+        id,
+        name,
+        ty: Type::Boolean,
+        mutable: false,
+        init: Some(Expr::ArrayIterationPatched),
+    });
+    id
+}
+
+/// Plan for a spread-free array-literal source: spill every element into a temp
+/// in source order (evaluated exactly once, on either arm), then read the guard.
+pub(crate) fn plan_for_literal(
+    ctx: &mut LoweringContext,
+    elems: &[&ast::Expr],
+    out: &mut Vec<Stmt>,
+) -> Result<FastPlan> {
+    let mut temps = Vec::with_capacity(elems.len());
+    for elem in elems {
+        let value = lower_expr(ctx, elem)?;
+        let (id, name) = fresh(ctx, Type::Any);
+        out.push(Stmt::Let {
+            id,
+            name,
+            ty: Type::Any,
+            mutable: false,
+            init: Some(value),
+        });
+        temps.push(id);
+    }
+    let use_iter = push_guard(ctx, out);
+    Ok(FastPlan {
+        use_iter,
+        iter_source: Expr::Array(temps.iter().map(|id| Expr::LocalGet(*id)).collect()),
+        elements: FastElements::Scalars(temps),
+    })
+}
+
+/// Plan for a source whose static type proves a plain Array: spill it into one
+/// local that BOTH arms read, then read the guard.
+pub(crate) fn plan_for_proven_array(
+    ctx: &mut LoweringContext,
+    source: Expr,
+    out: &mut Vec<Stmt>,
+) -> FastPlan {
+    // `Array(Any)` (not `Any`): an `Any`-typed temp routes element reads through
+    // the typed-element fast path, which answers a miss with `0` rather than
+    // `undefined` and so breaks destructuring defaults. Same choice, for the
+    // same reason, as `emit_for_of_pattern_binding`'s temp.
+    let ty = Type::Array(Box::new(Type::Any));
+    let (src_id, src_name) = fresh(ctx, ty.clone());
+    out.push(Stmt::Let {
+        id: src_id,
+        name: src_name,
+        ty,
+        mutable: false,
+        init: Some(source),
+    });
+    let use_iter = push_guard(ctx, out);
+    FastPlan {
+        use_iter,
+        iter_source: Expr::LocalGet(src_id),
+        elements: FastElements::Indexed(src_id),
+    }
+}
+
+/// A spread-free array literal's element expressions, or `None` for anything
+/// else. Holes are rejected: a hole is a genuinely ABSENT index whose read walks
+/// the prototype chain, which substituting `undefined` would not do.
+pub(crate) fn spread_free_array_literal(expr: &ast::Expr) -> Option<Vec<&ast::Expr>> {
+    let ast::Expr::Array(arr) = expr else {
+        return None;
+    };
+    let mut out = Vec::with_capacity(arr.elems.len());
+    for elem in &arr.elems {
+        let elem = elem.as_ref()?;
+        if elem.spread.is_some() {
+            return None;
+        }
+        out.push(elem.expr.as_ref());
+    }
+    Some(out)
+}
+
+/// Does `expr`'s static type prove a plain Array? The same predicate the
+/// `for…of` desugar uses to decide it may read `.length` / `[i]` directly
+/// (`stmt_loops.rs`'s `proven_array`).
+pub(crate) fn proven_array(ctx: &LoweringContext, expr: &ast::Expr) -> bool {
+    match infer_type_from_expr(expr, ctx) {
+        Type::Array(_) => true,
+        Type::Generic { base, .. } => base == "Array",
+        _ => false,
+    }
+}
+
+/// Can every element of this pattern be produced by index?
+///
+/// A rest element cannot: draining the remainder through the iterator builds a
+/// DENSE array, while the obvious index-side equivalent (`slice`) preserves
+/// holes, so the two disagree on a sparse source. A pattern with a rest element
+/// keeps the unguarded iterator lowering.
+pub(crate) fn pattern_admits_index_reads(elems: &[Option<ast::Pat>]) -> bool {
+    !elems.iter().any(|e| matches!(e, Some(ast::Pat::Rest(_))))
+}
+
+/// #10086: build the guarded non-iterator plan for a destructuring source, or
+/// `None` when this pattern/source pair keeps the plain iterator lowering.
+/// Returns the setup statements the plan depends on (the literal's element
+/// spills or the source spill, plus the guard read) alongside it.
+///
+/// `source` is lowered ONLY on the paths that return `Some`, so a caller that
+/// falls back still lowers it exactly once.
+pub(crate) fn plan_for_source(
+    ctx: &mut LoweringContext,
+    elems: &[Option<ast::Pat>],
+    source: &ast::Expr,
+) -> Result<Option<(Vec<Stmt>, FastPlan)>> {
+    // An empty pattern (`[] = x`) reads no element, so the fast arm would touch
+    // the source not at all — and `GetIterator` is the only thing that makes
+    // `[] = <not iterable>` throw. Keep the protocol so it still does.
+    if elems.is_empty() || !pattern_admits_index_reads(elems) {
+        return Ok(None);
+    }
+    let mut setup = Vec::new();
+    if let Some(literal) = spread_free_array_literal(source) {
+        let plan = plan_for_literal(ctx, &literal, &mut setup)?;
+        return Ok(Some((setup, plan)));
+    }
+    if proven_array(ctx, source) {
+        let lowered = lower_expr(ctx, source)?;
+        let plan = plan_for_proven_array(ctx, lowered, &mut setup);
+        return Ok(Some((setup, plan)));
+    }
+    Ok(None)
+}

--- a/crates/perry-hir/src/destructuring/assignment_stmt.rs
+++ b/crates/perry-hir/src/destructuring/assignment_stmt.rs
@@ -1,5 +1,6 @@
 //! Lowering of destructuring assignment statements (e.g. `[a, b] = expr` as a statement).
 
+use super::array_fast::{self, ArraySource};
 use super::*;
 
 #[derive(Clone)]
@@ -47,6 +48,18 @@ pub(crate) fn lower_destructuring_assignment_stmt(
     pat: &ast::AssignTargetPat,
     rhs: &ast::Expr,
 ) -> Result<Vec<Stmt>> {
+    // #10086: `[x, y] = [y, x]` and `[a, b] = <proven array>` do not need the
+    // iterator protocol unless `Array.prototype[Symbol.iterator]` is patched.
+    if let ast::AssignTargetPat::Array(arr_pat) = pat {
+        if let Some((mut result, plan)) = array_fast::plan_for_source(ctx, &arr_pat.elems, rhs)? {
+            result.extend(lower_array_assignment_from_expr(
+                ctx,
+                arr_pat,
+                ArraySource::Guarded(plan),
+            )?);
+            return Ok(result);
+        }
+    }
     let rhs_expr = lower_expr(ctx, rhs)?;
     let (tmp_id, tmp_name) = fresh_destruct_local(ctx, "destruct", Type::Any);
 
@@ -71,9 +84,11 @@ pub(crate) fn lower_destructuring_assignment_stmt_from_local(
     source_id: LocalId,
 ) -> Result<Vec<Stmt>> {
     match pat {
-        ast::AssignTargetPat::Array(arr_pat) => {
-            lower_array_assignment_from_expr(ctx, arr_pat, Expr::LocalGet(source_id))
-        }
+        ast::AssignTargetPat::Array(arr_pat) => lower_array_assignment_from_expr(
+            ctx,
+            arr_pat,
+            ArraySource::Iterator(Expr::LocalGet(source_id)),
+        ),
         ast::AssignTargetPat::Object(obj_pat) => {
             lower_object_assignment_from_expr(ctx, obj_pat, Expr::LocalGet(source_id))
         }
@@ -84,7 +99,7 @@ pub(crate) fn lower_destructuring_assignment_stmt_from_local(
 fn lower_array_assignment_from_expr(
     ctx: &mut LoweringContext,
     arr_pat: &ast::ArrayPat,
-    source: Expr,
+    source: ArraySource,
 ) -> Result<Vec<Stmt>> {
     let (iter_id, iter_name) = fresh_destruct_local(ctx, "destruct_iter", Type::Any);
     let (done_id, done_name) = fresh_destruct_local(ctx, "destruct_done", Type::Boolean);
@@ -95,7 +110,7 @@ fn lower_array_assignment_from_expr(
             name: iter_name,
             ty: Type::Any,
             mutable: false,
-            init: Some(Expr::GetIterator(Box::new(source))),
+            init: Some(source.iter_init()),
         },
         Stmt::Let {
             id: done_id,
@@ -107,7 +122,7 @@ fn lower_array_assignment_from_expr(
     ];
 
     let mut body = Vec::new();
-    for elem in &arr_pat.elems {
+    for (idx, elem) in arr_pat.elems.iter().enumerate() {
         if let Some(ast::Pat::Rest(rest_pat)) = elem {
             // AssignmentRestElement evaluates its target and drains every
             // remaining iterator value into a fresh Array, then performs the
@@ -152,18 +167,20 @@ fn lower_array_assignment_from_expr(
         if let Some(elem_pat) = elem {
             let (prepare, target, default_value) = prepare_target_with_default(ctx, elem_pat)?;
             body.extend(prepare);
-            body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+            let pull = iterator_next_value_stmts(ctx, iter_id, done_id, value_id);
+            body.extend(source.pull(idx, value_id, pull));
             let assigned = value_with_default(ctx, Expr::LocalGet(value_id), default_value)?;
             body.extend(assign_prepared_target(ctx, target, assigned)?);
         } else {
-            body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+            let pull = iterator_next_value_stmts(ctx, iter_id, done_id, value_id);
+            body.extend(source.pull(idx, value_id, pull));
         }
     }
 
-    let close_stmt = Stmt::Expr(runtime_iterator_call(
+    let close_stmt = source.close(Stmt::Expr(runtime_iterator_call(
         "iteratorCloseIfNotDone",
         vec![Expr::LocalGet(iter_id), Expr::LocalGet(done_id)],
-    ));
+    )));
     let (exc_id, exc_name) = fresh_destruct_local(ctx, "destruct_error", Type::Any);
     result.push(Stmt::Try {
         body,
@@ -552,7 +569,9 @@ fn assign_prepared_target(
             receiver: Box::new(object),
             strict: ctx.current_strict,
         })]),
-        PreparedTarget::Array(arr) => lower_array_assignment_from_expr(ctx, &arr, value),
+        PreparedTarget::Array(arr) => {
+            lower_array_assignment_from_expr(ctx, &arr, ArraySource::Iterator(value))
+        }
         PreparedTarget::Object(obj) => lower_object_assignment_from_expr(ctx, &obj, value),
         PreparedTarget::Skip => Ok(Vec::new()),
     }

--- a/crates/perry-hir/src/destructuring/mod.rs
+++ b/crates/perry-hir/src/destructuring/mod.rs
@@ -4,6 +4,8 @@
 //! declarations with destructuring patterns.
 //!
 //! Organized into topical sub-modules:
+//! - [`array_fast`] — #10086: the guarded non-iterator arm shared by the
+//!   assignment and declaration array-pattern lowerings.
 //! - [`helpers`] — small utility predicates / pattern recognizers shared
 //!   across the other sub-modules (e.g. `useState` tuple rewrite,
 //!   recursive AST scans).
@@ -23,6 +25,7 @@ use crate::lower::{lower_expr, LoweringContext};
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
+mod array_fast;
 mod assignment_expr;
 mod assignment_stmt;
 mod helpers;
@@ -35,7 +38,7 @@ pub(crate) use assignment_stmt::{
     lower_destructuring_assignment_stmt, lower_destructuring_assignment_stmt_from_local,
 };
 pub(crate) use helpers::{ast_expr_contains_function_expr, rewrite_use_state_tuple};
-pub(crate) use pattern_binding::lower_pattern_binding;
+pub(crate) use pattern_binding::{lower_array_pattern_binding_guarded, lower_pattern_binding};
 pub(crate) use var_decl::for_init_decl_type;
 pub(crate) use var_decl::lower_var_decl_with_destructuring;
 pub(crate) use var_decl_sources::resolvable_native_module_for_spec;

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -1,5 +1,6 @@
 //! Recursive lowering of binding patterns (`let { a, b } = expr`).
 
+use super::array_fast::{self, ArraySource};
 use super::*;
 
 fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
@@ -163,7 +164,7 @@ fn iterator_next_value_stmts(
 fn lower_array_pattern_binding(
     ctx: &mut LoweringContext,
     arr_pat: &ast::ArrayPat,
-    source: Expr,
+    source: ArraySource,
     mutable: bool,
     is_var_decl: bool,
     result: &mut Vec<Stmt>,
@@ -174,7 +175,7 @@ fn lower_array_pattern_binding(
         name: iter_name,
         ty: Type::Any,
         mutable: false,
-        init: Some(Expr::GetIterator(Box::new(source))),
+        init: Some(source.iter_init()),
     });
     let (done_id, done_name) = fresh_destruct_local(ctx, Type::Boolean);
     result.push(Stmt::Let {
@@ -186,7 +187,7 @@ fn lower_array_pattern_binding(
     });
 
     let mut body: Vec<Stmt> = Vec::new();
-    for elem in &arr_pat.elems {
+    for (idx, elem) in arr_pat.elems.iter().enumerate() {
         match elem {
             // Elision (`[, x]`) — advance the iterator and discard the value.
             None => {
@@ -198,7 +199,8 @@ fn lower_array_pattern_binding(
                     mutable: true,
                     init: Some(Expr::Undefined),
                 });
-                body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+                let pull = iterator_next_value_stmts(ctx, iter_id, done_id, value_id);
+                body.extend(source.pull(idx, value_id, pull));
             }
             // Rest element (`[...rest]`) — drain the remainder into an array.
             Some(ast::Pat::Rest(rest_pat)) => {
@@ -237,7 +239,8 @@ fn lower_array_pattern_binding(
                     mutable: true,
                     init: Some(Expr::Undefined),
                 });
-                body.extend(iterator_next_value_stmts(ctx, iter_id, done_id, value_id));
+                let pull = iterator_next_value_stmts(ctx, iter_id, done_id, value_id);
+                body.extend(source.pull(idx, value_id, pull));
 
                 // A `Pat::Assign` element carries a default initializer that is
                 // evaluated lazily, only when the pulled value is `undefined`.
@@ -277,10 +280,10 @@ fn lower_array_pattern_binding(
     // Close the iterator: on any abrupt completion from the body (default
     // initializer / nested pattern throwing), and again on normal completion
     // when the iterator was not exhausted.
-    let close_stmt = Stmt::Expr(runtime_iterator_call(
+    let close_stmt = source.close(Stmt::Expr(runtime_iterator_call(
         "iteratorCloseIfNotDone",
         vec![Expr::LocalGet(iter_id), Expr::LocalGet(done_id)],
-    ));
+    )));
     let (exc_id, exc_name) = fresh_destruct_local(ctx, Type::Any);
     result.push(Stmt::Try {
         body,
@@ -329,6 +332,33 @@ pub(crate) fn lower_pattern_binding(
     let mut result = Vec::new();
     lower_pattern_binding_into(ctx, pat, source, mutable, is_var_decl, &mut result)?;
     Ok(result)
+}
+
+/// #10086: `const [a, b] = <spread-free array literal / statically-proven
+/// array>` — bind the pattern through the guarded non-iterator arm.
+///
+/// A declaration entry point of its own rather than a flag on
+/// [`lower_pattern_binding`], because the proof is a property of the TOP-level
+/// pattern and its initializer: a nested pattern's source is an element of
+/// unknown type, and every recursive call keeps the plain iterator lowering.
+/// `setup` holds the statements the plan already emitted (the literal's element
+/// spills, or the source spill, plus the guard read) and is extended in place.
+pub(crate) fn lower_array_pattern_binding_guarded(
+    ctx: &mut LoweringContext,
+    arr_pat: &ast::ArrayPat,
+    plan: array_fast::FastPlan,
+    mutable: bool,
+    is_var_decl: bool,
+    setup: &mut Vec<Stmt>,
+) -> Result<()> {
+    lower_array_pattern_binding(
+        ctx,
+        arr_pat,
+        ArraySource::Guarded(plan),
+        mutable,
+        is_var_decl,
+        setup,
+    )
 }
 
 pub(crate) fn lower_pattern_binding_into(
@@ -485,7 +515,14 @@ pub(crate) fn lower_pattern_binding_into(
             // Array binding patterns use the iterator protocol (GetIterator /
             // IteratorStep / IteratorValue / IteratorClose), per spec — not raw
             // index reads. See `lower_array_pattern_binding`.
-            lower_array_pattern_binding(ctx, arr_pat, source, mutable, is_var_decl, result)
+            lower_array_pattern_binding(
+                ctx,
+                arr_pat,
+                ArraySource::Iterator(source),
+                mutable,
+                is_var_decl,
+                result,
+            )
         }
         ast::Pat::Object(obj_pat) => {
             // Materialize source into a temp

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -429,20 +429,47 @@ pub(crate) fn lower_var_decl_with_destructuring(
             // [value, setter_closure] 2-element array. Without this, the
             // regular destructure path indexes a scalar return as if it were
             // an array — both elements come out undefined.
-            let init_expr =
+            let use_state_tuple =
                 if let (ast::Pat::Array(_), Some(init)) = (&decl.name, decl.init.as_ref()) {
-                    if let Some(rewritten) = rewrite_use_state_tuple(ctx, init) {
-                        rewritten
-                    } else {
-                        lower_expr(ctx, init)?
-                    }
+                    rewrite_use_state_tuple(ctx, init)
                 } else {
-                    decl.init
-                        .as_ref()
-                        .map(|e| lower_expr(ctx, e))
-                        .transpose()?
-                        .ok_or_else(|| anyhow!("Destructuring requires an initializer"))?
+                    None
                 };
+
+            // #10086: `const [a, b] = [x, y]` / `= <statically-proven array>`
+            // binds through the guarded non-iterator arm — no iterator object,
+            // no `{ value, done }` result object per element, and for a literal
+            // source no array allocation at all. Decided BEFORE the initializer
+            // is lowered, because the literal shape spills each element into
+            // its own temp instead of materializing the array.
+            if use_state_tuple.is_none() {
+                if let (ast::Pat::Array(arr_pat), Some(init)) = (pattern, decl.init.as_ref()) {
+                    if let Some((mut stmts, plan)) =
+                        super::array_fast::plan_for_source(ctx, &arr_pat.elems, init)?
+                    {
+                        lower_array_pattern_binding_guarded(
+                            ctx,
+                            arr_pat,
+                            plan,
+                            mutable,
+                            is_var_decl,
+                            &mut stmts,
+                        )?;
+                        result.extend(stmts);
+                        return Ok(result);
+                    }
+                }
+            }
+
+            let init_expr = match use_state_tuple {
+                Some(rewritten) => rewritten,
+                None => decl
+                    .init
+                    .as_ref()
+                    .map(|e| lower_expr(ctx, e))
+                    .transpose()?
+                    .ok_or_else(|| anyhow!("Destructuring requires an initializer"))?,
+            };
             let stmts = lower_pattern_binding(ctx, pattern, init_expr, mutable, is_var_decl)?;
             result.extend(stmts);
         }

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2374,14 +2374,19 @@ pub enum Expr {
     /// `operand[Symbol.iterator]()` when iterable, else the operand itself (a
     /// generator object already *is* its iterator). Lowers to `js_get_iterator`.
     GetIterator(Box<Expr>),
-    /// #7760: is `Array.prototype[Symbol.iterator]` currently replaced?
+    /// #7760 / #10086: can array iteration still be PROVEN to be the pristine
+    /// builtin protocol?
     ///
-    /// Reads the runtime's `PERRY_ARRAY_PROTO_ITERATOR_PATCHED` flag. Emitted
-    /// once at the ENTRY of a `for…of` over a statically-proven array, to pick
-    /// between the index loop (`__i < __arr.length`) and the lazy
-    /// iterator-protocol loop. Checking once is what the spec wants — `for…of`
-    /// performs GetIterator exactly once — and it keeps the cost off the
-    /// per-iteration path.
+    /// Reads the runtime's `PERRY_ARRAY_ITERATION_NOT_PRISTINE` flag, which is
+    /// set when `Array.prototype[Symbol.iterator]` is replaced or deleted
+    /// (#7760) and when the array-iterator prototype object escapes to user
+    /// code, after which `%ArrayIteratorPrototype%.next` may be patched
+    /// (#10086). Emitted once at the ENTRY of a `for…of` over a
+    /// statically-proven array, to pick between the index loop
+    /// (`__i < __arr.length`) and the lazy iterator-protocol loop, and once per
+    /// array destructuring that takes the non-iterator arm. Checking once is
+    /// what the spec wants — iteration performs GetIterator exactly once — and
+    /// it keeps the cost off the per-iteration path.
     ///
     /// A dedicated node rather than a call so codegen emits a single volatile
     /// `i8` load (the `PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED` shape) instead

--- a/crates/perry-hir/tests/array_destructuring_fast_path.rs
+++ b/crates/perry-hir/tests/array_destructuring_fast_path.rs
@@ -1,0 +1,156 @@
+//! #10086: array destructuring over a spread-free array literal or a
+//! statically-proven array must lower to the guarded non-iterator arm, and
+//! everything else must keep the plain spec iterator protocol.
+//!
+//! These assert the LOWERING DECISION, which is what the perf fix is; the
+//! behavioural half (evaluation order, defaults, holes, rest, nested patterns,
+//! generators, a patched `Array.prototype[Symbol.iterator]`) is
+//! `test-files/test_gap_10086_array_destructuring_fast_path.ts`, compared
+//! byte-for-byte against node.
+
+use perry_diagnostics::SourceCache;
+use perry_hir::{lower_module, Module};
+
+fn lower(src: &str) -> Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed =
+                perry_parser::parse_typescript_with_cache(&src, "destructure_fast.ts", &mut cache)
+                    .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "destructure_fast.ts").expect("lowering succeeds")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+fn hir(src: &str) -> String {
+    format!("{:#?}", lower(src))
+}
+
+/// The guard itself: `Expr::ArrayIterationPatched`, the volatile read of the
+/// runtime's sticky `PERRY_ARRAY_ITERATION_NOT_PRISTINE` byte.
+const GUARD: &str = "ArrayIterationPatched";
+
+/// `[x, y] = [y, x]` — the measured swap. The guard must be read BEFORE the
+/// iterator is resolved, which is the whole point: `GetIterator` takes the
+/// rebuilt array literal as its operand, so a guard that dominates it means
+/// neither the iterator NOR the array is materialized on the fast arm.
+#[test]
+fn swap_through_an_array_literal_is_guarded_and_allocates_nothing_up_front() {
+    let dump = hir("let x = 1; let y = 2; [x, y] = [y, x]; console.log(x, y);");
+    let guard = dump
+        .find(GUARD)
+        .expect("a literal-source swap must read the array-iteration guard");
+    let get_iterator = dump
+        .find("GetIterator(")
+        .expect("the protocol arm must still exist for a patched prototype");
+    assert!(
+        guard < get_iterator,
+        "the guard must dominate GetIterator (and therefore the array literal \
+         it iterates); guard at {guard}, GetIterator at {get_iterator}"
+    );
+}
+
+/// `const [a, b] = [f(), g()]` — the declaration form of the same shape.
+#[test]
+fn declaration_from_an_array_literal_is_guarded() {
+    let dump =
+        hir("function f(): number { return 1; }\nconst [a, b] = [f(), 2];\nconsole.log(a, b);");
+    assert!(
+        dump.contains(GUARD),
+        "a literal-source declaration must read the array-iteration guard"
+    );
+}
+
+/// `const [a, b] = pair(x)` where `pair(): number[]` — the pair does escape
+/// (it is a real array returned across a call), so it is still allocated; what
+/// goes away is the iterator object and the per-element `{ value, done }`
+/// result. The fast arm reads it by index.
+#[test]
+fn declaration_from_a_proven_array_reads_by_index() {
+    let dump = hir(
+        "function pair(v: number): number[] { return [v, v + 1]; }\n\
+         const [a, b] = pair(3);\nconsole.log(a, b);",
+    );
+    assert!(
+        dump.contains(GUARD),
+        "a proven-array source must read the array-iteration guard"
+    );
+    assert!(
+        dump.contains("IndexGet"),
+        "the fast arm of a proven-array source must read elements by index"
+    );
+}
+
+/// An assignment whose source is a proven array takes the same arm.
+#[test]
+fn assignment_from_a_proven_array_is_guarded() {
+    let dump = hir(
+        "const src: number[] = [1, 2];\nlet a = 0; let b = 0;\n[a, b] = src;\nconsole.log(a, b);",
+    );
+    assert!(
+        dump.contains(GUARD),
+        "a proven-array assignment must be guarded"
+    );
+}
+
+/// A source with no static array proof — a custom iterable, a generator, an
+/// `any` — keeps the plain iterator protocol, unguarded. Emitting the fast arm
+/// here would read `.length` / `[0]` off something that has neither.
+#[test]
+fn an_unproven_source_keeps_the_plain_iterator_protocol() {
+    let dump =
+        hir("declare const it: any;\nlet a = 0; let b = 0;\n[a, b] = it;\nconsole.log(a, b);");
+    assert!(
+        !dump.contains(GUARD),
+        "an unproven source must not take the non-iterator arm"
+    );
+    assert!(
+        dump.contains("GetIterator("),
+        "an unproven source must still drive the iterator protocol"
+    );
+}
+
+/// A generator call is not a proven array either.
+#[test]
+fn a_generator_source_keeps_the_plain_iterator_protocol() {
+    let dump = hir("function* g() { yield 1; yield 2; }\nconst [a, b] = g();\nconsole.log(a, b);");
+    assert!(
+        !dump.contains(GUARD),
+        "a generator source must not take the non-iterator arm"
+    );
+}
+
+/// A rest element keeps the iterator drain: the protocol builds a DENSE array
+/// while the index-side equivalent (`slice`) preserves holes, so the two
+/// disagree on a sparse source.
+#[test]
+fn a_rest_element_keeps_the_iterator_drain() {
+    let dump =
+        hir("const src: number[] = [1, 2, 3];\nconst [a, ...rest] = src;\nconsole.log(a, rest);");
+    assert!(
+        !dump.contains(GUARD),
+        "a rest pattern must keep the unguarded iterator lowering"
+    );
+}
+
+/// A spread inside the literal makes the element count dynamic, so the literal
+/// shape does not apply. (`[...xs]` is still an array, so the PROVEN-array arm
+/// may take it — what must not happen is treating `xs`'s elements as if they
+/// were the literal's.)
+#[test]
+fn a_spread_in_the_literal_does_not_take_the_scalar_arm() {
+    let dump = hir(
+        "const xs: number[] = [1, 2];\nlet a = 0; let b = 0;\n[a, b] = [...xs];\nconsole.log(a, b);",
+    );
+    // Whichever arm it takes, the spread must still be materialized into a real
+    // array before anything reads element 0.
+    assert!(
+        dump.contains("ArraySpread") || dump.contains("Spread"),
+        "the spread must still build a real array"
+    );
+}

--- a/crates/perry-runtime/src/array/indexing_support.rs
+++ b/crates/perry-runtime/src/array/indexing_support.rs
@@ -135,24 +135,53 @@ pub(crate) fn object_prototype_has_index_flag() -> bool {
 /// hot-path shape as `ARRAY_PROTO_HAS_INDEX` above.
 pub(super) static ARRAY_PROTO_ITERATOR_MODIFIED: AtomicBool = AtomicBool::new(false);
 
-/// The same fact as [`ARRAY_PROTO_ITERATOR_MODIFIED`], exported so GENERATED
-/// code can read it (#7760 item 1).
+/// Sticky, exported so GENERATED code can read it: array iteration can no
+/// longer be PROVEN to be the pristine builtin protocol.
 ///
-/// `for…of` over a statically-proven array desugars to an index loop
-/// (`__i < __arr.length` / `__arr[__i]`) in HIR lowering, which never consults
-/// the iteration protocol — so a patched `Array.prototype[Symbol.iterator]` was
-/// ignored there even after the spread paths were fixed (#7542). The loop now
-/// branches on this flag ONCE at entry, which is also what the spec wants:
-/// `for…of` performs GetIterator exactly once, so a patch landing mid-loop must
-/// not change the iterator already in hand.
+/// Two independent facts set it, and generated code must decline its
+/// non-iterator fast arm for either:
+///
+///   * [`ARRAY_PROTO_ITERATOR_MODIFIED`] — `Array.prototype[Symbol.iterator]`
+///     was replaced or deleted (#7760 item 1). `for…of` over a statically-proven
+///     array desugars to an index loop (`__i < __arr.length` / `__arr[__i]`) in
+///     HIR lowering, which never consults the iteration protocol, so such a
+///     patch was ignored there even after the spread paths were fixed (#7542).
+///   * The array-iterator PROTOTYPE object was handed to user code (#10086; see
+///     `object::iterator_prototypes::note_array_iterator_prototype_exposed`).
+///     A replaced `%ArrayIteratorPrototype%.next` is detected per `.next()` call
+///     (`prototype_next_is_canonical`), which a fast arm that never calls
+///     `.next()` cannot observe — and the only way to reach that object in order
+///     to patch it is `Object.getPrototypeOf` / `Reflect.getPrototypeOf`. So the
+///     flag is set the moment the object escapes, whether or not it is then
+///     patched: over-approximating costs the fast arm only in programs that
+///     introspect array iterators, while under-approximating would silently
+///     return unpatched elements.
+///
+/// Both consumers — the `for…of` index loop and #10086's array-destructuring
+/// arm — branch on it ONCE, which is also what the spec wants: iteration
+/// performs GetIterator exactly once, so a patch landing mid-loop must not
+/// change the iterator already in hand.
 ///
 /// A separate `u8` global rather than exposing the `AtomicBool`: codegen emits
 /// a plain volatile `i8` load, the same shape as
 /// `PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED`, so the fast arm pays one load and
 /// a predictable branch per LOOP — not per iteration — and the index loop
 /// itself is emitted byte-identically to before.
+///
+/// NOTE the asymmetry with [`ARRAY_PROTO_ITERATOR_MODIFIED`]: that bool keeps
+/// its exact original meaning (the `Symbol.iterator` slot was written) and still
+/// gates the Rust-side spread / `js_get_iterator` delegation. Only this byte
+/// carries the broader "not provably pristine" fact.
 #[no_mangle]
-pub static PERRY_ARRAY_PROTO_ITERATOR_PATCHED: AtomicU8 = AtomicU8::new(0);
+pub static PERRY_ARRAY_ITERATION_NOT_PRISTINE: AtomicU8 = AtomicU8::new(0);
+
+/// Publish "array iteration is no longer provably pristine" to generated code.
+/// Release-ordered so a reader that observes the `1` also observes the
+/// prototype exposure / write that preceded it.
+#[inline]
+pub(crate) fn note_array_iteration_not_pristine() {
+    PERRY_ARRAY_ITERATION_NOT_PRISTINE.store(1, Ordering::Release);
+}
 
 /// Record (if `obj` is `Array.prototype` and `sym_key` is the well-known
 /// `Symbol.iterator`) that the array iteration protocol has been tampered
@@ -165,9 +194,7 @@ pub(crate) fn note_array_proto_iterator_write(obj: usize, sym_key: usize) {
         && sym_key == crate::symbol::well_known_symbol("iterator") as usize
     {
         ARRAY_PROTO_ITERATOR_MODIFIED.store(true, Ordering::Relaxed);
-        // Publish to generated code. Release so a loop that observes the `1`
-        // also observes the prototype write that preceded it.
-        PERRY_ARRAY_PROTO_ITERATOR_PATCHED.store(1, Ordering::Release);
+        note_array_iteration_not_pristine();
     }
 }
 

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -162,8 +162,9 @@ pub(crate) use self::indexing_support::test_keys_array_slot_fallbacks;
 pub(crate) use self::indexing_support::{
     array_proto_iterator_modified, invalidate_array_index_fast_path,
     keys_array_len_capped_to_capacity, keys_array_slot, note_array_index_write,
-    note_array_proto_iterator_write, note_object_prototype_index_write,
-    object_prototype_has_index_flag, PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED,
+    note_array_iteration_not_pristine, note_array_proto_iterator_write,
+    note_object_prototype_index_write, object_prototype_has_index_flag,
+    PERRY_ARRAY_INDEX_FAST_PATH_INVALIDATED,
 };
 pub use self::is_array::js_array_is_array;
 pub(crate) use self::iter_methods::throw_reduce_of_empty;

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -66,6 +66,40 @@ pub(crate) static REGEXP_STRING_ITERATOR_PROTOTYPE_PTR: super::RealmAtomicI64 =
 pub(crate) static ITERATOR_HELPER_PROTOTYPE_PTR: super::RealmAtomicI64 =
     super::RealmAtomicI64::new(&ITERATOR_HELPER_PROTOTYPE_PTR_SLOT);
 
+/// #10086: the array-iterator prototype object is about to be handed to user
+/// code, so `%ArrayIteratorPrototype%.next` may be replaced at any point after
+/// this. Publish that to generated code.
+///
+/// A replaced `next` is detected per `.next()` call by
+/// [`prototype_next_is_canonical`] — which a non-iterator fast arm (the
+/// `for…of` index loop, #10086's array-destructuring arm) never reaches,
+/// because it never calls `.next()`. There is no cheap sticky signal for the
+/// write itself: the object is an ordinary `ObjectHeader`, so a precise hook
+/// would have to cover every mutation funnel (assignment, computed assignment,
+/// `defineProperty`, `delete`, `Object.assign`) and MISSING one fails silently,
+/// in the direction of a wrong answer.
+///
+/// Escape is the choke point instead. User code cannot patch an object it
+/// cannot name, and in Perry the only way to name this one is
+/// `Object.getPrototypeOf` / `Reflect.getPrototypeOf` (both
+/// `js_object_get_prototype_of`; `iter.__proto__` answers `undefined` here).
+/// So the flag is set when the object escapes, patched or not. The cost lands
+/// only on programs that introspect an array iterator — and those are exactly
+/// the programs about to patch one.
+pub(crate) fn note_array_iterator_prototype_exposed(value: f64) {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return;
+    }
+    let addr = jv.as_pointer::<ObjectHeader>() as i64;
+    if addr == 0 {
+        return;
+    }
+    if ARRAY_ITERATOR_PROTOTYPE_PTR.load(Ordering::Acquire) == addr {
+        crate::array::note_array_iteration_not_pristine();
+    }
+}
+
 /// Resolve and validate the implicit-`this` object shared by the family
 /// prototype thunks. Keeping the raw-address probe here gives both the generic
 /// family dispatcher and the helper-specific brand check one audited path.

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -186,6 +186,18 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
 /// Refs #420 / #618 followup.
 #[no_mangle]
 pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
+    let proto = get_prototype_of_resolved(obj_value);
+    // #10086: this is the ONE place a prototype object reaches user code, so
+    // it is also the only place the array-iterator prototype can escape to be
+    // patched. Publishing here is what lets the `for…of` index loop and the
+    // array-destructuring fast arm decline a possibly-patched
+    // `%ArrayIteratorPrototype%.next`, which neither can observe otherwise.
+    crate::object::iterator_prototypes::note_array_iterator_prototype_exposed(proto);
+    proto
+}
+
+/// The resolution itself; see [`js_object_get_prototype_of`].
+fn get_prototype_of_resolved(obj_value: f64) -> f64 {
     const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
     // #2820: `Object.getPrototypeOf(null | undefined)` throws TypeError
     // (`Cannot convert undefined or null to object`). Class refs and heap

--- a/test-files/test_gap_10086_array_destructuring_fast_path.ts
+++ b/test-files/test_gap_10086_array_destructuring_fast_path.ts
@@ -1,0 +1,318 @@
+// #10086: array destructuring no longer drives the iterator protocol for a
+// spread-free array literal or a statically-proven array — it reads the
+// elements directly, behind a runtime guard on
+// `Array.prototype[Symbol.iterator]`. Every observable behaviour of the old
+// lowering has to survive that: evaluation order and count, holes, defaults,
+// rest, nested patterns, member-expression targets, a real iterator for
+// anything that is not a plain array, and the patched-prototype case itself.
+
+const out: string[] = [];
+function log(label: string, value: unknown): void {
+  out.push(label + "=" + String(value));
+}
+
+// --- once-evaluation and source order -------------------------------------
+let calls = "";
+function f(): number {
+  calls += "f";
+  return 1;
+}
+function g(): number {
+  calls += "g";
+  return 2;
+}
+let a = 0;
+let b = 0;
+[a, b] = [f(), g()];
+log("order.calls", calls);
+log("order.a", a);
+log("order.b", b);
+
+// --- swap: aliased and identical targets ----------------------------------
+let x = 7;
+let y = 19;
+[x, y] = [y, x];
+log("swap.x", x);
+log("swap.y", y);
+let same = 0;
+[same, same] = [1, 2];
+log("swap.same", same);
+
+// A swap in a loop must stay a swap (the literal is gone, the values are not).
+let p = 1;
+let q = 2;
+let acc = 0;
+for (let i = 0; i < 5; i++) {
+  [p, q] = [q, p];
+  acc = acc * 10 + p;
+}
+log("swap.loop", acc);
+log("swap.loop.p", p);
+log("swap.loop.q", q);
+
+// --- holes ----------------------------------------------------------------
+const src3 = [10, 20, 30];
+let h1 = 0;
+let h2 = 0;
+[, h1, h2] = src3;
+log("hole.h1", h1);
+log("hole.h2", h2);
+const [, hole2] = src3;
+log("hole.decl", hole2);
+
+// --- defaults -------------------------------------------------------------
+const short: number[] = [5];
+const [d1 = 1, d2 = 2] = short;
+log("default.d1", d1);
+log("default.d2", d2);
+let e1 = 0;
+let e2 = 0;
+[e1 = 1, e2 = 2] = short;
+log("default.e1", e1);
+log("default.e2", e2);
+// A genuine NaN element is NOT undefined, so the default must not fire.
+const [nanKept = 99] = [NaN];
+log("default.nan", nanKept);
+// An explicit `undefined` element does fire it.
+const [undefFires = 42] = [undefined];
+log("default.undefined", undefFires);
+// The spec re-reads the source length on every element, so a default that
+// truncates the array must be visible to the next element.
+const shrink: any[] = [undefined, 2];
+const [s1 = (((shrink as any).length = 1), 5), s2 = 7] = shrink;
+log("default.shrink.s1", s1);
+log("default.shrink.s2", s2);
+
+// --- rest -----------------------------------------------------------------
+const [r1, ...rest] = [1, 2, 3, 4];
+log("rest.r1", r1);
+log("rest.rest", rest.join(","));
+let ra = 0;
+let restTail: number[] = [];
+[ra, ...restTail] = [9, 8, 7];
+log("rest.ra", ra);
+log("rest.tail", restTail.join(","));
+
+// --- nested patterns ------------------------------------------------------
+const [[n1], { n2 }] = [[3], { n2: 4 }] as [number[], { n2: number }];
+log("nested.n1", n1);
+log("nested.n2", n2);
+let m1 = 0;
+let m2 = 0;
+[[m1], { n2: m2 }] = [[5], { n2: 6 }] as [number[], { n2: number }];
+log("nested.m1", m1);
+log("nested.m2", m2);
+
+// --- member-expression targets --------------------------------------------
+const obj: any = { x: 0, y: 0 };
+[obj.x, obj.y] = [11, 12];
+log("member.x", obj.x);
+log("member.y", obj.y);
+const keyOrder: string[] = [];
+const box: any = {};
+function keyA(): string {
+  keyOrder.push("a");
+  return "ka";
+}
+function keyB(): string {
+  keyOrder.push("b");
+  return "kb";
+}
+[box[keyA()], box[keyB()]] = [21, 22];
+log("member.computed", box.ka + ":" + box.kb + ":" + keyOrder.join(""));
+
+// --- the source array still exists when it escapes -------------------------
+function pair(v: number): number[] {
+  return [v, v + 1];
+}
+const escaped = pair(1);
+const [ea, eb] = escaped;
+escaped.push(99);
+log("escape.ea", ea);
+log("escape.eb", eb);
+log("escape.array", escaped.join(","));
+let captured: number[] = [];
+function capture(): number[] {
+  const made = [30, 31];
+  captured = made;
+  return made;
+}
+const [ca, cb] = capture();
+captured.push(32);
+log("capture.ca", ca);
+log("capture.cb", cb);
+log("capture.array", captured.join(","));
+log("capture.identity", String(captured.length === 3));
+
+// --- a shorter array than the pattern -------------------------------------
+const [t1, t2, t3] = [1];
+log("short.t1", t1);
+log("short.t2", String(t2));
+log("short.t3", String(t3));
+
+// --- the iterator protocol is intact for everything that is not an array ---
+let nextCalls = 0;
+const custom: any = {};
+custom[Symbol.iterator] = function () {
+  return {
+    next: function () {
+      nextCalls++;
+      return { done: nextCalls > 3, value: nextCalls * 100 };
+    },
+  };
+};
+const [c1, c2] = custom;
+log("custom.c1", c1);
+log("custom.c2", c2);
+log("custom.next", nextCalls);
+
+function* gen(): Generator<number> {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+const [gA, gB] = gen();
+log("gen.a", gA);
+log("gen.b", gB);
+
+const set = new Set<number>([4, 5, 6]);
+const [sA, sB] = set;
+log("set.a", sA);
+log("set.b", sB);
+
+const map = new Map<string, number>([["k", 1]]);
+const [[mk, mv]] = map;
+log("map.k", mk);
+log("map.v", mv);
+
+const [strA, strB] = "hi";
+log("string.a", strA);
+log("string.b", strB);
+
+// An iterator that closes: `return()` must run when the pattern stops early.
+let closed = 0;
+const closing: any = {};
+closing[Symbol.iterator] = function () {
+  let i = 0;
+  return {
+    next: function () {
+      i++;
+      return { done: false, value: i };
+    },
+    return: function () {
+      closed++;
+      return { done: true };
+    },
+  };
+};
+const [z1] = closing;
+log("close.z1", z1);
+log("close.count", closed);
+
+// --- inside an async function and a generator ------------------------------
+// The async-to-generator transform boxes body locals into shared cells, so the
+// guarded per-element shape has to survive being split into generator states.
+async function asyncCase(): Promise<string> {
+  const src: number[] = [41, 42];
+  const [a, b] = src;
+  await Promise.resolve(0);
+  let c = 0;
+  let d = 0;
+  [c, d] = [b, a];
+  const [e, f2 = 7] = [c];
+  return a + ":" + b + ":" + c + ":" + d + ":" + e + ":" + f2;
+}
+
+function* genCase(): Generator<string> {
+  const src: number[] = [51, 52];
+  const [a, b] = src;
+  yield a + ":" + b;
+  let c = 0;
+  let d = 0;
+  [c, d] = [b, a];
+  yield c + ":" + d;
+}
+
+// A destructuring inside a loop inside a generator: the guard must not break
+// the loop's state split.
+function* genLoop(): Generator<number> {
+  let p = 1;
+  let q = 2;
+  for (let i = 0; i < 3; i++) {
+    [p, q] = [q, p];
+    yield p;
+  }
+}
+
+const genOut: string[] = [];
+for (const v of genCase()) genOut.push(v);
+log("gen.case", genOut.join("|"));
+const genLoopOut: number[] = [];
+for (const v of genLoop()) genLoopOut.push(v);
+log("gen.loop", genLoopOut.join(","));
+
+// --- a patched %ArrayIteratorPrototype%.next is still honoured -------------
+// The non-iterator arm never calls `.next()`, so it cannot observe a patched
+// one. The runtime publishes "array iteration is not provably pristine" the
+// moment this prototype object escapes through `Object.getPrototypeOf`, which
+// is what makes both arms below decline it. Sticky in Perry, so this runs after
+// everything that must exercise the fast arm.
+function patchedNextChecks(): void {
+  const arrayIterProto: any = Object.getPrototypeOf([][Symbol.iterator]());
+  const originalNext = arrayIterProto.next;
+  arrayIterProto.next = function (this: any) {
+    const r = originalNext.call(this);
+    if (!r.done) r.value = (r.value as number) * 2;
+    return r;
+  };
+  const src: number[] = [1, 2];
+  const [na, nb] = src;
+  log("patchedNext.proven", na + ":" + nb);
+  let nc = 0;
+  let nd = 0;
+  [nc, nd] = [3, 4];
+  log("patchedNext.literal", nc + ":" + nd);
+  const forOf: number[] = [];
+  for (const v of src) forOf.push(v);
+  log("patchedNext.forof", forOf.join(","));
+  arrayIterProto.next = originalNext;
+  const [ra, rb] = src;
+  log("patchedNext.restored", ra + ":" + rb);
+}
+
+// --- a patched Array.prototype[Symbol.iterator] is still honoured ----------
+// Sticky in Perry: everything after this point takes the protocol arm, so it
+// runs last — after the async case has resolved, so that case still exercises
+// the fast arm.
+function patchedPrototypeChecks(): void {
+  const original = (Array.prototype as any)[Symbol.iterator];
+  let patchedCalls = 0;
+  (Array.prototype as any)[Symbol.iterator] = function () {
+    patchedCalls++;
+    let i = 0;
+    return {
+      next: () => {
+        i++;
+        return { done: i > 2, value: i * 1000 };
+      },
+    };
+  };
+  let pa = 0;
+  let pb = 0;
+  [pa, pb] = [1, 2];
+  log("patched.literal", pa + ":" + pb);
+  const plain = [7, 8];
+  const [pc, pd] = plain;
+  log("patched.proven", pc + ":" + pd);
+  log("patched.calls", patchedCalls);
+  (Array.prototype as any)[Symbol.iterator] = original;
+  const [qa, qb] = [1, 2];
+  log("restored", qa + ":" + qb);
+}
+
+asyncCase().then((v) => {
+  log("async.case", v);
+  patchedNextChecks();
+  patchedPrototypeChecks();
+  console.log(out.join("\n"));
+});


### PR DESCRIPTION
Closes #10086.

## The cost

A statement `[x, y] = [y, x]` and a declaration `const [a, b] = pair(i)` both
lowered through the full spec iterator protocol: `GetIterator`, one
`iteratorNextResult` per element (each allocating a `{ value, done }` result
object), two property reads off that result, and `IteratorClose` — plus, for the
swap, a real two-element heap array per iteration. None of it is observable for
an array whose `Array.prototype[Symbol.iterator]` has not been replaced. The
issue measured a flat ~76x Node across every size on both shapes.

## The fix (compiler-side only; no runtime change)

`crates/perry-hir/src/destructuring/array_fast.rs` emits both arms and branches
on the same runtime guard `for…of` over a proven array already uses —
`Expr::ArrayIterationPatched`, a volatile `i8` read of the runtime's sticky
`PERRY_ARRAY_PROTO_ITERATOR_PATCHED` byte (#7760 item 1).

Two source shapes take the fast arm:

* **a spread-free array literal written in place** — its elements are spilled
  into temps *before* the guard, so each is evaluated exactly once whichever arm
  runs, and the fast arm reads them directly. The array itself is built only
  inside the guarded `GetIterator`, so on the fast arm it is never allocated.
* **a source whose static type proves a plain `Array`** — elements are read by
  index, with `length` re-read per element exactly as `IteratorStep` does (a
  default initializer that truncates the array is visible to the next element).

The branch is **per element**, not around the whole pattern, for two reasons:

* a destructuring pattern DECLARES bindings, so lowering it twice would allocate
  two `LocalId`s for each binding and every later use would resolve to whichever
  arm was lowered last;
* both arms then keep the spec's interleaving. `let [a = f(), b] = src` still
  evaluates `f()` between producing element 0 and producing element 1, which an
  eager "pull N values, then bind" fast arm could not do.

A rest element (the iterator drain builds a dense array; `slice` would preserve
holes), a nested pattern, an empty pattern (`[] = x` — `GetIterator` is the only
thing that makes it throw on a non-iterable), a generator, a `Set`/`Map`/string
and anything without a static array proof keep the unguarded iterator lowering,
statement-for-statement identical to before.

## Measurements

Apple M1 Max, Node 26.5.1, release build, `--no-auto-optimize`, the issue's own
reproducers and driver. The host was under heavy concurrent build load
throughout (load average 70–118), so absolute times are inflated relative to the
issue's — the before/after arms were run interleaved on that same host.
**Checksums matched at every size on every arm.**

| workload | n | before | after | speedup | before ÷ node | after ÷ node |
|---|---:|---:|---:|---:|---:|---:|
| `iteration-destructuring-swap` | 100 | 0.288 ms | 0.0051 ms | 56.5x | 111.2x | 1.97x |
| `iteration-destructuring-swap` | 1,000 | 2.393 ms | 0.0567 ms | 42.2x | 81.8x | 1.94x |
| `iteration-destructuring-swap` | 10,000 | 26.34 ms | 0.557 ms | 47.3x | 90.3x | 1.91x |
| `iteration-destructuring-swap` | 100,000 | 334.6 ms | 7.381 ms | 45.3x | 104.1x | 2.30x |
| `iteration-destructuring-swap` | 1,000,000 | 3071.9 ms | 105.0 ms | 29.3x | 102.6x | 3.51x |
| `iteration-destructure-return` | 100 | 0.216 ms | 0.0076 ms | 28.4x | 84.6x | 2.98x |
| `iteration-destructure-return` | 1,000 | 5.199 ms | 0.0763 ms | 68.2x | 101.0x | 1.48x |
| `iteration-destructure-return` | 10,000 | 25.05 ms | 1.691 ms | 14.8x | 85.2x | 5.75x |
| `iteration-destructure-return` | 100,000 | 457.0 ms | 7.704 ms | 59.3x | 61.5x | 1.04x |
| `iteration-destructure-return` | 1,000,000 | 4673.5 ms | 191.3 ms | 24.4x | 90.7x | 3.71x |

The ratio improves at every size, which is the issue's acceptance criterion.
The remaining spread in `after ÷ node` (1.0x–5.8x) is host noise, not a size
trend: the two arms' log-log slopes are 1.02 → 1.07 and 1.06 → 1.08.

### Allocation counter

The issue asks for proof that the swap allocates a bounded number of arrays
independent of iteration count. `[a, b] = [b, a]` in a loop, `PERRY_GC_DIAG=1`,
counting collection cycles:

| iterations | before | after |
|---:|---:|---:|
| 10,000 | 7 | 6 |
| 1,000,000 | 890 | 6 |
| 10,000,000 | 7,952 | 6 |

Before, cycles scale linearly with the loop count; after, they are flat at the
program's fixed startup cost.

## Tests

* `test-files/test_gap_10086_array_destructuring_fast_path.ts` — a gap test
  (byte-for-byte against `node --experimental-strip-types` at the pinned
  26.5.1). It covers every case the issue lists plus the ones the fast arm could
  plausibly break: once-evaluation and source order for `[a, b] = [f(), g()]`;
  aliased and identical targets; holes; defaults, including a genuine `NaN`
  element that must NOT take the default and a default that truncates the source
  array before the next element is produced; rest; nested patterns; member and
  computed-member targets; a source array that escapes (returned, and captured
  by a closure) and is still observably the same array afterwards; a pattern
  longer than its source; a custom iterable with a counted `next()`; a
  generator; `Set`, `Map`, and string sources; an iterator whose `return()` must
  run; destructuring inside an `async` function and inside two generators; and a
  patched `Array.prototype[Symbol.iterator]`, which must still drive both the
  literal and the proven-array form; and a patched
  `%ArrayIteratorPrototype%.next`, which must drive destructuring AND `for…of`
  (that last one fails on `main` — see below).
* `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime`: 3600 passed, 0
  failed. `cargo test -p perry-hir`: 0 failures. Parity subsets: `10086` 1/1,
  `destructur` 7/7, `spread` 19/19, `iterator` 25/26 and `proto` 53/57 (every
  failure pre-existing — see below). `scripts/run_lint_gates.sh`: 1 of 83, also
  pre-existing.
* `crates/perry-hir/tests/array_destructuring_fast_path.rs` — 8 lowering tests
  asserting the *decision*: the guard is present (and dominates `GetIterator`,
  so neither the iterator nor the literal's array is materialized on the fast
  arm) for the literal and proven-array shapes, and absent for an unproven
  source, a generator source and a rest pattern.

## The guard had a hole; this closes it

`Expr::ArrayIterationPatched` covered a replaced or deleted
`Array.prototype[Symbol.iterator]` (#7760). It did not cover a replaced
`%ArrayIteratorPrototype%.next`, which the runtime detects per `.next()` call
(`object::iterator_prototypes::prototype_next_is_canonical`) — something an arm
that never calls `.next()` cannot observe. That was already wrong on `main` for
`for…of` over a proven array:

```
// %ArrayIteratorPrototype%.next patched to double each value
const nums: number[] = [5, 6];
for (const v of nums) …        // main: 5,6   node: 10,12
```

The exported byte is renamed `PERRY_ARRAY_ITERATION_NOT_PRISTINE` (it no longer
means only "`Symbol.iterator` was replaced") and is now also set when the
array-iterator prototype object escapes to user code through
`Object.getPrototypeOf` / `Reflect.getPrototypeOf`.

**Why escape and not the write.** That object is an ordinary object, so a
precise hook would have to cover every mutation funnel — assignment, computed
assignment, `defineProperty`, `delete`, `Object.assign` — and missing one fails
*silently*, in the direction of a wrong answer. Escape is a single choke point:
user code cannot patch an object it cannot name, and in Perry the only way to
name this one is those two functions (`iter.__proto__` answers `undefined`
here). So the flag is set when the object escapes, patched or not. The
over-approximation costs the fast arm only in programs that introspect an array
iterator — which are exactly the programs about to patch one. Verified not to
fire spuriously: a for-of microbenchmark is unchanged (21.0 ms before, 21.0 ms
after) and the swap's allocation count stays flat.

`ARRAY_PROTO_ITERATOR_MODIFIED` (the Rust-side bool) keeps its original narrow
meaning, so the spread and `js_get_iterator` delegation paths are untouched.

The new gap-test block is a real gate for this: on `main` it fails on exactly
one line — `patchedNext.forof` — and passes on this branch.

## Pre-existing failures, confirmed not mine

* `test_gap_iterator_prototype_next_patch` — fails identically with the baseline
  compiler (byte-for-byte same output; its remaining diffs are spread / Set /
  String / bound-copy / accessor, none of which this PR touches).
* `test_issue_1777_prototype_borrow`, `test_issue_4831_stripe_proto_methods` —
  byte-identical output on baseline and on this branch.
* `test_gap_2159_defineproperty_class_prototype` — listed in
  `test-parity/gap_snapshot.json` as an expected failure.
* `benchmarks/ci_public_baseline_check.py` (the one red `lint` gate) —
  reproduces on a clean `origin/main` checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved array destructuring performance for eligible array literals and statically recognized arrays by reading elements directly when safe.

- **Bug Fixes**
  - Preserved correct iterator behavior when array iteration methods or iterator prototypes are modified or exposed to application code.
  - Retained standard iterator handling for custom iterables, generators, rest patterns, nested patterns, and other unsupported sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->