### PR TITLE
fix(ui-macos): keep editable TextField single-line (#10155)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2967,6 +2967,7 @@ jobs:
             test_issue_610_smoke \
             test_issue_640_navstack_textfield \
             test_issue_763_reactive_textfield \
+            test_issue_10155_textfield_singleline \
             test_issue_764_state_at_module_init \
             test_ramda_user_import \
             test_take_screenshot \

--- a/changelog.d/10157-macos-textfield-single-line.md
+++ b/changelog.d/10157-macos-textfield-single-line.md
@@ -1,0 +1,8 @@
+Fixed macOS `TextField` wrapping to multiple lines when its text was wider than
+the field. `perry-ui-macos`'s `create()` built the field from
+`NSTextField::textFieldWithString`, whose cell wraps and grows, and never
+overrode it — so a fixed-width field grew tall instead of scrolling, unlike
+every other backend. The cell is now configured for single-line editing
+(`usesSingleLineMode`, `scrollable`, `wraps = false`, clipping line-break mode),
+matching iOS / GTK4 / Android / Windows. Multiline input keeps its own widget,
+`TextArea`.

--- a/crates/perry-ui-macos/src/widgets/textfield.rs
+++ b/crates/perry-ui-macos/src/widgets/textfield.rs
@@ -2,7 +2,7 @@ use crate::ffi::{js_gc_pin_user_ptr, js_string_from_bytes};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass};
-use objc2_app_kit::{NSTextField, NSView};
+use objc2_app_kit::{NSLineBreakMode, NSTextField, NSView};
 use objc2_foundation::{
     MainThreadMarker, NSNotification, NSNotificationCenter, NSObject, NSString,
 };
@@ -196,6 +196,17 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
         // Make it editable
         text_field.setEditable(true);
         text_field.setBezeled(true);
+
+        // Single-line, to match TextField on every other backend; TextArea is
+        // the multiline widget. textFieldWithString: hands back a cell that
+        // wraps and grows tall, so a fixed-width field must be told to keep one
+        // line and scroll horizontally instead.
+        if let Some(cell) = text_field.cell() {
+            cell.setUsesSingleLineMode(true);
+            cell.setScrollable(true);
+            cell.setWraps(false);
+            cell.setLineBreakMode(NSLineBreakMode::ByClipping);
+        }
 
         let view: Retained<NSView> = Retained::cast_unchecked(text_field);
         let handle = super::register_widget(view);

--- a/test-files/test_issue_10155_textfield_singleline.ts
+++ b/test-files/test_issue_10155_textfield_singleline.ts
@@ -1,0 +1,20 @@
+// Smoke test for issue #10155: a fixed-width editable TextField on macOS must
+// stay one line and scroll horizontally, not wrap and grow tall.
+// Run the built app and confirm the long value shows on one line inside the
+// 220px-wide field, matching a normal single-line NSTextField.
+import { App, VStack, Text, TextField, State, stateBindTextfield, widgetSetWidth } from "perry/ui"
+
+const text = State("assignee = currentUser() AND statusCategory != Done AND project = SU")
+const field = TextField("query...", (value: string) => text.set(value))
+stateBindTextfield(text, field)
+widgetSetWidth(field, 220)
+
+App({
+    title: "issue 10155 single-line TextField",
+    width: 300,
+    height: 160,
+    body: VStack(12, [
+        Text("Field below must stay one line and scroll, not wrap:"),
+        field,
+    ]),
+})


### PR DESCRIPTION
# Problem

On macOS an editable `TextField` wraps its text onto multiple lines when the text is wider than the field, so a fixed-width field grows tall and misrenders single-line input like URLs, paths, and queries. macOS is the only backend that does this — iOS, GTK4, Android, Windows, and web all make `TextField` single-line.

# Solution

Configure the macOS field for single-line editing in `create()`, matching the other backends, so it keeps one line and scrolls horizontally. Multiline input already has its own widget, `TextArea`.

# This PR

Fixes #10155 for the macOS backend only. `perry-ui-macos`'s `create()` built the field with `NSTextField::textFieldWithString`, which returns a cell configured to wrap and grow, and set only `editable`/`bezeled`. It now also configures the cell for single-line editing.

## Changes

- **Single-line cell config in `TextField::create()`** — `crates/perry-ui-macos/src/widgets/textfield.rs`. On the field's cell, set `usesSingleLineMode`, `scrollable`, `wraps = false`, and `lineBreakMode = .byClipping`. This mirrors Android's explicit `setSingleLine` and the inherently single-line iOS `UITextField` / GTK4 `Entry` / Win32 `EDIT` / web `<input type="text">` widgets. `.byClipping` (hard clip, no ellipsis) is what those five surfaces all do on overflow.

  https://github.com/steinybot/perry/blob/bf8de14d83d2fc5a323284f2f7664f0becde9823/crates/perry-ui-macos/src/widgets/textfield.rs#L200-L209

## Verification

- `cargo build --profile perry-dev -p perry-ui-macos` — compiles clean.
- Built the full `perry` compiler, compiled `test-files/test_issue_10155_textfield_singleline.ts` (a 220px-wide field carrying a long single-line query) as a native macOS app, and ran it under the `perry-ui-testkit` screenshot harness (`PERRY_UI_TEST_MODE=1 PERRY_UI_SCREENSHOT_PATH=…`). The captured window shows the value on **one line, clipped at the trailing edge** — single-line with horizontal scroll, no wrap, normal field height.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed macOS text fields wrapping long text onto multiple lines.
  - Long content now remains on a single line and scrolls horizontally as needed.
  - Multiline text entry continues to be supported through text areas.

- **Tests**
  - Added coverage verifying single-line macOS text field behavior with long initial text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->