### PR TITLE
fix(codegen): publish self namespace re-exports as live accessors (#10160)

### DIFF
--- a/changelog.d/10160-self-namespace-dynamic-import.md
+++ b/changelog.d/10160-self-namespace-dynamic-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `export * as Self from "./self"` now reads as the module's own namespace object through a dynamic `import()` namespace (and its destructuring); the entry was `undefined` because the populator loaded the module's namespace global before it was stored (#10160).

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1356,6 +1356,23 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
                     blk.ret(DOUBLE, &value);
                     continue;
                 }
+                crate::NamespaceEntryKind::NestedNamespace { source_prefix }
+                    if source_prefix == module_prefix =>
+                {
+                    // #10160: `export * as Self from "./self"` reads this
+                    // module's own namespace global at access time; the
+                    // populator publishes the entry as a live accessor.
+                    let wrapper = llmod.define_function(
+                        &wrapper_name,
+                        DOUBLE,
+                        vec![(I64, "%this_closure".to_string())],
+                    );
+                    let _ = wrapper.create_block("entry");
+                    let blk = wrapper.block_mut(0).unwrap();
+                    let value = blk.load(DOUBLE, &format!("@__perry_ns_{module_prefix}"));
+                    blk.ret(DOUBLE, &value);
+                    continue;
+                }
                 crate::NamespaceEntryKind::ForeignVar {
                     source_prefix,
                     source_local,

--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -1428,10 +1428,21 @@ pub(super) fn emit_namespace_populator(
             let len_slot = blk.gep(I32, &lens_buf, &[(I64, &idx_str)]);
             blk.store(I32, &format!("{}", key_len), &len_slot);
 
-            let is_live_binding = matches!(
-                entry.kind,
-                NamespaceEntryKind::LocalVar { .. } | NamespaceEntryKind::ForeignVar { .. }
+            // #10160: `export * as Self from "./self"` — this module's own
+            // `@__perry_ns_<prefix>` is only stored after `js_create_namespace`
+            // returns below, so loading it here would freeze `undefined` into
+            // the entry. Publish it as a live accessor instead; its getter
+            // wrapper (emitted next to the LocalVar wrappers in artifacts.rs)
+            // loads the global at read time.
+            let is_self_namespace = matches!(
+                &entry.kind,
+                NamespaceEntryKind::NestedNamespace { source_prefix } if source_prefix == module_prefix
             );
+            let is_live_binding = is_self_namespace
+                || matches!(
+                    entry.kind,
+                    NamespaceEntryKind::LocalVar { .. } | NamespaceEntryKind::ForeignVar { .. }
+                );
             let live_slot = blk.gep(I8, &live_buf, &[(I64, &idx_str)]);
             blk.store(I8, if is_live_binding { "1" } else { "0" }, &live_slot);
 
@@ -1493,6 +1504,16 @@ pub(super) fn emit_namespace_populator(
                         I64,
                         "js_closure_alloc_singleton",
                         &[(PTR, &format!("@{}", wrapper_name))],
+                    );
+                    crate::expr::nanbox_pointer_inline(blk, &handle)
+                }
+                NamespaceEntryKind::NestedNamespace { .. } if is_self_namespace => {
+                    let wrapper = namespace_live_getter_wrapper_symbol(module_prefix, i);
+                    let blk = ctx.block();
+                    let handle = blk.call(
+                        I64,
+                        "js_closure_alloc_singleton",
+                        &[(PTR, &format!("@{}", wrapper))],
                     );
                     crate::expr::nanbox_pointer_inline(blk, &handle)
                 }

--- a/crates/perry/tests/source_graph_export_regressions.rs
+++ b/crates/perry/tests/source_graph_export_regressions.rs
@@ -954,3 +954,5 @@ fn mixed_type_and_value_specifier_import_keeps_runtime_edge() {
         "dependency initialized\n42\n"
     );
 }
+#[path = "source_graph_export_regressions/issue_10160.rs"]
+mod issue_10160;

--- a/crates/perry/tests/source_graph_export_regressions/issue_10160.rs
+++ b/crates/perry/tests/source_graph_export_regressions/issue_10160.rs
@@ -1,0 +1,77 @@
+//! `export * as Self from "./self"` must read as the module's own namespace
+//! through a dynamic `import()` namespace, not as `undefined` (#10160).
+
+use super::{compile_and_run, write};
+
+fn store(dir: &std::path::Path) {
+    write(
+        dir,
+        "store.ts",
+        "export class Service {\n\
+         \x20 static use(f: (s: string) => string) { return f(\"store-ok\") }\n\
+         }\n\
+         export const node = \"node-layer\"\n\
+         export * as InstanceStore from \"./store\"\n",
+    );
+}
+
+#[test]
+fn self_namespace_reexport_is_defined_on_a_dynamic_import_namespace() {
+    let dir = tempfile::tempdir().unwrap();
+    store(dir.path());
+    write(
+        dir.path(),
+        "main.ts",
+        "import { InstanceStore as Static } from \"./store\"\n\
+         console.log(typeof Static, typeof Static.Service, Static.Service.use((s) => s))\n\
+         const mod = await import(\"./store\")\n\
+         console.log(Object.keys(mod).sort().join(\",\"))\n\
+         const { InstanceStore } = mod\n\
+         console.log(typeof InstanceStore, typeof InstanceStore.Service, InstanceStore.Service.use((s) => s + \"!\"))\n\
+         console.log(InstanceStore.InstanceStore === InstanceStore, InstanceStore.node, Static.node)\n",
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.ts"),
+        "object function store-ok\n\
+         InstanceStore,Service,node\n\
+         object function store-ok!\n\
+         true node-layer node-layer\n"
+    );
+}
+
+#[test]
+fn self_namespace_reexport_is_defined_on_a_static_star_import() {
+    let dir = tempfile::tempdir().unwrap();
+    store(dir.path());
+    write(
+        dir.path(),
+        "main.ts",
+        "import * as ns from \"./store\"\n\
+         console.log(typeof ns.InstanceStore, ns.InstanceStore.Service.use((s) => s), ns.InstanceStore.node)\n",
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.ts"),
+        "object store-ok node-layer\n"
+    );
+}
+
+#[test]
+fn foreign_namespace_reexport_stays_intact_on_a_dynamic_import_namespace() {
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "other.ts", "export const value = 42\n");
+    write(
+        dir.path(),
+        "barrel.ts",
+        "export * as Other from \"./other\"\nexport * as Barrel from \"./barrel\"\n",
+    );
+    write(
+        dir.path(),
+        "main.ts",
+        "const mod = await import(\"./barrel\")\n\
+         console.log(typeof mod.Other, mod.Other.value, typeof mod.Barrel, mod.Barrel.Other.value)\n",
+    );
+    assert_eq!(
+        compile_and_run(dir.path(), "main.ts"),
+        "object 42 object 42\n"
+    );
+}


### PR DESCRIPTION
## Summary

`export * as Self from "./self"` (a module re-exporting its own namespace — OpenCode does this in 265 modules) was `undefined` when read through a dynamic `import()` namespace, while the static import resolved. The `NestedNamespace` entry's value was a plain load of the module's own `@__perry_ns_<prefix>` global emitted inside the populator that builds that namespace, i.e. before the global is stored. OpenCode's command bootstrap reads it exactly that way (`const { InstanceStore } = await import("@/project/instance-store")`), so every real command (`run`, `models`, `serve`, TUI) died with `Cannot read properties of undefined (reading 'Service')`.

## Changes

- `emit_namespace_populator` (helpers.rs): a self-referencing `NestedNamespace` entry is published as a live binding — flagged live and materialized as a `js_closure_alloc_singleton` of its `__perry_ns_get_<prefix>__<i>` wrapper, like `LocalVar`/`ForeignVar`. Foreign `export * as` entries keep the direct load of the target's global.
- Getter wrapper emission (artifacts.rs): the self case defines the wrapper as a load of `@__perry_ns_<prefix>` at read time.
- Regression tests (`crates/perry/tests/source_graph_export_regressions/issue_10160.rs`): self re-export through a dynamic namespace (destructuring, property read, recursion `ns.Self.Self === ns.Self`), through a static `import * as`, and a foreign `export * as` on a dynamic namespace (unchanged behaviour). `changelog.d/10160-self-namespace-dynamic-import.md`.

Known separate gap, left alone: `mod.Self === StaticBinding` is `false` under Perry (the static import binding and the dynamic namespace are not the same object); ESM makes them identical.

## Related issue

Fixes #10160

## Test plan

- [x] `cargo test -p perry --test source_graph_export_regressions issue_10160` — 3 passed (Linux x86-64 build host, dedicated target dir)
- [x] `cargo fmt --all -- --check`, `./scripts/check_file_size.sh`
- [x] 2-module repro from the issue with a release perry: prints the Bun output (`dyn destructured: object function` / `dyn use: store-ok!`)
- [ ] Full OpenCode v1.18.30 graph (7,813 modules) recompiling on the build host with this + #10154 + #10156; `opencode models` / `run` are the acceptance rungs (results will be posted on #10107)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `fix:` prefix convention used in the log
- [x] I've read `CONTRIBUTING.md` and agree to the Code of Conduct

https://claude.ai/code/session_01GixUo7gwcatEk4kibdeCWF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed self-namespace re-exports so `export * as Self` correctly resolves through dynamic imports.
  - Preserved live namespace values, including exported classes, values, and recursive namespace identity.
  - Ensured foreign namespace re-exports continue to work correctly.

- **Tests**
  - Added regression coverage for static and dynamic self-namespace imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->