### PR TITLE
fix(runtime): honor number-to-string ties-to-even

### DIFF
--- a/changelog.d/10125-number-to-string-tie-even.md
+++ b/changelog.d/10125-number-to-string-tie-even.md
@@ -1,0 +1,4 @@
+Fix decimal number-to-string conversion to use ECMAScript's round-half-to-even
+tie rule. `String`, template literals, `Number.prototype.toString` and
+`toPrecision`, array joins, implicit concatenation, and JSON serialization now
+agree on the shortest representation for exact-tie doubles.

--- a/crates/perry-runtime/src/string/format.rs
+++ b/crates/perry-runtime/src/string/format.rs
@@ -175,17 +175,13 @@ pub(crate) fn js_format_f64(value: f64) -> String {
         // Integer-like, format without decimal
         format!("{}", value as i64)
     } else {
-        // ECMAScript NumberToString: switch to scientific notation when
-        // |n| >= 10^21 or |n| < 10^-6 (otherwise Rust's `{}` produces
-        // 300-digit decimals for `Number.MAX_VALUE` and 16-digit
-        // 0.000…0002… decimals for `Number.EPSILON`, neither of which
-        // matches Node's output).
-        let abs = value.abs();
-        if !(1e-6..1e21).contains(&abs) {
-            fix_exponent_format(&format!("{:e}", value))
-        } else {
-            format!("{}", value)
-        }
+        // Rust's Display formatter also emits a shortest round-tripping
+        // decimal, but it can choose the odd final digit when the two shortest
+        // candidates are equidistant. ECMA-262 Number::toString requires the
+        // even candidate. `ryu-js` implements that tie-break together with
+        // JavaScript's fixed/scientific notation thresholds.
+        let mut buffer = ryu_js::Buffer::new();
+        buffer.format_finite(value).to_owned()
     }
 }
 
@@ -716,30 +712,7 @@ pub(crate) fn fix_exponent_format(s: &str) -> String {
     }
 }
 
-/// Format a number per JS toString rules (helper for toPrecision when precision=0)
+/// Format a number per JS toString rules (helper for toPrecision with no precision).
 fn format_number_for_js(value: f64) -> String {
-    if value.is_nan() {
-        return "NaN".to_string();
-    }
-    if value.is_infinite() {
-        return if value > 0.0 {
-            "Infinity".to_string()
-        } else {
-            "-Infinity".to_string()
-        };
-    }
-    if value == 0.0 {
-        return "0".to_string();
-    }
-    if value.fract() == 0.0 && value.abs() < 1e15 {
-        format!("{}", value as i64)
-    } else {
-        // ECMAScript NumberToString — see js_number_to_string for rationale.
-        let abs = value.abs();
-        if !(1e-6..1e21).contains(&abs) {
-            fix_exponent_format(&format!("{:e}", value))
-        } else {
-            format!("{}", value)
-        }
-    }
+    js_format_f64(value)
 }

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -23,6 +23,67 @@ fn fnv1a_for_test(bytes: &[u8]) -> u64 {
 }
 
 #[test]
+fn number_to_string_uses_ecmascript_tie_to_even() {
+    let cases = [
+        // The issue's exact tie, its adjacent doubles, and positive counterpart.
+        (0xc0d9_2b80_21ff_ffff, "-25774.00207519531"),
+        (0xc0d9_2b80_2200_0000, "-25774.002075195312"),
+        (0xc0d9_2b80_2200_0001, "-25774.002075195316"),
+        (0x40d9_2b80_2200_0000, "25774.002075195312"),
+        // Further exact ties found by the issue's seeded differential sweep.
+        (0xc03c_d941_0000_0000, "-28.848648071289062"),
+        (0x40d1_4b6e_da00_0000, "17709.732055664062"),
+        (0x40c1_b0ff_d400_0000, "9057.998657226562"),
+    ];
+    for (bits, expected) in cases {
+        assert_eq!(js_format_f64(f64::from_bits(bits)), expected, "{bits:016x}");
+    }
+}
+
+#[test]
+fn number_to_string_preserves_special_values_and_notation_boundaries() {
+    let cases = [
+        (1e21, "1e+21"),
+        (1e-7, "1e-7"),
+        (1e20, "100000000000000000000"),
+        (1e-6, "0.000001"),
+        (f64::MAX, "1.7976931348623157e+308"),
+        (f64::MIN_POSITIVE, "2.2250738585072014e-308"),
+        (f64::from_bits(1), "5e-324"),
+        (f64::EPSILON, "2.220446049250313e-16"),
+        (999_999_999_999_999.0, "999999999999999"),
+        (999_999_999_999_999.9, "999999999999999.9"),
+        (1_000_000_000_000_000.0, "1000000000000000"),
+        (1_000_000_000_000_000.1, "1000000000000000.1"),
+        (-0.0, "0"),
+        (f64::INFINITY, "Infinity"),
+        (f64::NEG_INFINITY, "-Infinity"),
+    ];
+    for (value, expected) in cases {
+        assert_eq!(js_format_f64(value), expected, "{:016x}", value.to_bits());
+    }
+    assert_eq!(js_format_f64(f64::NAN), "NaN");
+}
+
+#[test]
+fn number_to_string_million_seeded_doubles_match_the_ecmascript_formatter() {
+    let mut seed = 0x1234_5678_u32;
+    let mut oracle = ryu_js::Buffer::new();
+    for index in 0..1_000_000 {
+        seed ^= seed << 13;
+        seed ^= seed >> 17;
+        seed ^= seed << 5;
+        let value = (seed as f64 / 4_294_967_296.0 - 0.5) * 1_000_000.0 / 7.0;
+        assert_eq!(
+            js_format_f64(value),
+            oracle.format_finite(value),
+            "seeded value {index}, bits {:016x}",
+            value.to_bits()
+        );
+    }
+}
+
+#[test]
 fn test_string_create() {
     let data = b"hello";
     let s = js_string_from_bytes(data.as_ptr(), data.len() as u32);

--- a/test-files/test_gap_10093_number_to_string_tie.ts
+++ b/test-files/test_gap_10093_number_to_string_tie.ts
@@ -1,0 +1,57 @@
+function fromBits(hi: number, lo: number): number {
+  const buffer = new ArrayBuffer(8);
+  const view = new DataView(buffer);
+  view.setUint32(0, hi, false);
+  view.setUint32(4, lo, false);
+  return view.getFloat64(0, false);
+}
+
+function observableForms(value: number): string {
+  return [
+    String(value),
+    `${value}`,
+    value.toString(),
+    value.toPrecision(),
+    JSON.stringify(value),
+    [value].join(","),
+    "" + value,
+    value + "",
+  ].join("|");
+}
+
+const ties = [
+  // The issue's exact tie, its adjacent doubles, and positive counterpart.
+  fromBits(0xc0d92b80, 0x21ffffff),
+  fromBits(0xc0d92b80, 0x22000000),
+  fromBits(0xc0d92b80, 0x22000001),
+  fromBits(0x40d92b80, 0x22000000),
+  // Further exact ties found by the issue's seeded differential sweep.
+  fromBits(0xc03cd941, 0x00000000),
+  fromBits(0x40d14b6e, 0xda000000),
+  fromBits(0x40c1b0ff, 0xd4000000),
+];
+for (let i = 0; i < ties.length; i++) {
+  console.log("tie", i, observableForms(ties[i]));
+}
+
+const boundaries: [string, number][] = [
+  ["large-scientific", 1e21],
+  ["small-scientific", 1e-7],
+  ["large-fixed", 1e20],
+  ["small-fixed", 1e-6],
+  ["max-value", Number.MAX_VALUE],
+  ["min-normal", 2.2250738585072014e-308],
+  ["min-value", Number.MIN_VALUE],
+  ["epsilon", Number.EPSILON],
+  ["below-fast-integer", 999999999999999],
+  ["below-fast-fraction", 999999999999999.9],
+  ["above-fast-integer", 1000000000000000],
+  ["above-fast-fraction", 1000000000000000.1],
+  ["negative-zero", -0],
+  ["positive-infinity", Infinity],
+  ["negative-infinity", -Infinity],
+  ["nan", NaN],
+];
+for (let i = 0; i < boundaries.length; i++) {
+  console.log(boundaries[i][0], observableForms(boundaries[i][1]));
+}


### PR DESCRIPTION
Fixes #10093

## Summary

- format finite non-integer numbers with the existing ECMAScript-compatible `ryu-js` formatter
- route omitted-precision `Number.prototype.toPrecision()` through the same shared formatter
- cover exact ties, neighboring doubles, notation boundaries, special values, and all observable coercion paths

## Validation

- `cargo test --release -p perry-runtime number_to_string -- --test-threads=1`: 3 passed
- pinned Node 26.5.1 gap test: PASS
- pinned Node/Perry exact differential: 1,000,000 output lines matched byte-for-byte (SHA-256 `2c248ec546aedbbb5b5b57910a8e4f07f8c9a24139b00f8d00abae2201602eb5`)
- `cargo fmt --all -- --check`, file-size gate, Node-version consistency, and `git diff --check`: PASS

The full runtime suite passed 3,610 tests and hit one unrelated, reproducible compute-host failure in `native_stack::tests::stack_top_respects_custom_thread_stack_sizes` (worker stack-bound assertion).

## `number-string-double` benchmark

Release build with `--no-auto-optimize`, pinned Node 26.5.1, serialized on the same Linux x86_64 compute host. Checksums matched at every size.

| n | Node ms | Perry ms | Perry/Node | checksum |
|---:|---:|---:|---:|---:|
| 100 | 0.0276 | 0.0208 | 0.76x | 695271445 |
| 1,000 | 0.2575 | 0.2664 | 1.03x | 847024834 |
| 10,000 | 3.1708 | 2.9445 | 0.93x | 726726494 |
| 100,000 | 31.3840 | 29.3252 | 0.93x | 115366391 |
| 1,000,000 | 313.0223 | 294.0840 | 0.94x | 186724520 |

Log/log slopes: Node 1.020, Perry 1.034.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal number-to-string conversion to follow ECMAScript’s round-half-to-even behavior.
  * Ensured consistent shortest representations across string conversion, precision formatting, array joins, implicit concatenation, and JSON serialization.
  * Preserved correct handling of special values, subnormal numbers, and scientific-notation boundaries.

* **Tests**
  * Added coverage for exact rounding ties, adjacent values, boundary cases, and a broad set of floating-point values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->