### PR TITLE
Merge train 171: resolve Perex from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5685,7 +5685,8 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perex"
 version = "0.1.0"
-source = "git+https://github.com/PerryTS/perex?rev=007a2f7b604d47e36f3f501d3dbcfba1071da6e0#007a2f7b604d47e36f3f501d3dbcfba1071da6e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf"
 
 [[package]]
 name = "perry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,9 +399,7 @@ chrono = "0.4"
 regex = "1.12"
 aho-corasick = "1.1"
 # The single regular-expression engine, through crates/perry-perex.
-# Pinned to a revision of the public engine repository so CI resolves it
-# without a sibling checkout. Becomes a crates.io version once published.
-perex = { git = "https://github.com/PerryTS/perex", rev = "007a2f7b604d47e36f3f501d3dbcfba1071da6e0" }
+perex = "0.1"
 hex = "0.4"
 tempfile = "3"
 itoa = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,3 @@ multiple-versions = "warn"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-# The regular-expression engine resolves from its public repository at a pinned
-# revision until it is published to crates.io; remove this entry then.
-allow-git = ["https://github.com/PerryTS/perex"]


### PR DESCRIPTION
Merge train 171: Perry resolves Perex from crates.io.

`perex` 0.1.0 is [published](https://crates.io/crates/perex), so the workspace depends on `perex = "0.1"` instead of the pinned git revision train 170 landed, and the `deny.toml` allowance for that git source goes.

## Same code

- `static.crates.io` serves checksum `4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf`, which is the new `Cargo.lock` entry.
- The crate's `.cargo_vcs_info.json` records `007a2f7b604d47e36f3f501d3dbcfba1071da6e0`, the revision this replaces.
- All 60 packaged files are byte-identical to that revision (`Cargo.toml.orig` included).

## Soak window

0.1.0 is younger than `global-min-publish-age = "7 days"`. The lock entry was resolved once with `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow`, by maintainer decision for this first-party crate; a plain `--locked` resolve then accepts it, which is what CI does. Nothing in `.cargo/config.toml` changes.

## Validation

- `RUSTFLAGS=-D warnings cargo check --locked -p perry --bins`
- `cargo check --locked -p perry-runtime --no-default-features --features full --lib` (the auto-optimize regex-free build)
- `cargo test --locked -p perry-perex`: 24 unit + 3 dialect-parity tests pass
- `cargo test --locked -p perry-runtime --lib perex`, single-threaded: 78 passed
- `cargo fmt --check`, workspace architecture policy

No `crates/` files change.

https://claude.ai/code/session_01RJkA4Fhqz9J5F5fzDk5HWv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the perex dependency to use its crates.io release instead of a pinned Git source.
  - Removed the corresponding Git source exception from dependency policy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->