### PR TITLE
Merge train 173: #10154

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1544
+**Current Version:** 0.5.1545
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5690,7 +5690,7 @@ checksum = "4b2094dda4d997bf73a372cb660d02e9abdb0a13cbf834ddd2b2f8847bffe2cf"
 
 [[package]]
 name = "perry"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-dispatch",
  "serde",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "cc",
  "libc",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5789,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5814,7 +5814,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5870,14 +5870,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "serde",
  "serde_json",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1544"
+version = "0.5.1545"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "clap",
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "block2",
  "objc2",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "chrono",
  "cron",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5997,7 +5997,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "rand 0.10.2",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6021,14 +6021,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -6046,7 +6046,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -6121,7 +6121,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "bson",
  "futures-util",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-node-forge"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "const-oid 0.10.2",
  "der 0.8.1",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-parcel-watcher"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "notify",
  "perry-ffi",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-qs"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-typescript"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-ffi",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-undici"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-validation",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -6331,7 +6331,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "brotli",
  "flate2",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "dashmap 6.2.1",
  "once_cell",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -6372,11 +6372,11 @@ dependencies = [
 
 [[package]]
 name = "perry-native-registration"
-version = "0.5.1544"
+version = "0.5.1545"
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -6390,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "perry-perex"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perex",
  "regex",
@@ -6398,7 +6398,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6458,14 +6458,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "aes 0.8.4",
  "aes 0.9.1",
@@ -6560,14 +6560,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "perry-ffi",
  "perry-ui-model",
@@ -6584,7 +6584,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "itoa",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "rand 0.10.2",
  "serde",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "cairo-rs 0.22.9",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1544"
+version = "0.5.1545"
 
 [[package]]
 name = "perry-ui-test"
@@ -6680,11 +6680,11 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1544"
+version = "0.5.1545"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "block2",
  "libc",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6751,7 +6751,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -6764,7 +6764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "perry-validation"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "idna",
  "regex",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1544"
+version = "0.5.1545"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ codegen-units = 1
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.1544"
+version = "0.5.1545"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/changelog.d/10152-cgu-str-bytes.md
+++ b/changelog.d/10152-cgu-str-bytes.md
@@ -1,0 +1,13 @@
+### Fix split-unit dispatch descriptors referencing missing string bytes (#10152)
+
+Close initializer dependencies for otherwise-unreferenced globals retained in
+codegen unit 0. OpenTUI's node-backend chunk discarded a function after an export
+getter claimed the same symbol, leaving its `segment` dispatch descriptor in
+unit 0 while only the string initializer in unit 1 referenced the bytes.
+
+Preserve existing ELF/COFF owners and add external declarations for these
+dependencies; include the additional consumers in Mach-O's replication counts.
+This keeps unrelated strings and single-unit cache globals in their existing
+units and linkage. Regression coverage includes a reduced TypeScript module
+compiled through both LLVM construction paths and unit tests for ELF, COFF,
+Mach-O, and transitive initializer dependencies.

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -23,6 +23,9 @@ use crate::types::LlvmType;
 mod linkage;
 pub(crate) use linkage::*;
 
+#[cfg(test)]
+mod unit_partition_tests;
+
 fn push_statepoint_declarations(ir: &mut String) {
     ir.push_str(
         "declare token @llvm.experimental.gc.statepoint.p0(i64 immarg, i32 immarg, ptr, \
@@ -825,7 +828,7 @@ impl LlModule {
                 refs
             })
             .collect();
-        let bucket_needs: Vec<HashSet<usize>> = bucket_refs
+        let mut bucket_needs: Vec<HashSet<usize>> = bucket_refs
             .iter()
             .map(|refs| {
                 let mut need: HashSet<usize> = refs
@@ -858,6 +861,26 @@ impl LlModule {
                     .unwrap_or(0)
             })
             .collect();
+        // #10152: otherwise-unreferenced globals are retained in unit 0, but
+        // their initializers were absent from the function-rooted closure
+        // above. An orphaned string dispatch descriptor can still name bytes
+        // owned by another unit. Close those retained roots too, AFTER choosing
+        // owners so ELF/COFF keep existing definitions and only add declares;
+        // Mach-O's replication counts below include the added dependencies.
+        let mut work: Vec<usize> = global_owners
+            .iter()
+            .enumerate()
+            .filter_map(|(gi, &owner)| (owner == 0 && bucket_needs[0].insert(gi)).then_some(gi))
+            .collect();
+        while let Some(gi) = work.pop() {
+            for nm in &global_refs[gi] {
+                if let Some(&next) = global_index.get(nm.as_str()) {
+                    if bucket_needs[0].insert(next) {
+                        work.push(next);
+                    }
+                }
+            }
+        }
         let replicate_globals = self.target_triple.contains("apple");
         // #9610: how many units end up DEFINING each global. Under the
         // replicated (Mach-O) policy that is one unit per referencing bucket;

--- a/crates/perry-codegen/src/module/unit_partition_tests.rs
+++ b/crates/perry-codegen/src/module/unit_partition_tests.rs
@@ -1,0 +1,97 @@
+//! Regression coverage for globals retained without function-body references.
+
+use super::LlModule;
+use crate::types::{PTR, VOID};
+
+#[test]
+fn owner_only_dispatch_resolves_bytes_in_another_unit() {
+    for target in [
+        "x86_64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
+        "arm64-apple-macosx15.0.0",
+    ] {
+        let mut module = LlModule::new(target);
+        module.add_named_string_constant("m_.str.67.bytes", 8, "c\"segment\\00\"");
+        module.add_raw_global(
+            "@m_.str.67.dispatch = private unnamed_addr constant { i32, i32, i64, ptr } \
+             { i32 7, i32 0, i64 0, ptr @m_.str.67.bytes }"
+                .to_string(),
+        );
+        module.declare_function("consume", VOID, &[PTR]);
+        // The largest function takes unit 0; only the smaller function uses
+        // the bytes. The unreferenced dispatch descriptor falls back to unit 0.
+        let block = module
+            .define_function("big", VOID, vec![])
+            .create_block("entry");
+        for _ in 0..20 {
+            block.call_void("consume", &[(PTR, "null")]);
+        }
+        block.ret_void();
+        module
+            .define_function("bytes_user", PTR, vec![])
+            .create_block("entry")
+            .ret(PTR, "@m_.str.67.bytes");
+
+        let parts = module.codegen_unit_parts(2);
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].funcs[0].name, "big");
+        assert_eq!(parts[1].funcs[0].name, "bytes_user");
+        assert!(parts[0].pre.contains("@m_.str.67.dispatch ="));
+        assert!(!parts[1].pre.contains("@m_.str.67.dispatch ="));
+
+        // Parse the skeleton itself: this is where native construction failed
+        // in #10152, before there were any function bodies to dump.
+        #[cfg(feature = "llvm-inprocess")]
+        for part in &parts {
+            let context = inkwell::context::Context::create();
+            let skeleton = format!("{}{}", part.pre, part.post);
+            crate::inprocess::parse_ir_text(&context, &skeleton, "dispatch_skeleton")
+                .expect("retained dispatch initializer must resolve its bytes")
+                .verify()
+                .expect("valid unit skeleton");
+        }
+
+        if target.contains("apple") {
+            for part in &parts {
+                assert!(part
+                    .pre
+                    .contains("@m_.str.67.bytes = linkonce_odr unnamed_addr constant [8 x i8]"));
+            }
+        } else {
+            assert!(parts[0]
+                .pre
+                .contains("@m_.str.67.bytes = external constant [8 x i8]"));
+            assert!(parts[1]
+                .pre
+                .contains("@m_.str.67.bytes = unnamed_addr constant [8 x i8]"));
+        }
+    }
+}
+
+#[test]
+fn owner_only_global_dependencies_are_transitive() {
+    let mut module = LlModule::new("x86_64-unknown-linux-gnu");
+    module.add_internal_constant("anchor", PTR, "@middle");
+    module.add_internal_constant("middle", PTR, "@payload");
+    module.add_internal_constant("payload", PTR, "null");
+    module.declare_function("consume", VOID, &[PTR]);
+    let block = module
+        .define_function("big", VOID, vec![])
+        .create_block("entry");
+    for _ in 0..20 {
+        block.call_void("consume", &[(PTR, "null")]);
+    }
+    block.ret_void();
+    module
+        .define_function("middle_user", PTR, vec![])
+        .create_block("entry")
+        .ret(PTR, "@middle");
+
+    let units = module.render_codegen_units(2);
+    assert!(units[0].contains("@anchor = constant ptr @middle"));
+    assert!(units[0].contains("@middle = external constant ptr"));
+    assert!(units[0].contains("@payload = external constant ptr"));
+    assert!(units[1].contains("@middle = constant ptr @payload"));
+    assert!(units[1].contains("@payload = constant ptr null"));
+    assert!(!units[1].contains("@anchor ="));
+}

--- a/crates/perry/tests/issue_10152_cgu_str_bytes.rs
+++ b/crates/perry/tests/issue_10152_cgu_str_bytes.rs
@@ -1,0 +1,71 @@
+//! A discarded function can leave a dispatch descriptor whose bytes belong
+//! to another codegen unit. Both native skeletons and text units must resolve it.
+
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn orphan_dispatch_compiles_with_bytes_owned_by_another_unit() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test-files/test_codegen_unit_orphan_dispatch.ts");
+    for backend in ["native", "1"] {
+        let dir = tempfile::tempdir().expect("temporary compile directory");
+        let ll_dir = dir.path().join("ll");
+        std::fs::create_dir(&ll_dir).unwrap();
+        let output = dir.path().join("out.o");
+        let compiled = Command::new(env!("CARGO_BIN_EXE_perry"))
+            .arg("compile")
+            .arg(&fixture)
+            .args(["--no-link", "--no-auto-optimize", "--output"])
+            .arg(&output)
+            .arg("--cache-dir")
+            .arg(dir.path().join("cache"))
+            .env("PERRY_CODEGEN_UNITS", "2")
+            .env("PERRY_LLVM_INPROCESS", backend)
+            .env("PERRY_SAVE_LL", &ll_dir)
+            .env("PERRY_NO_CACHE", "1")
+            .env("PERRY_DISABLE_WELL_KNOWN", "1")
+            .output()
+            .expect("run perry compile");
+        assert!(
+            compiled.status.success(),
+            "{backend} compile failed:\n{}\n{}",
+            String::from_utf8_lossy(&compiled.stdout),
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+        assert!(std::fs::metadata(output).unwrap().len() > 0);
+
+        let suffix = if backend == "native" {
+            "native.ll"
+        } else {
+            "ll"
+        };
+        let prefix = "test_codegen_unit_orphan_dispatch_ts";
+        let units: Vec<String> = (0..2)
+            .map(|i| {
+                std::fs::read_to_string(ll_dir.join(format!("{prefix}.unit{i}.{suffix}")))
+                    .expect("forced split must emit both units")
+            })
+            .collect();
+        let bytes_line = units[1]
+            .lines()
+            .find(|line| line.contains("c\"segment\\00\""))
+            .expect("unit 1 must define the segment bytes");
+        let bytes = bytes_line.split_once(" = ").unwrap().0;
+        let dispatch = bytes.replace(".bytes", ".dispatch");
+        assert!(units[0].contains(&format!("{dispatch} =")));
+        assert!(!units[1].contains(&format!("{dispatch} =")));
+        assert!(units[0].contains(&format!("ptr {bytes}")));
+        // The descriptor is an owner-only fallback, not a live function use.
+        assert!(units.iter().flat_map(|unit| unit.lines()).all(|line| {
+            !line.contains(&dispatch) || line.starts_with(&format!("{dispatch} ="))
+        }));
+        if cfg!(target_os = "macos") {
+            assert!(units[0].contains(&format!("{bytes} = linkonce_odr")));
+            assert!(bytes_line.contains("linkonce_odr"));
+        } else {
+            assert!(units[0].contains(&format!("{bytes} = external constant [8 x i8]")));
+            assert!(!bytes_line.contains("external constant"));
+        }
+    }
+}

--- a/test-files/test_codegen_unit_orphan_dispatch.ts
+++ b/test-files/test_codegen_unit_orphan_dispatch.ts
@@ -1,0 +1,13 @@
+// #10152: the export getter claims `read`'s symbol, so function deduplication
+// discards its body after lowering has already interned a dispatch descriptor.
+function read(value: any) {
+    return value.segment();
+}
+const readAlias = read;
+export { readAlias as read };
+
+// Keep unit 0 larger than the string initializer so `segment`'s bytes go to
+// unit 1 when the compile regression forces PERRY_CODEGEN_UNITS=2.
+export function pad(value: any) {
+    return value.alpha + value.beta + value.gamma;
+}


### PR DESCRIPTION
Merge train 173: lands #10154 (fix for #10152, where a split codegen unit referenced string bytes owned by another unit) at head `cffe0c01c9`, plus the workspace version bump to 0.5.1545.

The commit was cherry-picked onto `95bef3da2c`; the tree before the bump equals the PR head.

Local validation on macOS (the PR's own runs were Linux-only):
- `cargo fmt --all -- --check`, `check_file_size.sh`, `check_test_registration.py`, `RUSTFLAGS=-Dwarnings cargo check -p perry --bins`
- `cargo test --release -p perry-codegen`: 1984 passed, including `module::unit_partition_tests::{owner_only_dispatch_resolves_bytes_in_another_unit, owner_only_global_dependencies_are_transitive}`
- after building `-p perry -p perry-runtime-static -p perry-stdlib-static`: `cargo test --release -p perry --test issue_10152_cgu_str_bytes` passes (native and textual LLVM paths)
- sabotage: with `module.rs` reverted to main and only the test module kept, both unit-partition tests FAIL. The first reproduces `use of undefined value '@m_.str.67.bytes'` when parsing the skeleton.

PR CI on `cffe0c01c9` (run 34733330017): every red job fails identically on main at `95bef3da2c` (run 34725110891). That covers the same lint/check/warnings/cargo-test steps and the same failing test (`native_stack::tests::stack_top_respects_custom_thread_stack_sizes`), the same four gated gap regressions with identical output (`iterator_prototype_next_patch`, `2899_2779_2777_static_helpers`, `disposablestack_2875`, `gc_http2_pending_event_callback_rooting`), and the same single gc-stress failure. e2e-scoped passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed compilation failures involving exported dispatch descriptors and string data split across code-generation units.
  - Improved reliability across native and LLVM backends, including platform-specific behavior on macOS and other targets.
  - Preserved correct handling of transitive global dependencies during multi-unit builds.

- **Tests**
  - Added regression coverage for cross-platform code generation and multi-unit compilation scenarios.

- **Chores**
  - Bumped the project version to 0.5.1545.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->