### PR TITLE
Merge train 172: #10148

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1543
+**Current Version:** 0.5.1544
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5685,7 +5685,8 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perex"
 version = "0.1.0"
-source = "git+https://github.com/PerryTS/perex?rev=007a2f7b604d47e36f3f501d3dbcfba1071da6e0#007a2f7b604d47e36f3f501d3dbcfba1071da6e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf"
 
 [[package]]
 name = "perry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5690,7 +5690,7 @@ checksum = "4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf"
 
 [[package]]
 name = "perry"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "cc",
  "libc",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5814,7 +5814,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5870,14 +5870,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "serde",
  "serde_json",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1543"
+version = "0.5.1544"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "clap",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "block2",
  "objc2",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "chrono",
  "cron",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6021,14 +6021,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "bson",
  "futures-util",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "notify",
  "perry-ffi",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-validation",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "brotli",
  "flate2",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6372,11 +6372,11 @@ dependencies = [
 
 [[package]]
 name = "perry-native-registration"
-version = "0.5.1543"
+version = "0.5.1544"
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6390,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-perex"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perex",
  "regex",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6458,14 +6458,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6560,14 +6560,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.9",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1543"
+version = "0.5.1544"
 
 [[package]]
 name = "perry-ui-test"
@@ -6680,11 +6680,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1543"
+version = "0.5.1544"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "block2",
  "libc",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6751,7 +6751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6764,7 +6764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-validation"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "idna",
  "regex",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1543"
+version = "0.5.1544"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,9 +399,7 @@ chrono = "0.4"
 regex = "1.12"
 aho-corasick = "1.1"
 # The single regular-expression engine, through crates/perry-perex.
-# Pinned to a revision of the public engine repository so CI resolves it
-# without a sibling checkout. Becomes a crates.io version once published.
-perex = { git = "https://github.com/PerryTS/perex", rev = "007a2f7b604d47e36f3f501d3dbcfba1071da6e0" }
+perex = "0.1"
 hex = "0.4"
 tempfile = "3"
 itoa = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1543"
+version = "0.5.1544"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/deny.toml
+++ b/deny.toml
@@ -52,6 +52,3 @@ multiple-versions = "warn"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-# The regular-expression engine resolves from its public repository at a pinned
-# revision until it is published to crates.io; remove this entry then.
-allow-git = ["https://github.com/PerryTS/perex"]


### PR DESCRIPTION
Merge train 172: lands #10148 (resolve Perex from crates.io) at head `75b0e97508`, plus the workspace version bump to 0.5.1544.

The commit was cherry-picked onto `5603d63d17`; the tree before the bump equals the PR head.

Audit:
- `perex-0.1.0.crate` from static.crates.io has sha256 `4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf`, which matches the new `Cargo.lock` checksum. Its `.cargo_vcs_info.json` records `007a2f7b604d47e36f3f501d3dbcfba1071da6e0`, the revision train 170 (#10146) pinned.
- I cloned PerryTS/perex at that revision and compared the packaged files: all 57 source files, including `Cargo.toml.orig`, are byte-identical. The only other packaged files are the generated `.cargo_vcs_info.json`, the normalized `Cargo.toml`, and `Cargo.lock`.
- `cargo metadata --locked` on this tree resolves `perex 0.1.0` from `registry+https://github.com/rust-lang/crates.io-index` with no publish-age override in the environment. The 7-day `global-min-publish-age` does not reject it because the version is already locked.

Local validation (`--locked`):
- `RUSTFLAGS=-Dwarnings cargo check -p perry --bins`, which checks `perex v0.1.0` from the registry
- `cargo check -p perry-runtime --no-default-features --features full --lib`
- `cargo test --release -p perry-perex`: 27 passed
- `cargo test --release -p perry-runtime --lib perex`: 78 passed
- `cargo fmt --all -- --check`

PR CI on `75b0e97508`: cargo-deny, soak-gate, security-audit, e2e-scoped, gap-suite-build and gc-stress-build pass. lint, check, warnings and cargo-test fail on the same steps with identical errors and the identical failing test (`native_stack::tests::stack_top_respects_custom_thread_stack_sizes`) as main (run 34711566628).
