### PR TITLE
fix(codegen): resolve orphan dispatch bytes in split units

### DIFF
--- a/changelog.d/10152-cgu-str-bytes.md
+++ b/changelog.d/10152-cgu-str-bytes.md
@@ -1,0 +1,13 @@
+### Fix split-unit dispatch descriptors referencing missing string bytes (#10152)
+
+Close initializer dependencies for otherwise-unreferenced globals retained in
+codegen unit 0. OpenTUI's node-backend chunk discarded a function after an export
+getter claimed the same symbol, leaving its `segment` dispatch descriptor in
+unit 0 while only the string initializer in unit 1 referenced the bytes.
+
+Preserve existing ELF/COFF owners and add external declarations for these
+dependencies; include the additional consumers in Mach-O's replication counts.
+This keeps unrelated strings and single-unit cache globals in their existing
+units and linkage. Regression coverage includes a reduced TypeScript module
+compiled through both LLVM construction paths and unit tests for ELF, COFF,
+Mach-O, and transitive initializer dependencies.

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -23,6 +23,9 @@ use crate::types::LlvmType;
 mod linkage;
 pub(crate) use linkage::*;
 
+#[cfg(test)]
+mod unit_partition_tests;
+
 fn push_statepoint_declarations(ir: &mut String) {
     ir.push_str(
         "declare token @llvm.experimental.gc.statepoint.p0(i64 immarg, i32 immarg, ptr, \
@@ -825,7 +828,7 @@ impl LlModule {
                 refs
             })
             .collect();
-        let bucket_needs: Vec<HashSet<usize>> = bucket_refs
+        let mut bucket_needs: Vec<HashSet<usize>> = bucket_refs
             .iter()
             .map(|refs| {
                 let mut need: HashSet<usize> = refs
@@ -858,6 +861,26 @@ impl LlModule {
                     .unwrap_or(0)
             })
             .collect();
+        // #10152: otherwise-unreferenced globals are retained in unit 0, but
+        // their initializers were absent from the function-rooted closure
+        // above. An orphaned string dispatch descriptor can still name bytes
+        // owned by another unit. Close those retained roots too, AFTER choosing
+        // owners so ELF/COFF keep existing definitions and only add declares;
+        // Mach-O's replication counts below include the added dependencies.
+        let mut work: Vec<usize> = global_owners
+            .iter()
+            .enumerate()
+            .filter_map(|(gi, &owner)| (owner == 0 && bucket_needs[0].insert(gi)).then_some(gi))
+            .collect();
+        while let Some(gi) = work.pop() {
+            for nm in &global_refs[gi] {
+                if let Some(&next) = global_index.get(nm.as_str()) {
+                    if bucket_needs[0].insert(next) {
+                        work.push(next);
+                    }
+                }
+            }
+        }
         let replicate_globals = self.target_triple.contains("apple");
         // #9610: how many units end up DEFINING each global. Under the
         // replicated (Mach-O) policy that is one unit per referencing bucket;

--- a/crates/perry-codegen/src/module/unit_partition_tests.rs
+++ b/crates/perry-codegen/src/module/unit_partition_tests.rs
@@ -1,0 +1,97 @@
+//! Regression coverage for globals retained without function-body references.
+
+use super::LlModule;
+use crate::types::{PTR, VOID};
+
+#[test]
+fn owner_only_dispatch_resolves_bytes_in_another_unit() {
+    for target in [
+        "x86_64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
+        "arm64-apple-macosx15.0.0",
+    ] {
+        let mut module = LlModule::new(target);
+        module.add_named_string_constant("m_.str.67.bytes", 8, "c\"segment\\00\"");
+        module.add_raw_global(
+            "@m_.str.67.dispatch = private unnamed_addr constant { i32, i32, i64, ptr } \
+             { i32 7, i32 0, i64 0, ptr @m_.str.67.bytes }"
+                .to_string(),
+        );
+        module.declare_function("consume", VOID, &[PTR]);
+        // The largest function takes unit 0; only the smaller function uses
+        // the bytes. The unreferenced dispatch descriptor falls back to unit 0.
+        let block = module
+            .define_function("big", VOID, vec![])
+            .create_block("entry");
+        for _ in 0..20 {
+            block.call_void("consume", &[(PTR, "null")]);
+        }
+        block.ret_void();
+        module
+            .define_function("bytes_user", PTR, vec![])
+            .create_block("entry")
+            .ret(PTR, "@m_.str.67.bytes");
+
+        let parts = module.codegen_unit_parts(2);
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].funcs[0].name, "big");
+        assert_eq!(parts[1].funcs[0].name, "bytes_user");
+        assert!(parts[0].pre.contains("@m_.str.67.dispatch ="));
+        assert!(!parts[1].pre.contains("@m_.str.67.dispatch ="));
+
+        // Parse the skeleton itself: this is where native construction failed
+        // in #10152, before there were any function bodies to dump.
+        #[cfg(feature = "llvm-inprocess")]
+        for part in &parts {
+            let context = inkwell::context::Context::create();
+            let skeleton = format!("{}{}", part.pre, part.post);
+            crate::inprocess::parse_ir_text(&context, &skeleton, "dispatch_skeleton")
+                .expect("retained dispatch initializer must resolve its bytes")
+                .verify()
+                .expect("valid unit skeleton");
+        }
+
+        if target.contains("apple") {
+            for part in &parts {
+                assert!(part
+                    .pre
+                    .contains("@m_.str.67.bytes = linkonce_odr unnamed_addr constant [8 x i8]"));
+            }
+        } else {
+            assert!(parts[0]
+                .pre
+                .contains("@m_.str.67.bytes = external constant [8 x i8]"));
+            assert!(parts[1]
+                .pre
+                .contains("@m_.str.67.bytes = unnamed_addr constant [8 x i8]"));
+        }
+    }
+}
+
+#[test]
+fn owner_only_global_dependencies_are_transitive() {
+    let mut module = LlModule::new("x86_64-unknown-linux-gnu");
+    module.add_internal_constant("anchor", PTR, "@middle");
+    module.add_internal_constant("middle", PTR, "@payload");
+    module.add_internal_constant("payload", PTR, "null");
+    module.declare_function("consume", VOID, &[PTR]);
+    let block = module
+        .define_function("big", VOID, vec![])
+        .create_block("entry");
+    for _ in 0..20 {
+        block.call_void("consume", &[(PTR, "null")]);
+    }
+    block.ret_void();
+    module
+        .define_function("middle_user", PTR, vec![])
+        .create_block("entry")
+        .ret(PTR, "@middle");
+
+    let units = module.render_codegen_units(2);
+    assert!(units[0].contains("@anchor = constant ptr @middle"));
+    assert!(units[0].contains("@middle = external constant ptr"));
+    assert!(units[0].contains("@payload = external constant ptr"));
+    assert!(units[1].contains("@middle = constant ptr @payload"));
+    assert!(units[1].contains("@payload = constant ptr null"));
+    assert!(!units[1].contains("@anchor ="));
+}

--- a/crates/perry/tests/issue_10152_cgu_str_bytes.rs
+++ b/crates/perry/tests/issue_10152_cgu_str_bytes.rs
@@ -1,0 +1,71 @@
+//! A discarded function can leave a dispatch descriptor whose bytes belong
+//! to another codegen unit. Both native skeletons and text units must resolve it.
+
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn orphan_dispatch_compiles_with_bytes_owned_by_another_unit() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test-files/test_codegen_unit_orphan_dispatch.ts");
+    for backend in ["native", "1"] {
+        let dir = tempfile::tempdir().expect("temporary compile directory");
+        let ll_dir = dir.path().join("ll");
+        std::fs::create_dir(&ll_dir).unwrap();
+        let output = dir.path().join("out.o");
+        let compiled = Command::new(env!("CARGO_BIN_EXE_perry"))
+            .arg("compile")
+            .arg(&fixture)
+            .args(["--no-link", "--no-auto-optimize", "--output"])
+            .arg(&output)
+            .arg("--cache-dir")
+            .arg(dir.path().join("cache"))
+            .env("PERRY_CODEGEN_UNITS", "2")
+            .env("PERRY_LLVM_INPROCESS", backend)
+            .env("PERRY_SAVE_LL", &ll_dir)
+            .env("PERRY_NO_CACHE", "1")
+            .env("PERRY_DISABLE_WELL_KNOWN", "1")
+            .output()
+            .expect("run perry compile");
+        assert!(
+            compiled.status.success(),
+            "{backend} compile failed:\n{}\n{}",
+            String::from_utf8_lossy(&compiled.stdout),
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+        assert!(std::fs::metadata(output).unwrap().len() > 0);
+
+        let suffix = if backend == "native" {
+            "native.ll"
+        } else {
+            "ll"
+        };
+        let prefix = "test_codegen_unit_orphan_dispatch_ts";
+        let units: Vec<String> = (0..2)
+            .map(|i| {
+                std::fs::read_to_string(ll_dir.join(format!("{prefix}.unit{i}.{suffix}")))
+                    .expect("forced split must emit both units")
+            })
+            .collect();
+        let bytes_line = units[1]
+            .lines()
+            .find(|line| line.contains("c\"segment\\00\""))
+            .expect("unit 1 must define the segment bytes");
+        let bytes = bytes_line.split_once(" = ").unwrap().0;
+        let dispatch = bytes.replace(".bytes", ".dispatch");
+        assert!(units[0].contains(&format!("{dispatch} =")));
+        assert!(!units[1].contains(&format!("{dispatch} =")));
+        assert!(units[0].contains(&format!("ptr {bytes}")));
+        // The descriptor is an owner-only fallback, not a live function use.
+        assert!(units.iter().flat_map(|unit| unit.lines()).all(|line| {
+            !line.contains(&dispatch) || line.starts_with(&format!("{dispatch} ="))
+        }));
+        if cfg!(target_os = "macos") {
+            assert!(units[0].contains(&format!("{bytes} = linkonce_odr")));
+            assert!(bytes_line.contains("linkonce_odr"));
+        } else {
+            assert!(units[0].contains(&format!("{bytes} = external constant [8 x i8]")));
+            assert!(!bytes_line.contains("external constant"));
+        }
+    }
+}

--- a/test-files/test_codegen_unit_orphan_dispatch.ts
+++ b/test-files/test_codegen_unit_orphan_dispatch.ts
@@ -1,0 +1,13 @@
+// #10152: the export getter claims `read`'s symbol, so function deduplication
+// discards its body after lowering has already interned a dispatch descriptor.
+function read(value: any) {
+    return value.segment();
+}
+const readAlias = read;
+export { readAlias as read };
+
+// Keep unit 0 larger than the string initializer so `segment`'s bytes go to
+// unit 1 when the compile regression forces PERRY_CODEGEN_UNITS=2.
+export function pad(value: any) {
+    return value.alpha + value.beta + value.gamma;
+}


### PR DESCRIPTION
## Summary

Fix OpenTUI's node-backend chunk failing to parse a split LLVM unit.

The `.bytes` owner is the first unit whose function-reference closure reaches the string; for `"segment"` (`.str.67`), that is the string initializer in unit 1. The `.dispatch` header falls back to unit 0 because its function use disappeared: `stringWidth2 as stringWidth` emits a getter before the same-named function, and symbol deduplication drops that function after lowering registered its descriptor. The fallback ran after dependency closure, leaving unit 0's header initializer without a definition or declaration of its bytes.

## Changes

- Close initializer dependencies for otherwise-unreferenced globals retained in unit 0, after selecting owners. ELF/COFF keep existing definitions and gain external declarations; Mach-O includes the additional consumers in its existing replication/linkage policy.
- Add a 13-line TypeScript reproducer with forced two-unit compilation through both native construction and textual LLVM transport. Assert that the header has no function uses, remains in unit 0, and resolves the bytes defined in unit 1.
- Add library tests for ELF, COFF, Mach-O, and transitive initializer dependencies, plus `changelog.d/10152-cgu-str-bytes.md`. `module.rs` remains below the cap at 1,884 lines.

## Related issue

Fixes #10152

## Test plan

All builds, tests, and checks ran on `perrymaster` through `./remote.sh`. Compiler commands use the configured shared `$CARGO_TARGET_DIR`; no builds or tests ran on the Mac.

- [x] `./remote.sh 'cargo build --release -p perry'` — passed in 2m 55s; existing `perry-runtime::box::relevant_box_roots` dead-code warning.
- [x] `./remote.sh 'cargo test -p perry-codegen --lib'` — 1,486 passed, 0 failed, 1 ignored.
- [x] `./remote.sh 'CARGO_TARGET_DIR=/tmp/perry-10152-test-target cargo test --release -p perry --test issue_10152_cgu_str_bytes'` — 1 passed, exercising both native and textual paths. Uses an isolated target directory to prevent another build lane replacing the compiler executable.
- [x] `./remote.sh 'cargo fmt --all -- --check'` — passed.
- [x] `./remote.sh './scripts/check_file_size.sh'` — passed.
- [x] `./remote.sh 'python3 scripts/check_node_version_consistency.py --list'` — passed.
- [x] `./remote.sh 'python3 scripts/check_test_registration.py'` — passed.

The full three-module OpenTUI repro passed (exit 0, all 13 LLVM units compiled):

```sh
./remote.sh 'mkdir -p /tmp/10152-after-ll /tmp/10152-after-objects && PERRY_LL_SIZE_OPT=1 PERRY_LL_PREOPT_OPTNONE_INSTRS=8192 PERRY_CODEGEN_UNIT_JOBS=2 PERRY_SAVE_LL=/tmp/10152-after-ll "$CARGO_TARGET_DIR/release/perry" compile "$OPENTUI_CORE/index.node.js" --no-link --output /tmp/10152-after-objects/out.o --cache-dir /tmp/10152-after-cache-$$'
```

The two new library tests failed before the fix (`cargo test -p perry-codegen --lib unit_partition`), including LLVM's `use of undefined value '@m_.str.67.bytes'`, and passed after it. The checked-in TypeScript fixture also failed before the fix with `.str.0.dispatch` in unit 0 and `.str.0.bytes` in unit 1:

```sh
./remote.sh 'mkdir -p /tmp/10152-small3-before-ll && PERRY_CODEGEN_UNITS=2 PERRY_LLVM_INPROCESS=1 PERRY_SAVE_LL=/tmp/10152-small3-before-ll "$CARGO_TARGET_DIR/release/perry" compile test-files/test_codegen_unit_orphan_dispatch.ts --no-link --no-auto-optimize --output /tmp/10152-small3-before.o --cache-dir /tmp/10152-small3-before-cache-$$'
```

Object-size check: all **12 previously successful unit objects are byte-identical** after the fix. The unaffected module objects are also byte-identical: `chunk_node_51kpf0mz_js.o` stays 12,050,136 bytes and `index_node_js.o` stays 16,661,976 bytes. The three surviving native IR dumps for the affected chunk have identical SHA-256 hashes before/after; unit 0 now declares `.str.67.bytes` externally while unit 1 still defines it.

## Checklist

- [x] No workspace version bump or edits to CLAUDE.md / CHANGELOG.md.
- [x] Added regression coverage and a changelog fragment.
- [x] Commit follows the `fix:` convention.
- [x] Read CONTRIBUTING.md and agree to the Code of Conduct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed split compilation failures involving string data referenced by dispatch descriptors when functions are discarded.
  - Ensured required initializer dependencies remain available across compilation units and platforms.
  - Preserved correct ownership and linkage for shared string data.

- **Tests**
  - Added regression coverage for native and alternate LLVM backends.
  - Added validation for transitive initializer dependencies across supported object formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->