### PR TITLE
fix(hir): keep large JSON defines as serialized data

### DIFF
--- a/benchmarks/large_json_literals/README.md
+++ b/benchmarks/large_json_literals/README.md
@@ -1,0 +1,83 @@
+# Large JSON literal lowering (#10151 / #10161)
+
+`generate.py` reproduces the typed record shape and 2,000-element numeric table
+from the #10161 performance audit. `hot.ts` runs 20,000 passes over each: numeric
+array indexing, then `q.w + q.tags.length + q.id` on 400 records. The separate
+`records-N.ts` files scale the same record shape to locate the LLVM codegen cliff.
+`numbers.ts` and `records.ts` run those same loops in separate entrypoints. The
+generated fixtures are deliberately outside the repository.
+
+Run on a Linux build host with LLVM 22 and a release compiler plus matching
+runtime/stdlib archives. In the issue lane, every command below is passed through
+`./remote.sh`; do not build or run the probes on the Mac.
+
+```sh
+python3 benchmarks/large_json_literals/generate.py /tmp/literal-probes
+cd /tmp/literal-probes
+# Avoid inheriting unrelated define settings from a parent directory.
+printf '{}\n' > perry.json
+export PERRY_RUNTIME_DIR=/path/to/pinned/compiler-and-archives
+PERRY_BIN=$PERRY_RUNTIME_DIR/perry
+/usr/bin/time -v timeout 600 env PERRY_CODEGEN_PROGRESS=all "$PERRY_BIN" compile hot.ts \
+  --no-auto-optimize --output ./hot --cache-dir cache-hot
+./hot
+/usr/bin/time -v timeout 600 env PERRY_CODEGEN_PROGRESS=all "$PERRY_BIN" compile records-4800.ts \
+  --no-link --no-auto-optimize --output records-4800.o --cache-dir cache-records-4800
+```
+
+For an A/B, compile with each pinned compiler to separate outputs and fresh cache
+directories, then run the executables in alternating order five times. Compare
+both checksums as well as median `table_ms` / `recs_ms`. Repeat the no-link command
+for the other record counts. The 600-second timeout bounds an intentionally
+pathological **ordinary-lowering** measurement; it is not a CI performance test.
+
+The compact path has two tiers. Flat primitive arrays qualify at 1,024 AST value
+nodes or 64 KiB of UTF-8 string content. Records and nested arrays have a much
+higher threshold of 24,576 nodes or 1 MiB of UTF-8 key/string content. This
+preserves ordinary lowering's static record shapes
+for mid-size hot data; JSON-parsed records otherwise pay the generic property IC
+cost. The cutoff tests live in `perry-hir`, and the timed define/semantics/cache
+regressions live in `crates/perry/tests/issue_10151_large_json_define.rs`.
+
+## Linux measurements (LLVM 22.1.8, 2026-09-13)
+
+The ordinary control is the compiler code at `8a058e2053` (the PR's base), built
+by removing the compact-lowering hook from this branch. Both variants link the
+same freshly built runtime/stdlib archives. Compilers and archives were copied
+together to separate directories, away from the shared Cargo target. The
+original broad compact rule at `d0bb9b1fd5` was also retained for comparison.
+
+| Record count | Literal source bytes | AST value nodes | Ordinary compile | Compact compile |
+| ---: | ---: | ---: | ---: | ---: |
+| 4,800 | 307,740 | 33,601 | 475.17 s | 0.35 s |
+| 6,400 | 412,540 | 44,801 | >600 s (timeout) | 0.37 s |
+
+These are no-link compiles with fresh caches. At 6,400 records, IR emission
+finished in 4.5 seconds, producing about 85.1 MiB of estimated IR and a
+1,446,386-instruction function before optimization. Four of five LLVM units
+finished in under a second; the remaining unit timed out. The 24,576-node
+threshold switches this shape at 3,511 records, 27% below even the 4,800-record
+eight-minute case and 45% below the 6,400-record timeout. It is 24 times the
+primitive node threshold; the text threshold is 16 times larger.
+
+Five interleaved runs of the final binaries gave these medians:
+
+| Fixture / hot loop | Ordinary control | Two-tier rule |
+| --- | ---: | ---: |
+| Separate 2,000-number array | 71 ms | 71 ms |
+| Separate 400 typed records | 295 ms | 294 ms |
+| Combined audit file: numbers | 290 ms | 291 ms |
+| Combined audit file: records | 292 ms | 291 ms |
+
+Checksums match (`79042210000` for numbers, `2011000000` for records). The
+original broad rule measured 71 ms / 938 ms in the combined file. Restoring
+ordinary record lowering removes that record-read regression. However, its
+622k-instruction initialization keeps the **combined** unit above the existing
+100k-instruction O0 machine-code limit, also slowing its numeric loop. HIR
+inspection confirms that the numeric array still uses `JsonParse`. The isolated
+number probe shows no intrinsic runtime speedup on this host. Do not describe
+the earlier combined-file speedup as an unconditional primitive-array win.
+
+With the final compiler, the preserved OpenCode define (4,623,800 bytes,
+213 providers) compiles and links in 1.52 seconds. The refreshed installed
+snapshot (4,637,074 bytes, also 213 providers) takes 1.54 seconds. Both print 213.

--- a/benchmarks/large_json_literals/generate.py
+++ b/benchmarks/large_json_literals/generate.py
@@ -1,0 +1,69 @@
+"""Generate the #10161 typed hot-loop and record-array codegen probes.
+
+Usage: python3 benchmarks/large_json_literals/generate.py /tmp/literal-probes
+This only writes TypeScript; compile/run it with the compiler being measured.
+"""
+
+import json
+from pathlib import Path
+import sys
+
+
+def records(count):
+    return [dict(id=i, name=f"n{i}", tags=["a", f"b{i % 5}"], w=i / 4)
+            for i in range(count)]
+
+
+def table():
+    values = []
+    for i in range(2000):
+        n = (i * 427799) % 1000003 - 500000
+        values.append(n + (0.5 if n >= 0 else -0.5) if i % 7 == 0 else n)
+    return values
+
+
+REC_TYPE = "type Rec = { id: number; name: string; tags: string[]; w: number };\n"
+HOT_LOOP = """
+let t0 = performance.now();
+let s = 0;
+for (let r = 0; r < 20000; r++) { for (let i = 0; i < table.length; i++) { s += table[i] * (i & 3); } }
+const t1 = performance.now();
+let w = 0;
+for (let r = 0; r < 20000; r++) { for (let j = 0; j < recs.length; j++) { const q = recs[j]; w += q.w + q.tags.length + q.id; } }
+const t2 = performance.now();
+console.log("table_ms", Math.round(t1 - t0), "recs_ms", Math.round(t2 - t1), s, w);
+"""
+
+
+def main():
+    root = Path(sys.argv[1])
+    root.mkdir(parents=True, exist_ok=True)
+    source = ("const table: number[] = " + json.dumps(table()) + ";\n" + REC_TYPE
+              + "const recs: Rec[] = " + json.dumps(records(400)) + ";\n" + HOT_LOOP)
+    (root / "hot.ts").write_text(source)
+    # Separate entrypoints distinguish representation cost from the existing
+    # whole-function LLVM size guards triggered by another literal in main.
+    numbers = ("const table: number[] = " + json.dumps(table()) + ";\n"
+               + HOT_LOOP.split("const t1 =")[0]
+               + 'console.log("table_ms", Math.round(performance.now() - t0), s);\n')
+    (root / "numbers.ts").write_text(numbers)
+    record_hot = (REC_TYPE + "const recs: Rec[] = " + json.dumps(records(400)) + ";\n"
+                  + "const t1 = performance.now();\n"
+                  + HOT_LOOP.split("const t1 = performance.now();", 1)[1].split("console.log(")[0]
+                  + 'console.log("recs_ms", Math.round(t2 - t1), w);\n')
+    (root / "records.ts").write_text(record_hot)
+    for count in [400, 1600, 3200, 4800, 6400, 12800]:
+        data = records(count)
+        literal = json.dumps(data)
+        source = (REC_TYPE + "const recs: Rec[] = " + literal + ";\n"
+                  + "let w = 0;\n"
+                  + "for (let j = 0; j < recs.length; j++) { const q = recs[j]; w += q.w + q.tags.length + q.id; }\n"
+                  + "console.log(recs.length, w);\n")
+        (root / f"records-{count}.ts").write_text(source)
+        text_bytes = sum(11 + len(r["name"]) + sum(map(len, r["tags"])) for r in data)
+        print(f"records={count} source_bytes={len(literal)} "
+              f"value_nodes={1 + 7 * count} key_string_bytes={text_bytes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/changelog.d/10151-large-json-define.md
+++ b/changelog.d/10151-large-json-define.md
@@ -1,17 +1,22 @@
 ### Fix large JSON defines stalling LLVM code generation
 
-- Lower large JSON-compatible object/array literals, including build-time
-  defines, to the same serialized-string `JSON.parse` intrinsic used for JSON
-  imports. The threshold is 1,024 value nodes or 64 KiB of key/string data,
-  independent of generated function instruction budgets.
+- Lower large JSON-compatible literals, including build-time defines, to the
+  serialized-string `JSON.parse` intrinsic used for JSON imports. Flat arrays
+  of primitives use the 1,024-value-node / 64 KiB string threshold; other
+  object/array literals use a higher 24,576-node / 1 MiB key/string threshold.
+  Either size limit is sufficient, independent of function instruction budgets.
+- Keep mid-size records on ordinary lowering so hot property reads retain their
+  static layouts. The higher threshold bounds the LLVM cost of huge record
+  literals while still handling the 4.6 MB OpenCode models.dev define.
 - Keep parsing at the original evaluation site, preserving fresh values on
   repeated reads and avoiding evaluation in untaken branches. Existing
   `typeof` folding and define inputs to both cache keys are unchanged.
 - Preserve property order, string escaping and negative zero; fall back for
   JavaScript-specific constructs such as prototype setters, holes, spreads,
   getters and non-finite numbers.
-- Add threshold unit tests and timed compile/run regressions for a >1 MiB
-  define, cache invalidation, small direct literals, fresh nested objects,
+- Add unit coverage for both threshold tiers and direct lowering of 400 typed
+  records, a reproducible record-array/codegen benchmark, and timed regressions
+  for a >1 MiB define, cache invalidation, small direct literals, fresh nested objects,
   shadowed `JSON` bindings and array behavior.
 
 Fixes #10151.

--- a/changelog.d/10151-large-json-define.md
+++ b/changelog.d/10151-large-json-define.md
@@ -1,0 +1,17 @@
+### Fix large JSON defines stalling LLVM code generation
+
+- Lower large JSON-compatible object/array literals, including build-time
+  defines, to the same serialized-string `JSON.parse` intrinsic used for JSON
+  imports. The threshold is 1,024 value nodes or 64 KiB of key/string data,
+  independent of generated function instruction budgets.
+- Keep parsing at the original evaluation site, preserving fresh values on
+  repeated reads and avoiding evaluation in untaken branches. Existing
+  `typeof` folding and define inputs to both cache keys are unchanged.
+- Preserve property order, string escaping and negative zero; fall back for
+  JavaScript-specific constructs such as prototype setters, holes, spreads,
+  getters and non-finite numbers.
+- Add threshold unit tests and timed compile/run regressions for a >1 MiB
+  define, cache invalidation, small direct literals, fresh nested objects,
+  shadowed `JSON` bindings and array behavior.
+
+Fixes #10151.

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -29,6 +29,7 @@ mod arm_optchain;
 mod arm_unary;
 mod assignment;
 mod helpers;
+mod json_literal;
 mod reactive_text;
 
 pub(crate) use arm_bin::lower_bin_expr;
@@ -99,6 +100,11 @@ pub(crate) fn lower_expr(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<
 }
 
 fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> {
+    if matches!(expr, ast::Expr::Object(_) | ast::Expr::Array(_)) {
+        if let Some(value) = json_literal::lower_large_json_literal(expr) {
+            return Ok(value);
+        }
+    }
     match expr {
         ast::Expr::Lit(lit) => lower_lit(lit),
         ast::Expr::Ident(ident) => lower_ident_expr(ctx, ident),

--- a/crates/perry-hir/src/lower/lower_expr/json_literal.rs
+++ b/crates/perry-hir/src/lower/lower_expr/json_literal.rs
@@ -11,6 +11,12 @@ use crate::ir::Expr;
 
 const MIN_NODES: usize = 1024;
 const MIN_TEXT_BYTES: usize = 64 * 1024;
+// Parsed records lose the static shapes used by ordinary literal lowering.
+// Reserve that tradeoff for codegen-sized data: the record-array probe in
+// benchmarks/large_json_literals measures the LLVM cliff independently of
+// function instruction budgets. Keep mid-size typed records on the fast read path.
+const CODEGEN_NODES: usize = 24 * 1024;
+const CODEGEN_TEXT_BYTES: usize = 1024 * 1024;
 // Bound speculative subtree walks, including on deeply nested non-JSON input.
 const MAX_DEPTH: usize = 128;
 
@@ -30,6 +36,11 @@ pub(super) fn lower_large_json_literal(expr: &ast::Expr) -> Option<Expr> {
 /// irrelevant. Stop as soon as either threshold is reached, then validate and
 /// serialize the whole candidate exactly once.
 fn is_large(expr: &ast::Expr) -> bool {
+    let (min_nodes, min_bytes) = if is_primitive_array(expr) {
+        (MIN_NODES, MIN_TEXT_BYTES)
+    } else {
+        (CODEGEN_NODES, CODEGEN_TEXT_BYTES)
+    };
     let mut pending = vec![(expr, 0)];
     let (mut nodes, mut bytes) = (0, 0);
     while let Some((expr, depth)) = pending.pop() {
@@ -74,11 +85,40 @@ fn is_large(expr: &ast::Expr) -> bool {
             ast::Expr::Lit(ast::Lit::Num(_) | ast::Lit::Bool(_) | ast::Lit::Null(_)) => {}
             _ => return false,
         }
-        if nodes >= MIN_NODES || bytes >= MIN_TEXT_BYTES {
+        if nodes >= min_nodes || bytes >= min_bytes {
             return true;
         }
     }
     false
+}
+
+/// Only flat arrays get the lower threshold. In particular, an array of
+/// records must not lose its statically known property layout at this size.
+fn is_primitive_array(expr: &ast::Expr) -> bool {
+    let ast::Expr::Array(array) = expr else {
+        return false;
+    };
+    array.elems.iter().all(|elem| {
+        elem.as_ref()
+            .is_some_and(|elem| elem.spread.is_none() && is_primitive(&elem.expr, 0))
+    })
+}
+
+fn is_primitive(expr: &ast::Expr, depth: usize) -> bool {
+    if depth > MAX_DEPTH {
+        return false;
+    }
+    match expr {
+        ast::Expr::Lit(
+            ast::Lit::Num(_) | ast::Lit::Str(_) | ast::Lit::Bool(_) | ast::Lit::Null(_),
+        ) => true,
+        ast::Expr::Paren(paren) => is_primitive(&paren.expr, depth + 1),
+        ast::Expr::Unary(unary) => {
+            matches!(unary.op, ast::UnaryOp::Minus | ast::UnaryOp::Plus)
+                && matches!(unary.arg.as_ref(), ast::Expr::Lit(ast::Lit::Num(_)))
+        }
+        _ => false,
+    }
 }
 
 fn string(text: &mut Vec<u8>, value: &str) -> Option<()> {

--- a/crates/perry-hir/src/lower/lower_expr/json_literal.rs
+++ b/crates/perry-hir/src/lower/lower_expr/json_literal.rs
@@ -1,0 +1,172 @@
+//! Keep large data literals out of generated constructor/store sequences (#10151).
+//!
+//! Defines have already been substituted and their `typeof` guards folded by
+//! the parser. Use the same intrinsic as JSON imports (#8418), at the original
+//! evaluation site: every evaluation still creates a fresh object/array, and
+//! an untaken branch does not parse anything. No user `JSON` binding is read.
+
+use swc_ecma_ast as ast;
+
+use crate::ir::Expr;
+
+const MIN_NODES: usize = 1024;
+const MIN_TEXT_BYTES: usize = 64 * 1024;
+// Bound speculative subtree walks, including on deeply nested non-JSON input.
+const MAX_DEPTH: usize = 128;
+
+pub(super) fn lower_large_json_literal(expr: &ast::Expr) -> Option<Expr> {
+    if !is_large(expr) {
+        return None;
+    }
+    let mut text = Vec::new();
+    serialize(expr, &mut text, 0)?;
+    Some(Expr::JsonParse(Box::new(Expr::String(
+        String::from_utf8(text).ok()?,
+    ))))
+}
+
+/// Cheap, bounded probe. Count AST value nodes and UTF-8 key/string bytes;
+/// whitespace and source spans (which defines inherit from another file) are
+/// irrelevant. Stop as soon as either threshold is reached, then validate and
+/// serialize the whole candidate exactly once.
+fn is_large(expr: &ast::Expr) -> bool {
+    let mut pending = vec![(expr, 0)];
+    let (mut nodes, mut bytes) = (0, 0);
+    while let Some((expr, depth)) = pending.pop() {
+        if depth > MAX_DEPTH {
+            return false;
+        }
+        nodes += 1;
+        match expr {
+            ast::Expr::Object(object) => {
+                for prop in &object.props {
+                    let ast::PropOrSpread::Prop(prop) = prop else {
+                        return false;
+                    };
+                    let ast::Prop::KeyValue(kv) = prop.as_ref() else {
+                        return false;
+                    };
+                    bytes += match &kv.key {
+                        ast::PropName::Ident(key) => key.sym.len(),
+                        ast::PropName::Str(key) => key.value.len(),
+                        ast::PropName::Num(_) => 0,
+                        _ => return false,
+                    };
+                    pending.push((&kv.value, depth + 1));
+                }
+            }
+            ast::Expr::Array(array) => {
+                for elem in &array.elems {
+                    let Some(elem) = elem else { return false };
+                    if elem.spread.is_some() {
+                        return false;
+                    }
+                    pending.push((&elem.expr, depth + 1));
+                }
+            }
+            ast::Expr::Paren(paren) => pending.push((&paren.expr, depth + 1)),
+            ast::Expr::Unary(unary)
+                if matches!(unary.op, ast::UnaryOp::Minus | ast::UnaryOp::Plus) =>
+            {
+                pending.push((&unary.arg, depth + 1));
+            }
+            ast::Expr::Lit(ast::Lit::Str(value)) => bytes += value.value.len(),
+            ast::Expr::Lit(ast::Lit::Num(_) | ast::Lit::Bool(_) | ast::Lit::Null(_)) => {}
+            _ => return false,
+        }
+        if nodes >= MIN_NODES || bytes >= MIN_TEXT_BYTES {
+            return true;
+        }
+    }
+    false
+}
+
+fn string(text: &mut Vec<u8>, value: &str) -> Option<()> {
+    serde_json::to_writer(text, value).ok()
+}
+
+fn number(text: &mut Vec<u8>, value: f64) -> Option<()> {
+    // JSON cannot represent Infinity/NaN. serde_json would silently emit null.
+    if !value.is_finite() {
+        return None;
+    }
+    // Serialize the parsed f64, preserving negative zero and numeric semantics
+    // for JS spellings such as hex literals and unary plus.
+    serde_json::to_writer(text, &value).ok()
+}
+
+fn serialize(expr: &ast::Expr, text: &mut Vec<u8>, depth: usize) -> Option<()> {
+    if depth > MAX_DEPTH {
+        return None;
+    }
+    match expr {
+        ast::Expr::Object(object) => {
+            text.push(b'{');
+            for (i, prop) in object.props.iter().enumerate() {
+                let ast::PropOrSpread::Prop(prop) = prop else {
+                    return None;
+                };
+                let ast::Prop::KeyValue(kv) = prop.as_ref() else {
+                    return None;
+                };
+                let key = match &kv.key {
+                    ast::PropName::Ident(key) => key.sym.to_string(),
+                    ast::PropName::Str(key) => key.value.as_str()?.to_owned(),
+                    ast::PropName::Num(key) => crate::lower::number_to_js_key(key.value),
+                    _ => return None,
+                };
+                // Object literals set [[Prototype]] here; JSON.parse creates an
+                // own data property. Leave that expression on ordinary lowering.
+                if key == "__proto__" {
+                    return None;
+                }
+                if i != 0 {
+                    text.push(b',');
+                }
+                string(text, &key)?;
+                text.push(b':');
+                serialize(&kv.value, text, depth + 1)?;
+            }
+            text.push(b'}');
+        }
+        ast::Expr::Array(array) => {
+            text.push(b'[');
+            for (i, elem) in array.elems.iter().enumerate() {
+                let elem = elem.as_ref()?;
+                if elem.spread.is_some() {
+                    return None;
+                }
+                if i != 0 {
+                    text.push(b',');
+                }
+                serialize(&elem.expr, text, depth + 1)?;
+            }
+            text.push(b']');
+        }
+        ast::Expr::Paren(paren) => serialize(&paren.expr, text, depth + 1)?,
+        ast::Expr::Unary(unary) => {
+            let ast::Expr::Lit(ast::Lit::Num(value)) = unary.arg.as_ref() else {
+                return None;
+            };
+            number(
+                text,
+                match unary.op {
+                    ast::UnaryOp::Minus => -value.value,
+                    ast::UnaryOp::Plus => value.value,
+                    _ => return None,
+                },
+            )?;
+        }
+        ast::Expr::Lit(ast::Lit::Str(value)) => string(text, value.value.as_str()?)?,
+        ast::Expr::Lit(ast::Lit::Num(value)) => number(text, value.value)?,
+        ast::Expr::Lit(ast::Lit::Bool(value)) => {
+            text.extend_from_slice(if value.value { b"true" } else { b"false" })
+        }
+        ast::Expr::Lit(ast::Lit::Null(_)) => text.extend_from_slice(b"null"),
+        _ => return None,
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/perry-hir/src/lower/lower_expr/json_literal/tests.rs
+++ b/crates/perry-hir/src/lower/lower_expr/json_literal/tests.rs
@@ -31,15 +31,76 @@ fn node_threshold_is_inclusive_and_small_arrays_stay_direct() {
 }
 
 #[test]
-fn text_threshold_counts_key_and_string_bytes_without_source_spans() {
-    let below = format!(r#"{{key:"{}"}}"#, "x".repeat(MIN_TEXT_BYTES - 4));
-    let at = format!(r#"{{key:"{}"}}"#, "x".repeat(MIN_TEXT_BYTES - 3));
+fn primitive_array_text_threshold_is_inclusive() {
+    let below = format!(r#"["{}"]"#, "x".repeat(MIN_TEXT_BYTES - 1));
+    let at = format!(r#"["{}"]"#, "x".repeat(MIN_TEXT_BYTES));
+    assert!(matches!(lower(&below), Expr::Array(_)));
+    assert!(matches!(lower(&at), Expr::JsonParse(_)));
+}
+
+#[test]
+fn record_text_threshold_counts_key_and_string_bytes_without_source_spans() {
+    let below = format!(r#"{{key:"{}"}}"#, "x".repeat(CODEGEN_TEXT_BYTES - 4));
+    let at = format!(r#"{{key:"{}"}}"#, "x".repeat(CODEGEN_TEXT_BYTES - 3));
     assert!(lower_large_json_literal(&expression(&below)).is_none());
     assert!(matches!(lower(&at), Expr::JsonParse(_)));
     assert!(!matches!(
         lower(r#"{model:"small",items:[1,true,null]}"#),
         Expr::JsonParse(_)
     ));
+}
+
+#[test]
+fn non_primitive_array_node_threshold_is_inclusive() {
+    // Root array and empty record count as two nodes; this is not a primitive array.
+    let below = format!("[{{}},{}]", vec!["0"; CODEGEN_NODES - 3].join(","));
+    let at = format!("[{{}},{}]", vec!["0"; CODEGEN_NODES - 2].join(","));
+    assert!(lower_large_json_literal(&expression(&below)).is_none());
+    assert!(matches!(lower(&at), Expr::JsonParse(_)));
+}
+
+#[test]
+fn mid_size_typed_records_keep_static_shapes() {
+    let records: Vec<_> = (0..400)
+        .map(|i| format!(r#"{{id:{i},name:"n{i}",tags:["a","b"],w:0.25}}"#))
+        .collect();
+    let source = format!(
+        "type Rec = {{id:number;name:string;tags:string[];w:number}}; const recs: Rec[] = [{}];",
+        records.join(",")
+    );
+    let ast = perry_parser::parse_typescript(&source, "test.ts").unwrap();
+    let hir = crate::lower::lower_module(&ast, "test", "test.ts").unwrap();
+    assert!(!format!("{hir:?}").contains("JsonParse("));
+    assert!(
+        !hir.classes.is_empty(),
+        "records must retain their static shapes"
+    );
+    let object = format!(r#"{{padding:"{}"}}"#, "x".repeat(MIN_TEXT_BYTES));
+    assert!(!matches!(lower(&object), Expr::JsonParse(_)));
+}
+
+#[test]
+fn only_flat_primitive_arrays_get_the_lower_threshold() {
+    assert!(is_primitive_array(&expression(
+        r#"[1,-0,+2,(3),"x",true,false,null]"#
+    )));
+    for source in [
+        "[{}]",
+        "[[1]]",
+        "[undefined]",
+        "[1,,2]",
+        "[...other]",
+        "[f()]",
+        "{x:1}",
+    ] {
+        assert!(!is_primitive_array(&expression(source)), "{source}");
+    }
+    // A record/nested array after the low node threshold must still select
+    // the higher tier; a short-circuiting size probe alone would miss it.
+    for last in ["{}", "[]"] {
+        let source = format!("[{},{}]", vec!["0"; MIN_NODES].join(","), last);
+        assert!(lower_large_json_literal(&expression(&source)).is_none());
+    }
 }
 
 #[test]
@@ -73,7 +134,7 @@ fn non_json_semantics_fall_back_even_after_the_size_probe_succeeds() {
     ] {
         // The probe visits the final array element first, reaching the size
         // threshold before serialization discovers the incompatible value.
-        let source = format!(r#"[{value},"{}"]"#, "x".repeat(MIN_TEXT_BYTES));
+        let source = format!(r#"[{value},"{}"]"#, "x".repeat(CODEGEN_TEXT_BYTES));
         let expr = expression(&source);
         assert!(is_large(&expr));
         assert!(lower_large_json_literal(&expr).is_none(), "{value}");

--- a/crates/perry-hir/src/lower/lower_expr/json_literal/tests.rs
+++ b/crates/perry-hir/src/lower/lower_expr/json_literal/tests.rs
@@ -1,0 +1,112 @@
+use super::*;
+use crate::lower::{lower_expr, LoweringContext};
+
+fn expression(source: &str) -> Box<ast::Expr> {
+    let module = perry_parser::parse_typescript(&format!("({source});"), "test.ts").unwrap();
+    let ast::ModuleItem::Stmt(ast::Stmt::Expr(stmt)) = &module.body[0] else {
+        panic!()
+    };
+    let ast::Expr::Paren(paren) = stmt.expr.as_ref() else {
+        panic!()
+    };
+    paren.expr.clone()
+}
+
+fn lower(source: &str) -> Expr {
+    lower_expr(&mut LoweringContext::new("test.ts"), &expression(source)).unwrap()
+}
+
+#[test]
+fn node_threshold_is_inclusive_and_small_arrays_stay_direct() {
+    // The root array counts as one value node.
+    let below = format!("[{}]", vec!["0"; MIN_NODES - 2].join(","));
+    let at = format!("[{}]", vec!["0"; MIN_NODES - 1].join(","));
+    assert!(matches!(lower(&below), Expr::Array(_)));
+    let Expr::JsonParse(text) = lower(&at) else {
+        panic!("threshold must select JSON.parse")
+    };
+    let Expr::String(text) = *text else { panic!() };
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(value.as_array().unwrap().len(), MIN_NODES - 1);
+}
+
+#[test]
+fn text_threshold_counts_key_and_string_bytes_without_source_spans() {
+    let below = format!(r#"{{key:"{}"}}"#, "x".repeat(MIN_TEXT_BYTES - 4));
+    let at = format!(r#"{{key:"{}"}}"#, "x".repeat(MIN_TEXT_BYTES - 3));
+    assert!(lower_large_json_literal(&expression(&below)).is_none());
+    assert!(matches!(lower(&at), Expr::JsonParse(_)));
+    assert!(!matches!(
+        lower(r#"{model:"small",items:[1,true,null]}"#),
+        Expr::JsonParse(_)
+    ));
+}
+
+#[test]
+fn serialization_preserves_order_duplicates_escaping_and_numbers() {
+    let expr = expression(r#"{z:0, a:-0, z:+2, 1e-7:0xff, nested:[true,null,"quote\"\n\\☃"]}"#);
+    let mut text = Vec::new();
+    serialize(&expr, &mut text, 0).unwrap();
+    let text = String::from_utf8(text).unwrap();
+    assert!(text.starts_with(r#"{"z":0.0,"a":-0.0,"z":2.0,"1e-7":255.0,"nested":["#));
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(value["z"], 2.0);
+    assert!(value["a"].as_f64().unwrap().is_sign_negative());
+    assert_eq!(value["nested"][2], "quote\"\n\\☃");
+}
+
+#[test]
+fn non_json_semantics_fall_back_even_after_the_size_probe_succeeds() {
+    for value in [
+        "{__proto__:null}",
+        "{\"__proto__\":{}}",
+        "[1,,2]",
+        "[...other]",
+        "{get x(){return 1}}",
+        "{x:sideEffect()}",
+        "{[key]:1}",
+        "{x:undefined}",
+        "{x:1e999}",
+        "{x:/a/}",
+        "{x:1n}",
+        r#"{x:"\ud800"}"#,
+    ] {
+        // The probe visits the final array element first, reaching the size
+        // threshold before serialization discovers the incompatible value.
+        let source = format!(r#"[{value},"{}"]"#, "x".repeat(MIN_TEXT_BYTES));
+        let expr = expression(&source);
+        assert!(is_large(&expr));
+        assert!(lower_large_json_literal(&expr).is_none(), "{value}");
+    }
+}
+
+#[test]
+fn speculative_walk_is_bounded_for_deep_literals() {
+    let source = format!(
+        "{}0{}",
+        "[".repeat(MAX_DEPTH + 2),
+        "]".repeat(MAX_DEPTH + 2)
+    );
+    assert!(lower_large_json_literal(&expression(&source)).is_none());
+}
+
+#[test]
+fn defines_fold_typeof_before_large_literal_lowering() {
+    use std::collections::BTreeMap;
+    let source = r#"declare const BIG: any; export const snapshot = typeof BIG === "undefined" ? undefined : BIG;"#;
+    let module = perry_parser::parse_typescript(source, "test.ts").unwrap();
+    for (value, expected_parse) in [
+        (format!("[{}]", vec!["0"; MIN_NODES].join(",")), true),
+        ("undefined".into(), false),
+    ] {
+        let defines =
+            perry_parser::defines::Defines::parse(&BTreeMap::from([("BIG".into(), value)]))
+                .unwrap();
+        let ast = defines.apply(&module).unwrap();
+        let hir = crate::lower::lower_module(&ast, "test", "test.ts").unwrap();
+        let dump = format!("{hir:?}");
+        assert_eq!(dump.contains("JsonParse("), expected_parse);
+        assert!(!dump.contains("TypeOf("));
+        assert!(!dump.contains("Conditional"));
+    }
+}

--- a/crates/perry/tests/issue_10151_large_json_define.rs
+++ b/crates/perry/tests/issue_10151_large_json_define.rs
@@ -151,14 +151,28 @@ console.log(b.items[0]);
     );
     assert_eq!(run(root), "items,name\n1 true null small\nfalse\n1\n");
 
+    // A record above the primitive-array text threshold still stays direct.
+    let mid = format!(
+        r#"{{items:[1,true,null],name:"small",padding:"{}"}}"#,
+        "x".repeat(65_536)
+    );
+    config(root, &mid);
+    let hir = compile(root, &["--print-hir"]);
+    assert!(hir.contains("=== HIR") && !hir.contains("JsonParse("));
+    assert_eq!(
+        run(root),
+        "items,name,padding\n1 true null small\nfalse\n1\n"
+    );
+
     // Large define literals share the lowering path. Shadowing JSON must not
     // intercept compiler-generated parsing, and mutations must stay local.
     let large = format!(
         r#"{{items:[1,true,null],name:"small",padding:"{}"}}"#,
-        "x".repeat(65_536)
+        "x".repeat(1024 * 1024)
     );
     config(root, &large);
-    compile(root, &[]);
+    let hir = compile(root, &["--print-hir"]);
+    assert!(hir.contains("JsonParse("), "huge records must stay compact");
     assert_eq!(
         run(root),
         "items,name,padding\n1 true null small\nfalse\n1\n"
@@ -184,7 +198,11 @@ console.log(a.length, a.pop(), a.length);
 "#,
     )
     .unwrap();
-    compile(root, &[]);
+    let hir = compile(root, &["--print-hir"]);
+    assert!(
+        hir.contains("JsonParse("),
+        "primitive arrays keep the fast path"
+    );
     assert_eq!(run(root), "true 1024 true 255 2\n1025 7 1024\n");
 }
 
@@ -199,7 +217,7 @@ console.log(Object.keys(value).join(","));
 console.log(value.z, Object.is(value.a, -0), value[1e-7]);
 console.log(JSON.stringify(value.nested));
 "#,
-        "x".repeat(65_536),
+        "x".repeat(1024 * 1024),
     );
     std::fs::write(root.join("main.ts"), source).unwrap();
     compile(root, &[]);

--- a/crates/perry/tests/issue_10151_large_json_define.rs
+++ b/crates/perry/tests/issue_10151_large_json_define.rs
@@ -1,0 +1,210 @@
+//! Large defines must stay data, not millions of allocation/store instructions.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+fn success(output: Output) -> String {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n")
+}
+
+fn compile(root: &Path, args: &[&str]) -> String {
+    // File-backed output avoids a full pipe blocking the child before timeout.
+    let stdout = tempfile::tempfile().unwrap();
+    let stderr = tempfile::tempfile().unwrap();
+    let mut command = Command::new(
+        std::env::var_os("PERRY_BIN").unwrap_or_else(|| env!("CARGO_BIN_EXE_perry").into()),
+    );
+    command
+        .current_dir(root)
+        .args([
+            "compile",
+            "main.ts",
+            "-o",
+            "app.exe",
+            "--no-auto-optimize",
+            "--cache-dir",
+            "cache",
+        ])
+        .args(args)
+        .env_remove("PERRY_NO_CACHE")
+        .env_remove("PERRY_DISABLE_BUILD_CACHE")
+        .stdout(Stdio::from(stdout.try_clone().unwrap()))
+        .stderr(Stdio::from(stderr.try_clone().unwrap()));
+    if cfg!(windows) {
+        command.env("PERRY_RS4GC", "0");
+    }
+    let started = Instant::now();
+    let mut child = command.spawn().expect("start compiler");
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        // Normal compilation takes seconds; leave headroom for loaded CI.
+        if started.elapsed() > Duration::from_secs(60) {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("large JSON define did not compile within 60 seconds");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    use std::io::{Read, Seek, SeekFrom};
+    let read = |mut file: std::fs::File| {
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        bytes
+    };
+    success(Output {
+        status,
+        stdout: read(stdout),
+        stderr: read(stderr),
+    })
+}
+
+fn run(root: &Path) -> String {
+    success(
+        Command::new(root.join("app.exe"))
+            .current_dir(root)
+            .output()
+            .unwrap(),
+    )
+}
+
+fn config(root: &Path, value: &str) {
+    std::fs::write(
+        root.join("perry.json"),
+        serde_json::to_vec(&serde_json::json!({"define": {"BIG": value}})).unwrap(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn megabyte_define_finishes_and_invalidates_build_and_object_caches() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("main.ts"),
+        r#"
+declare const BIG: Record<string, any> | undefined;
+export const snapshot = typeof BIG === "undefined" ? undefined : BIG;
+console.log(snapshot ? Object.keys(snapshot).length : "no snapshot");
+console.log(snapshot ? snapshot.k00000.id : "missing");
+"#,
+    )
+    .unwrap();
+    // Many actual data nodes, not just a single giant string.
+    let mut entries: Vec<String> = (0..12_000)
+        .map(|i| {
+            format!(
+                r#""k{i:05}":{{"id":{i},"enabled":true,"text":"{}"}}"#,
+                "x".repeat(64)
+            )
+        })
+        .collect();
+    let value = format!("{{{}}}", entries.join(","));
+    assert!(value.len() > 1024 * 1024);
+    config(root, &value);
+    compile(root, &[]);
+    assert_eq!(run(root), "12000\n0\n");
+    // Reusing the same source/output/cache must observe the changed define.
+    entries.push(r#""extra":null"#.into());
+    config(root, &format!("{{{}}}", entries.join(",")));
+    compile(root, &[]);
+    assert_eq!(run(root), "12001\n0\n");
+    // CLI precedence and the undefined guard still apply to a large config.
+    compile(root, &["--define", "BIG=undefined"]);
+    assert_eq!(run(root), "no snapshot\nmissing\n");
+}
+
+#[test]
+fn small_define_stays_direct_and_large_reads_create_fresh_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(
+        root.join("main.ts"),
+        r#"
+function read(JSON: any) { return BIG; }
+const a = read(null);
+const b = read(null);
+console.log(Object.keys(a).join(","));
+console.log(a.items[0], a.items[1], a.items[2], a.name);
+console.log(a === b);
+a.items[0] = 9;
+console.log(b.items[0]);
+"#,
+    )
+    .unwrap();
+    let value = r#"{items:[1,true,null],name:"small"}"#;
+    let define = format!("BIG={value}");
+    let hir = compile(root, &["--define", &define, "--print-hir"]);
+    assert!(hir.contains("=== HIR"), "must inspect an actual HIR dump");
+    assert!(
+        !hir.contains("JsonParse("),
+        "small literals must lower directly"
+    );
+    assert_eq!(run(root), "items,name\n1 true null small\nfalse\n1\n");
+
+    // Large define literals share the lowering path. Shadowing JSON must not
+    // intercept compiler-generated parsing, and mutations must stay local.
+    let large = format!(
+        r#"{{items:[1,true,null],name:"small",padding:"{}"}}"#,
+        "x".repeat(65_536)
+    );
+    config(root, &large);
+    compile(root, &[]);
+    assert_eq!(
+        run(root),
+        "items,name,padding\n1 true null small\nfalse\n1\n"
+    );
+}
+
+#[test]
+fn large_array_define_preserves_array_behavior_and_numeric_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let mut items = vec!["0"; 1024];
+    items[0] = "-0";
+    items[1] = "0xff";
+    items[2] = "+2";
+    config(root, &format!("[{}]", items.join(",")));
+    std::fs::write(
+        root.join("main.ts"),
+        r#"
+const a = BIG;
+console.log(Array.isArray(a), a.length, Object.is(a[0], -0), a[1], a[2]);
+a.push(7);
+console.log(a.length, a.pop(), a.length);
+"#,
+    )
+    .unwrap();
+    compile(root, &[]);
+    assert_eq!(run(root), "true 1024 true 255 2\n1025 7 1024\n");
+}
+
+#[test]
+fn source_literal_preserves_key_order_and_duplicate_last_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let source = format!(
+        r#"
+const value = {{z:0,a:-0,z:+2,1e-7:0xff,nested:[true,null,"quote\"\n\\☃"],padding:"{}"}};
+console.log(Object.keys(value).join(","));
+console.log(value.z, Object.is(value.a, -0), value[1e-7]);
+console.log(JSON.stringify(value.nested));
+"#,
+        "x".repeat(65_536),
+    );
+    std::fs::write(root.join("main.ts"), source).unwrap();
+    compile(root, &[]);
+    assert_eq!(
+        run(root),
+        "z,a,1e-7,nested,padding\n2 true 255\n[true,null,\"quote\\\"\\n\\\\☃\"]\n"
+    );
+}

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -34,6 +34,14 @@ Existing `package.json` `perry.define` strings keep their literal-string
 meaning. Precedence is package literals, then `perry.json`, then CLI flags;
 the last CLI value wins. Both build and object caches include the effective map.
 
+Large JSON-compatible object and array literals (including defines) stay
+serialized in the executable and use the built-in JSON parser when evaluated.
+This avoids generating a constructor/store sequence for every data value.
+The threshold is 1,024 value nodes or 64 KiB of key/string data; small literals
+keep their existing lowering. Each evaluation creates a fresh value, and
+`typeof` guards still fold before lowering. Literals with JavaScript-specific
+behavior, such as a `__proto__` setter, keep ordinary expression lowering.
+
 `import.meta.resolve(specifier[, parent])` returns a `file://` URL for filesystem
 targets and a `node:` specifier for supported builtins. Literal
 module and asset specifiers resolve at compile time; dynamic specifiers resolve

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -34,12 +34,19 @@ Existing `package.json` `perry.define` strings keep their literal-string
 meaning. Precedence is package literals, then `perry.json`, then CLI flags;
 the last CLI value wins. Both build and object caches include the effective map.
 
-Large JSON-compatible object and array literals (including defines) stay
-serialized in the executable and use the built-in JSON parser when evaluated.
-This avoids generating a constructor/store sequence for every data value.
-The threshold is 1,024 value nodes or 64 KiB of key/string data; small literals
-keep their existing lowering. Each evaluation creates a fresh value, and
-`typeof` guards still fold before lowering. Literals with JavaScript-specific
+Large JSON-compatible literals (including defines) can stay serialized in the
+executable and use the built-in JSON parser when evaluated. Two thresholds
+control this, independently of generated function instruction budgets:
+
+- Flat arrays of numbers, strings, booleans and null use this path at 1,024
+  value nodes or 64 KiB of string data.
+- All other JSON-compatible object/array literals use it at 24,576 value nodes
+  or 1 MiB of key/string data, to avoid excessive LLVM code generation.
+
+Nodes include the root and nested values; bytes count UTF-8 key/string content,
+excluding whitespace. Mid-size records keep ordinary lowering and its static
+property layouts for fast reads. Each evaluation still creates a fresh value,
+and `typeof` guards fold before lowering. Literals with JavaScript-specific
 behavior, such as a `__proto__` setter, keep ordinary expression lowering.
 
 `import.meta.resolve(specifier[, parent])` returns a `file://` URL for filesystem


### PR DESCRIPTION
## Summary

Fix multi-MB JSON defines that never finish LLVM code generation, while preserving ordinary lowering and static property layouts for mid-size records (Option 2 from the review).

The original 4,623,800-byte OpenCode snapshot expanded into 395 synthetic classes and 772,701,328 bytes of saved LLVM IR across 30 units. HIR-to-LLVM emission took roughly 11 seconds; the last LLVM unit did not finish in 600 seconds. Its entry function reached 8,445,662 instructions, with peak RSS of 13,667,064 KiB. The stall is in LLVM after literal expansion, not an AST-to-HIR lowering loop.

## Changes

- Flat arrays of primitives (numbers, strings, booleans, null): compact lowering at **1,024 value nodes or 64 KiB of string content**.
- Other JSON-compatible object/array literals: compact lowering at **24,576 value nodes or 1 MiB of key/string content**. Mid-size records retain ordinary lowering and static shapes.
- Thresholds count AST values and UTF-8 content, independently of function instruction budgets. A nested record/array anywhere in a candidate prevents admission to the lower tier.
- Keep `Expr::JsonParse(Expr::String(...))` at the original evaluation site, matching the JSON-import intrinsic from #8418. Each evaluation creates a fresh value; untaken branches do not parse. Existing define substitution, `typeof` folding, and both define-dependent cache keys are unchanged.
- Preserve key order, duplicate last-write behavior, escaping and negative zero. JavaScript-specific semantics (prototype setters, holes, spreads, effects, unsupported strings, non-finite values) retain ordinary lowering.
- Add coverage for both threshold tiers, direct lowering of 400 typed records and a 64 KiB record, plus a reproducible benchmark generator. Update CLI documentation and the issue's changelog fragment.

The record-array cutoff was measured using the exact regressing shape (`id`, `name`, `tags`, `w`), with a freshly built ordinary-lowering control equivalent to base `8a058e2053`:

| Records | Literal bytes | Value nodes | Ordinary no-link compile | Compact no-link compile |
| ---: | ---: | ---: | ---: | ---: |
| 4,800 | 307,740 | 33,601 | 475.17 s | 0.35 s |
| 6,400 | 412,540 | 44,801 | >600 s, timeout | 0.37 s |

At 6,400 records, emission completed in 4.5 seconds with approximately 85.1 MiB estimated IR and a 1,446,386-instruction function before optimization; four of five LLVM units completed within a second. The remaining unit timed out. The selected node threshold switches this shape at **3,511 records**, 27% below the eight-minute case and 45% below the timeout. It is 24 times the old node threshold; the text threshold is 16 times larger.

## Related issue

Fixes #10151

## Test plan

All builds and tests ran through `./remote.sh` on the Linux host with LLVM 22.1.8. None ran on the Mac. The compiler and matching runtime/stdlib archives were copied together out of the shared Cargo target. The ordinary control was built with the compact hook removed; the final compiler uses the code in this revision. Both link the same runtime/stdlib sources and archives.

Final build/check commands (inside `./remote.sh`):

```sh
export PERRY_BUILD_COMMIT=62bc84338176825534
cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static
mkdir -p /tmp/def/two-tier/final-bin
cp "$CARGO_TARGET_DIR/release/perry" "$CARGO_TARGET_DIR/release/libperry_runtime.a" "$CARGO_TARGET_DIR/release/libperry_stdlib.a" /tmp/def/two-tier/final-bin/
export PERRY_BIN=/tmp/def/two-tier/final-bin/perry
export PERRY_RUNTIME_DIR=/tmp/def/two-tier/final-bin
cargo test -p perry-hir --lib
cargo test --release -p perry --test issue_10151_large_json_define -- --nocapture
cargo test -p perry-hir --test shape_inference nested_object_literal_lowers_in_linear_time -- --nocapture
cargo fmt --all -- --check
./scripts/check_file_size.sh
python3 scripts/check_test_registration.py
python3 scripts/check_node_version_consistency.py --list
```

- Release build succeeded (existing runtime dead-code and Redis future-compatibility warnings).
- HIR: **411 passed, 1 ignored**, including all ten JSON-literal unit tests (2.35 s).
- Compile/run regressions: **4 passed** (6.32 s), including >1 MiB data, cache invalidation, CLI undefined override, small/mid-size direct lowering, fresh nested values, shadowed JSON, array mutations, negative zero, duplicate keys and escaping.
- Deep-literal regression passed (1.46 s). Formatting, file-size policy, registration and Node-version consistency passed.

Reproduction commands, with each snapshot stored as the JS-expression value of `BIG` in its directory's `perry.json`:

```sh
cd /tmp/def/two-tier/original-snapshot
/usr/bin/time -v timeout 60 "$PERRY_BIN" compile main.ts --output main-final --no-auto-optimize --cache-dir cache-final
./main-final
cd /tmp/def/two-tier/snapshot
/usr/bin/time -v timeout 60 "$PERRY_BIN" compile main.ts --output main-final --no-auto-optimize --cache-dir cache-final
./main-final
```

The **preserved 4,623,800-byte snapshot compiles and links in 1.52 s**, printing **213**. The installed snapshot has since refreshed to **4,637,074 bytes** (still 213 providers); it compiles and links in **1.54 s**, also printing **213**. Both use fresh caches. Peak RSS is about 410 MiB.

Real OpenCode verification keeps the installed `perry.json` unchanged and uses a temporary entry in `packages/opencode` importing `../core/src/models-dev`:

```sh
cd "$OPENCODE_SRC/packages/opencode"
/usr/bin/time -v timeout 600 env PERRY_DISABLE_BUILD_CACHE=1 PERRY_MODULE_JOBS=8 PERRY_DISABLE_WELL_KNOWN=1 PERRY_CODEGEN_PROGRESS=all "$PERRY_BIN" compile perry-10151-models.ts --platform bun --no-link --no-auto-optimize --output /tmp/def/two-tier/oc-final/main.o --cache-dir /tmp/def/oc-models-cache
```

The final compiler regenerated **`packages/core/src/models-dev.ts` in 10.6 s** (its matching object was held out of the cache to force codegen). The surrounding compile timed out at 600 s later in unrelated Effect dependency codegen. Resuming with the same final compiler and object cache completed **all 621 native modules**, exit 0, in **60.42 s**:

```sh
/usr/bin/time -v timeout 900 env -u PERRY_NO_CACHE -u PERRY_DISABLE_BUILD_CACHE PERRY_MODULE_JOBS=8 PERRY_DISABLE_WELL_KNOWN=1 PERRY_CODEGEN_PROGRESS=1 "$PERRY_BIN" compile perry-10151-models.ts --platform bun --no-link --no-auto-optimize --output /tmp/def/two-tier/oc-final/main.o --cache-dir /tmp/def/oc-models-cache
```

An additional ordinary-lowering 3,200-record probe exceeded its 180-second diagnostic timeout on the busy host. The selected threshold is a data-size heuristic below the measured 4,800/6,400-record cliff, not a universal compilation deadline for all smaller programs.

The no-link pipeline still resolves linker support archives; `PERRY_DISABLE_WELL_KNOWN=1` avoids building those unrelated archives. The temporary entry is removed afterward. The full 7,800-module application was not built.

Runtime A/B uses `benchmarks/large_json_literals/generate.py`, the exact audit fixture, separate caches, and five interleaved runs. Commands and cutoff reproduction are documented in that directory's README.

| Hot loop | Ordinary control | Final two-tier rule |
| --- | ---: | ---: |
| Separate 2,000-number array | 71 ms | 71 ms |
| Separate 400 typed records | 295 ms | 294 ms |
| Combined audit file: numbers | 290 ms | 291 ms |
| Combined audit file: records | 292 ms | 291 ms |

**Performance limitation:** the old broad rule measured 71 ms / 938 ms in the combined file. This revision restores record-read performance, but does **not** retain that combined file's numeric speedup. HIR confirms the numeric array still takes `JsonParse`; ordinary record initialization makes the same unit exceed LLVM's existing 100k-instruction O0 machine-code limit (about 622k instructions). The independent number probe shows no intrinsic runtime improvement on this host. Changing initialization/unit splitting would be additional codegen work; this revision keeps the requested two-tier scope. This limitation is reported explicitly for re-audit.

All numeric and record checksums match. The original semantic probe (mutations, key order, fresh arrays, Float64Array and Map) produced identical stdout across the ordinary control, old broad rule and revised rule. The combined file takes 58.90 s to compile under the final rule versus 60.07 s for ordinary lowering; mid-size record codegen is intentionally retained.

## Checklist

- [x] Added regression coverage for both tiers and mid-size static shapes.
- [x] Measured the record-array LLVM cutoff with margin below it.
- [x] Verified both original and current installed OpenCode defines.
- [x] Ran the requested remote build, tests and formatting/file-size checks.
- [x] Documented the A/B results, including the numeric-performance limitation.
- [x] Updated CLI docs and changelog fragment.
- [x] No version bump or edits to CLAUDE.md / CHANGELOG.md.
- [x] Read CONTRIBUTING.md and follow its PR conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Large JSON-compatible literals and build-time defines are processed more efficiently.
  * Flat primitive arrays use lower size thresholds, while larger objects and nested arrays use higher thresholds to preserve efficient property access for mid-sized records.

* **Bug Fixes**
  * Repeated evaluations continue to produce fresh values, with unused branches remaining unevaluated.
  * Property order, escaping, numeric edge cases, and nested JSON data are preserved.
  * JavaScript-specific constructs retain standard expression behavior.

* **Documentation**
  * Expanded guidance on thresholds and supported JSON-compatible literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->