### PR TITLE
fix(cjs): preserve live getter re-export bindings

### DIFF
--- a/changelog.d/10153-cjs-getter-reexport-binding.md
+++ b/changelog.d/10153-cjs-getter-reexport-binding.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Recognize CommonJS exports installed with `Object.defineProperty`, including
+  Babel's getter re-exports, as value exports. ESM named and namespace imports
+  now read the current property through the existing getter-aware runtime
+  lookup and call the returned value, instead of referencing a function symbol
+  that the CommonJS barrel never defined.
+- Avoid evaluating synthetic CommonJS property exports during initialization,
+  preserving accessor side effects and exports assigned or replaced later.
+  Regression coverage includes named imports, namespace calls, ESM barrels,
+  materialized namespaces, writable descriptors, and late assignments (#10153).

--- a/changelog.d/10153-cjs-getter-reexport-binding.md
+++ b/changelog.d/10153-cjs-getter-reexport-binding.md
@@ -8,4 +8,5 @@
 - Avoid evaluating synthetic CommonJS property exports during initialization,
   preserving accessor side effects and exports assigned or replaced later.
   Regression coverage includes named imports, namespace calls, ESM barrels,
-  materialized namespaces, writable descriptors, and late assignments (#10153).
+  materialized and dynamic namespaces, writable descriptors, and late
+  assignments (#10153).

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1955,5 +1955,7 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
     );
     progress.checkpoint("string pool and registration initializer");
 
+    super::namespace_value_getters::emit(llmod, module_prefix, cross_module);
+
     Ok(())
 }

--- a/crates/perry-codegen/src/codegen/cjs_exports.rs
+++ b/crates/perry-codegen/src/codegen/cjs_exports.rs
@@ -1,0 +1,123 @@
+//! Turn the CJS wrapper's synthetic property exports into live value getters.
+
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+
+use perry_hir::{Expr, Module, Stmt};
+
+use crate::module::LlModule;
+use crate::types::{DOUBLE, I32, I64, PTR};
+
+pub(super) type PropertyExports = HashMap<String, (u32, String)>;
+
+/// The wrapper emits `export const x = _cjs.x` to register value-export
+/// metadata. Do not execute that read during module initialization: it can
+/// invoke a getter too early and freezes exports assigned after initialization.
+/// Keep the caller's HIR immutable (it is also the object-cache input).
+pub(super) fn prepare(hir: &Module) -> (Cow<'_, Module>, PropertyExports) {
+    // Pair the wrapper's private binding with its compiler-owned preamble;
+    // an ordinary ESM variable named `_cjs` still has snapshot semantics.
+    let has_preamble = hir.imports.iter().any(|import| {
+        import
+            .source
+            .strip_prefix("node:")
+            .unwrap_or(&import.source)
+            == "module"
+            && import.specifiers.iter().any(|specifier| {
+                matches!(specifier, perry_hir::ImportSpecifier::Named { imported, local }
+                    if imported == "createRequire" && local == "__perry_cjs_create_require")
+            })
+    });
+    if !has_preamble {
+        return (Cow::Borrowed(hir), HashMap::new());
+    }
+    let entry = super::entry_outline::logical_entry_stmts(hir);
+    let Some(object_id) = entry.iter().find_map(|stmt| match stmt {
+        Stmt::Let { id, name, .. } if name == "_cjs" => Some(*id),
+        _ => None,
+    }) else {
+        return (Cow::Borrowed(hir), HashMap::new());
+    };
+    let exported: HashSet<&str> = hir
+        .exports
+        .iter()
+        .filter_map(|export| match export {
+            perry_hir::Export::Named { local, .. } => Some(local.as_str()),
+            _ => None,
+        })
+        .collect();
+    let mut properties = HashMap::new();
+    let mut bindings = HashSet::new();
+    for stmt in entry {
+        if let Stmt::Let {
+            id,
+            name,
+            init: Some(Expr::PropertyGet {
+                object, property, ..
+            }),
+            ..
+        } = stmt
+        {
+            if exported.contains(name.as_str())
+                && matches!(object.as_ref(), Expr::LocalGet(id) if *id == object_id)
+            {
+                properties.insert(name.clone(), (object_id, property.clone()));
+                bindings.insert(*id);
+            }
+        }
+    }
+    if properties.is_empty() {
+        return (Cow::Borrowed(hir), properties);
+    }
+    let mut owned = hir.clone();
+    let clear_snapshots = |stmts: &mut [Stmt]| {
+        for stmt in stmts {
+            if let Stmt::Let { id, init, .. } = stmt {
+                if bindings.contains(id) {
+                    *init = None;
+                }
+            }
+        }
+    };
+    clear_snapshots(&mut owned.init);
+    for function in &mut owned.functions {
+        if super::entry_outline::is_entry_chunk(function) {
+            clear_snapshots(&mut function.body);
+        }
+    }
+    (Cow::Owned(owned), properties)
+}
+
+pub(super) fn emit_getter(
+    llmod: &mut LlModule,
+    getter_name: &str,
+    module_prefix: &str,
+    object_id: u32,
+    property: &str,
+) {
+    let (key_global, key_len) = llmod.add_string_constant(property);
+    let getter = llmod.define_function(getter_name, DOUBLE, vec![]);
+    getter.create_block("entry");
+    let blk = getter.block_mut(0).unwrap();
+    // Allocate the key before loading the GC-rooted namespace. No raw object
+    // pointer survives that allocation; the boxed property helper handles
+    // accessors, prototypes and function-valued module.exports.
+    let key = blk.call(
+        I64,
+        "js_string_from_bytes",
+        &[
+            (PTR, &format!("@{key_global}")),
+            (I32, &key_len.to_string()),
+        ],
+    );
+    let object = blk.load(
+        DOUBLE,
+        &format!("@perry_global_{module_prefix}__{object_id}"),
+    );
+    let value = blk.call(
+        DOUBLE,
+        "js_object_get_field_by_name_boxed",
+        &[(DOUBLE, &object), (I64, &key)],
+    );
+    blk.ret(DOUBLE, &value);
+}

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -182,6 +182,7 @@ mod artifact_display_names;
 mod artifact_source_text;
 mod artifacts;
 mod boxed_locals;
+mod cjs_exports;
 #[cfg(test)]
 mod clone_suffix_tests;
 mod closure;
@@ -213,6 +214,7 @@ mod method;
 mod method_registry;
 mod method_trampolines;
 mod module_globals_emit;
+pub(crate) mod namespace_value_getters;
 mod native_namespace_exports;
 #[cfg(test)]
 mod number_exactness_tests;
@@ -410,6 +412,8 @@ pub fn user_function_symbol(module_name: &str, function_name: &str) -> String {
 /// guarantee — do not change to `&mut` without also moving the cache
 /// hash to AFTER codegen.
 pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> {
+    let (live_cjs_hir, cjs_property_exports) = cjs_exports::prepare(hir);
+    let hir = live_cjs_hir.as_ref();
     let progress = CompileProgress::new(&hir.name, module_callable_count(hir));
     let triple = opts.target.clone().unwrap_or_else(default_target_triple);
     let fp_flags = crate::block::FpFlags::new(opts.fast_math, opts.fp_contract_mode);
@@ -2731,6 +2735,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         &opts.imported_classes,
         &cross_module.compile_time_constants,
         &module_prefix,
+        &cjs_property_exports,
     );
     cross_module.module_global_proven_types = module_global_proven_types;
 

--- a/crates/perry-codegen/src/codegen/module_globals_emit.rs
+++ b/crates/perry-codegen/src/codegen/module_globals_emit.rs
@@ -160,6 +160,7 @@ pub(crate) fn emit_module_globals(
     imported_classes: &[ImportedClass],
     compile_time_constants: &HashMap<u32, f64>,
     module_prefix: &str,
+    cjs_property_exports: &super::cjs_exports::PropertyExports,
 ) -> ModuleGlobals {
     // Module-level globals registry. Pre-walk:
     //   1. Collect every LocalId referenced from any function or method
@@ -170,6 +171,9 @@ pub(crate) fn emit_module_globals(
     //      as cheap stack alloca (preserves perf for the bench
     //      benchmarks that don't share state with helper functions).
     let mut referenced_from_fn: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    // Live CJS value getters read the namespace even after its synthetic
+    // snapshot initializers have been removed.
+    referenced_from_fn.extend(cjs_property_exports.values().map(|(id, _)| *id));
     // Helper that handles "params + lets define a scope, refs minus
     // defines flow out". Used for every function/method/closure body.
     let scan_body = |params: &[perry_hir::Param],
@@ -505,11 +509,21 @@ pub(crate) fn emit_module_globals(
                         let getter_name =
                             format!("perry_fn_{}__{}", module_prefix, sanitize(public_name));
                         if !llmod.has_function(&getter_name) {
-                            let getter = llmod.define_function(&getter_name, DOUBLE, vec![]);
-                            let _ = getter.create_block("entry");
-                            let blk = getter.block_mut(0).unwrap();
-                            let val = blk.load(DOUBLE, &format!("@{}", global_name));
-                            blk.ret(DOUBLE, &val);
+                            if let Some((object_id, property)) = cjs_property_exports.get(name) {
+                                super::cjs_exports::emit_getter(
+                                    llmod,
+                                    &getter_name,
+                                    module_prefix,
+                                    *object_id,
+                                    property,
+                                );
+                            } else {
+                                let getter = llmod.define_function(&getter_name, DOUBLE, vec![]);
+                                let _ = getter.create_block("entry");
+                                let blk = getter.block_mut(0).unwrap();
+                                let val = blk.load(DOUBLE, &format!("@{}", global_name));
+                                blk.ret(DOUBLE, &val);
+                            }
                         }
 
                         // Import-origin metadata preserves the raw exported

--- a/crates/perry-codegen/src/codegen/namespace_value_getters.rs
+++ b/crates/perry-codegen/src/codegen/namespace_value_getters.rs
@@ -1,0 +1,41 @@
+//! Closure-ABI adapters for live exports in materialized static namespaces.
+
+use super::helpers::sanitize_member;
+use super::opts::CrossModuleCtx;
+use crate::module::LlModule;
+use crate::types::{DOUBLE, I64};
+
+pub(crate) fn symbol(module_prefix: &str, namespace: &str, member: &str) -> String {
+    format!(
+        "__perry_namespace_value_{}__{}",
+        module_prefix,
+        sanitize_member(&format!("{namespace}:{member}"))
+    )
+}
+
+pub(super) fn emit(llmod: &mut LlModule, module_prefix: &str, imports: &CrossModuleCtx) {
+    let mut members: Vec<_> = imports.namespace_member_prefixes.iter().collect();
+    members.sort_by_key(|(key, _)| *key);
+    for ((namespace, member), source_prefix) in members {
+        let wrapper_name = symbol(module_prefix, namespace, member);
+        // Lowering declares an adapter only when a namespace value actually
+        // escapes. Direct `ns.x` reads need no additional wrapper.
+        if !llmod.is_declared(&wrapper_name) || llmod.has_function(&wrapper_name) {
+            continue;
+        }
+        let origin = crate::expr::import_origin_suffix_ns(
+            &imports.import_function_origin_names,
+            &imports.namespace_member_origin_names,
+            namespace,
+            member,
+        );
+        let getter_name = format!("perry_fn_{source_prefix}__{origin}");
+        llmod.declare_function(&getter_name, DOUBLE, &[]);
+        let wrapper =
+            llmod.define_function(wrapper_name, DOUBLE, vec![(I64, "%closure".to_string())]);
+        wrapper.create_block("entry");
+        let block = wrapper.block_mut(0).unwrap();
+        let value = block.call(DOUBLE, &getter_name, &[]);
+        block.ret(DOUBLE, &value);
+    }
+}

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail, Result};
 use perry_hir::types::Type as HirType;
 use perry_hir::Expr;
 
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::double_literal;
 use crate::rooting::{with_rooted_accumulator, with_rooted_group, Arg, Repr};
 use crate::types::{DOUBLE, I32, I64, PTR};
 
@@ -436,9 +436,10 @@ fn materialize_compiled_namespace(ctx: &mut FnCtx<'_>, name: &str) -> Result<Opt
     let object = ctx
         .block()
         .call(I64, "js_object_alloc", &[(I32, &zero), (I32, &count)]);
+    let object = nanbox_pointer_inline(ctx.block(), &object);
     with_rooted_accumulator(
         ctx,
-        Repr::Ptr,
+        Repr::Boxed,
         &object,
         true,
         |ctx, accumulator| {
@@ -452,29 +453,53 @@ fn materialize_compiled_namespace(ctx: &mut FnCtx<'_>, name: &str) -> Result<Opt
                     }),
                     property: member.clone(),
                 };
-                let value = lower_expr(ctx, &member_get)?;
+                // #10153: materializing `ns` must not snapshot a variable
+                // export or invoke a CJS getter. Install a closure that reads
+                // the producer's value getter on each subsequent access.
+                let is_live = ctx
+                    .imported_vars
+                    .contains(&crate::namespace_member_var_key(name, member))
+                    && !ctx
+                        .namespace_member_nested
+                        .contains(&(name.to_string(), member.clone()));
+                let value = if is_live {
+                    let wrapper = crate::codegen::namespace_value_getters::symbol(
+                        ctx.strings.module_prefix(),
+                        name,
+                        member,
+                    );
+                    ctx.pending_declares
+                        .push((wrapper.clone(), DOUBLE, vec![I64]));
+                    let handle = ctx.block().call(
+                        I64,
+                        "js_closure_alloc_singleton",
+                        &[(PTR, &format!("@{wrapper}"))],
+                    );
+                    nanbox_pointer_inline(ctx.block(), &handle)
+                } else {
+                    lower_expr(ctx, &member_get)?
+                };
                 let key_index = ctx.strings.intern(member);
                 let key_global = format!("@{}", ctx.strings.entry(key_index).handle_global);
-                let key = {
-                    let block = ctx.block();
-                    let key = block.load(DOUBLE, &key_global);
-                    let key_bits = block.bitcast_double_to_i64(&key);
-                    block.and(I64, &key_bits, POINTER_MASK_I64)
-                };
-                accumulator.call_void(
+                let key = ctx.block().load(DOUBLE, &key_global);
+                accumulator.call(
                     ctx,
-                    "js_object_set_field_by_name",
-                    &[Arg::Plain(I64, &key), Arg::Plain(DOUBLE, &value)],
+                    DOUBLE,
+                    if is_live {
+                        "js_object_define_get_accessor"
+                    } else {
+                        "js_object_set_property_key"
+                    },
+                    &[Arg::Plain(DOUBLE, &key), Arg::Plain(DOUBLE, &value)],
                 );
             }
             Ok(())
         },
         |ctx, object| {
-            let value = nanbox_pointer_inline(ctx.block(), object);
             Ok(Some(ctx.block().call(
                 DOUBLE,
                 "js_finalize_namespace",
-                &[(DOUBLE, &value)],
+                &[(DOUBLE, object)],
             )))
         },
     )

--- a/crates/perry/src/commands/compile/cjs_wrap/detect.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/detect.rs
@@ -62,7 +62,11 @@ pub(in crate::commands::compile) fn is_commonjs(source: &str) -> bool {
         // — no `exports.X =`, no `require(`. Without this arm they fall
         // through to the ESM pipeline, where the bare `exports` identifier
         // throws a ReferenceError at module init.
-        || stripped.contains("defineProperty(exports,")
+        || perry_perex::tooling::Regex::new(
+            r"(?:^|[^A-Za-z0-9_$.])Object\s*\.\s*defineProperty\s*\(\s*(?:module\s*\.\s*)?exports\s*,",
+        )
+        .unwrap()
+        .is_match(&stripped)
     {
         return true;
     }

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_exports.rs
@@ -385,7 +385,8 @@ pub fn extract_object_literal_exports_from_require(source: &str) -> Vec<(String,
     out
 }
 
-/// Extract named-export patterns from CJS source. Three shapes are matched:
+/// Extract named-export patterns from CJS source. These are value bindings,
+/// including properties installed by accessors or by later function calls.
 ///
 ///   1. `exports.X = ...` and `module.exports.X = ...` — the canonical CJS
 ///      named-export form. Skips `__esModule` (the interop marker injected
@@ -460,6 +461,23 @@ pub fn extract_exports_from_source(source: &str) -> Vec<String> {
     for cap in bracket_re.captures_iter(source) {
         if let Some(m) = cap.get(1) {
             push_unique(&mut names, m.as_str());
+        }
+    }
+
+    // #10153: Babel emits accessor re-exports with defineProperty rather
+    // than an assignment. A descriptor's `get` or `value` may hold a function,
+    // but that is not a function declaration in this module. Surface the name
+    // through the same value-export path as ordinary exports assignments.
+    let descriptor_re = perry_perex::tooling::Regex::new(
+        r#"(?:^|[^A-Za-z0-9_$.])(Object\s*\.\s*defineProperty\s*\(\s*(?:module\s*\.\s*)?exports\s*,\s*['"]([A-Za-z_$][A-Za-z0-9_$]*)['"]\s*,)"#,
+    )
+    .unwrap();
+    let stripped = detect::strip_comments_and_strings(source);
+    for cap in descriptor_re.captures_iter(source) {
+        let call = cap.get(1).unwrap();
+        // Ignore examples embedded in comments and strings.
+        if stripped[call.start()..].starts_with("Object") {
+            push_unique(&mut names, cap.get(2).unwrap().as_str());
         }
     }
 

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -21,7 +21,8 @@
 //!      `_req_N` bindings, runs the original code, and returns
 //!      `module.exports`. The IIFE result is bound to `_cjs`.
 //!   3. Emit `export default _cjs;` plus `export const X = _cjs.X;` for each
-//!      detected named export.
+//!      detected named export. Codegen turns these synthetic property exports
+//!      into live getters on `_cjs`, without evaluating a snapshot at init.
 //!
 //! Two named-export sources are unioned:
 //!

--- a/crates/perry/src/commands/compile/cjs_wrap/tests/source_graph.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/tests/source_graph.rs
@@ -1,6 +1,52 @@
 use super::{extract_exports_from_source, wrap_commonjs, PathBuf};
 
 #[test]
+fn detects_whitespace_separated_descriptor_exports() {
+    let source = "Object . defineProperty (\n exports , 'answer', { value: 42 });";
+    assert!(super::is_commonjs(source));
+    assert_eq!(extract_exports_from_source(source), ["answer"]);
+}
+
+#[test]
+fn descriptor_and_late_exports_are_values_not_declared_functions() {
+    let source = r#"
+Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, "transform", {
+  enumerable: true, get: function () { return impl.transform; }
+});
+Object.defineProperty(module.exports, 'value', { value: function () { return 42; } });
+exports.update = function () { exports.late = function () { return 43; }; };
+// Object.defineProperty(exports, "comment", { value: 0 });
+var text = 'Object.defineProperty(exports, "text", { value: 0 });';
+other.Object.defineProperty(exports, "other", { value: 0 });
+Object.defineProperty(other.exports, "inner", { value: 0 });
+"#;
+    let names = extract_exports_from_source(source);
+    assert_eq!(names, ["update", "late", "transform", "value"]);
+    let wrapped = wrap_commonjs(source, &PathBuf::from("/tmp/descriptor/index.cjs"));
+    for name in &names {
+        assert!(wrapped.contains(&format!("export const {name} = _cjs.{name};")));
+        assert!(!wrapped.contains(&format!("export function {name}")));
+    }
+    let ast = perry_parser::parse_typescript(&wrapped, "index.cjs").unwrap();
+    let hir = perry_hir::lower_module(&ast, "index", "/tmp/descriptor/index.cjs").unwrap();
+    for name in names {
+        assert!(hir
+            .exported_objects
+            .iter()
+            .any(|exported| exported == &name));
+        assert!(!hir
+            .functions
+            .iter()
+            .any(|function| function.is_exported && function.name == name));
+        assert!(!hir
+            .exported_functions
+            .iter()
+            .any(|(exported, _)| exported == &name));
+    }
+}
+
+#[test]
 fn extracts_esbuild_export_helper_keys() {
     let src = r#"
 var __export = (target, all) => {

--- a/crates/perry/tests/source_graph_export_regressions.rs
+++ b/crates/perry/tests/source_graph_export_regressions.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Once;
 
+#[path = "source_graph_export_regressions/issue_10153.rs"]
+mod issue_10153;
+
 const GC_ENV_OVERRIDES: &[&str] = &[
     "PERRY_GEN_GC",
     "PERRY_GC_SCAVENGE",

--- a/crates/perry/tests/source_graph_export_regressions/issue_10153.rs
+++ b/crates/perry/tests/source_graph_export_regressions/issue_10153.rs
@@ -1,0 +1,108 @@
+//! Babel's CommonJS accessor re-exports must remain live value bindings.
+
+use super::{compile_and_run, write};
+
+fn fixtures(dir: &std::path::Path) {
+    write(
+        dir,
+        "index.cjs",
+        include_str!("../../../../test-files/cjs_getter_reexport/index.cjs"),
+    );
+    write(
+        dir,
+        "transform.cjs",
+        include_str!("../../../../test-files/cjs_getter_reexport/transform.cjs"),
+    );
+}
+
+#[test]
+fn named_cjs_getter_reexport_is_a_live_value() {
+    let dir = tempfile::tempdir().unwrap();
+    fixtures(dir.path());
+    write(
+        dir.path(),
+        "main.mjs",
+        include_str!("../../../../test-files/test_cjs_getter_reexport.ts")
+            .replace("./cjs_getter_reexport/index.cjs", "./index.cjs")
+            .as_str(),
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.mjs"),
+        "0\nfunction\n2\n3\nundefined\n12\n13\n14\n3\n"
+    );
+}
+
+#[test]
+fn namespace_cjs_getter_reexport_is_a_live_value() {
+    let dir = tempfile::tempdir().unwrap();
+    fixtures(dir.path());
+    write(
+        dir.path(),
+        "main.mjs",
+        "import * as ns from './index.cjs';\n\
+         console.log(ns.reads());\n\
+         console.log(typeof ns.transform);\n\
+         console.log(ns.transform(1));\n\
+         console.log(ns.value(2));\n\
+         console.log(typeof ns.late);\n\
+         ns.update();\n\
+         console.log(ns.transform(1));\n\
+         console.log(ns.value(2));\n\
+         console.log(ns.late(3));\n\
+         console.log(ns.reads());\n",
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.mjs"),
+        "0\nfunction\n2\n3\nundefined\n12\n13\n14\n3\n"
+    );
+}
+
+#[test]
+fn cjs_getter_reexport_survives_barrels_and_materialized_namespaces() {
+    let dir = tempfile::tempdir().unwrap();
+    fixtures(dir.path());
+    write(
+        dir.path(),
+        "barrel.mjs",
+        "export { transform as renamed, update, reads } from './index.cjs';\n",
+    );
+    write(
+        dir.path(),
+        "main.mjs",
+        "import { renamed as transform, update, reads } from './barrel.mjs';\n\
+         import * as ns from './barrel.mjs';\n\
+         const materialized = ns;\n\
+         console.log(reads());\n\
+         console.log(transform(1));\n\
+         console.log(materialized.renamed(2));\n\
+         update();\n\
+         console.log(transform(1));\n\
+         console.log(materialized.renamed(2));\n\
+         console.log(reads());\n",
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.mjs"),
+        "0\n2\n3\n12\n13\n4\n"
+    );
+}
+
+#[test]
+fn ordinary_esm_property_export_keeps_its_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "value.mjs",
+        "const _cjs = { value: 1 };\n\
+         export const value = _cjs.value;\n\
+         export function update() { _cjs.value = 2; }\n",
+    );
+    write(
+        dir.path(),
+        "main.mjs",
+        "import { value, update } from './value.mjs';\n\
+         console.log(value);\n\
+         update();\n\
+         console.log(value);\n",
+    );
+    assert_eq!(compile_and_run(dir.path(), "main.mjs"), "1\n1\n");
+}

--- a/crates/perry/tests/source_graph_export_regressions/issue_10153.rs
+++ b/crates/perry/tests/source_graph_export_regressions/issue_10153.rs
@@ -87,6 +87,24 @@ fn cjs_getter_reexport_survives_barrels_and_materialized_namespaces() {
 }
 
 #[test]
+fn dynamic_cjs_namespace_keeps_getter_reexports_live() {
+    let dir = tempfile::tempdir().unwrap();
+    fixtures(dir.path());
+    write(
+        dir.path(),
+        "main.mjs",
+        "const ns = await import('./index.cjs');\n\
+         const key = process.argv[2] || 'transform';\n\
+         console.log(ns.reads());\n\
+         console.log(Reflect.get(ns, key)(1));\n\
+         ns.update();\n\
+         console.log(Reflect.get(ns, key)(1));\n\
+         console.log(ns.reads());\n",
+    );
+    assert_eq!(compile_and_run(dir.path(), "main.mjs"), "0\n2\n12\n2\n");
+}
+
+#[test]
 fn ordinary_esm_property_export_keeps_its_snapshot() {
     let dir = tempfile::tempdir().unwrap();
     write(

--- a/test-files/cjs_getter_reexport/index.cjs
+++ b/test-files/cjs_getter_reexport/index.cjs
@@ -1,0 +1,20 @@
+var _transform = require("./transform.cjs");
+var readCount = 0;
+Object.defineProperty(exports, "transform", {
+  enumerable: true,
+  get: function () {
+    readCount++;
+    return _transform.transform;
+  }
+});
+Object.defineProperty(module.exports, "value", {
+  enumerable: true,
+  writable: true,
+  value: function (value) { return value + 1; }
+});
+exports.reads = function () { return readCount; };
+exports.update = function () {
+  _transform.update();
+  exports.value = function (value) { return value + 11; };
+  exports.late = function (value) { return value + 11; };
+};

--- a/test-files/cjs_getter_reexport/index.cjs
+++ b/test-files/cjs_getter_reexport/index.cjs
@@ -1,9 +1,8 @@
+Object.defineProperty(exports, "__esModule", { value: true });
 var _transform = require("./transform.cjs");
-var readCount = 0;
 Object.defineProperty(exports, "transform", {
   enumerable: true,
   get: function () {
-    readCount++;
     return _transform.transform;
   }
 });
@@ -12,7 +11,7 @@ Object.defineProperty(module.exports, "value", {
   writable: true,
   value: function (value) { return value + 1; }
 });
-exports.reads = function () { return readCount; };
+exports.reads = function () { return _transform.reads(); };
 exports.update = function () {
   _transform.update();
   exports.value = function (value) { return value + 11; };

--- a/test-files/cjs_getter_reexport/transform.cjs
+++ b/test-files/cjs_getter_reexport/transform.cjs
@@ -1,4 +1,14 @@
-exports.transform = function (value) { return value + 1; };
+Object.defineProperty(exports, "__esModule", { value: true });
+var transform = function (value) { return value + 1; };
+var readCount = 0;
+Object.defineProperty(exports, "transform", {
+  enumerable: true,
+  get: function () {
+    readCount++;
+    return transform;
+  }
+});
+exports.reads = function () { return readCount; };
 exports.update = function () {
-  exports.transform = function (value) { return value + 11; };
+  transform = function (value) { return value + 11; };
 };

--- a/test-files/cjs_getter_reexport/transform.cjs
+++ b/test-files/cjs_getter_reexport/transform.cjs
@@ -1,0 +1,4 @@
+exports.transform = function (value) { return value + 1; };
+exports.update = function () {
+  exports.transform = function (value) { return value + 11; };
+};

--- a/test-files/test_cjs_getter_reexport.ts
+++ b/test-files/test_cjs_getter_reexport.ts
@@ -1,3 +1,5 @@
+// #10153 requires live CJS value reads. The parity runner uses the companion
+// test-parity/expected file because Node snapshots CJS named imports.
 import { transform, value, late, update, reads } from "./cjs_getter_reexport/index.cjs";
 
 console.log(reads());

--- a/test-files/test_cjs_getter_reexport.ts
+++ b/test-files/test_cjs_getter_reexport.ts
@@ -1,0 +1,12 @@
+import { transform, value, late, update, reads } from "./cjs_getter_reexport/index.cjs";
+
+console.log(reads());
+console.log(typeof transform);
+console.log(transform(1));
+console.log(value(2));
+console.log(typeof late);
+update();
+console.log(transform(1));
+console.log(value(2));
+console.log(late(3));
+console.log(reads());

--- a/test-parity/expected/test_cjs_getter_reexport.txt
+++ b/test-parity/expected/test_cjs_getter_reexport.txt
@@ -1,0 +1,9 @@
+0
+function
+2
+3
+undefined
+12
+13
+14
+3


### PR DESCRIPTION
## Summary

CommonJS export discovery skipped `Object.defineProperty` descriptors, so Babel's named `transformAsync` import fell through to a direct `perry_fn_<barrel>__transformAsync` function binding. The accessor returns a function from another module, and the CommonJS factory never emits that top-level function symbol in the barrel. Recognized property exports were also snapshotted during initialization, invoking getters too early and losing subsequent export assignments.

## Changes

- Discover getter/value descriptor exports as values, using the existing value-export classification.
- Generate getter-aware reads from the CommonJS exports object at use time; calls invoke the returned value. Preserve ordinary ESM initializer semantics.
- Keep value bindings live when static namespaces are materialized or passed through ESM barrels.
- Add Babel-shaped fixtures with `__esModule` markers, getter/value descriptors, and exports assigned inside functions; cover named imports, namespace calls, barrels, materialized namespaces, and dynamic namespace reads.
- Add five end-to-end tests, two CommonJS unit tests, expected output for the standalone fixture, and `changelog.d/10153-cjs-getter-reexport-binding.md`. No new runtime ABI is needed.

## Related issue

Fixes #10153

## Test plan

**Draft: the missing-symbol failure is fixed, but the real Babel runtime acceptance check still fails.**

All builds and tests ran on the Linux host with LLVM 22 through `./remote.sh`; none ran on the Mac. The helper was invoked as `GIT_DIR=/private/tmp/perry-10153-git/.git ./remote.sh '<payload>'` because the worktree's original Git administration directory is read-only.

Before the fix, `cargo test -p perry --test source_graph_export_regressions issue_10153 -- --nocapture` with original production sources produced **3 failures and 1 passing ESM control**: named/barrel imports failed to link, and namespace calls read undefined. The final exact Babel-shaped fixture was also compiled with a separate compiler built from base `95bef3da2cd42a9989b0e785738059eedc5357cb`; it fails with:

```text
undefined reference to `__perry_wrap_perry_fn_cjs_getter_reexport_index_cjs__transform'
undefined reference to `perry_fn_cjs_getter_reexport_index_cjs__transform'
```

The final committed tree passed this remote payload (output: `/tmp/perry-10153-committed-tests.log` on the host):

```sh
cargo fmt --all -- --check
cargo build -p perry -p perry-runtime-static -p perry-stdlib-static
mkdir -p /tmp/perry-10153-committed-debug
cp "$CARGO_TARGET_DIR/debug/"libperry*.a /tmp/perry-10153-committed-debug/
export PERRY_RUNTIME_DIR=/tmp/perry-10153-committed-debug
export PERRY_NO_AUTO_OPTIMIZE=1
cargo test -p perry --test source_graph_export_regressions
cargo test -p perry --test source_graph_export_regressions issue_10153
cargo test -p perry --bin perry cjs_wrap
./scripts/check_file_size.sh
python3 scripts/check_test_registration.py
python3 scripts/check_node_version_consistency.py --list
```

Results: **26/26** source-graph tests (148.71 s), **5/5** focused regressions (45.32 s), **121/121** CommonJS unit tests (0.03 s); formatting, the 2,000-line file-size gate, registration, and Node-version consistency passed.

`cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static` also passed. With matching release artifacts copied to `/tmp/perry-10153-fixed-artifacts`, the standalone fixture passed **1/1**:

```sh
export PERRY_BIN=/tmp/perry-10153-fixed-artifacts/perry
export PERRY_RUNTIME_DIR=/tmp/perry-10153-fixed-artifacts
export PERRY_NO_AUTO_OPTIMIZE=1 PERRY_SKIP_BUILD=1
npx --yes --package node@26.5.1 --call './run_parity_tests.sh --filter test_cjs_getter_reexport'
```

The companion expected-output file deliberately checks the requested live CJS bindings; Node snapshots CJS named imports. Runtime archives were copied to isolated directories after matching builds because the shared target and optimized-runtime caches produced build-stamp mismatches during verification.

### Real Babel acceptance check

OpenCode's package configuration aliases `@babel/core` to a shim that deliberately throws. The isolated project at `/tmp/perry-10153-babel-728` instead resolves the installed **7.28.0** package and its installed dependencies directly, without aliases. Its package configuration is `{"type":"module","perry":{"compilePackages":["*","@babel/core"]}}`; `node_modules/@babel/core` points to the installed `@babel+core@7.28.0+e33be1330ecc2599` instance.

```js
import { transformAsync } from "@babel/core";
console.log(typeof transformAsync);
const out = await transformAsync("const a = 1;", { babelrc: false, configFile: false });
console.log(out.code);
```

Exact remote commands for the original fixed release check:

```sh
export PERRY_RUNTIME_DIR="$CARGO_TARGET_DIR/release"
export PERRY_NO_AUTO_OPTIMIZE=1
cd /tmp/perry-10153-babel-728
node -e 'console.log(require.resolve("@babel/core")); console.log(require("@babel/core/package.json").version)'
node main.mjs
"$CARGO_TARGET_DIR/release/perry" compile main.mjs --output /tmp/perry-10153-babel-728-bin --cache-dir /tmp/perry-10153-babel-728-cache --no-cache
/tmp/perry-10153-babel-728-bin
```

Node prints `function` and `const a = 1;`. Perry compiles and links **291 modules** (191.5 MB), then exits 1 before the entry's logging:

```text
TypeError: Cannot read properties of undefined (reading 'defineAliasedType')
    at <anonymous>
```

A separate unpatched compiler built from the base revision also compiles this graph when the entry uses a default import plus `Reflect.get` to bypass the missing named binding. Its executable aborts with exit 134 (`panic in a function that cannot unwind`). That control establishes no successful Babel runtime baseline and does **not** prove the exact `defineAliasedType` failure predates this patch.

### Additional repository checks

- `./scripts/test_affected_crates.sh --base 95bef3da2cd42a9989b0e785738059eedc5357cb`: exit 101 in unchanged runtime test `native_stack::tests::stack_top_respects_custom_thread_stack_sizes` (`bound must belong to this worker`); 3,677 runtime tests passed, 1 failed, 4 ignored. `cargo test -p perry-runtime --lib native_stack::tests::stack_top_respects_custom_thread_stack_sizes -- --test-threads=1` reproduces it.
- `./scripts/pre-tag-check.sh --quick`: failed only public benchmark evidence freshness.
- After `npm ci --ignore-scripts --no-audit --no-fund`, `npx --yes --package node@26.5.1 --call './scripts/run_gap_tests.sh'` with the release `PERRY_BIN`, matching `PERRY_RUNTIME_DIR`, `PERRY_SKIP_BUILD=1`, and `PERRY_NO_AUTO_OPTIMIZE=1`: **752 passed, 10 output mismatches, 15 compile failures, 0 crashes, 0 Node failures**; gate exit 1. All 15 compile logs report stale optimized-runtime build stamps. Six output mismatches were already in the failure snapshot; four remain untriaged. Host log: `/tmp/perry-10153-gap.log`; full report preserved at `/tmp/perry-10153-gap-report.json`.
- `PERRY_UI_TEST_MODE=1 ./scripts/run_doc_tests.sh --perry "$PERRY_BIN" --skip-xcompile` with isolated release artifacts: exit 1; **33/91 passed, 55 compile failures, 3 skipped**. Failures: 53 missing GTK archives, one missing Fastify pump feature, one runtime build-stamp mismatch. Host log: `/tmp/perry-10153-docs-host.log`. The initial invocation without `--perry` exited 2 because the harness assumed a worktree-local `target/release/perry` instead of the shared `CARGO_TARGET_DIR`.

## Checklist

- [x] Added user-facing regression coverage under `test-files/` and registered Rust end-to-end tests.
- [x] No CLI, stdlib API, runtime ABI, or platform UI API changes requiring documentation updates.
- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md.
- [x] Commits follow the `fix:` prefix convention.
- [x] Read CONTRIBUTING.md and agree to the Code of Conduct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CommonJS exports defined with `Object.defineProperty`, including getter-based re-exports, are now recognized correctly.
  - ESM named, namespace, and dynamic imports now read current CommonJS property values through live getters.
  - Accessor side effects and later CommonJS assignments are preserved instead of being replaced by initialization-time snapshots.
  - Improved detection of CommonJS export definitions with varied whitespace and `module.exports` receivers.

- **Tests**
  - Added regression coverage for getter re-exports, late assignments, namespace access, and dynamic imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->